### PR TITLE
handle different thumb paths

### DIFF
--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -55,9 +55,10 @@ namespace Thumbs
             app.UseCors(); 
             // TODO: Consider better caching solutions
             app.UseResponseCaching();
+            var respondsTo = Configuration.GetValue<string>("RespondsTo", "thumbs");
             app.UseEndpoints(endpoints =>
             {
-                endpoints.Map("/thumbs/{*any}", 
+                endpoints.Map($"/{respondsTo}/{{*any}}", 
                     endpoints.CreateApplicationBuilder()
                     .UseMiddleware<ThumbsMiddleware>()
                     .Build());


### PR DESCRIPTION
This feels a bit dumb - best way to have same service handle alternative paths for testing?