### PR TITLE
Allow thumbs to resize existing thumbs to meet request

### DIFF
--- a/DLCS.Model/Assets/IThumbRepository.cs
+++ b/DLCS.Model/Assets/IThumbRepository.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
-using DLCS.Model.Storage;
 using IIIF.ImageApi;
 
 namespace DLCS.Model.Assets
@@ -13,7 +11,7 @@ namespace DLCS.Model.Assets
         // it's fine for this to know about the IIIF part of the request path, as that's an
         // external context.
         
-        Task<Stream?> GetThumbnail(int customerId, int spaceId, ImageRequest imageRequest);
+        Task<ThumbnailResponse> GetThumbnail(int customerId, int spaceId, ImageRequest imageRequest);
         
         public Task<List<int[]>> GetSizes(int customerId, int spaceId, ImageRequest imageRequest);
     }

--- a/DLCS.Model/Assets/IThumbRepository.cs
+++ b/DLCS.Model/Assets/IThumbRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using DLCS.Model.Storage;
 using IIIF.ImageApi;
@@ -11,8 +12,9 @@ namespace DLCS.Model.Assets
         // But I that represents the full path of a web request.
         // it's fine for this to know about the IIIF part of the request path, as that's an
         // external context.
-
-        public Task<ObjectInBucket> GetThumbLocation(int customerId, int spaceId, ImageRequest imageRequest);
+        
+        Task<Stream?> GetThumbnail(int customerId, int spaceId, ImageRequest imageRequest);
+        
         public Task<List<int[]>> GetSizes(int customerId, int spaceId, ImageRequest imageRequest);
     }
 }

--- a/DLCS.Model/Assets/ThumbnailResponse.cs
+++ b/DLCS.Model/Assets/ThumbnailResponse.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DLCS.Model.Assets
+{
+    /// <summary>
+    /// Represents request to get a Thumbnail.
+    /// </summary>
+    /// <see cref="https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync"/>
+    public class ThumbnailResponse : IDisposable, IAsyncDisposable
+    {
+        /// <summary>
+        /// True if thumbnail was an exact match for request.
+        /// </summary>
+        public bool IsExactMatch { get; private set; }
+        
+        /// <summary>
+        /// True if result was resized from generated thumbnail.
+        /// </summary>
+        public bool WasResized { get; private set; }
+        
+        /// <summary>
+        /// Thumbnail data, either streamed from S3 or resized on the fly.
+        /// </summary>
+        public Stream? ThumbnailStream { get; private set; }
+
+        /// <summary>
+        /// True if no thumbnail has been found.
+        /// </summary>
+        public bool IsEmpty => ThumbnailStream == null;
+        
+        public static ThumbnailResponse ExactSize(Stream? stream) 
+            => new ThumbnailResponse {IsExactMatch = true, ThumbnailStream = stream};
+        
+        public static ThumbnailResponse Resized(Stream? stream) 
+            => new ThumbnailResponse {WasResized = true, ThumbnailStream = stream};
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+
+            Dispose(false);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        
+        private async ValueTask DisposeAsyncCore()
+        {
+            // Cascade async dispose calls
+            if (ThumbnailStream != null)
+            {
+                await ThumbnailStream.DisposeAsync();
+                ThumbnailStream = null;
+            }
+        }
+
+        private bool disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed) return;
+
+            if (disposing) ThumbnailStream?.Dispose();
+
+            disposed = true;
+        }
+    }
+}

--- a/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -1,0 +1,210 @@
+﻿using System.Collections.Generic;
+using DLCS.Repository.Assets;
+using FluentAssertions;
+using IIIF;
+using IIIF.ImageApi;
+using Xunit;
+
+namespace DLCS.Repository.Tests.Assets
+{
+    public class ThumbnailCalculatorTests
+    {
+        private readonly List<Size> landscapeSizes;
+        private readonly List<Size> portraitSizes;
+
+        public ThumbnailCalculatorTests()
+        {
+            portraitSizes = new List<Size>
+            {
+                new Size(400, 800),
+                new Size(200, 400),
+                new Size(100, 200),
+            };
+
+            landscapeSizes = new List<Size>
+            {
+                new Size(800, 400),
+                new Size(400, 200),
+                new Size(200, 100),
+            };
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetCandidates_ReturnsCorrectLongestEdge_IfSizeAndHeightProvided(bool resize)
+        {
+            // Arrange
+            var imageRequest = new ImageRequest
+            {
+                Size = new SizeParameter
+                {
+                    Width = 110,
+                    Height = 200
+                }
+            };
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, resize);
+            
+            // Assert
+            result.KnownSize.Should().BeTrue();
+            result.LongestEdge.Should().Be(200);
+        }
+        
+        [Fact]
+        public void GetCandidates_NoResize_ReturnsEmptyLongestEdge_IfSizeAndHeightProvidedButNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest
+            {
+                Size = new SizeParameter
+                {
+                    Width = 110,
+                    Height = 210
+                }
+            };
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, false);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetCandidates_ReturnsCorrectLongestEdge_IfWidthProvidedAndFound(bool resize)
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Width = 200,}};
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, resize);
+            
+            // Assert
+            result.KnownSize.Should().BeTrue();
+            result.LongestEdge.Should().Be(200);
+        }
+        
+        [Fact]
+        public void GetCandidates_NoResize_ReturnsEmptyLongestEdge_IfWidthProvidedAndNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Width = 210,}};
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, false);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetCandidates_ReturnsCorrectLongestEdge_IfHeightProvidedAndFound(bool resize)
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Height = 200,}};
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, resize);
+            
+            // Assert
+            result.KnownSize.Should().BeTrue();
+            result.LongestEdge.Should().Be(400);
+        }
+        
+        [Fact]
+        public void GetCandidates_NoResize_ReturnsEmptyLongestEdge_IfHeightProvidedAndNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Height = 210,}};
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, false);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetCandidates_ReturnsLargestLongestEdge_IfMax(bool resize)
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Max = true,}};
+            
+            // Act
+            var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, resize);
+            
+            // Assert
+            result.KnownSize.Should().BeTrue();
+            result.LongestEdge.Should().Be(800);
+        }
+
+        [Fact]
+        public void GetCandidates_Resize_ReturnsResizeCandidate_WithLargerAndSmaller_IfExactMatchNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Width = 300}};
+            
+            // Act
+            var result = (ResizableSize)ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, true);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+            result.Ideal.Height.Should().Be(600);
+            result.Ideal.Width.Should().Be(300);
+            result.LargerSize.Height.Should().Be(800);
+            result.LargerSize.Width.Should().Be(400);
+            result.SmallerSize.Height.Should().Be(400);
+            result.SmallerSize.Width.Should().Be(200);
+        }
+        
+        [Fact]
+        public void GetCandidates_Resize_ReturnsResizeCandidate_WithLarger_IfExactMatchNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Width = 50}};
+            
+            // Act
+            var result = (ResizableSize)ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, true);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+            result.Ideal.Height.Should().Be(100);
+            result.Ideal.Width.Should().Be(50);
+            result.LargerSize.Height.Should().Be(200);
+            result.LargerSize.Width.Should().Be(100);
+            result.SmallerSize.Should().BeNull();
+        }
+        
+        [Fact]
+        public void GetCandidates_Resize_ReturnsResizeCandidate_WithSmaller_IfExactMatchNotFound()
+        {
+            // Arrange
+            var imageRequest = new ImageRequest {Size = new SizeParameter {Width = 500}};
+            
+            // Act
+            var result = (ResizableSize)ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, true);
+            
+            // Assert
+            result.KnownSize.Should().BeFalse();
+            result.LongestEdge.Should().BeNull();
+            result.Ideal.Height.Should().Be(1000);
+            result.Ideal.Width.Should().Be(500);
+            result.SmallerSize.Height.Should().Be(800);
+            result.SmallerSize.Width.Should().Be(400);
+            result.LargerSize.Should().BeNull();
+        }
+    }
+}

--- a/DLCS.Repository/Assets/ThumbRepository.cs
+++ b/DLCS.Repository/Assets/ThumbRepository.cs
@@ -40,7 +40,7 @@ namespace DLCS.Repository.Assets
             var openSizes = await GetSizes(customerId, spaceId, imageRequest);
             var sizes = openSizes.Select(Size.FromArray).ToList();
 
-            var sizeCandidate = ThumbnailCalculator.GetCandidates(sizes, imageRequest, settings.CurrentValue.Resize);
+            var sizeCandidate = ThumbnailCalculator.GetCandidate(sizes, imageRequest, settings.CurrentValue.Resize);
             
             if (sizeCandidate.KnownSize)
             {

--- a/DLCS.Repository/Assets/ThumbRepository.cs
+++ b/DLCS.Repository/Assets/ThumbRepository.cs
@@ -134,7 +134,7 @@ namespace DLCS.Repository.Assets
             // if upscaling, verify % difference isn't too great
             if ((maxDifference ?? 0) > 0 && idealSize.MaxDimension > toResize.MaxDimension)
             {
-                var difference = (toResize.MaxDimension / idealSize.MaxDimension) * 100;
+                var difference = (idealSize.MaxDimension / (double)toResize.MaxDimension) * 100;
                 if (difference > maxDifference.Value)
                 {
                     logger.LogDebug("The next smallest thumbnail {ToResize} breaks the threshold for '{Path}'",

--- a/DLCS.Repository/Assets/ThumbRepository.cs
+++ b/DLCS.Repository/Assets/ThumbRepository.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Model.Assets;
 using DLCS.Model.Storage;
@@ -9,6 +9,10 @@ using IIIF.ImageApi;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
+using Size = IIIF.Size;
 
 namespace DLCS.Repository.Assets
 {
@@ -31,58 +35,50 @@ namespace DLCS.Repository.Assets
             this.thumbReorganiser = thumbReorganiser;
         }
 
-        public async Task<ObjectInBucket> GetThumbLocation(int customerId, int spaceId, ImageRequest imageRequest)
+        public async Task<Stream?> GetThumbnail(int customerId, int spaceId, ImageRequest imageRequest)
         {
-            await EnsureNewLayout(customerId, spaceId, imageRequest);
-            int longestEdge = 0;
-            if (imageRequest.Size.Width > 0 && imageRequest.Size.Height > 0)
-            {
-                // We don't actually need to check imageRequest.Size.Confined (!w,h) because same logic applies...
-                longestEdge = Math.Max(imageRequest.Size.Width, imageRequest.Size.Height);
-            }
-            else
-            {
-                // we need to know the sizes of things...
-                var sizes = await GetSizes(customerId, spaceId, imageRequest);
-                if (imageRequest.Size.Width > 0)
-                {
-                    foreach (var size in sizes)
-                    {
-                        if (size[0] == imageRequest.Size.Width)
-                        {
-                            longestEdge = Math.Max(size[0], size[1]);
-                            break;
-                        }
-                    }
-                }
-                if (imageRequest.Size.Height > 0)
-                {
-                    foreach (var size in sizes)
-                    {
-                        if (size[1] == imageRequest.Size.Height)
-                        {
-                            longestEdge = Math.Max(size[0], size[1]);
-                            break;
-                        }
-                    }
-                }
+            var openSizes = await GetSizes(customerId, spaceId, imageRequest);
+            var sizes = openSizes.Select(Size.FromArray).ToList();
 
-                if (imageRequest.Size.Max)
-                {
-                    longestEdge = Math.Max(sizes[0][0], sizes[0][1]);
-                }
-            }
-            return new ObjectInBucket
+            var sizeCandidate = ThumbnailCalculator.GetCandidates(sizes, imageRequest, settings.CurrentValue.Resize);
+            
+            if (sizeCandidate.KnownSize)
             {
-                Bucket = settings.CurrentValue.ThumbsBucket,
-                Key = $"{GetKeyRoot(customerId, spaceId, imageRequest)}open/{longestEdge}.jpg"
-            };
+                var location =
+                    GetObjectInBucket(customerId, spaceId, imageRequest, sizeCandidate.LongestEdge!.Value);
+                return await bucketReader.GetObjectFromBucket(location);
+            }
+
+            if (!settings.CurrentValue.Resize)
+            {
+                logger.LogDebug("Could not find thumbnail for '{Path}' and resizing disabled",
+                    imageRequest.OriginalPath);
+                return null;
+            }
+            
+            var resizableSize = (ResizableSize) sizeCandidate;
+            
+            // First try larger size
+            if (resizableSize.LargerSize != null)
+            {
+                var downscaled = await ResizeThumbnail(customerId, spaceId, imageRequest, resizableSize.LargerSize,
+                    resizableSize.Ideal);
+                if (downscaled != null) return downscaled;
+            }
+
+            // Then try smaller size if allowed
+            if (resizableSize.SmallerSize != null && settings.CurrentValue.Upscale)
+            {
+                return await ResizeThumbnail(customerId, spaceId, imageRequest, resizableSize.SmallerSize,
+                    resizableSize.Ideal, settings.CurrentValue.UpscaleThreshold);
+            }
+
+            return null;
         }
 
         public async Task<List<int[]>> GetSizes(int customerId, int spaceId, ImageRequest imageRequest)
         {
             await EnsureNewLayout(customerId, spaceId, imageRequest);
-
             ObjectInBucket sizesList = new ObjectInBucket
             {
                 Bucket = settings.CurrentValue.ThumbsBucket,
@@ -103,6 +99,15 @@ namespace DLCS.Repository.Assets
             return thumbnailSizes.Open;
         }
 
+        private ObjectInBucket GetObjectInBucket(int customerId, int spaceId, ImageRequest imageRequest, int longestEdge)
+        {
+            return new ObjectInBucket
+            {
+                Bucket = settings.CurrentValue.ThumbsBucket,
+                Key = $"{GetKeyRoot(customerId, spaceId, imageRequest)}open/{longestEdge}.jpg"
+            };
+        }
+
         private string GetKeyRoot(int customerId, int spaceId, ImageRequest imageRequest) 
             => $"{customerId}/{spaceId}/{imageRequest.Identifier}/";
 
@@ -121,6 +126,34 @@ namespace DLCS.Repository.Assets
             };
 
             return thumbReorganiser.EnsureNewLayout(rootKey);
+        }
+
+        private async Task<Stream?> ResizeThumbnail(int customerId, int spaceId, ImageRequest imageRequest,
+            Size toResize, Size idealSize, int? maxDifference = 0)
+        {
+            if (maxDifference.HasValue)
+            {
+                var difference = (toResize.MaxDimension / idealSize.MaxDimension) * 100;
+                if (difference > maxDifference.Value)
+                {
+                    logger.LogDebug("The next smallest thumbnail {ToResize} breaks the threshold for '{Path}'",
+                        toResize.ToString(), imageRequest.OriginalPath);
+                    return null;
+                }
+            }
+
+            // we now have a candidate size - resize that and return
+            logger.LogDebug("Resize the {Size} thumbnail for {Path}", toResize.MaxDimension,
+                imageRequest.OriginalPath);
+
+            var key = GetObjectInBucket(customerId, spaceId, imageRequest, toResize.MaxDimension);
+            var thumbnail = await bucketReader.GetObjectFromBucket(key);
+            await using var memStream = new MemoryStream();
+            using var image = await Image.LoadAsync(thumbnail);
+            image.Mutate(x => x.Resize(idealSize.Width, idealSize.Height, KnownResamplers.Lanczos3));
+            await image.SaveAsync(memStream, new JpegEncoder());
+
+            return memStream;
         }
     }
 }

--- a/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using IIIF;
+using IIIF.ImageApi;
+
+namespace DLCS.Repository.Assets
+{
+    public static class ThumbnailCalculator
+    {
+        public static SizeCandidate GetCandidates(List<Size> sizes, ImageRequest imageRequest, bool allowResize)
+        {
+            return allowResize
+                ? GetLongestEdgeAndSize(sizes, imageRequest)
+                : GetLongestEdge(sizes, imageRequest);
+        }
+        
+        private static SizeCandidate GetLongestEdge(List<Size> sizes, ImageRequest imageRequest)
+        {
+            int? longestEdge = null;
+            if (imageRequest.Size.Width > 0 && imageRequest.Size.Height > 0)
+            {
+                // We don't actually need to check imageRequest.Size.Confined (!w,h) because same logic applies...
+                longestEdge = Math.Max(imageRequest.Size.Width ?? 0, imageRequest.Size.Height ?? 0);
+            }
+            else
+            {
+                // we need to know the sizes of things...
+                if (imageRequest.Size.Width > 0)
+                {
+                    foreach (var size in sizes)
+                    {
+                        if (size.Width == imageRequest.Size.Width)
+                        {
+                            longestEdge = size.MaxDimension;
+                            break;
+                        }
+                    }
+                }
+                if (imageRequest.Size.Height > 0)
+                {
+                    foreach (var size in sizes)
+                    {
+                        if (size.Height == imageRequest.Size.Height)
+                        {
+                            longestEdge = size.MaxDimension;
+                            break;
+                        }
+                    }
+                }
+
+                if (imageRequest.Size.Max)
+                {
+                    longestEdge = sizes[0].MaxDimension;
+                }
+            }
+
+            return new SizeCandidate(longestEdge);
+        }
+        
+        private static ResizableSize GetLongestEdgeAndSize(List<Size> sizes, ImageRequest imageRequest)
+        {
+            // TODO - handle there being none "open"?
+            
+            var sizeCandidate = GetLongestEdge(sizes, imageRequest);
+            if (sizeCandidate.LongestEdge.HasValue)
+            {
+                // We have found a matching size, use that.
+                return new ResizableSize(sizeCandidate.LongestEdge.Value);
+            }
+            
+            // calculate the size using requested dimensions
+            Size idealSize;
+            var sizeParameter = imageRequest.Size;
+            if (sizeParameter.Confined)
+            {
+                var widthIsLarger = imageRequest.Size.Width > imageRequest.Size.Height;
+                var width = widthIsLarger ? imageRequest.Size.Width.Value : (int?) null;
+                var height = widthIsLarger ? (int?) null : imageRequest.Size.Height.Value;
+                idealSize = Size.Resize(sizes[0], width, height);
+            }
+            else
+            {
+                idealSize = Size.Resize(sizes[0], sizeParameter.Width, sizeParameter.Height);
+            }
+
+            // iterate through all of the known sizes until we find a smaller one
+            int count = 0;
+            Size? larger = null;
+            foreach (var s in sizes)
+            {
+                // Iterate until we find one that is smaller
+                if (!idealSize.IsConfinedWithin(s))
+                {
+                    break;
+                }
+
+                larger = s;
+                count++;
+            }
+
+            return new ResizableSize
+            {
+                Ideal = idealSize,
+                LargerSize = larger,
+                SmallerSize = count == sizes.Count ? null : sizes[count]
+            };
+        }
+    }
+    
+    /// <summary>
+    /// Size candidate for a single longest edge.
+    /// </summary>
+    public class SizeCandidate
+    {
+        public int? LongestEdge { get; }
+        
+        public bool KnownSize { get; }
+        
+        public SizeCandidate(int? longestEdge)
+        {
+            LongestEdge = longestEdge;
+            KnownSize = longestEdge.HasValue;
+        }
+
+        public SizeCandidate()
+        {
+        }
+    }
+
+    /// <summary>
+    /// Size candidates for size where no exact match is found.
+    /// </summary>
+    public class ResizableSize : SizeCandidate
+    {
+        public Size? LargerSize { get; set;}
+        public Size? SmallerSize { get; set;}
+        public Size Ideal { get; set; }
+
+        public ResizableSize(int? longestEdge) : base(longestEdge)
+        {
+        }
+
+        public ResizableSize()
+        {
+        }
+    }
+}

--- a/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -65,7 +65,7 @@ namespace DLCS.Repository.Assets
             // TODO - handle there being none "open"?
             
             var sizeCandidate = GetLongestEdge(sizes, imageRequest);
-            if (sizeCandidate.LongestEdge.HasValue)
+            if (sizeCandidate.KnownSize)
             {
                 // We have found a matching size, use that.
                 return new ResizableSize(sizeCandidate.LongestEdge.Value);

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.1" />
     <PackageReference Include="Npgsql" Version="4.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DLCS.Repository/Settings/ThumbsSettings.cs
+++ b/DLCS.Repository/Settings/ThumbsSettings.cs
@@ -1,10 +1,35 @@
 ﻿namespace DLCS.Repository.Settings
 {
+    /// <summary>
+    /// Options to manage configuration of thumbnails
+    /// </summary>
     public class ThumbsSettings
     {
+        /// <summary>
+        /// If true, when a request is received old thumbnail layout will be rearranged to match new.
+        /// </summary>
         public bool EnsureNewThumbnailLayout { get; set; } = false;
         
+        /// <summary>
+        /// The name of the bucket containing thumbnail jpg.
+        /// </summary>
         public string ThumbsBucket { get; set; }
+        
+        /// <summary>
+        /// If true the service will attempt to resize an existing jpg to serve images.
+        /// </summary>
+        public bool Resize { get; set; }
+        
+        /// <summary>
+        /// If true, smaller thumbnails will be upscaled to handle non-matching requests.
+        /// This is ignored if Resize=False
+        /// </summary>
+        public bool Upscale { get; set; }
+        
+        /// <summary>
+        /// The maximum % size difference for upscaling.
+        /// </summary>
+        public int UpscaleThreshold { get; set; }
 
         public class Constants
         {

--- a/IIIF.Tests/SizeTests.cs
+++ b/IIIF.Tests/SizeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -98,6 +99,116 @@ namespace IIIF.Tests
             confined.Height.Should().Be(testData.ExpectedHeight);
         }
 
+        [Fact]
+        public void Resize_Throws_IfHeightAndWidthNull()
+        {
+            // Arrange
+            var size = new Size(100, 100);
+            
+            // Act
+            Action action = () => Size.Resize(size, null, null);
+            
+            // Assert
+            action.Should().Throw<InvalidOperationException>();
+        }
+        
+        [Fact]
+        public void Resize_ReturnsCorrectSize_IfHeightAndWidthSpecified()
+        {
+            // Arrange
+            var size = new Size(100, 100);
+            
+            // Act
+            var newSize = Size.Resize(size, 90, 400);
+            
+            // Assert
+            newSize.Width.Should().Be(90);
+            newSize.Height.Should().Be(400);
+        }
+        
+        [Theory]
+        [InlineData(400, null)]
+        [InlineData(null, 400)]
+        public void Resize_ReturnsNewSize_Square(int? width, int? height)
+        {
+            // Arrange
+            var size = new Size(100, 100);
+            
+            // Act
+            var newSize = Size.Resize(size, width, height);
+            
+            // Assert
+            newSize.Width.Should().Be(width ?? height);
+            newSize.Height.Should().Be(width ?? height);
+        }
+
+        [Theory]
+        [InlineData(400, 200)]
+        [InlineData(50, 25)]
+        public void Resize_ReturnsCorrectSize_Landscape_FromWidth(int width, int expectedHeight)
+        {
+            // Arrange
+            var size = new Size(200, 100);
+            
+            // Act
+            var newSize = Size.Resize(size, width);
+            
+            // Assert
+            newSize.Width.Should().Be(width);
+            newSize.Height.Should().Be(expectedHeight);
+        }
+        
+        [Theory]
+        [InlineData(200, 400)]
+        [InlineData(25, 50)]
+        public void Resize_ReturnsCorrectSize_Landscape_FromHeight(int height, int expectedWidth)
+        {
+            // Arrange
+            var size = new Size(200, 100);
+            
+            // Act
+            var newSize = Size.Resize(size, targetHeight: height);
+            
+            // Assert
+            newSize.Height.Should().Be(height);
+            newSize.Width.Should().Be(expectedWidth);
+        }
+        
+        
+        [Theory]
+        [InlineData(200, 400)]
+        [InlineData(25, 50)]
+        public void Resize_ReturnsCorrectSize_Portrait_FromWidth(int width, int expectedHeight)
+        {
+            // Arrange
+            var size = new Size(100, 200);
+            
+            // Act
+            var newSize = Size.Resize(size, width);
+            
+            // Assert
+            newSize.Width.Should().Be(width);
+            newSize.Height.Should().Be(expectedHeight);
+        }
+        
+        [Theory]
+        [InlineData(400, 200)]
+        [InlineData(50, 25)]
+        public void Resize_ReturnsCorrectSize_Portrait_FromHeight(int height, int expectedWidth)
+        {
+            // Arrange
+            var size = new Size(100, 200);
+            
+            // Act
+            var newSize = Size.Resize(size, targetHeight: height);
+            
+            // Assert
+            newSize.Height.Should().Be(height);
+            newSize.Width.Should().Be(expectedWidth);
+        }
+        
+        
+
         [Theory]
         [InlineData(10, 10, 10, 10)] // square same size
         [InlineData(10, 5, 10, 5)] // landscape same size
@@ -135,6 +246,13 @@ namespace IIIF.Tests
         [InlineData(10, 5, 10)]
         public void MaxDimension_Correct(int w, int h, int expected)
             => new Size(w, h).MaxDimension.Should().Be(expected);
+        
+        [Theory]
+        [InlineData(10, 10, ImageShape.Square)]
+        [InlineData(5, 10, ImageShape.Portrait)]
+        [InlineData(10, 5, ImageShape.Landscape)]
+        public void GetShape_Correct(int w, int h, ImageShape expected)
+            => new Size(w, h).GetShape().Should().Be(expected);
 
         private static List<TestSizeData> sampleTestData = new List<TestSizeData>
         {

--- a/IIIF/ImageApi/SizeParameter.cs
+++ b/IIIF/ImageApi/SizeParameter.cs
@@ -9,9 +9,9 @@ namespace IIIF.ImageApi
     /// <remarks>see https://iiif.io/api/image/3.0/#42-size </remarks>
     public class SizeParameter
     {
-        public int Width { get; set; }
+        public int? Width { get; set; }
         
-        public int Height { get; set; }
+        public int? Height { get; set; }
         
         public bool Max { get; set; }
         

--- a/Thumbs/Program.cs
+++ b/Thumbs/Program.cs
@@ -12,6 +12,7 @@ namespace Thumbs
         {
             Log.Logger = new LoggerConfiguration()
                 .Enrich.FromLogContext()
+                .Enrich.WithCorrelationIdHeader()
                 .WriteTo.Console()
                 .CreateLogger();
             try
@@ -27,11 +28,14 @@ namespace Thumbs
                 Log.CloseAndFlush();
             }
         }
-        
+
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .UseSerilog((hostingContext, loggerConfiguration)
-                    => loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration)
+                    => loggerConfiguration
+                        .ReadFrom.Configuration(hostingContext.Configuration)
+                        .Enrich.FromLogContext()
+                        .Enrich.WithCorrelationIdHeader()
                 )
                 .ConfigureAppConfiguration((context, builder) =>
                 {
@@ -40,7 +44,7 @@ namespace Thumbs
                     {
                         configurationSource.Path = "/thumbs/";
                         configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    
+
                         // Using ParameterStore optional if Development
                         configurationSource.Optional = isDevelopment;
                     });
@@ -51,9 +55,6 @@ namespace Thumbs
                         builder.AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true);
                     }
                 })
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                });
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
     }
 }

--- a/Thumbs/Properties/launchSettings.json
+++ b/Thumbs/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     },
     "Thumbs": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Thumbs/Readme.md
+++ b/Thumbs/Readme.md
@@ -45,10 +45,30 @@ Where sizes.json looks like this (for example):
 
 ## Configuration
 
-Can run in 2 "modes" via the `Repository:EnsureNewThumbnailLayout` app setting:
+There are a few app settings that can control the behaviour of the application:
+
+### `Thumbs:EnsureNewThumbnailLayout`
 
 * `True` - when a request is received the `ThumbReorganiser` class will ensure that the above format exists in S3 by consulting an images `ThumbnailPolicy` and copying thumbnails from existing level 0 image API paths in same bucket.
 * `False` - when a request is received the assumption is that the above format exists in S3. If it doesn't a 404 will be returned.
+
+### `Thumbs:Resize`
+
+* `True` - if an exact matching thumbnail is not found, we will attempt to resize the next largest thumbnail to match requirements.
+* `False` - if an exact matching thumbnail is not found, the request will return 404.
+
+### `Thumbs:Upscale`
+
+* `True` - when resizing, the next largest thumbnail will be used to resize. If a larger thumbnail is not found, and `Upscale = true` then we will upscale the next smallest.
+* `False` - upsizing is not attempted.
+
+### `Thumbs:UpscaleThreshold`
+
+Integer value - the maximum % that we will attempt to increase a thumbnail by. If required upscaling exceeds this a 404 will be returned.
+
+For no limit use `0`.
+
+### `RespondsTo`
 
 By default intercepts all requests to `/thumbs/` (e.g. `https://my.dlcs/thumbs/*`) but the path can be configured with the `RespondsTo` app setting.
 

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Serilog;
+using SixLabors.ImageSharp.Memory;
 
 namespace Thumbs
 {
@@ -69,6 +70,9 @@ namespace Thumbs
                         opts.Overrides.Add(key, value);
                     }
                 }
+
+                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator =
+                    ArrayPoolMemoryAllocator.CreateWithModeratePooling();
             });
         }
 

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Serilog;
-using SixLabors.ImageSharp.Memory;
 
 namespace Thumbs
 {
@@ -70,9 +69,6 @@ namespace Thumbs
                         opts.Overrides.Add(key, value);
                     }
                 }
-
-                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator =
-                    ArrayPoolMemoryAllocator.CreateWithModeratePooling();
             });
         }
 

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -49,7 +49,7 @@ namespace Thumbs
             services.AddSingleton<IAssetRepository, AssetRepository>();
             services.AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>();
 
-            services.Configure<ThumbsSettings>(Configuration.GetSection("Repository"));
+            services.Configure<ThumbsSettings>(Configuration.GetSection("Thumbs"));
             services.Configure<PathTemplateOptions>(Configuration.GetSection("PathRules"));
 
             // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
@@ -90,6 +90,7 @@ namespace Thumbs
             logger.LogInformation("ThumbsMiddleware mapped to '/{RespondsTo}/*'", respondsTo);
             app.UseEndpoints(endpoints =>
             {
+                // 'normal' thumbs handling - will only return if we have it
                 endpoints.Map($"/{respondsTo}/{{*any}}",
                     endpoints.CreateApplicationBuilder()
                         .UseMiddleware<AlwaysCorsMiddleware>()

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Serilog;
 
 namespace Thumbs
 {
@@ -71,9 +72,10 @@ namespace Thumbs
             });
         }
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             app.UseForwardedHeaders();
+            loggerFactory.AddSerilog();
             
             if (env.IsDevelopment())
             {
@@ -84,6 +86,7 @@ namespace Thumbs
             // TODO: Consider better caching solutions
             app.UseResponseCaching();
             var respondsTo = Configuration.GetValue<string>("RespondsTo", "thumbs");
+            var logger = loggerFactory.CreateLogger<Startup>();
             logger.LogInformation("ThumbsMiddleware mapped to '/{RespondsTo}/*'", respondsTo);
             app.UseEndpoints(endpoints =>
             {

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -90,7 +90,6 @@ namespace Thumbs
             logger.LogInformation("ThumbsMiddleware mapped to '/{RespondsTo}/*'", respondsTo);
             app.UseEndpoints(endpoints =>
             {
-                // 'normal' thumbs handling - will only return if we have it
                 endpoints.Map($"/{respondsTo}/{{*any}}",
                     endpoints.CreateApplicationBuilder()
                         .UseMiddleware<AlwaysCorsMiddleware>()

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -74,7 +74,11 @@ namespace Thumbs
             {
                 context.Response.ContentType = "image/jpeg";
                 SetCacheControl(context);
-                response.Position = 0;
+                if (response.CanSeek)
+                {
+                    response.Position = 0;
+                }
+
                 await response.CopyToAsync(context.Response.Body);
             }
         }

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -61,16 +61,6 @@ namespace Thumbs
 
         private async Task WritePixels(HttpContext context, ThumbnailRequest request)
         {
-            /* Is this a known thumb size?
-             If so get that thumb in bucket
-             If not - do we have a size larger/smaller that we could resize?
-             control via appSetting
-             deploy to /thumbs/ with "False"
-             deploy to /mirothumbs/ with "True"
-             */
-            /*var thumbInBucket = thumbRepository.GetThumbLocation(
-                request.Customer.Id, request.Space, request.IIIFImageRequest);*/
-            // var response = await bucketReader.GetObjectFromBucket(await thumbInBucket);
             var response =
                 await thumbRepository.GetThumbnail(request.Customer.Id, request.Space, request.IIIFImageRequest);
 

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -61,9 +61,9 @@ namespace Thumbs
 
         private async Task WritePixels(HttpContext context, ThumbnailRequest request)
         {
-            var response =
+            await using var response =
                 await thumbRepository.GetThumbnail(request.Customer.Id, request.Space, request.IIIFImageRequest);
-
+            
             if (response == null)
             {
                 await StatusCodeResponse
@@ -74,6 +74,7 @@ namespace Thumbs
             {
                 context.Response.ContentType = "image/jpeg";
                 SetCacheControl(context);
+                response.Position = 0;
                 await response.CopyToAsync(context.Response.Body);
             }
         }

--- a/Thumbs/appSettings-Development-Example.json
+++ b/Thumbs/appSettings-Development-Example.json
@@ -7,9 +7,10 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "Repository": {
+  "Thumbs": {
     "ThumbsBucket": "--supplied-by-env-var-from-tf-on-live--",
-    "EnsureNewThumbnailLayout": true
+    "EnsureNewThumbnailLayout": true,
+    "Resize": false
   },  
   "ConnectionStrings": {
     "PostgreSQLConnection": "--supplied-by-env-var-from-tf-on-live--"


### PR DESCRIPTION
Added (configurable) logic to resize existing thumbnails to meet image request. Configuration block renamed from `"Repository"` to `"Thumbs"` as it now contains all-thumbnail logic:

```
"Thumbs": {
    "ThumbsBucket": "dlcs-thumbs",
    "EnsureNewThumbnailLayout": true,
    "Resize": true,
    "Upscale": true,
    "UpscaleThreshold": 100
  }, 
```

Logic is:

* Iterate through thumbnails to find if any are exact match. If resizing is supported, while iterating build list of larger + smaller sibling.
* If exact match found, return. If resizing _not_ supported request ends. else,
* Resize next largest thumbnail if available. If not available and upscaling _not_ supported request ends. else,
* Try to resize next smallest thumbnail, as long as it doesn't exceed `"UpscaleThreshold"` value.

In addition to this I added Serilog and correlation-id to Thumbnails.