### PR TITLE
Handle generated thumbs rounding difference

### DIFF
--- a/DLCS.Model/Storage/IBucketReader.cs
+++ b/DLCS.Model/Storage/IBucketReader.cs
@@ -14,8 +14,16 @@ namespace DLCS.Model.Storage
         /// <param name="objectInBucket">Object to read.</param>
         Task<Stream?> GetObjectFromBucket(ObjectInBucket objectInBucket);
         
+        /// <summary>
+        /// Get a list of all keys within specified root.
+        /// </summary>
+        /// <param name="rootKey"><see cref="ObjectInBucket"/> </param>
+        /// <returns></returns>
         Task<string[]> GetMatchingKeys(ObjectInBucket rootKey);
         
+        /// <summary>
+        /// Copy key to new key within same bucket.
+        /// </summary>
         Task CopyWithinBucket(string bucket, string sourceKey, string destKey);
         
         Task WriteToBucket(ObjectInBucket dest, string content, string contentType);

--- a/DLCS.Repository/Storage/S3/BucketReader.cs
+++ b/DLCS.Repository/Storage/S3/BucketReader.cs
@@ -65,7 +65,7 @@ namespace DLCS.Repository.Storage.S3
             logger.LogDebug("Copying {Source} to {Destination} in {Bucket}", sourceKey, destKey, bucket);
             try
             {
-                CopyObjectRequest request = new CopyObjectRequest
+                var request = new CopyObjectRequest
                 {
                     SourceBucket = bucket,
                     SourceKey = sourceKey,

--- a/IIIF.Tests/SizeTests.cs
+++ b/IIIF.Tests/SizeTests.cs
@@ -24,6 +24,20 @@ namespace IIIF.Tests
         }
 
         [Fact]
+        public void FromString_ReturnsCorrect_WH()
+        {
+            // Arrange
+            const string actual = "100,200";
+            
+            // Act
+            var size = Size.FromString(actual);
+            
+            // Assert
+            size.Width.Should().Be(100);
+            size.Height.Should().Be(200);
+        }
+
+        [Fact]
         public void ToArray_ReturnsWidthHeight()
         {
             // Arrange

--- a/IIIF/Size.cs
+++ b/IIIF/Size.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace IIIF
@@ -59,6 +60,17 @@ namespace IIIF
                 size[0],
                 size[1]
             );
+        
+        /// <summary>
+        /// Create new Size object from "w,h" string.
+        /// </summary>
+        /// <param name="size">String representing size.</param>
+        /// <returns>New Size object</returns>
+        public static Size FromString(string size)
+        {
+            var parts = size.Split(",");
+            return new Size(int.Parse(parts[0]), int.Parse(parts[1]));
+        }
 
         /// <summary>
         /// Confine specified Size object to bounding square of specified size.

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -9,7 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.5.1.34" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.1.16" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />


### PR DESCRIPTION
Some thumbs generated by legacy code will have a slight difference in dimensions due to difference in rounding between python + .net. This has been resolved with latest implementations of Tizer/Appetiser and Deliverator but for now the thumb reorganising logic can fall foul of this.

Updated to use the actual dimensions of generated files, rather than the computed dimensions.