### PR TITLE
Support different path constructs depending on host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 mono_crash.*
 
 appsettings.Development.json
+appsettings.Development*
 
 # Build results
 [Dd]ebug/

--- a/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
+++ b/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
@@ -35,6 +35,7 @@ namespace DLCS.Web.Tests.Requests.AssetDelivery
             thumbnailRequest.Customer.Should().Be(customer);
             thumbnailRequest.BasePath.Should().Be("/thumbs/99/1/");
             thumbnailRequest.Space.Should().Be(1);
+            thumbnailRequest.AssetPath.Should().Be("the-astronaut");
         }
 
         [Fact]
@@ -54,6 +55,7 @@ namespace DLCS.Web.Tests.Requests.AssetDelivery
             thumbnailRequest.Customer.Should().Be(customer);
             thumbnailRequest.BasePath.Should().Be("/thumbs/test-customer/1/");
             thumbnailRequest.Space.Should().Be(1);
+            thumbnailRequest.AssetPath.Should().Be("the-astronaut");
         }
     }
 }

--- a/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
+++ b/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
@@ -32,6 +32,7 @@ namespace DLCS.Web.Tests.Requests.AssetDelivery
             
             // Assert
             thumbnailRequest.RoutePrefix.Should().Be("thumbs");
+            thumbnailRequest.CustomerPathValue.Should().Be("99");
             thumbnailRequest.Customer.Should().Be(customer);
             thumbnailRequest.BasePath.Should().Be("/thumbs/99/1/");
             thumbnailRequest.Space.Should().Be(1);
@@ -52,6 +53,7 @@ namespace DLCS.Web.Tests.Requests.AssetDelivery
 
             // Assert
             thumbnailRequest.RoutePrefix.Should().Be("thumbs");
+            thumbnailRequest.CustomerPathValue.Should().Be("test-customer");
             thumbnailRequest.Customer.Should().Be(customer);
             thumbnailRequest.BasePath.Should().Be("/thumbs/test-customer/1/");
             thumbnailRequest.Space.Should().Be(1);

--- a/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using DLCS.Model.PathElements;
+using DLCS.Web.Requests.AssetDelivery;
+using DLCS.Web.Response;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace DLCS.Web.Tests.Response
+{
+    public class ConfigDrivenAssetPathGeneratorTests
+    {
+        [Theory]
+        [InlineData("123")]
+        [InlineData("test-customer")]
+        public void GetPathForRequest_Default(string customerPathValue)
+        {
+            // Arrange
+            var sut = GetSut("default.com");
+            var request = new BaseAssetRequest
+            {
+                Customer = new CustomerPathElement(123, "test-customer"),
+                CustomerPathValue = customerPathValue,
+                Space = 10,
+                AssetPath = "path/to/asset",
+                BasePath = "thumbs/123/10",
+                RoutePrefix = "thumbs"
+            };
+
+            var expected = $"/thumbs/{customerPathValue}/10/path/to/asset";
+            
+            // Act
+            var actual = sut.GetPathForRequest(request);
+            
+            // Assert
+            actual.Should().Be(expected);
+        }
+        
+        [Theory]
+        [InlineData("123")]
+        [InlineData("test-customer")]
+        public void GetPathForRequest_Override(string customerPathValue)
+        {
+            // Arrange
+            var sut = GetSut("test.example.com");
+            var request = new BaseAssetRequest
+            {
+                Customer = new CustomerPathElement(123, "test-customer"),
+                CustomerPathValue = customerPathValue,
+                Space = 10,
+                AssetPath = "path/to/asset",
+                BasePath = "thumbs/123/10",
+                RoutePrefix = "thumbs"
+            };
+
+            var expected = "/thumbs/path/to/asset";
+            
+            // Act
+            var actual = sut.GetPathForRequest(request);
+            
+            // Assert
+            actual.Should().Be(expected);
+        }
+        
+        private ConfigDrivenAssetPathGenerator GetSut(string host)
+        {
+            var context = new DefaultHttpContext();
+            var request = new DefaultHttpRequest(context);
+            var contextAccessor = A.Fake<IHttpContextAccessor>();
+            A.CallTo(() => contextAccessor.HttpContext).Returns(context);
+            request.Host = new HostString(host);
+
+            var options = Options.Create(new PathTemplateOptions
+            {
+                Overrides = new Dictionary<string, string>
+                {
+                    ["test.example.com"] = "/{prefix}/{assetPath}"
+                }
+            });
+
+            return new ConfigDrivenAssetPathGenerator(options, contextAccessor);
+        }
+    }
+}

--- a/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -65,6 +65,58 @@ namespace DLCS.Web.Tests.Response
             actual.Should().Be(expected);
         }
         
+        [Theory]
+        [InlineData("123")]
+        [InlineData("test-customer")]
+        public void GetFullPathForRequest_Default(string customerPathValue)
+        {
+            // Arrange
+            var sut = GetSut("default.com");
+            var request = new BaseAssetRequest
+            {
+                Customer = new CustomerPathElement(123, "test-customer"),
+                CustomerPathValue = customerPathValue,
+                Space = 10,
+                AssetPath = "path/to/asset",
+                BasePath = "thumbs/123/10",
+                RoutePrefix = "thumbs"
+            };
+
+            var expected = $"https://default.com/thumbs/{customerPathValue}/10/path/to/asset";
+            
+            // Act
+            var actual = sut.GetFullPathForRequest(request);
+            
+            // Assert
+            actual.Should().Be(expected);
+        }
+        
+        [Theory]
+        [InlineData("123")]
+        [InlineData("test-customer")]
+        public void GetFullPathForRequest_Override(string customerPathValue)
+        {
+            // Arrange
+            var sut = GetSut("test.example.com");
+            var request = new BaseAssetRequest
+            {
+                Customer = new CustomerPathElement(123, "test-customer"),
+                CustomerPathValue = customerPathValue,
+                Space = 10,
+                AssetPath = "path/to/asset",
+                BasePath = "thumbs/123/10",
+                RoutePrefix = "thumbs"
+            };
+
+            var expected = "https://test.example.com/thumbs/path/to/asset";
+            
+            // Act
+            var actual = sut.GetFullPathForRequest(request);
+            
+            // Assert
+            actual.Should().Be(expected);
+        }
+
         private ConfigDrivenAssetPathGenerator GetSut(string host)
         {
             var context = new DefaultHttpContext();
@@ -72,6 +124,7 @@ namespace DLCS.Web.Tests.Response
             var contextAccessor = A.Fake<IHttpContextAccessor>();
             A.CallTo(() => contextAccessor.HttpContext).Returns(context);
             request.Host = new HostString(host);
+            request.Scheme = "https";
 
             var options = Options.Create(new PathTemplateOptions
             {

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
+++ b/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
@@ -33,6 +33,7 @@ namespace DLCS.Web.Requests.AssetDelivery
             string[] parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
             
             request.RoutePrefix = parts[routeIndex];
+            request.CustomerPathValue = parts[customerIndex];
             request.Customer = await pathCustomerRepository.GetCustomer(parts[customerIndex]);
             request.Space = int.Parse(parts[spacesIndex]);
             request.AssetPath = string.Join("/", parts.Skip(3));

--- a/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
+++ b/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using DLCS.Model.PathElements;
 using IIIF.ImageApi;
@@ -24,14 +26,16 @@ namespace DLCS.Web.Requests.AssetDelivery
 
         private async Task ParseBaseAssetRequest(string path, BaseAssetRequest request)
         {
-            const int customerIndex = 2;
-            const int spacesIndex = 3;
-            const int routeIndex = 1;
+            const int routeIndex = 0;
+            const int customerIndex = 1;
+            const int spacesIndex = 2;
             
-            string[] parts = path.Split('/');
+            string[] parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            
             request.RoutePrefix = parts[routeIndex];
             request.Customer = await pathCustomerRepository.GetCustomer(parts[customerIndex]);
             request.Space = int.Parse(parts[spacesIndex]);
+            request.AssetPath = string.Join("/", parts.Skip(3));
             request.BasePath = new StringBuilder("/", 50)
                 .Append(parts[routeIndex])
                 .Append("/")

--- a/DLCS.Web/Requests/AssetDelivery/BaseAssetRequest.cs
+++ b/DLCS.Web/Requests/AssetDelivery/BaseAssetRequest.cs
@@ -4,9 +4,32 @@ namespace DLCS.Web.Requests.AssetDelivery
 {
     public class BaseAssetRequest
     {
+        /// <summary>
+        /// The request root, e.g. "thumbs", "iiif-img" etc.
+        /// </summary>
         public string RoutePrefix { get; set; }
+        
+        /// <summary>
+        /// The customer for this request.
+        /// </summary>
         public CustomerPathElement Customer { get; set; }
+        
+        /// <summary>
+        /// The Space for this request.
+        /// </summary>
         public int Space { get; set; }
+        
+        /// <summary>
+        /// The BasePath for this request, this is {routePrefix}/{customer}/{space}
+        /// </summary>
         public string BasePath { get; set; }
+        
+        /// <summary>
+        /// The AssetPath for this request, this is everything after space. e.g.
+        /// my-image/full/61,100/0/default.jpg
+        /// my-audio/full/full/max/max/0/default.mp4
+        /// file-identifier
+        /// </summary>
+        public string AssetPath { get; set; }
     }
 }

--- a/DLCS.Web/Requests/AssetDelivery/BaseAssetRequest.cs
+++ b/DLCS.Web/Requests/AssetDelivery/BaseAssetRequest.cs
@@ -15,6 +15,11 @@ namespace DLCS.Web.Requests.AssetDelivery
         public CustomerPathElement Customer { get; set; }
         
         /// <summary>
+        /// The "customer" value from request (int or string value). 
+        /// </summary>
+        public string CustomerPathValue { get; set; }
+        
+        /// <summary>
         /// The Space for this request.
         /// </summary>
         public int Space { get; set; }

--- a/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.Web.Requests.AssetDelivery;
+﻿using System.Text;
+using DLCS.Web.Requests.AssetDelivery;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -11,6 +12,7 @@ namespace DLCS.Web.Response
     {
         private readonly IHttpContextAccessor httpContextAccessor;
         private readonly PathTemplateOptions pathTemplateOptions;
+        private const string SchemeDelimiter = "://";
 
         public ConfigDrivenAssetPathGenerator(IOptions<PathTemplateOptions> pathTemplateOptions,
             IHttpContextAccessor httpContextAccessor)
@@ -20,15 +22,50 @@ namespace DLCS.Web.Response
         }
 
         public string GetPathForRequest(BaseAssetRequest assetRequest)
+            => GetPathForRequestInternal(assetRequest, false);
+
+        public string GetFullPathForRequest(BaseAssetRequest assetRequest)
+            => GetPathForRequestInternal(assetRequest, true);
+        
+        private string GetPathForRequestInternal(BaseAssetRequest assetRequest, bool fullRequest)
         {
-            var host = httpContextAccessor.HttpContext.Request.Host;
+            var request = httpContextAccessor.HttpContext.Request;
+            var host = request.Host.Value ?? string.Empty;
             
-            var template = pathTemplateOptions.GetPathTemplateForHost(host.Host);
+            var path = GeneratePathFromTemplate(assetRequest, host);
+
+            return fullRequest ? GetDisplayUrl(request, host, path) : path;
+        }
+
+        private string GeneratePathFromTemplate(BaseAssetRequest assetRequest, string host)
+        {
+            var template = pathTemplateOptions.GetPathTemplateForHost(host);
             return template
                 .Replace("{prefix}", assetRequest.RoutePrefix)
                 .Replace("{customer}", assetRequest.CustomerPathValue)
                 .Replace("{space}", assetRequest.Space.ToString())
                 .Replace("{assetPath}", assetRequest.AssetPath);
+        }
+
+        // based on Microsoft.AspNetCore.Http.Extensions.UriHelper.GetDisplayUrl(this HttpRequest request)
+        private static string GetDisplayUrl(HttpRequest request, string host, string path)
+        {
+            var scheme = request.Scheme ?? string.Empty;
+            var pathBase = request.PathBase.Value ?? string.Empty;
+            var queryString = request.QueryString.Value ?? string.Empty;
+
+            // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
+            var length = scheme.Length + SchemeDelimiter.Length + host.Length
+                         + pathBase.Length + path.Length + queryString.Length;
+
+            return new StringBuilder(length)
+                .Append(scheme)
+                .Append(SchemeDelimiter)
+                .Append(host)
+                .Append(pathBase)
+                .Append(path)
+                .Append(queryString)
+                .ToString();
         }
     }
 }

--- a/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -1,0 +1,34 @@
+﻿using DLCS.Web.Requests.AssetDelivery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace DLCS.Web.Response
+{
+    /// <summary>
+    /// Generate paths related to running Dlcs instance using appSettings config for rules.
+    /// </summary>
+    public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
+    {
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly PathTemplateOptions pathTemplateOptions;
+
+        public ConfigDrivenAssetPathGenerator(IOptions<PathTemplateOptions> pathTemplateOptions,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+            this.pathTemplateOptions = pathTemplateOptions.Value;
+        }
+
+        public string GetPathForRequest(BaseAssetRequest assetRequest)
+        {
+            var host = httpContextAccessor.HttpContext.Request.Host;
+            
+            var template = pathTemplateOptions.GetPathTemplateForHost(host.Host);
+            return template
+                .Replace("{prefix}", assetRequest.RoutePrefix)
+                .Replace("{customer}", assetRequest.CustomerPathValue)
+                .Replace("{space}", assetRequest.Space.ToString())
+                .Replace("{assetPath}", assetRequest.AssetPath);
+        }
+    }
+}

--- a/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -1,0 +1,15 @@
+﻿using DLCS.Web.Requests.AssetDelivery;
+
+namespace DLCS.Web.Response
+{
+    /// <summary>
+    /// Generate paths related to running Dlcs instance.
+    /// </summary>
+    public interface IAssetPathGenerator
+    {
+        /// <summary>
+        /// Generate path for specified assetRequest.
+        /// </summary>
+        string GetPathForRequest(BaseAssetRequest assetRequest);
+    }
+}

--- a/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -8,8 +8,15 @@ namespace DLCS.Web.Response
     public interface IAssetPathGenerator
     {
         /// <summary>
-        /// Generate path for specified assetRequest.
+        /// Generate path for specified <see cref="BaseAssetRequest"/> excluding host.
         /// </summary>
         string GetPathForRequest(BaseAssetRequest assetRequest);
+
+        /// <summary>
+        /// Generate full path for specified <see cref="BaseAssetRequest"/>, including host. 
+        /// </summary>
+        /// <param name="assetRequest"></param>
+        /// <returns></returns>
+        string GetFullPathForRequest(BaseAssetRequest assetRequest);
     }
 }

--- a/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/DLCS.Web/Response/PathTemplateOptions.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+namespace DLCS.Web.Response
+{
+    /// <summary>
+    /// A collection of options related to path generation.
+    /// </summary>
+    public class PathTemplateOptions
+    {
+        /// <summary>
+        /// Default path template if no overrides found.
+        /// </summary>
+        public string Default { get; set; } = "/{prefix}/{customer}/{space}/{assetPath}";
+
+        /// <summary>
+        /// Collection of path template overrides, keyed by hostname.
+        /// </summary>
+        public Dictionary<string, string> Overrides { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Get template path for host. 
+        /// </summary>
+        /// <param name="host">Host to get template path for.</param>
+        /// <returns>Returns path for host, or default if override not found.</returns>
+        public string GetPathTemplateForHost(string host)
+            => Overrides.TryGetValue(host, out var template) ? template : Default;
+    }
+}

--- a/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/DLCS.Web/Response/PathTemplateOptions.cs
@@ -16,6 +16,12 @@ namespace DLCS.Web.Response
         /// Collection of path template overrides, keyed by hostname.
         /// </summary>
         public Dictionary<string, string> Overrides { get; set; } = new Dictionary<string, string>();
+        
+        /// <summary>
+        /// "Overrides" dictionary as JSON blob, will be use to populate Overrides
+        /// Added as convenience for setting per-env settings using string-based config settings like ParameterStore
+        /// </summary>
+        public string? OverridesAsJson { get; set; }
 
         /// <summary>
         /// Get template path for host. 

--- a/Thumbs/Program.cs
+++ b/Thumbs/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Serilog;
 
 namespace Thumbs
 {
@@ -10,16 +11,29 @@ namespace Thumbs
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            Log.Logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .CreateLogger();
+            try
+            {
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Application start-up failed");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
         
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureLogging(logging =>
-                {
-                    logging.ClearProviders()
-                        .AddConsole();
-                })
+                .UseSerilog((hostingContext, loggerConfiguration)
+                    => loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration)
+                )
                 .ConfigureAppConfiguration((context, builder) =>
                 {
                     var isDevelopment = context.HostingEnvironment.IsDevelopment();
@@ -35,7 +49,7 @@ namespace Thumbs
                     // If development then ensure appsettings.Development.json wins
                     if (isDevelopment)
                     {
-                        builder.AddJsonFile($"appsettings.Development.json", optional: true, reloadOnChange: true);
+                        builder.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
                     }
                 })
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/Thumbs/Program.cs
+++ b/Thumbs/Program.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Serilog;
 
 namespace Thumbs

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -58,7 +58,7 @@ namespace Thumbs
             // TODO: Consider better caching solutions
             app.UseResponseCaching();
             var respondsTo = Configuration.GetValue<string>("RespondsTo", "thumbs");
-            logger.LogInformation($"ThumbsMiddleware mapped to '/{respondsTo}/*'");
+            logger.LogInformation("ThumbsMiddleware mapped to '/{RespondsTo}/*'", respondsTo);
             app.UseEndpoints(endpoints =>
             {
                 endpoints.Map($"/{respondsTo}/{{*any}}",

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -9,6 +9,7 @@ using DLCS.Repository.Settings;
 using DLCS.Repository.Storage.S3;
 using DLCS.Web.Middleware;
 using DLCS.Web.Requests.AssetDelivery;
+using DLCS.Web.Response;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -43,14 +44,17 @@ namespace Thumbs
             services.AddSingleton<IThumbReorganiser, ThumbReorganiser>();
             services.AddSingleton<IThumbnailPolicyRepository, ThumbnailPolicyRepository>();
             services.AddSingleton<IAssetRepository, AssetRepository>();
+            services.AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>();
 
             services.Configure<ThumbsSettings>(Configuration.GetSection("Repository"));
+            services.Configure<PathTemplateOptions>(Configuration.GetSection("PathRules"));
 
             // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
             services.Configure<ForwardedHeadersOptions>(opts =>
             {
                 opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
             });
+            services.AddHttpContextAccessor();
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Amazon.S3;
 using DLCS.Model.Assets;
 using DLCS.Model.Customer;
@@ -17,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Thumbs
 {
@@ -55,6 +57,18 @@ namespace Thumbs
                 opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
             });
             services.AddHttpContextAccessor();
+
+            services.PostConfigure<PathTemplateOptions>(opts =>
+            {
+                if (!string.IsNullOrEmpty(opts.OverridesAsJson))
+                {
+                    var overridesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(opts.OverridesAsJson);
+                    foreach (var (key, value) in overridesDict)
+                    {
+                        opts.Overrides.Add(key, value);
+                    }
+                }
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -11,6 +11,7 @@ using DLCS.Web.Middleware;
 using DLCS.Web.Requests.AssetDelivery;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -44,11 +45,18 @@ namespace Thumbs
             services.AddSingleton<IAssetRepository, AssetRepository>();
 
             services.Configure<ThumbsSettings>(Configuration.GetSection("Repository"));
+
+            // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
+            services.Configure<ForwardedHeadersOptions>(opts =>
+            {
+                opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+            });
         }
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
         {
+            app.UseForwardedHeaders();
+            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -38,16 +38,6 @@ namespace Thumbs
             IBucketReader bucketReader,
             AssetDeliveryPathParser parser)
         {
-            try
-            {
-                var headers = string.Join("|", context.Request.Headers.Select(h => $"{h.Key}:{h.Value}"));
-                logger.LogInformation("{Url} Headers: {Headers}", context.Request.GetDisplayUrl(), headers);
-            }
-            catch
-            {
-                // for debug purposes only
-            }
-
             var thumbnailRequest = await parser.Parse(context.Request.Path.Value);
             if (thumbnailRequest.IIIFImageRequest.IsBase)
             {

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -116,7 +116,6 @@ namespace Thumbs
             await context.Response.WriteAsync(infoJsonText);
         }
 
-
         private Task RedirectToInfoJson(HttpContext context, ThumbnailRequest thumbnailRequest)
         {
             var redirectPath = pathGenerator.GetPathForRequest(thumbnailRequest);

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -105,12 +105,9 @@ namespace Thumbs
             context.Response.ContentType = "application/json";
             context.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding" };
             SetCacheControl(context);
-
-            // TODO - not like this, construct it properly
-            var displayUrl = context.Request.GetDisplayUrl();
             
-            // if X-Forwarded-Host == "dlcs.io" construct full url
-            // else construct using X-Forwarded-Host + minimal details
+            var displayUrl = pathGenerator.GetFullPathForRequest(request);
+            
             var id = displayUrl.Substring(0, displayUrl.Length - 10);  // the length of "/info.json" ... yeah
             var infoJsonText = InfoJsonBuilder.GetImageApi2_1(id, sizes);
             await context.Response.WriteAsync(infoJsonText);

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -98,7 +98,7 @@ namespace Thumbs
             
             var displayUrl = pathGenerator.GetFullPathForRequest(request);
             
-            var id = displayUrl.Substring(0, displayUrl.Length - 10);  // the length of "/info.json" ... yeah
+            var id = displayUrl.Substring(0, displayUrl.LastIndexOf("/", StringComparison.CurrentCultureIgnoreCase));
             var infoJsonText = InfoJsonBuilder.GetImageApi2_1(id, sizes);
             await context.Response.WriteAsync(infoJsonText);
         }

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using DLCS.Core.Exceptions;
@@ -36,6 +37,16 @@ namespace Thumbs
             IBucketReader bucketReader,
             AssetDeliveryPathParser parser)
         {
+            try
+            {
+                var headers = string.Join("|", context.Request.Headers.Select(h => $"{h.Key}:{h.Value}"));
+                logger.LogInformation("Headers: {Headers}", headers);
+            }
+            catch
+            {
+                // for debug purposes only
+            }
+
             var thumbnailRequest = await parser.Parse(context.Request.Path.Value);
             if (thumbnailRequest.IIIFImageRequest.IsBase)
             {

--- a/Thumbs/appSettings-Development-Example.json
+++ b/Thumbs/appSettings-Development-Example.json
@@ -18,6 +18,12 @@
     "Profile": "default",
     "Region": "eu-west-1"
   },
+  "PathRules": {
+    "Default": "/{prefix}/{customer}/{space}/{assetPath}",
+    "Overrides": {
+      "my-proxy.com": "/{prefix}/{assetPath}"
+    }
+  },
   "ResponseCacheSeconds": 60,
   "RespondsTo": "thumbs"
 }

--- a/Thumbs/appsettings.json
+++ b/Thumbs/appsettings.json
@@ -1,11 +1,22 @@
 {
-  "WhoAmI": "Root",
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
       "Default": "Debug",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information",
-      "System": "Warning"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "IIIF-Builder"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
Added "PathRules" config section, this can set "Default" and "Overrides" based on incoming host. e.g.

```
  "PathRules": {
    "Default": "/{prefix}/{customer}/{space}/{assetPath}",
    "Overrides": {
      "prod.example.com": "/{prefix}/{assetPath}",
      "test.example.com": "/{prefix}/{space}/{assetPath}",
    }
  },
```
These values are replaced in `ConfigDrivenAssetPathGenerator` using values from `BaseAssetRequest`. It is used to redirect requests for asset-root to `/info.json` and also to set the `@id` parameter of info.json.

These are read into `PathTemplateOptions`. `PathTemplateOptions` also contains `OverridesFromString` to enable a string containing a json blob to be read from a config source that only supports strings (e.g. AWS ParameterStore).


Used `ForwardedHeaders` functionality to get `x-forwarded-host` and `x-forwarded-proto` values into HttpContext.Request.