### PR TITLE
Add support for assets not-found to return 404

### DIFF
--- a/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
+++ b/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
@@ -278,5 +278,28 @@ namespace DLCS.Repository.Tests.Assets
             A.CallTo(() => assetRepository.GetAsset(A<string>._))
                 .MustHaveHappened(3, Times.Exactly);
         }
+
+        [Fact]
+        public async Task EnsureNewLayout_AssetNotFound()
+        {
+
+            // Arrange
+            var rootKey = new ObjectInBucket { Bucket = "the-bucket", Key = "2/1/doesnotexit/" };
+
+            Asset returnvalue = null;
+            A.CallTo(() => assetRepository.GetAsset(rootKey.Key.TrimEnd('/')))
+                     .Returns(returnvalue);
+            A.CallTo(() => bucketReader.GetMatchingKeys(rootKey))
+                    .Returns(new string[0]);
+
+           
+            // Act
+            await sut.EnsureNewLayout(rootKey);
+
+            // Assert
+            A.CallTo(() => assetRepository.GetAsset(A<string>._))
+                  .MustHaveHappened();
+
+        }
     }
 }

--- a/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
+++ b/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
@@ -289,9 +289,6 @@ namespace DLCS.Repository.Tests.Assets
             Asset returnvalue = null;
             A.CallTo(() => assetRepository.GetAsset(rootKey.Key.TrimEnd('/')))
                      .Returns(returnvalue);
-            A.CallTo(() => bucketReader.GetMatchingKeys(rootKey))
-                    .Returns(new string[0]);
-
            
             // Act
             await sut.EnsureNewLayout(rootKey);

--- a/DLCS.Repository/Assets/ThumbReorganiser.cs
+++ b/DLCS.Repository/Assets/ThumbReorganiser.cs
@@ -55,7 +55,12 @@ namespace DLCS.Repository.Assets
             // Then sanity check them against the known sizes.
             
             var asset = await assetRepository.GetAsset(rootKey.Key.TrimEnd('/'));
-            var policy = await thumbnailPolicyRepository.GetThumbnailPolicy(asset.ThumbnailPolicy);
+
+            //404 Not Found Asset
+            if (asset == null)
+                return;
+
+            var policy = await thumbnailPolicyRepository.GetThumbnailPolicy(asset!.ThumbnailPolicy);
 
             var maxAvailableThumb = GetMaxAvailableThumb(asset, policy);
 

--- a/DLCS.Repository/Assets/ThumbReorganiser.cs
+++ b/DLCS.Repository/Assets/ThumbReorganiser.cs
@@ -60,7 +60,7 @@ namespace DLCS.Repository.Assets
             if (asset == null)
                 return;
 
-            var policy = await thumbnailPolicyRepository.GetThumbnailPolicy(asset!.ThumbnailPolicy);
+            var policy = await thumbnailPolicyRepository.GetThumbnailPolicy(asset.ThumbnailPolicy);
 
             var maxAvailableThumb = GetMaxAvailableThumb(asset, policy);
 


### PR DESCRIPTION
**Issue cause** 
Asset not found returning null from repo which was generating an exception further down the chain.

**Fix / Changes**
Return if asset is null from repo on  ThumbReorganiser.EnsureNewLayout
Add unit test to cover change

**Tests (manual)**
- Existing image   = shows image
- Non-existing image = 404
- Existing supported thumb size = shows image
- Non existing supported thumb (1400x1400) =  404 
