### PR TITLE
Add API project and allow image to be ingest by bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 .ionide/
 
 .idea
+
+# Generated xml documentation files
+API/API.xml

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
+      <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -2,14 +2,22 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
+      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+      <PackageReference Include="AWSSDK.S3" Version="3.5.3.12" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.16" />
+      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+      <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\DLCS.Repository\DLCS.Repository.csproj" />
       <ProjectReference Include="..\DLCS.Web\DLCS.Web.csproj" />
     </ItemGroup>
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -9,4 +9,8 @@
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\DLCS.Web\DLCS.Web.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
         <Nullable>enable</Nullable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,6 +15,7 @@
       <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
       <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/API/Auth/DlcsDelegatedBasicAuthenticationHandler.cs
+++ b/API/Auth/DlcsDelegatedBasicAuthenticationHandler.cs
@@ -77,6 +77,7 @@ namespace API.Auth
             {
                 new Claim(ClaimTypes.Name, user.Name),
                 new Claim("Customer", customerId), 
+                new Claim("DlcsAuth", headerValue.Parameter), 
             };
             var identity = new ClaimsIdentity(claims, Scheme.Name);
             var principal = new ClaimsPrincipal(identity);

--- a/API/Auth/DlcsDelegatedBasicAuthenticationHandler.cs
+++ b/API/Auth/DlcsDelegatedBasicAuthenticationHandler.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using DLCS.Web.Requests;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace API.Auth
+{
+    /// <summary>
+    /// AuthenticationHandler that hands off calls to DLCS for carrying out authentication.
+    /// </summary>
+    /// <remarks>This is temporary and will be replaced in the future by an implementation that has auth logic</remarks>
+    public class DlcsDelegatedBasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticationOptions>
+    {
+        private readonly IHttpClientFactory httpClientFactory;
+        
+        private const string AuthHeader = "Authorization";
+        private const string BasicScheme = "Basic";
+        
+        public DlcsDelegatedBasicAuthenticationHandler(
+            IOptionsMonitor<BasicAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock,
+            IHttpClientFactory httpClientFactory)
+            : base(options, logger, encoder, clock)
+        {
+            this.httpClientFactory = httpClientFactory;
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.ContainsKey(AuthHeader))
+            {
+                // Authorization header not in request
+                return AuthenticateResult.NoResult();
+            }
+
+            if (!AuthenticationHeaderValue.TryParse(Request.Headers[AuthHeader],
+                out AuthenticationHeaderValue headerValue))
+            {
+                // Invalid Authorization header
+                return AuthenticateResult.NoResult();
+            }
+
+            if (!BasicScheme.Equals(headerValue.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                // Not Basic authentication header
+                return AuthenticateResult.NoResult();
+            }
+            
+            if (!Request.RouteValues.TryGetValue("customerId", out var customerIdRouteVal))
+            {
+                Logger.LogInformation($"Unable to identify customerId in auth request to {Request.Path}");
+                return AuthenticateResult.NoResult();
+            }
+            
+            var customerId = customerIdRouteVal.ToString();;
+            
+            var userAndPassword = Encoding.UTF8.GetString(Convert.FromBase64String(headerValue.Parameter));
+            string[] cred = userAndPassword.Split(':');
+            
+            var user = new {Name = cred[0], Pass = cred[1]};
+            if (!await IsValidUser(user.Name, user.Pass, customerId))
+            {
+                return AuthenticateResult.Fail("Invalid username or password");
+            }
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Name, user.Name),
+                new Claim("Customer", customerId), 
+            };
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return AuthenticateResult.Success(ticket);
+        }
+        
+        protected override Task HandleChallengeAsync(AuthenticationProperties properties)
+        {
+            Response.Headers["WWW-Authenticate"] = $"Basic realm=\"{Options.Realm}\"";
+            return base.HandleChallengeAsync(properties);
+        }
+
+        private async Task<bool> IsValidUser(string name, string pass, string customerId)
+        {
+            // Parse the CustomerId out of this.
+            var delegatePath = $"/customers/{customerId}"; 
+
+            // make a request to DLCS and verify the result received
+            var httpClient = httpClientFactory.CreateClient("dlcs-api");
+            var request = new HttpRequestMessage(HttpMethod.Get, delegatePath);
+            request.Headers.AddBasicAuth(name, pass);
+            var response = await httpClient.SendAsync(request);
+
+            return response.StatusCode == HttpStatusCode.OK;
+        }
+    }
+}

--- a/API/Auth/ServiceCollectionX.cs
+++ b/API/Auth/ServiceCollectionX.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace API.Auth
+{
+    public static class ServiceCollectionX
+    {
+        /// <summary>
+        /// Add DlcsDelegatedBasicAuthenticationHandler to services collection.
+        /// </summary>
+        public static AuthenticationBuilder AddDlcsDelegatedBasicAuth(this IServiceCollection services,
+            Action<BasicAuthenticationOptions> configureOptions)
+            => services
+                .AddAuthentication(BasicAuthenticationDefaults.AuthenticationScheme)
+                .AddScheme<BasicAuthenticationOptions, DlcsDelegatedBasicAuthenticationHandler>(
+                    BasicAuthenticationDefaults.AuthenticationScheme, configureOptions);
+    }
+    
+    /// <summary>
+    /// Options for use with BasicAuth handler.
+    /// </summary>
+    public class BasicAuthenticationOptions : AuthenticationSchemeOptions
+    {
+        /// <summary>
+        /// Get or set the Realm for use in auth challenges.
+        /// </summary>
+        public string Realm { get; set; }
+    }
+    
+    /// <summary>
+    /// Contains constants for use with basic auth.
+    /// </summary>
+    public static class BasicAuthenticationDefaults
+    {
+        public const string AuthenticationScheme = "Basic";
+    }
+}

--- a/API/Features/Image/Commands/IngestImageFromFile.cs
+++ b/API/Features/Image/Commands/IngestImageFromFile.cs
@@ -1,0 +1,134 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Features.Image.Models;
+using API.Settings;
+using DLCS.Core;
+using DLCS.Model.Storage;
+using DLCS.Web.Requests;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace API.Features.Image.Commands
+{
+    /// <summary>
+    /// Request object to ingest image directly from a file.
+    /// </summary>
+    public class IngestImageFromFile : IRequest<ResultStatus<DelegatedIngestResponse>>
+    {
+        // NOTE - these 3 will often come together, maybe have something to handle as a group
+        public string CustomerId { get; }
+        public string SpaceId { get; }
+        public string ImageId { get; }
+        public Stream File { get; }
+        
+        public AssetJsonLD Body { get; }
+        
+        // TODO - temporary as we forward this on from those the user sent
+        public string BasicAuth { get; } 
+
+        public IngestImageFromFile(string customerId, string spaceId, string imageId, Stream file, AssetJsonLD body, string basicAuth)
+        {
+            CustomerId = customerId;
+            SpaceId = spaceId;
+            ImageId = imageId;
+            File = file;
+            Body = body;
+            BasicAuth = basicAuth;
+        }
+    }
+    
+    /// <summary>
+    /// Handler for direct ingesting image by delegating logic to dlcs API.
+    /// </summary>
+    public class IngestImageFromFileHandler : IRequestHandler<IngestImageFromFile, ResultStatus<DelegatedIngestResponse>>
+    {
+        private readonly IBucketReader bucketReader;
+        private readonly IHttpClientFactory clientFactory;
+        private readonly ILogger<IngestImageFromFileHandler> logger;
+        private readonly ApiSettings settings;
+
+        public IngestImageFromFileHandler(
+            IBucketReader bucketReader, 
+            IOptions<ApiSettings> settings,
+            IHttpClientFactory clientFactory,
+            ILogger<IngestImageFromFileHandler> logger)
+        {
+            this.bucketReader = bucketReader;
+            this.clientFactory = clientFactory;
+            this.logger = logger;
+            this.settings = settings.Value;
+        }
+
+        public async Task<ResultStatus<DelegatedIngestResponse>> Handle(
+            IngestImageFromFile request,
+            CancellationToken cancellationToken)
+        {
+            // Save to S3
+            var objectInBucket = GetObjectInBucket(request);
+            var bucketSuccess = await bucketReader.WriteToBucket(objectInBucket, request.File, request.Body.MediaType);
+
+            if (!bucketSuccess)
+            {
+                // Failed, abort
+                logger.LogError($"Failed to upload file to S3, aborting ingest. Key: '{objectInBucket}'");
+                return new ResultStatus<DelegatedIngestResponse>(false);
+            }
+
+            request.Body.Origin = objectInBucket.GetHttpUri();
+            var ingestResponse = await CallDlcsIngest(request, cancellationToken);
+            var responseBody = await ingestResponse.Content.ReadAsStringAsync();
+            var imageResult = JsonConvert.DeserializeObject<AssetJsonLD>(responseBody);
+
+            return ResultStatus<DelegatedIngestResponse>.Successful(new DelegatedIngestResponse(
+                ingestResponse.StatusCode,
+                imageResult));
+        }
+
+        private async Task<HttpResponseMessage> CallDlcsIngest(IngestImageFromFile request, CancellationToken cancellationToken)
+        {
+            string ingestJson = JsonConvert.SerializeObject(request.Body,
+                new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    ContractResolver = new DefaultContractResolver {NamingStrategy = new CamelCaseNamingStrategy()}
+                });
+
+            var client = clientFactory.CreateClient("dlcs-api");
+            var requestUri = $"/customers/{request.CustomerId}/spaces/{request.SpaceId}/images/{request.ImageId}";
+            
+            logger.LogDebug($"Ingesting '{ingestJson}' at '{requestUri}'");
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Put, requestUri)
+            {
+                Content = new StringContent(ingestJson, Encoding.UTF8, "application/json")
+            };
+            requestMessage.Headers.AddBasicAuth(request.BasicAuth);
+            return await client.SendAsync(requestMessage, cancellationToken);
+        }
+
+        private RegionalisedObjectInBucket GetObjectInBucket(IngestImageFromFile request)
+            => new RegionalisedObjectInBucket(settings.DLCS.OriginBucket,
+                $"{request.CustomerId}/{request.SpaceId}/{request.ImageId}", settings.AWS.Region);
+    }
+
+    public class DelegatedIngestResponse
+    {
+        public AssetJsonLD? Body { get; }
+        
+        // NOTE - this isn't ideal but is temporary
+        public HttpStatusCode? DownstreamStatusCode { get; }
+
+        public DelegatedIngestResponse(HttpStatusCode? downstreamStatusCode, AssetJsonLD? body)
+        {
+            DownstreamStatusCode = downstreamStatusCode;
+            Body = body;
+        }
+    }
+}

--- a/API/Features/Image/Commands/IngestImageFromFile.cs
+++ b/API/Features/Image/Commands/IngestImageFromFile.cs
@@ -31,9 +31,12 @@ namespace API.Features.Image.Commands
         public AssetJsonLD Body { get; }
         
         // TODO - temporary as we forward this on from those the user sent
-        public string BasicAuth { get; } 
+        public string BasicAuth { get; }
 
-        public IngestImageFromFile(string customerId, string spaceId, string imageId, Stream file, AssetJsonLD body, string basicAuth)
+        public override string ToString() => $"{CustomerId}/{SpaceId}/{ImageId}";
+
+        public IngestImageFromFile(string customerId, string spaceId, string imageId, Stream file, AssetJsonLD body,
+            string basicAuth)
         {
             CustomerId = customerId;
             SpaceId = spaceId;
@@ -124,6 +127,8 @@ namespace API.Features.Image.Commands
         
         // NOTE - this isn't ideal but is temporary
         public HttpStatusCode? DownstreamStatusCode { get; }
+
+        public override string ToString() => DownstreamStatusCode?.ToString() ?? "_unknown_";
 
         public DelegatedIngestResponse(HttpStatusCode? downstreamStatusCode, AssetJsonLD? body)
         {

--- a/API/Features/Image/ImageController.cs
+++ b/API/Features/Image/ImageController.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace API.Features.Image
+{
+    [Route("/customers/{customerId}/spaces/{spaceId}/images/")]
+    [ApiController]
+    public class Image : Controller
+    {
+        [HttpPost]
+        [Route("{imageId}")]
+        public IActionResult Index([FromRoute]int customerId, [FromRoute]int spaceId, string imageId)
+        {
+            return Ok(new
+            {
+                customerId, spaceId, imageId
+            });
+        }
+    }
+}

--- a/API/Features/Image/ImageController.cs
+++ b/API/Features/Image/ImageController.cs
@@ -1,4 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.IO;
+using System.Net;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using API.Features.Image.Commands;
+using API.Features.Image.Models;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
 
 namespace API.Features.Image
 {
@@ -6,14 +13,34 @@ namespace API.Features.Image
     [ApiController]
     public class Image : Controller
     {
+        private readonly IMediator mediator;
+
+        public Image(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+        
+        /// <summary>
+        /// Ingest specified file bytes to DLCS.
+        /// </summary>
         [HttpPost]
         [Route("{imageId}")]
-        public IActionResult Index([FromRoute]int customerId, [FromRoute]int spaceId, string imageId)
+        public async Task<IActionResult> IngestBytes([FromRoute] string customerId, [FromRoute] string spaceId,
+            [FromRoute] string imageId, AssetJsonLdWithBytes asset)
         {
-            return Ok(new
-            {
-                customerId, spaceId, imageId
-            });
+            var claimsIdentity = User.Identity as ClaimsIdentity;
+            var claim = claimsIdentity?.FindFirst("DlcsAuth").Value;
+            var command = new IngestImageFromFile(customerId, spaceId, imageId,
+                new MemoryStream(asset.File), asset.ToImageJsonLD(), claim);
+            
+            var response = await mediator.Send(command);
+
+            HttpStatusCode? statusCode = response.Value?.DownstreamStatusCode ??
+                                         (response.Success
+                                             ? HttpStatusCode.Created
+                                             : HttpStatusCode.InternalServerError);
+
+            return StatusCode((int) statusCode, response.Value?.Body);
         }
     }
 }

--- a/API/Features/Image/Models/AssetJsonLD.cs
+++ b/API/Features/Image/Models/AssetJsonLD.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace API.Features.Image.Models
+{
+    // NOTE - these classes will be worked on when 'real' implementation of API is added. These are passed directly
+    // to API for now.
+    // TODO - Ideally we could inherit from DLCS.Model.Assets.Asset here but would need to make all props nullable
+    // and I'm unsure of side effects
+
+    public class AssetJsonLD 
+    {
+        [JsonProperty("@context")]
+        public string? Context { get; set; }
+        
+        [JsonProperty("@type")]
+        public string? Type { get; set; }
+        
+        [JsonProperty("@id")]
+        public string? Id { get; set; }
+        public DateTime? Created { get; set; }
+        public string? Origin { get; set; }
+        public List<string>? Tags { get; set; }
+        public List<string>? Roles { get; set; }
+        public string? PreservedUri { get; set; }
+        public string? Reference1 { get; set; }
+        public string? Reference2 { get; set; }
+        public string? Reference3 { get; set; }
+        public int? MaxUnauthorised { get; set; }
+        public long? NumberReference1 { get; set; }
+        public long? NumberReference2 { get; set; }
+        public long? NumberReference3 { get; set; }
+        public int? Width { get; set; }
+        public int? Height { get; set; }
+        public long? Duration { get; set; }
+        public string? Error { get; set; }
+        public int? Batch { get; set; }
+        public DateTime? Finished { get; set; }
+        public bool? Ingesting { get; set; }
+        public string? ImageOptimisationPolicy { get; set; }
+        public string? ThumbnailPolicy { get; set; }
+        public string? InitialOrigin { get; set; }
+        public char? Family { get; set; }
+        public string? MediaType { get; set; }
+    }
+    
+    public class AssetJsonLdWithBytes : AssetJsonLD
+    {
+        public byte[] File { get; set; }
+
+        public AssetJsonLD ToImageJsonLD() =>
+            new AssetJsonLD
+            {
+                Type = Type,
+                Id = Id,
+                Created = Created,
+                Origin = Origin,
+                Tags = Tags,
+                Roles = Roles,
+                PreservedUri = PreservedUri,
+                Reference1 = Reference1,
+                Reference2 = Reference2,
+                Reference3 = Reference3,
+                MaxUnauthorised = MaxUnauthorised,
+                NumberReference1 = NumberReference1,
+                NumberReference2 = NumberReference2,
+                NumberReference3 = NumberReference3,
+                Width = Width,
+                Height = Height,
+                Duration = Duration,
+                Error = Error,
+                Batch = Batch,
+                Finished = Finished,
+                Ingesting = Ingesting,
+                ImageOptimisationPolicy = ImageOptimisationPolicy,
+                ThumbnailPolicy = ThumbnailPolicy,
+                InitialOrigin = InitialOrigin,
+                Family = Family,
+                MediaType = MediaType,
+            };
+    }
+}

--- a/API/Features/Image/Models/AssetJsonLD.cs
+++ b/API/Features/Image/Models/AssetJsonLD.cs
@@ -24,13 +24,13 @@ namespace API.Features.Image.Models
         public List<string>? Tags { get; set; }
         public List<string>? Roles { get; set; }
         public string? PreservedUri { get; set; }
-        public string? Reference1 { get; set; }
-        public string? Reference2 { get; set; }
-        public string? Reference3 { get; set; }
+        public string? String1 { get; set; }
+        public string? String2 { get; set; }
+        public string? String3 { get; set; }
         public int? MaxUnauthorised { get; set; }
-        public long? NumberReference1 { get; set; }
-        public long? NumberReference2 { get; set; }
-        public long? NumberReference3 { get; set; }
+        public long? Number1 { get; set; }
+        public long? Number2 { get; set; }
+        public long? Number3 { get; set; }
         public int? Width { get; set; }
         public int? Height { get; set; }
         public long? Duration { get; set; }
@@ -59,13 +59,13 @@ namespace API.Features.Image.Models
                 Tags = Tags,
                 Roles = Roles,
                 PreservedUri = PreservedUri,
-                Reference1 = Reference1,
-                Reference2 = Reference2,
-                Reference3 = Reference3,
+                String1 = String1,
+                String2 = String2,
+                String3 = String3,
                 MaxUnauthorised = MaxUnauthorised,
-                NumberReference1 = NumberReference1,
-                NumberReference2 = NumberReference2,
-                NumberReference3 = NumberReference3,
+                Number1 = Number1,
+                Number2 = Number2,
+                Number3 = Number3,
                 Width = Width,
                 Height = Height,
                 Duration = Duration,

--- a/API/Infrastructure/ApplicationBuilderX.cs
+++ b/API/Infrastructure/ApplicationBuilderX.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using API.Settings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.OpenApi.Models;
+
+namespace API.Infrastructure
+{
+    public static class ApplicationBuilderX
+    {
+        /// <summary>
+        /// Add swagger + swagger UI to app
+        /// </summary>
+        public static IApplicationBuilder UseSwaggerWithUI(this IApplicationBuilder app, IConfiguration configuration)
+        {
+            var applicationOptions = configuration.Get<ApiSettings>();
+            var pathBase = applicationOptions.PathBase;
+            var havePathBase = !string.IsNullOrEmpty(pathBase);
+            if (havePathBase)
+            {
+                app.UsePathBase($"/{pathBase}");
+            }
+
+            return app
+                .UseSwagger(c =>
+                {
+                    if (havePathBase)
+                    {
+                        c.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
+                        {
+                            swaggerDoc.Servers = new List<OpenApiServer>
+                                {new OpenApiServer {Url = $"https://{httpReq.Host.Value}/{pathBase}"}};
+                        });
+                    }
+                })
+                .UseSwaggerUI(c =>
+                    c.SwaggerEndpoint($"/{(havePathBase ? pathBase + "/" : string.Empty)}swagger/v2/swagger.json",
+                        "DLCS API"));
+        }
+    }
+}

--- a/API/Infrastructure/ApplicationBuilderX.cs
+++ b/API/Infrastructure/ApplicationBuilderX.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using API.Settings;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;
 
 namespace API.Infrastructure
@@ -11,15 +9,9 @@ namespace API.Infrastructure
         /// <summary>
         /// Add swagger + swagger UI to app
         /// </summary>
-        public static IApplicationBuilder UseSwaggerWithUI(this IApplicationBuilder app, IConfiguration configuration)
+        public static IApplicationBuilder UseSwaggerWithUI(this IApplicationBuilder app, string pathBase)
         {
-            var applicationOptions = configuration.Get<ApiSettings>();
-            var pathBase = applicationOptions.PathBase;
             var havePathBase = !string.IsNullOrEmpty(pathBase);
-            if (havePathBase)
-            {
-                app.UsePathBase($"/{pathBase}");
-            }
 
             return app
                 .UseSwagger(c =>

--- a/API/Infrastructure/LoggingBehaviour.cs
+++ b/API/Infrastructure/LoggingBehaviour.cs
@@ -1,0 +1,36 @@
+﻿using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace API.Infrastructure
+{
+    /// <summary>
+    /// Mediatr Pipeline Behaviour that logs incoming requests
+    /// </summary>
+    public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    {
+        private readonly ILogger<LoggingBehavior<TRequest, TResponse>> logger;
+
+        public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+        {
+            this.logger = logger;
+        }
+
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken,
+            RequestHandlerDelegate<TResponse> next)
+        {
+            // This could be cleverer, currently will just log ToString()
+            logger.LogDebug($"Handling '{typeof(TRequest).Name}' request. {request}");
+
+            Stopwatch sw = Stopwatch.StartNew();
+            var response = await next();
+
+            sw.Stop();
+            logger.LogDebug($"Handled '{typeof(TResponse).Name}' in {sw.ElapsedMilliseconds}ms. {response}");
+
+            return response;
+        }
+    }
+}

--- a/API/Infrastructure/ServiceCollectionX.cs
+++ b/API/Infrastructure/ServiceCollectionX.cs
@@ -1,5 +1,9 @@
-﻿using MediatR;
+﻿using System;
+using System.IO;
+using System.Reflection;
+using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 
 namespace API.Infrastructure
 {
@@ -12,5 +16,49 @@ namespace API.Infrastructure
             => services
                 .AddMediatR(typeof(Startup))
                 .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+
+        /// <summary>
+        /// Add SwaggerGen services to service collection.
+        /// </summary>
+        public static IServiceCollection ConfigureSwagger(this IServiceCollection services)
+            => services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v2", new OpenApiInfo
+                {
+                    Title = "DLCS API", 
+                    Version = "v2",
+                    Description = "API for interacting with DLCS"
+                });
+
+                c.AddSecurityDefinition(
+                    "basic", new OpenApiSecurityScheme
+                    {
+                        Name = "Authorization",
+                        Type = SecuritySchemeType.Http,
+                        Scheme = "basic",
+                        In = ParameterLocation.Header,
+                        Description = "Basic Authorization header using the Bearer scheme.",
+                    });
+
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "basic",
+                            },
+                        },
+                        new string[] { }
+                    },
+                });
+                
+                // Set the comments path for the Swagger JSON and UI.
+                var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+                var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+                c.IncludeXmlComments(xmlPath);
+            });
     }
 }

--- a/API/Infrastructure/ServiceCollectionX.cs
+++ b/API/Infrastructure/ServiceCollectionX.cs
@@ -1,0 +1,16 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace API.Infrastructure
+{
+    public static class ServiceCollectionX
+    {
+        /// <summary>
+        /// Add MediatR services and pipeline behaviours to service collection.
+        /// </summary>
+        public static IServiceCollection ConfigureMediatR(this IServiceCollection services)
+            => services
+                .AddMediatR(typeof(Startup))
+                .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace API
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .CreateLogger();
+            
+            try
+            {
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Application start-up failed");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .UseSerilog((hostingContext, loggerConfiguration)
+                    => loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration)
+                )
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
+}

--- a/API/Properties/launchSettings.json
+++ b/API/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "profiles": {
+    "API": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5002;http://localhost:5012",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/API/Settings/ApiSettings.cs
+++ b/API/Settings/ApiSettings.cs
@@ -8,13 +8,25 @@ namespace API.Settings
         /// The base URI of DLCS to hand-off requests to.
         /// </summary>
         public DlcsSettings DLCS { get; set; }
+        
+        public AwsSettings AWS { get; set; }
     }
-    
+
     public class DlcsSettings
     {
         /// <summary>
         /// The base URI of DLCS to hand-off requests to.
         /// </summary>
         public Uri Root { get; set; }
+
+        /// <summary>
+        /// Name of the bucket to act as storage origin for uploaded files.
+        /// </summary>
+        public string OriginBucket { get; set; }
+    }
+
+    public class AwsSettings
+    {
+        public string Region { get; set; }
     }
 }

--- a/API/Settings/ApiSettings.cs
+++ b/API/Settings/ApiSettings.cs
@@ -10,6 +10,8 @@ namespace API.Settings
         public DlcsSettings DLCS { get; set; }
         
         public AwsSettings AWS { get; set; }
+        
+        public string PathBase { get; set; }
     }
 
     public class DlcsSettings

--- a/API/Settings/ApiSettings.cs
+++ b/API/Settings/ApiSettings.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace API.Settings
+{
+    public class ApiSettings
+    {
+        /// <summary>
+        /// The base URI of DLCS to hand-off requests to.
+        /// </summary>
+        public DlcsSettings DLCS { get; set; }
+    }
+    
+    public class DlcsSettings
+    {
+        /// <summary>
+        /// The base URI of DLCS to hand-off requests to.
+        /// </summary>
+        public Uri Root { get; set; }
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Amazon.S3;
 using API.Auth;
 using API.Infrastructure;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Serilog;
 
@@ -70,9 +72,9 @@ namespace API
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseSwagger().UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v2/swagger.json", "DLCS API"));
-
-            app.UseRouting()
+            app
+                .UseSwaggerWithUI(configuration)
+                .UseRouting()
                 .UseSerilogRequestLogging()
                 .UseCors()
                 .UseAuthentication()

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,5 +1,6 @@
 using Amazon.S3;
 using API.Auth;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Model.Storage;
 using DLCS.Repository.Storage.S3;
@@ -38,7 +39,7 @@ namespace API
             });
 
             services
-                .AddMediatR(typeof(Startup))
+                .ConfigureMediatR()
                 .AddAWSService<IAmazonS3>()
                 .AddSingleton<IBucketReader, BucketReader>();;
 

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,0 +1,48 @@
+using API.Settings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace API
+{
+    public class Startup
+    {
+        private readonly IConfiguration configuration;
+        
+        public Startup(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+        
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var apiSettings = configuration.Get<ApiSettings>();
+
+            services
+                .AddControllers()
+                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+
+            services
+                .AddHealthChecks()
+                .AddUrlGroup(apiSettings.DLCS.Root, "DLCS API");
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting()
+                .UseSerilogRequestLogging()
+                .UseCors()
+                .UseHealthChecks("/ping")
+                .UseEndpoints(endpoints => endpoints.MapControllers());
+        }
+    }
+}

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -1,3 +1,4 @@
+using API.Auth;
 using API.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -21,10 +22,25 @@ namespace API
         public void ConfigureServices(IServiceCollection services)
         {
             var apiSettings = configuration.Get<ApiSettings>();
+            
+            services.AddHttpClient();
+            services.AddHttpClient("dlcs-api", c =>
+            {
+                c.BaseAddress = apiSettings.DLCS.Root;
+                c.DefaultRequestHeaders.Add("User-Agent", "DLCS-APIv2-Protagonist");
+            });
+
+            services.AddDlcsDelegatedBasicAuth(options => options.Realm = "DLCS-API");
 
             services
                 .AddControllers()
-                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+                .SetCompatibilityVersion(CompatibilityVersion.Latest)
+                .AddJsonOptions(
+                    options =>
+                    {
+                        options.JsonSerializerOptions.IgnoreNullValues = true;
+                        options.JsonSerializerOptions.WriteIndented = true;
+                    });
 
             services
                 .AddHealthChecks()
@@ -41,8 +57,10 @@ namespace API
             app.UseRouting()
                 .UseSerilogRequestLogging()
                 .UseCors()
+                .UseAuthentication()
+                .UseAuthorization()
                 .UseHealthChecks("/ping")
-                .UseEndpoints(endpoints => endpoints.MapControllers());
+                .UseEndpoints(endpoints => endpoints.MapControllers().RequireAuthorization());
         }
     }
 }

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -4,7 +4,6 @@ using API.Infrastructure;
 using API.Settings;
 using DLCS.Model.Storage;
 using DLCS.Repository.Storage.S3;
-using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -40,6 +39,7 @@ namespace API
 
             services
                 .ConfigureMediatR()
+                .ConfigureSwagger()
                 .AddAWSService<IAmazonS3>()
                 .AddSingleton<IBucketReader, BucketReader>();;
 
@@ -69,6 +69,8 @@ namespace API
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.UseSwagger().UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v2/swagger.json", "DLCS API"));
 
             app.UseRouting()
                 .UseSerilogRequestLogging()

--- a/API/appsettings.Development-Example.json
+++ b/API/appsettings.Development-Example.json
@@ -1,0 +1,11 @@
+{
+  "AWS": {
+    "Profile": "default",
+    "Region": "eu-west-1"
+  },
+  "DLCS": {
+    "Root": "https://api.dlcs.digirati.io",
+    "OriginBucket": "storage-bucket-name"
+  },
+  "PathBase": ""
+}

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Debug",
+        "System": "Debug"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "Engine"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/API/appsettings.json
+++ b/API/appsettings.json
@@ -19,5 +19,6 @@
       "ApplicationName": "Engine"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "PathBase": ""
 }

--- a/DLCS.Core.Tests/Guard/GuardXTests.cs
+++ b/DLCS.Core.Tests/Guard/GuardXTests.cs
@@ -31,5 +31,32 @@ namespace DLCS.Core.Tests.Guard
             // Assert
             actual.Should().Be(val);
         }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ThrowIfNullOrEmpty_Throws_IfNullOrEmpty(string val)
+        {
+            // Act
+            Action action = () => GuardX.ThrowIfNullOrEmpty(val, "foo");
+
+            // Assert
+            action.Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null. (Parameter 'foo')");
+        }
+
+        [Fact]
+        public void ThrowIfNullOrEmpty_ReturnsProvidedString_IfNotNullOrEmpty()
+        {
+            // Arrange
+            const string val = "foo bar";
+            
+            // Act
+            var actual = val.ThrowIfNullOrEmpty(nameof(val));
+            
+            // Assert
+            actual.Should().Be(val);
+        }
     }
 }

--- a/DLCS.Core.Tests/Guard/GuardXTests.cs
+++ b/DLCS.Core.Tests/Guard/GuardXTests.cs
@@ -58,5 +58,33 @@ namespace DLCS.Core.Tests.Guard
             // Assert
             actual.Should().Be(val);
         }
+        
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void ThrowIfNullOrWhiteSpace_Throws_IfArgumentNullOrWhiteSpace(string str)
+        {
+            // Act
+            Action action = () => str.ThrowIfNullOrWhiteSpace("foo");
+            
+            // Assert
+            action.Should()
+                .Throw<ArgumentNullException>()
+                .WithMessage("Value cannot be null. (Parameter 'foo')");
+        }
+        
+        [Fact]
+        public void ThrowIfNullOrWhiteSpace_ReturnsProvidedString_IfNotNull()
+        {
+            // Arrange
+            const string val = "hi";
+
+            // Act
+            var actual = val.ThrowIfNull(nameof(val));
+            
+            // Assert
+            actual.Should().Be(val);
+        }
     }
 }

--- a/DLCS.Core/Guard/GuardX.cs
+++ b/DLCS.Core/Guard/GuardX.cs
@@ -24,5 +24,22 @@ namespace DLCS.Core.Guard
 
             return argument;
         }
+        
+        /// <summary>
+        /// Throw <see cref="ArgumentNullException"/> if provided string is null or empty.
+        /// </summary>
+        /// <param name="val">Value to check.</param>
+        /// <param name="argName">Argument name for exception.</param>
+        /// <returns>Provided value if not null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if val is null or empty.</exception>
+        public static string ThrowIfNullOrEmpty(this string val, string argName = "argument")
+        {
+            if (string.IsNullOrEmpty(val))
+            {
+                throw new ArgumentNullException(argName);
+            }
+
+            return val;
+        }
     }
 }

--- a/DLCS.Core/Guard/GuardX.cs
+++ b/DLCS.Core/Guard/GuardX.cs
@@ -26,6 +26,23 @@ namespace DLCS.Core.Guard
         }
         
         /// <summary>
+        /// Throw <see cref="ArgumentNullException"/> if provided value is null, empty or whitespace.
+        /// </summary>
+        /// <param name="argument">Argument to check.</param>
+        /// <param name="argName">Name of argument.</param>
+        /// <returns>Passed string, if not null.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if provided argument is null.</exception>
+        public static string ThrowIfNullOrWhiteSpace(this string argument, string argName)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentNullException(argName);
+            }
+
+            return argument;
+        }
+        
+        /// <summary>
         /// Throw <see cref="ArgumentNullException"/> if provided string is null or empty.
         /// </summary>
         /// <param name="val">Value to check.</param>

--- a/DLCS.Core/ResultStatus.cs
+++ b/DLCS.Core/ResultStatus.cs
@@ -1,0 +1,51 @@
+﻿namespace DLCS.Core
+{
+    public class ResultStatus<T>
+        where T : class
+    {
+        /// <summary>
+        /// Indicates whether the operation was successful
+        /// </summary>
+        public bool Success { get; }
+
+        /// <summary>
+        /// The associated value.
+        /// </summary>
+        public T? Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResultStatus{T}"/> class.
+        /// </summary>
+        /// <param name="success">if set to <c>true</c> [success].</param>
+        public ResultStatus(bool success)
+        {
+            Success = success;
+            Value = default!;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResultStatus{T}"/> class.
+        /// </summary>
+        /// <param name="success">if set to <c>true</c> [success].</param>
+        /// <param name="value">The value.</param>
+        public ResultStatus(bool success, T value)
+        {
+            Success = success;
+            Value = value;
+        }
+
+        /// <summary>
+        /// Creates an unsuccessful result with specified value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static ResultStatus<T> Unsuccessful(T value) => new ResultStatus<T>(false, value);
+
+        /// <summary>
+        /// Creates a successful result with specified value
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public static ResultStatus<T> Successful(T value) => new ResultStatus<T>(true, value);
+    }
+}

--- a/DLCS.Model.Tests/DLCS.Model.Tests.csproj
+++ b/DLCS.Model.Tests/DLCS.Model.Tests.csproj
@@ -15,7 +15,12 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\API\API.csproj" />
       <ProjectReference Include="..\DLCS.Model\DLCS.Model.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Storage" />
     </ItemGroup>
 
 </Project>

--- a/DLCS.Model.Tests/Storage/RegionalisedObjectInBucketTests.cs
+++ b/DLCS.Model.Tests/Storage/RegionalisedObjectInBucketTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using DLCS.Model.Storage;
+using FluentAssertions;
+using Xunit;
+
+namespace DLCS.Model.Tests.Storage
+{
+    public class RegionalisedObjectInBucketTests
+    {
+        [Theory]
+        [InlineData("s3://eu-west-1/dlcs-storage/2/1/foo-bar", true)]
+        [InlineData("http://s3-eu-west-1.amazonaws.com/dlcs-storage/2/1/foo-bar", true)]
+        [InlineData("https://s3.eu-west-1.amazonaws.com/dlcs-storage/2/1/foo-bar", true)]
+        [InlineData("http://dlcs-storage.s3.amazonaws.com/2/1/foo-bar", false)]
+        [InlineData("https://dlcs-storage.s3.amazonaws.com/2/1/foo-bar", false)]
+        [InlineData("http://dlcs-storage.s3.eu-west-1.amazonaws.com/2/1/foo-bar", true)]
+        [InlineData("https://dlcs-storage.s3.eu-west-1.amazonaws.com/2/1/foo-bar", true)]
+        [InlineData("http://s3.amazonaws.com/dlcs-storage/2/1/foo-bar", false)]
+        [InlineData("https://s3.amazonaws.com/dlcs-storage/2/1/foo-bar", false)]
+        public void Parse_Correct_Http1(string uri, bool hasRegion)
+        {
+            // Arrange
+            var expected = new RegionalisedObjectInBucket(
+                "dlcs-storage",
+                "2/1/foo-bar",
+                hasRegion ? "eu-west-1" : null);
+
+            // Act
+            var actual = RegionalisedObjectInBucket.Parse(uri);
+
+            // Assert
+            actual.Should().BeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void Parse_Null_IfNoMatches()
+        {
+            // Arrange
+            const string uri = "http://example.org";
+
+            // Act
+            var actual = RegionalisedObjectInBucket.Parse(uri);
+
+            // Assert
+            actual.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void GetS3QualifiedUri_Throws_IfRegionNullOrEmpty(string region)
+        {
+            // Arrange
+            var bucket = new RegionalisedObjectInBucket("dlcs-storage", "2/1/foo-bar");
+            bucket.Region = region;
+
+            Action action = () => bucket.GetS3QualifiedUri();
+
+            // Assert
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetS3QualifiedUri_Correct()
+        {
+            // Arrange
+            var bucket = new RegionalisedObjectInBucket(
+                "dlcs-storage",
+                "2/1/foo-bar",
+                "eu-west-1");
+            const string expected = "s3://eu-west-1/dlcs-storage/2/1/foo-bar";
+
+            // Act
+            var actual = bucket.GetS3QualifiedUri();
+            
+            // Assert
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/DLCS.Model/Storage/IBucketReader.cs
+++ b/DLCS.Model/Storage/IBucketReader.cs
@@ -19,6 +19,11 @@ namespace DLCS.Model.Storage
         Task CopyWithinBucket(string bucket, string sourceKey, string destKey);
         
         Task WriteToBucket(ObjectInBucket dest, string content, string contentType);
+        
+        /// <summary>
+        /// Write content from provided stream to S3
+        /// </summary>
+        Task<bool> WriteToBucket(ObjectInBucket dest, Stream content, string? contentType = null);
 
         /// <summary>
         /// Delete specified objects underlying storage.

--- a/DLCS.Model/Storage/RegionalisedObjectInBucket.cs
+++ b/DLCS.Model/Storage/RegionalisedObjectInBucket.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using DLCS.Core.Guard;
+
+namespace DLCS.Model.Storage
+{
+    public class RegionalisedObjectInBucket : ObjectInBucket
+    {
+        public string Region { get; set; }
+        
+        public RegionalisedObjectInBucket(string bucket, string key = null, string region = null)
+        {
+            Region = region;
+            Bucket = bucket;
+            Key = key;
+        }
+        
+        /// <summary>
+        /// Get fully qualified S3 uri (e.g. s3://eu-west-1/bucket/key)
+        /// </summary>
+        public string GetS3QualifiedUri() => $"s3://{Region.ThrowIfNullOrWhiteSpace(nameof(Region))}/{Bucket}/{Key}";
+        
+        // TODO - naive implementation, won't work for us-east-1
+        /// <summary>
+        /// Get http uri for S3 object (e.g. https://s3.eu-west-1/bucket/key)
+        /// </summary>
+        public string GetHttpUri() => $"https://{Bucket}.s3-{Region.ThrowIfNullOrWhiteSpace(nameof(Region))}.amazonaws.com/{Key}";
+        
+        // NOTE(DG) Regex's and logic moved from deliverator
+        private static readonly Regex RegexS3Qualified = new Regex(@"s3\:\/\/(.*?)\/(.*?)\/(.*)", RegexOptions.Compiled);
+        
+        // us-east-1 uses period instead of dash
+        private static readonly Regex RegexHttp1 = new Regex(@"^http[s]?\:\/\/s3[\-\.](\S+\-\S+\-\d)\.amazonaws\.com\/(.*?)\/(.*)$", RegexOptions.Compiled); 
+        
+        // no region for this one
+        private static readonly Regex RegexHttp2 = new Regex(@"^http[s]?:\/\/(.*?)\.s3\.amazonaws\.com\/(.*)$", RegexOptions.Compiled); 
+        
+        // includes region
+        private static readonly Regex RegexHttp3 = new Regex(@"^http[s]?:\/\/(.*?)\.s3\.(.*?)\.amazonaws\.com\/(.*)$", RegexOptions.Compiled); 
+        
+        // bucket name in path (assumes same region as caller)
+        private static readonly Regex RegexHttp4 = new Regex(@"^http[s]?:\/\/s3\.amazonaws\.com\/(.*?)\/(.*)$", RegexOptions.Compiled); 
+
+        public static RegionalisedObjectInBucket Parse(string uri)
+        {
+            if (TryParseBucketInfo(RegexS3Qualified, uri, out var result, qualified: true))
+            {
+                return result;
+            }
+
+            if (TryParseBucketInfo(RegexHttp1, uri, out result, qualified: true))
+            {
+                return result;
+            }
+
+            if (TryParseBucketInfo(RegexHttp2, uri, out result, qualified: false))
+            {
+                return result;
+            }
+
+            if (TryParseBucketInfo(RegexHttp3, uri, out result, qualified: true, following: true))
+            {
+                return result;
+            }
+
+            if (TryParseBucketInfo(RegexHttp4, uri, out result, qualified: false))
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        private static bool TryParseBucketInfo(Regex regex, string s, out RegionalisedObjectInBucket bucket,
+            bool qualified = false, bool following = false)
+        {
+            var match = regex.Match(s);
+
+            if (!match.Success)
+            {
+                bucket = null;
+                return false;
+            }
+
+            if (qualified)
+            {
+                if (following)
+                {
+                    bucket = new RegionalisedObjectInBucket(
+                        match.Groups[1].Value,
+                        match.Groups[3].Value,
+                        match.Groups[2].Value);
+                    return true;
+                }
+
+                bucket = new RegionalisedObjectInBucket(
+                    match.Groups[2].Value,
+                    match.Groups[3].Value,
+                    match.Groups[1].Value);
+                return true;
+            }
+
+            bucket = new RegionalisedObjectInBucket(
+                match.Groups[1].Value,
+                match.Groups[2].Value);
+            return true;
+        }
+    }
+}

--- a/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
+++ b/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.3.110.14" />
+        <PackageReference Include="AWSSDK.S3" Version="3.5.3.12" />
         <PackageReference Include="FakeItEasy" Version="6.0.0" />
         <PackageReference Include="FluentAssertions" Version="5.10.2" />
         <PackageReference Include="LazyCache" Version="2.0.4" />

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.110.14" />
+    <PackageReference Include="AWSSDK.S3" Version="3.5.3.12" />
     <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="LazyCache" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.1" />

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
   </ItemGroup>
 

--- a/DLCS.Web/Requests/HttpRequestHeadersX.cs
+++ b/DLCS.Web/Requests/HttpRequestHeadersX.cs
@@ -15,12 +15,24 @@ namespace DLCS.Web.Requests
         /// <param name="secret">Secret/Password for basic auth.</param>
         public static void AddBasicAuth(this HttpRequestHeaders headers, string key, string secret)
         {
-            headers.ThrowIfNull(nameof(headers));
             key.ThrowIfNullOrEmpty(nameof(key));
             secret.ThrowIfNullOrEmpty(nameof(secret));
 
             var creds = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{key}:{secret}"));
-            headers.Authorization = new AuthenticationHeaderValue("Basic", creds);
+            headers.AddBasicAuth(creds);
+        }
+        
+        /// <summary>
+        /// Add Basic auth header to <see cref="HttpRequestHeaders"/> object.
+        /// </summary>
+        /// <param name="headers"><see cref="HttpRequestHeaders"/> object to add headers to.</param>
+        /// <param name="base64Encoded">uname:pword as base64 encoded string.</param>
+        public static void AddBasicAuth(this HttpRequestHeaders headers, string base64Encoded)
+        {
+            headers.ThrowIfNull(nameof(headers));
+            base64Encoded.ThrowIfNull(nameof(base64Encoded));
+            
+            headers.Authorization = new AuthenticationHeaderValue("Basic", base64Encoded);
         }
     }
 }

--- a/DLCS.Web/Requests/HttpRequestHeadersX.cs
+++ b/DLCS.Web/Requests/HttpRequestHeadersX.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Net.Http.Headers;
+using System.Text;
+using DLCS.Core.Guard;
+
+namespace DLCS.Web.Requests
+{
+    public static class HttpRequestHeadersX
+    {
+        /// <summary>
+        /// Add Basic auth header to <see cref="HttpRequestHeaders"/> object.
+        /// </summary>
+        /// <param name="headers"><see cref="HttpRequestHeaders"/> object to add headers to.</param>
+        /// <param name="key">Key/Username for basic auth.</param>
+        /// <param name="secret">Secret/Password for basic auth.</param>
+        public static void AddBasicAuth(this HttpRequestHeaders headers, string key, string secret)
+        {
+            headers.ThrowIfNull(nameof(headers));
+            key.ThrowIfNullOrEmpty(nameof(key));
+            secret.ThrowIfNullOrEmpty(nameof(secret));
+
+            var creds = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{key}:{secret}"));
+            headers.Authorization = new AuthenticationHeaderValue("Basic", creds);
+        }
+    }
+}

--- a/Dockerfile.API
+++ b/Dockerfile.API
@@ -1,0 +1,28 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+WORKDIR /src
+COPY ["API/API.csproj", "API/"]
+COPY ["IIIF/IIIF.csproj", "IIIF/"]
+COPY ["DLCS.Repository/DLCS.Repository.csproj", "DLCS.Repository/"]
+COPY ["DLCS.Model/DLCS.Model.csproj", "DLCS.Model/"]
+COPY ["DLCS.Core/DLCS.Core.csproj", "DLCS.Core/"]
+COPY ["DLCS.Web/DLCS.Web.csproj", "DLCS.Web/"]
+
+RUN dotnet restore "API/API.csproj"
+COPY . .
+
+WORKDIR "/src/API"
+RUN dotnet build "API.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "API.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "API.dll"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,59 @@
+pipeline {
+ agent {
+  node {
+   label 'master'
+  }
+ }
+ options {
+  buildDiscarder(logRotator(numToKeepStr: '100'))
+ }
+ stages {
+  stage('Fetch') {
+   steps {
+    deleteDir()
+    checkout scm: [
+     $class: 'GitSCM',
+     branches: scm.branches,
+     doGenerateSubmoduleConfigurations: false,
+     extensions: [
+      [$class: 'SubmoduleOption',
+       disableSubmodules: false,
+       parentCredentials: true,
+       recursiveSubmodules: true,
+       reference: '',
+       trackingSubmodules: false
+      ]
+     ],
+     submoduleCfg: [],
+     userRemoteConfigs: scm.userRemoteConfigs
+    ]
+   }
+  }
+  stage('Image') {
+   steps {
+    sh "docker build -t ${DOCKER_IMAGE}:latest -f ${DOCKER_FILE} ."
+   }
+  }
+  stage('Tag') {
+   steps {
+    sh "docker tag ${DOCKER_IMAGE}:latest ${DOCKER_IMAGE}:`git rev-parse HEAD`"
+    sh "docker tag ${DOCKER_IMAGE}:latest ${DOCKER_IMAGE}:production"
+   }
+  }
+  stage('Push') {
+   steps {
+    sh "\$(aws ecr get-login --no-include-email --region ${REGION})"
+    sh "docker push ${DOCKER_IMAGE}:`git rev-parse HEAD`"
+    sh "docker push ${DOCKER_IMAGE}:production"
+   }
+  }
+  stage('Bounce') {
+   steps {
+    sh "curl --data '{\"text\": \"Jenkins bouncing ${REGION}/${CLUSTER}/${SERVICE}...\"}' ${SLACK_WEBHOOK_URL}"
+    sh "aws ecs update-service --force-new-deployment --cluster ${CLUSTER} --service ${SERVICE} --region ${REGION}"
+    sh "aws ecs wait services-stable --cluster ${CLUSTER} --services ${SERVICE} --region ${REGION}"
+    sh "curl --data '{\"text\": \"${REGION}/${CLUSTER}/${SERVICE} is now stable\"}' ${SLACK_WEBHOOK_URL}"
+   }
+  }
+ }
+}

--- a/docs/adr/0000-api-project-design.md
+++ b/docs/adr/0000-api-project-design.md
@@ -17,7 +17,7 @@ How best can we structure the API project to make it easy for developers to navi
 
 ## Decision Outcome
 
-"Organise by Feature and use MediatR", because we can use MediatR to encapsulate the various use-cases of the API. Together with feature folders this should allow developers to more easily identify the capabilities of the API and target the section they need to,
+"Organise by Feature and use MediatR", because we can use MediatR to encapsulate the various use-cases of the API. Together with feature folders this should allow developers to more easily identify the capabilities of the API and target the section they need to.
 
 ## Pros and Cons of the Options
 

--- a/docs/adr/0000-api-project-design.md
+++ b/docs/adr/0000-api-project-design.md
@@ -1,0 +1,93 @@
+# API Project Design
+
+* Status: proposed
+* Deciders: Donald Gray
+* Date: 2020-11-10
+
+## Context and Problem Statement
+
+### Context
+
+How best can we structure the API project to make it easy for developers to navigate and comprehend.
+
+## Considered Options
+
+* Organise by Feature and use MediatR
+* Traditional ASP.NET/MVC layout
+
+## Decision Outcome
+
+"Organise by Feature and use MediatR", because we can use MediatR to encapsulate the various use-cases of the API. Together with feature folders this should allow developers to more easily identify the capabilities of the API and target the section they need to,
+
+## Pros and Cons of the Options
+
+### Organise by Feature and use MediatR
+
+MediatR doesn't do a huge amount in itself but allows controllers to easily fire off commands and request (will use 'request' for clarity from now on) without knowing how they are handled. The input/output of each request is clearly identified in the request contract. It allows a pipeline to be built for processing requests inside of MediatR, which can help with cross cutting concerns like timing or logging and helps keep handler logic clean.
+
+If we name the requests after use cases, and use the same name for the containing .cs file, it will help to document the capabilities of the API e.g. `IngestImage`, `ReingestImage`, `CreateSpace`, `DeleteCustomer`.
+
+This leads on to feature folders, these can help contain everything related together rather than having everything spread out. At a glance you can see this project handles Images/Spaces etc (rather than at a glance seeing it handles Controllers/Models/Views as is the traditional setup) E.g.
+
+```bash
+Features/
+  Image/
+    - ImageController.cs
+    Commands/
+      - ReingestImage.cs
+      - IngestImage.cs
+      - DeleteImage.cs
+    Request/
+      - GetImages.cs # this 1 command could allow querying by stringX, space, customer etc rather that lots of granular commands. Handler sorts logic
+  /Space 
+    - SpaceController.cs
+- Program.cs
+- Startup.cs
+```
+
+Controllers are very thin using this approach, they only need to know the request to construct and have a dependency in `IMediatr` to send this command.
+
+```cs
+public class ImageController : Controller
+{
+  public ImageController(IMediatr mediatr){
+    this.mediatr = mediatr
+  }
+  public Task<ActionResult> ReingestImage(string imageId){
+    var ingestImageCommand = new IngestImage(imageId);
+    var result = await mediatr.Send(ingestImageCommand);
+    // handle result/set status code etc
+  }
+}
+```
+
+#### Positive Consequences
+
+* Better organisation of application, related components together. Easier for a new developer to comprehend what's happening.
+* Use-cases of system documented by classes.
+* Prevent dependency explosion in controllers; controller only constructs and sends request.
+* Ability to use pipeline behaviours with generic constraints to only target specific requests (this would involve using a different IoC container).
+
+#### Negative Consequences
+
+* Debugging. In the above example, stepping into `await mediatr.Send(ingestImageCommand);` would take you to MediatR framework code, rather than the handler for ingesting an image. This can be mitigated by having Request + Handler in same classfile but can make debugging less intuitive.
+* Overuse of pipeline behaviours can lead to obfuscated and difficult to understand code. Any pipeline behavious should be well documented in readme etc.
+* Overuse of `mediatr.Send(ingestImageCommand);` (e.g. controller sends to handler which sends to handler which sends to handler etc.) is awful. Best to try to stick to one single `.Send()` from the controller only.
+
+### Traditional ASP.NET/MVC layout
+
+This is the default project layout that is configured by default when starting a new project. Classes are stored by type (`/Controller`, `/Model`) rather than by functional area.
+
+#### Positive Consequences
+
+* Familiar, expected layout. Any .net developer will be aware of this approach
+
+#### Negative Consequences
+
+* Looking at the solution shows this is a MVC application but not _what_ it does.
+
+## Links
+
+* [MediatR Project](https://github.com/jbogard/MediatR)
+* [MediatR Pipeline Behaviours](https://github.com/jbogard/MediatR/wiki/Behaviors)
+* [MSDN Article on Feature Slices](https://docs.microsoft.com/en-us/archive/msdn-magazine/2016/september/asp-net-core-feature-slices-for-asp-net-core-mvc)

--- a/protagonist.sln
+++ b/protagonist.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DLCS.Core.Tests", "DLCS.Cor
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IIIF.Tests", "IIIF.Tests\IIIF.Tests.csproj", "{8FAE9A1A-6969-4221-B05B-B4D420921167}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "API\API.csproj", "{60FD5CBB-A61E-4CE6-8E24-7CDF799F7CC9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +79,10 @@ Global
 		{8FAE9A1A-6969-4221-B05B-B4D420921167}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8FAE9A1A-6969-4221-B05B-B4D420921167}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8FAE9A1A-6969-4221-B05B-B4D420921167}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60FD5CBB-A61E-4CE6-8E24-7CDF799F7CC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60FD5CBB-A61E-4CE6-8E24-7CDF799F7CC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60FD5CBB-A61E-4CE6-8E24-7CDF799F7CC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60FD5CBB-A61E-4CE6-8E24-7CDF799F7CC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add new API project, this is very minimal just now and hands off auth + actual ingest request to existing API. 

This adds a single `POST /customers/{customer}/spaces/{space}/images/{image-name}` endpoint that takes base64 encoded file in new `file` property, alongside any other properties that can be sent to existing PUT image endpoint. The bytes are saved to S3, and then the JSON body is forwarded to the existing API with Origin set to point to new S3 location.