### PR TITLE
Handle not-found thumbs

### DIFF
--- a/DLCS.Model/Assets/IAssetRepository.cs
+++ b/DLCS.Model/Assets/IAssetRepository.cs
@@ -4,6 +4,6 @@ namespace DLCS.Model.Assets
 {
     public interface IAssetRepository
     {
-        public Task<Asset> GetAsset(string id);
+        public Task<Asset?> GetAsset(string id);
     }
 }

--- a/DLCS.Model/Assets/IThumbRepository.cs
+++ b/DLCS.Model/Assets/IThumbRepository.cs
@@ -13,6 +13,6 @@ namespace DLCS.Model.Assets
         
         Task<ThumbnailResponse> GetThumbnail(int customerId, int spaceId, ImageRequest imageRequest);
         
-        public Task<List<int[]>> GetSizes(int customerId, int spaceId, ImageRequest imageRequest);
+        public Task<List<int[]>?> GetSizes(int customerId, int spaceId, ImageRequest imageRequest);
     }
 }

--- a/DLCS.Model/Assets/ThumbnailResponse.cs
+++ b/DLCS.Model/Assets/ThumbnailResponse.cs
@@ -10,6 +10,8 @@ namespace DLCS.Model.Assets
     /// <see cref="https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-disposeasync"/>
     public class ThumbnailResponse : IDisposable, IAsyncDisposable
     {
+        public static readonly ThumbnailResponse Empty = new ThumbnailResponse();
+        
         /// <summary>
         /// True if thumbnail was an exact match for request.
         /// </summary>

--- a/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
+++ b/DLCS.Repository.Tests/Assets/ThumbReorganiserTests.cs
@@ -5,6 +5,7 @@ using DLCS.Model.Assets;
 using DLCS.Model.Storage;
 using DLCS.Repository.Assets;
 using FakeItEasy;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -36,13 +37,14 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new[] {"2/1/the-astronaut/s.json", "2/1/the-astronaut/200.jpg"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
             
             // Assert
+            response.Should().Be(ReorganiseResult.HasExpectedLayout);
             A.CallTo(() => assetRepository.GetAsset(A<string>._))
                 .MustNotHaveHappened();
         }
-        
+
         [Fact]
         public async Task EnsureNewLayout_CreatesExpectedResources_AllOpen()
         {
@@ -62,9 +64,10 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "400,200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
+            response.Should().Be(ReorganiseResult.Reorganised);
             
             // move jpg per thumbnail size
             A.CallTo(() =>
@@ -112,10 +115,11 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "400,200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
-            
+            response.Should().Be(ReorganiseResult.Reorganised);
+
             // move jpg per thumbnail size
             A.CallTo(() =>
                     bucketReader.CopyWithinBucket("the-bucket", 
@@ -164,10 +168,11 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "1024,400,200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
-            
+            response.Should().Be(ReorganiseResult.Reorganised);
+
             // move jpg per thumbnail size
             A.CallTo(() =>
                     bucketReader.CopyWithinBucket("the-bucket",
@@ -219,10 +224,11 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "1024,400,200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
-            
+            response.Should().Be(ReorganiseResult.Reorganised);
+
             // move jpg per thumbnail size
             A.CallTo(() =>
                     bucketReader.CopyWithinBucket("the-bucket",
@@ -275,9 +281,10 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "1024,400,200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
+            response.Should().Be(ReorganiseResult.Reorganised);
             
             // move jpg per thumbnail size
             A.CallTo(() =>
@@ -329,9 +336,10 @@ namespace DLCS.Repository.Tests.Assets
                 .Returns(new ThumbnailPolicy {Sizes = "200,100"});
             
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
+            response.Should().Be(ReorganiseResult.Reorganised);
             var expectedDeletions = new[]
             {
                 "the-bucket:::2/1/the-astronaut/100.jpg", "the-bucket:::2/1/the-astronaut/sizes.json"
@@ -423,12 +431,12 @@ namespace DLCS.Repository.Tests.Assets
                      .Returns(returnvalue);
            
             // Act
-            await sut.EnsureNewLayout(rootKey);
+            var response = await sut.EnsureNewLayout(rootKey);
 
             // Assert
             A.CallTo(() => assetRepository.GetAsset(A<string>._))
                   .MustHaveHappened();
-
+            response.Should().Be(ReorganiseResult.AssetNotFound);
         }
     }
 }

--- a/DLCS.Repository/Assets/AssetRepository.cs
+++ b/DLCS.Repository/Assets/AssetRepository.cs
@@ -18,7 +18,7 @@ namespace DLCS.Repository.Assets
             this.logger = logger;
         }
 
-        public async Task<Asset> GetAsset(string id)
+        public async Task<Asset?> GetAsset(string id)
         {
             await using var connection = await DatabaseConnectionManager.GetOpenNpgSqlConnection(configuration);
             return await connection.QuerySingleOrDefaultAsync<Asset>(AssetSql, new {Id = id});

--- a/DLCS.Repository/Assets/IThumbReorganiser.cs
+++ b/DLCS.Repository/Assets/IThumbReorganiser.cs
@@ -5,6 +5,6 @@ namespace DLCS.Repository.Assets
 {
     public interface IThumbReorganiser
     {
-        Task EnsureNewLayout(ObjectInBucket rootKey);
+        Task<ReorganiseResult> EnsureNewLayout(ObjectInBucket rootKey);
     }
 }

--- a/DLCS.Repository/Storage/S3/BucketReader.cs
+++ b/DLCS.Repository/Storage/S3/BucketReader.cs
@@ -33,7 +33,7 @@ namespace DLCS.Repository.Storage.S3
             }
             catch (AmazonS3Exception e) when (e.StatusCode == HttpStatusCode.NotFound)
             {
-                logger.LogInformation(e, "Could not find S3 object '{S3ObjectRequest}'", getObjectRequest.AsBucketAndKey());
+                logger.LogInformation("Could not find S3 object '{S3ObjectRequest}'", getObjectRequest.AsBucketAndKey());
                 return null;
             }
             catch (AmazonS3Exception e)

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
@@ -93,7 +94,7 @@ namespace Thumbs
         private async Task WriteInfoJson(HttpContext context, ThumbnailRequest request)
         {
             var sizes = await thumbRepository.GetSizes(request.Customer.Id, request.Space, request.IIIFImageRequest);
-            if (sizes == null)
+            if (sizes.IsNullOrEmpty())
             {
                 await StatusCodeResponse
                     .NotFound("Could not find requested thumbnail")

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -93,6 +93,14 @@ namespace Thumbs
         private async Task WriteInfoJson(HttpContext context, ThumbnailRequest request)
         {
             var sizes = await thumbRepository.GetSizes(request.Customer.Id, request.Space, request.IIIFImageRequest);
+            if (sizes == null)
+            {
+                await StatusCodeResponse
+                    .NotFound("Could not find requested thumbnail")
+                    .WriteJsonResponse(context.Response);
+                return;
+            }
+            
             context.Response.ContentType = "application/json";
             context.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding" };
             SetCacheControl(context);


### PR DESCRIPTION
Added a enum result type when reorganising thumbs to highlight if asset not found.

`GetSizes()` returns `null` rather than empty list to signify nothing found - rather than possibility of none `.Open`.