### PR TITLE
Add AWS ParameterStore as config source

### DIFF
--- a/DLCS.Model/Assets/IThumbRepository.cs
+++ b/DLCS.Model/Assets/IThumbRepository.cs
@@ -14,6 +14,6 @@ namespace DLCS.Model.Assets
 
         public Task<ObjectInBucket> GetThumbLocation(int customerId, int spaceId, ImageRequest imageRequest);
         public Task<List<int[]>> GetSizes(int customerId, int spaceId, ImageRequest imageRequest);
-        public ThumbnailPolicy GeThumbnailPolicy(string thumbnailPolicyId);
+        public ThumbnailPolicy GetThumbnailPolicy(string thumbnailPolicyId);
     }
 }

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
     <PackageReference Include="Npgsql" Version="4.1.2" />
   </ItemGroup>
 

--- a/DLCS.Repository/Settings/ThumbsSettings.cs
+++ b/DLCS.Repository/Settings/ThumbsSettings.cs
@@ -1,0 +1,9 @@
+﻿namespace DLCS.Repository.Settings
+{
+    public class ThumbsSettings
+    {
+        public bool EnsureNewThumbnailLayout { get; set; } = false;
+        
+        public string ThumbsBucket { get; set; }
+    }
+}

--- a/Thumbs/Program.cs
+++ b/Thumbs/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -10,10 +11,22 @@ namespace Thumbs
         {
             CreateHostBuilder(args).Build().Run();
         }
-
-        // TODO: Read config from parameter store, investigate polling of config for live update
+        
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((context, builder) =>
+                {
+                    builder.AddSystemsManager(configurationSource =>
+                    {
+                        configurationSource.Path = "/thumbs/";
+                        
+                        // TODO - what's a sensible value here?
+                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
+
+                        // Using ParameterStore optional if Development
+                        configurationSource.Optional = context.HostingEnvironment.IsDevelopment();
+                    });
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -5,6 +5,7 @@ using DLCS.Model.PathElements;
 using DLCS.Model.Storage;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
+using DLCS.Repository.Settings;
 using DLCS.Repository.Storage.S3;
 using DLCS.Web.Requests.AssetDelivery;
 using Microsoft.AspNetCore.Builder;
@@ -38,6 +39,8 @@ namespace Thumbs
             services.AddSingleton<IPathCustomerRepository, CustomerPathElementRepository>();
             services.AddSingleton<IThumbRepository, ThumbRepository>();
             services.AddSingleton<IAssetRepository, AssetRepository>();
+            
+            services.Configure<ThumbsSettings>(Configuration.GetSection("Repository"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -26,8 +26,8 @@ namespace Thumbs
 
         public void ConfigureServices(IServiceCollection services)
         {
-            // TODO: more healthchecks for DB etc.
-            services.AddHealthChecks();
+            services.AddHealthChecks()
+                .AddNpgSql(Configuration.GetConnectionString("PostgreSQLConnection"));
             services.AddCors();
             services.AddMemoryCache();
             services.AddDefaultAWSOptions(Configuration.GetAWSOptions());

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />

--- a/Thumbs/appSettings-Development-Example.json
+++ b/Thumbs/appSettings-Development-Example.json
@@ -7,7 +7,9 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "ThumbsBucket": "--supplied-by-env-var-from-tf-on-live--",
+  "Repository": {
+    "ThumbsBucket": "--supplied-by-env-var-from-tf-on-live--"
+  },  
   "ConnectionStrings": {
     "PostgreSQLConnection": "--supplied-by-env-var-from-tf-on-live--"
   },


### PR DESCRIPTION
Added `ThumbsSettings` to store config values used by `ThumbsRepository`. Set `ReloadAfter` parameter to 90mins, using this in conjunction with `IOptionsMonitor<ThumbsSettings>` for Singleton dependencies, or `IOptionsSnapshot<ThumbsSettings>` for scoped dependencies allows values to be changed without redeploying.

If this is accepted as a way to go we'll need to alter other resources that have a dependency on `IConfiguration`.

Other changes:
* Add healthcheck for postgresql db.
* Fixed sync over async call (remove `.Result`).
* Use new c#8 using syntax.
* Fixed small typos, scoping + whitespace issues.