### PR TITLE
Set admin role on login, add sample /Admin page

### DIFF
--- a/Portal/ClaimsPrincipalUtils.cs
+++ b/Portal/ClaimsPrincipalUtils.cs
@@ -8,22 +8,34 @@ namespace Portal
     /// </summary>
     public static class ClaimsPrincipalUtils
     {
-        /// <summary>
-        /// Name of claim containing CustomerId.
-        /// </summary>
-        public static string CustomerClaim = "Customer";
+        public class Claims
+        {
+            /// <summary>
+            /// Name of claim containing CustomerId.
+            /// </summary>
+            public static string Customer = "Customer";
         
+            /// <summary>
+            /// Name of claim containing api basic auth credentials.
+            /// </summary>
+            public static string ApiCredentials = "ApiCredentials";    
+        }
+
         /// <summary>
-        /// Name of claim containing api basic auth credentials.
+        /// Collection of roles associated with Claims
         /// </summary>
-        public static string ApiCredentialsClaim = "ApiCredentials";
+        public class Roles
+        {
+            public static string Customer = "Customer";
+            public static string Admin = "Admin";
+        }
         
         /// <summary>
         /// Get CustomerId value from principal claims, if present.
         /// </summary>
         public static int? GetCustomerId(this ClaimsPrincipal claimsPrincipal)
         {
-            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == CustomerClaim);
+            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == Claims.Customer);
             if (customerClaim == null) return null;
             
             return int.TryParse(customerClaim.Value, out int customerId) ? customerId : null;
@@ -34,7 +46,7 @@ namespace Portal
         /// </summary>
         public static string? GetApiCredentials(this ClaimsPrincipal claimsPrincipal)
         {
-            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == ApiCredentialsClaim);
+            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == Claims.ApiCredentials);
             return customerClaim?.Value;
         }
     }

--- a/Portal/Pages/Admin/Index.cshtml
+++ b/Portal/Pages/Admin/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@page
-@model Portal.Pages.Spaces.Index
 
 @{
     ViewData["Title"] = "Admin Homepage";

--- a/Portal/Pages/Admin/Index.cshtml
+++ b/Portal/Pages/Admin/Index.cshtml
@@ -1,0 +1,9 @@
+﻿@page
+@model Portal.Pages.Spaces.Index
+
+@{
+    ViewData["Title"] = "Admin Homepage";
+}
+
+<h2>@ViewData["Title"]</h2>
+<p>You should only be able to see this if you are an admin</p>

--- a/Portal/Pages/Admin/Index.cshtml.cs
+++ b/Portal/Pages/Admin/Index.cshtml.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Portal.Pages.Admin
+{
+    public class Index : PageModel
+    {
+        public void OnGet()
+        {
+            
+        }
+    }
+}

--- a/Portal/Pages/Admin/_ViewImports.cshtml
+++ b/Portal/Pages/Admin/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using Portal.Pages.Admin

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
       <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.17" />
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.6" />


### PR DESCRIPTION
On login, give user "Admin" role if they are related to admin customer.

Added 'Administrators' auth policy and added sample page at `/admin` to validate.