### PR TITLE
List, Create, Delete User functionality

### DIFF
--- a/API/JsonLd/JsonLdBase.cs
+++ b/API/JsonLd/JsonLdBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using Microsoft.VisualBasic;
 using Newtonsoft.Json;
 
 namespace API.JsonLd

--- a/API/JsonLd/PortalUser.cs
+++ b/API/JsonLd/PortalUser.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace API.JsonLd
+{
+    /// <summary>
+    /// Hydra entity representing User of Portal UI.
+    /// </summary>
+    public class PortalUser : JsonLdBase
+    {
+        public string Email { get; set; }
+        public string EncryptedPassword { get; set; }
+        public DateTime Created { get; set; }
+        public bool Enabled { get; set; }
+    }
+}

--- a/API/JsonLd/PortalUser.cs
+++ b/API/JsonLd/PortalUser.cs
@@ -8,8 +8,11 @@ namespace API.JsonLd
     public class PortalUser : JsonLdBase
     {
         public string Email { get; set; }
+        
         public string EncryptedPassword { get; set; }
-        public DateTime Created { get; set; }
+        public DateTime? Created { get; set; }
         public bool Enabled { get; set; }
+        
+        public string? Password { get; set; }
     }
 }

--- a/API/JsonLd/SimpleCollection.cs
+++ b/API/JsonLd/SimpleCollection.cs
@@ -11,6 +11,8 @@ namespace API.JsonLd
     public class SimpleCollection<T> : JsonLdBase
         where T : JsonLdBase
     {
+        public override string Type => "Collection";
+
         [JsonProperty("totalItems", Order = 5)]
         public int TotalItems { get; set; }
 
@@ -19,10 +21,5 @@ namespace API.JsonLd
         
         [JsonProperty("member", Order = 7)] 
         public IEnumerable<T> Members { get; set; } = Enumerable.Empty<T>();
-
-        protected SimpleCollection()
-        {
-            Type = "Collection";
-        }
     }
 }

--- a/API/appsettings.Development-Example.json
+++ b/API/appsettings.Development-Example.json
@@ -4,7 +4,7 @@
     "Region": "eu-west-1"
   },
   "DLCS": {
-    "Root": "https://api.dlcs.digirati.io",
+    "ApiRoot": "https://api.dlcs.digirati.io",
     "OriginBucket": "storage-bucket-name"
   },
   "PathBase": ""

--- a/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
+++ b/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
@@ -28,8 +28,8 @@ namespace DLCS.Mediatr.Behaviours
             var response = await next();
 
             sw.Stop();
-            logger.LogDebug("Handled '{RequestType}' in {Elapsed}ms. {Response}",
-                typeof(TResponse).Name, sw.ElapsedMilliseconds, response);
+            logger.LogDebug("Handled '{RequestType}' in {Elapsed}ms",
+                typeof(TResponse).Name, sw.ElapsedMilliseconds);
 
             return response;
         }

--- a/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
+++ b/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
@@ -29,7 +29,7 @@ namespace DLCS.Mediatr.Behaviours
 
             sw.Stop();
             logger.LogDebug("Handled '{RequestType}' in {Elapsed}ms",
-                typeof(TResponse).Name, sw.ElapsedMilliseconds);
+                typeof(TRequest).Name, sw.ElapsedMilliseconds);
 
             return response;
         }

--- a/Portal/Behaviours/AuditBehaviour.cs
+++ b/Portal/Behaviours/AuditBehaviour.cs
@@ -1,0 +1,35 @@
+﻿using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Mediatr.Behaviours;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Portal.Behaviours
+{
+    /// <summary>
+    /// Audits request by logging message type/contents and UserId
+    /// </summary>
+    public class AuditBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IAuditable
+    {
+        private readonly ILogger<LoggingBehavior<TRequest, TResponse>> logger;
+        private readonly ClaimsPrincipal claimsPrincipal;
+
+        public AuditBehaviour(ILogger<LoggingBehavior<TRequest, TResponse>> logger, ClaimsPrincipal claimsPrincipal)
+        {
+            this.logger = logger;
+            this.claimsPrincipal = claimsPrincipal;
+        }
+
+        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken,
+            RequestHandlerDelegate<TResponse> next)
+        {
+            var response = await next();
+            logger.LogInformation("User '{UserId}': req:{@Request} - res:{@Response}", claimsPrincipal.GetUserId(),
+                request, response);
+            
+            return response;
+        }
+    }
+}

--- a/Portal/Behaviours/IAuditable.cs
+++ b/Portal/Behaviours/IAuditable.cs
@@ -1,0 +1,10 @@
+﻿namespace Portal.Behaviours
+{
+    /// <summary>
+    /// Marker interface for any IRequests that should be audited.
+    /// Log destructured Request/Response and current UserId.
+    /// </summary>
+    public interface IAuditable
+    {
+    }
+}

--- a/Portal/ClaimsPrincipalUtils.cs
+++ b/Portal/ClaimsPrincipalUtils.cs
@@ -40,14 +40,28 @@ namespace Portal
             
             return int.TryParse(customerClaim.Value, out int customerId) ? customerId : null;
         }
-        
+
         /// <summary>
         /// Get Api basic auth credentials value from principal claims, if present.
         /// </summary>
         public static string? GetApiCredentials(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.GetClaimValue(Claims.ApiCredentials);
+        
+        /// <summary>
+        /// Get User Id value from claim. 
+        /// </summary>
+        public static string? GetUserId(this ClaimsPrincipal claimsPrincipal)
+            => claimsPrincipal.GetClaimValue(ClaimTypes.NameIdentifier);
+        
+        /// <summary>
+        /// Get first value of claim with specified type
+        /// </summary>
+        public static string? GetClaimValue(this ClaimsPrincipal claimsPrincipal, string claimType)
         {
-            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == Claims.ApiCredentials);
+            var customerClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == claimType);
             return customerClaim?.Value;
         }
+        
+        
     }
 }

--- a/Portal/Features/Account/AccountController.cs
+++ b/Portal/Features/Account/AccountController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Portal.Controllers
+namespace Portal.Features.Account
 {
     [Route("[controller]/[action]")]
     public class AccountController : Controller

--- a/Portal/Features/Account/Commands/LoginPortalUser.cs
+++ b/Portal/Features/Account/Commands/LoginPortalUser.cs
@@ -119,6 +119,7 @@ namespace Portal.Features.Account.Commands
             var claims = new List<Claim>
             {
                 new (ClaimTypes.Name, user.Email),
+                new (ClaimTypes.NameIdentifier, user.Id),
                 new (ClaimsPrincipalUtils.Claims.Customer, user.Customer.ToString()),
                 new (ClaimTypes.Role, ClaimsPrincipalUtils.Roles.Customer),
             };

--- a/Portal/Features/Users/Commands/CreatePortalUser.cs
+++ b/Portal/Features/Users/Commands/CreatePortalUser.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using API.JsonLd;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Portal.Legacy;
+
+namespace Portal.Features.Users.Commands
+{
+    /// <summary>
+    /// Create a new portal user with specified username and password
+    /// </summary>
+    public class CreatePortalUser : IRequest<PortalUser?>
+    {
+        public string Email { get; set; }
+        public string Password { get; set; }
+
+        public CreatePortalUser(string email, string password)
+        {
+            Email = email;
+            Password = password;
+        }
+    }
+    
+    public class CreatePortalUserHandler : IRequestHandler<CreatePortalUser, PortalUser?>
+    {
+        private readonly DlcsClient dlcsClient;
+        private readonly ILogger<CreatePortalUserHandler> logger;
+        private readonly ClaimsPrincipal claimsPrincipal;
+
+        public CreatePortalUserHandler(
+            DlcsClient dlcsClient, 
+            ILogger<CreatePortalUserHandler> logger,
+            ClaimsPrincipal claimsPrincipal)
+        {
+            this.dlcsClient = dlcsClient;
+            this.logger = logger;
+            this.claimsPrincipal = claimsPrincipal;
+        }
+        
+        public async Task<PortalUser?> Handle(CreatePortalUser request, CancellationToken cancellationToken)
+        {
+            // TODO - validation
+            var newPortalUser = new PortalUser
+            {
+                Email = request.Email,
+                Password = request.Password,
+                Enabled = true
+            };
+            try
+            {
+                var createdUser = await dlcsClient.CreatePortalUser(newPortalUser);
+
+                logger.LogInformation("New Portal user '{PortalUser}' created by '{CurrentUser}'",
+                    createdUser.GetLastPathElement(),
+                    claimsPrincipal.GetUserId());
+                return createdUser;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error creating new Portal User");
+            }
+
+            return null;
+        }
+    }
+}

--- a/Portal/Features/Users/Commands/DeletePortalUser.cs
+++ b/Portal/Features/Users/Commands/DeletePortalUser.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Portal.Behaviours;
+using Portal.Legacy;
+
+namespace Portal.Features.Users.Commands
+{
+    /// <summary>
+    /// Delete Portal user by Id
+    /// </summary>
+    public class DeletePortalUser : IRequest<bool>, IAuditable
+    {
+        public string UserId { get; }
+
+        public DeletePortalUser(string userId)
+        {
+            UserId = userId;
+        }
+    }
+    
+    public class DeletePortalUserHandler : IRequestHandler<DeletePortalUser, bool>
+    {
+        private readonly DlcsClient dlcsClient;
+
+        public DeletePortalUserHandler(DlcsClient dlcsClient)
+        {
+            this.dlcsClient = dlcsClient;
+        }
+        
+        public Task<bool> Handle(DeletePortalUser request, CancellationToken cancellationToken)
+        {
+            return dlcsClient.DeletePortalUser(request.UserId);
+        }
+    }
+}

--- a/Portal/Features/Users/Requests/GetPortalUsers.cs
+++ b/Portal/Features/Users/Requests/GetPortalUsers.cs
@@ -9,11 +9,11 @@ namespace Portal.Features.Users.Requests
     /// <summary>
     /// Get all PortalUsers for current customer
     /// </summary>
-    public class GetPortalUsers : IRequest<Collection<PortalUser>?>
+    public class GetPortalUsers : IRequest<SimpleCollection<PortalUser>?>
     {
     }
     
-    public class GetPortalUsersHandler : IRequestHandler<GetPortalUsers, Collection<PortalUser>?>
+    public class GetPortalUsersHandler : IRequestHandler<GetPortalUsers, SimpleCollection<PortalUser>?>
     {
         private readonly DlcsClient dlcsClient;
 
@@ -22,7 +22,7 @@ namespace Portal.Features.Users.Requests
             this.dlcsClient = dlcsClient;
         }
         
-        public Task<Collection<PortalUser>?> Handle(GetPortalUsers request, CancellationToken cancellationToken)
+        public Task<SimpleCollection<PortalUser>?> Handle(GetPortalUsers request, CancellationToken cancellationToken)
         {
             var portalUsers = dlcsClient.GetPortalUsers();
             return portalUsers;

--- a/Portal/Features/Users/Requests/GetPortalUsers.cs
+++ b/Portal/Features/Users/Requests/GetPortalUsers.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.JsonLd;
+using MediatR;
+using Portal.Legacy;
+
+namespace Portal.Features.Users.Requests
+{
+    /// <summary>
+    /// Get all PortalUsers for current customer
+    /// </summary>
+    public class GetPortalUsers : IRequest<Collection<PortalUser>?>
+    {
+    }
+    
+    public class GetPortalUsersHandler : IRequestHandler<GetPortalUsers, Collection<PortalUser>?>
+    {
+        private readonly DlcsClient dlcsClient;
+
+        public GetPortalUsersHandler(DlcsClient dlcsClient)
+        {
+            this.dlcsClient = dlcsClient;
+        }
+        
+        public Task<Collection<PortalUser>?> Handle(GetPortalUsers request, CancellationToken cancellationToken)
+        {
+            var portalUsers = dlcsClient.GetPortalUsers();
+            return portalUsers;
+        }
+    }
+}

--- a/Portal/Features/Users/UserController.cs
+++ b/Portal/Features/Users/UserController.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Portal.Features.Users.Commands;
+
+namespace Portal.Features.Users
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public class UserController : Controller
+    {
+        private readonly IMediator mediator;
+
+        public UserController(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+        
+        [HttpDelete]
+        public async Task<IActionResult> DeleteAsync(string id)
+        {
+            var deleteSuccess = await mediator.Send(new DeletePortalUser(id));
+            if (deleteSuccess)
+            {
+                return Ok(new {message = "Portal user '{id}' deleted"});
+            }
+
+            return StatusCode(500, new {message = "Error deleting portal user"});
+        }
+    }
+}

--- a/Portal/Legacy/DlcsClient.cs
+++ b/Portal/Legacy/DlcsClient.cs
@@ -100,11 +100,11 @@ namespace Portal.Legacy
             return image;
         }
         
-        public async Task<Collection<PortalUser>?> GetPortalUsers()
+        public async Task<SimpleCollection<PortalUser>?> GetPortalUsers()
         {
             var url = $"/customers/{currentUser.GetCustomerId()}/portalUsers";
             var response = await httpClient.GetAsync(url);
-            var portalUsers = await response.ReadAsJsonAsync<Collection<PortalUser>>();
+            var portalUsers = await response.ReadAsJsonAsync<SimpleCollection<PortalUser>>();
             return portalUsers;
         }
 

--- a/Portal/Legacy/DlcsClient.cs
+++ b/Portal/Legacy/DlcsClient.cs
@@ -98,5 +98,13 @@ namespace Portal.Legacy
             var image = await response.ReadAsJsonAsync<Image>(true, jsonSerializerSettings);
             return image;
         }
+        
+        public async Task<Collection<PortalUser>?> GetPortalUsers()
+        {
+            var url = $"/customers/{currentUser.GetCustomerId()}/portalUsers";
+            var response = await httpClient.GetAsync(url);
+            var portalUsers = await response.ReadAsJsonAsync<Collection<PortalUser>>();
+            return portalUsers;
+        }
     }
 }

--- a/Portal/Legacy/DlcsClient.cs
+++ b/Portal/Legacy/DlcsClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -115,6 +116,21 @@ namespace Portal.Legacy
             var response = await httpClient.PostAsync(url, ApiBody(portalUser));
             var newUser = await response.ReadAsJsonAsync<PortalUser>(true, jsonSerializerSettings);
             return newUser;
+        }
+
+        public async Task<bool> DeletePortalUser(string portalUserId)
+        {
+            var url = $"/customers/{currentUser.GetCustomerId()}/portalUsers/{portalUserId}";
+            try
+            {
+                var response = await httpClient.DeleteAsync(url);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error deleting portalUser '{PortalUserId}'", portalUserId);
+                return false;
+            }
         }
     }
 }

--- a/Portal/Legacy/DlcsClient.cs
+++ b/Portal/Legacy/DlcsClient.cs
@@ -106,5 +106,15 @@ namespace Portal.Legacy
             var portalUsers = await response.ReadAsJsonAsync<Collection<PortalUser>>();
             return portalUsers;
         }
+
+        public async Task<PortalUser> CreatePortalUser(PortalUser portalUser)
+        {
+            // TODO - a 400 - badRequest is likely an email address that already exists.
+            // Handle that with some sort of nicer response code or known error enum.
+            var url = $"/customers/{currentUser.GetCustomerId()}/portalUsers";
+            var response = await httpClient.PostAsync(url, ApiBody(portalUser));
+            var newUser = await response.ReadAsJsonAsync<PortalUser>(true, jsonSerializerSettings);
+            return newUser;
+        }
     }
 }

--- a/Portal/Pages/Keys/Index.cshtml.cs
+++ b/Portal/Pages/Keys/Index.cshtml.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Portal.Features.Keys;
 using Portal.Features.Keys.Requests;
 
 namespace Portal.Pages.Keys

--- a/Portal/Pages/Shared/_Layout.cshtml
+++ b/Portal/Pages/Shared/_Layout.cshtml
@@ -99,5 +99,6 @@
   <script src="~/assets/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/feather-icons@4.28.0/dist/feather.min.js" integrity="sha384-uO3SXW5IuS1ZpFPKugNNWqTZRRglnUJK6UAZ/gxOX80nxEkN9NcGZTftn6RzhGWE" crossorigin="anonymous"></script>
   <script src="~/js/portal.js" asp-append-version="true"></script>
+  @await RenderSectionAsync("Scripts", required: false)
   </body>
 </html>

--- a/Portal/Pages/Users/Index.cshtml
+++ b/Portal/Pages/Users/Index.cshtml
@@ -1,0 +1,49 @@
+﻿@page
+@using DLCS.Core.Collections
+@model Portal.Pages.Users.IndexModel
+
+@{
+    ViewData["Title"] = "Users";
+}
+
+<h2>@ViewData["Title"]</h2>
+<form method="post" asp-page="/Keys/Create" class="row row-cols-lg-auto g-3 align-items-center">
+    <div class="col-4">
+        <button type="submit" class="btn btn-primary">Create new user</button>
+    </div>
+</form>
+
+<div class="row">
+    <div class="col-md-3">
+        @if (Model.PortalUsers.IsNullOrEmpty())
+        {
+            <div class="alert alert-info" role="alert">
+                No Portal Users found for customer
+            </div>
+        }
+        else
+        {
+            <table class="table">
+                <thead>
+                <tr>
+                    <th scope="col">Email Address</th>
+                    <th scope="col">Created</th>
+                    <th scope="col">Enabled</th>
+                    <th scope="col">Actions</th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach (var m in Model.PortalUsers)
+                {
+                    <tr>
+                        <td>@m.Email</td>
+                        <td>@m.Created</td>
+                        <td>@m.Enabled</td>
+                        <td></td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>

--- a/Portal/Pages/Users/Index.cshtml
+++ b/Portal/Pages/Users/Index.cshtml
@@ -7,11 +7,35 @@
 }
 
 <h2>@ViewData["Title"]</h2>
-<form method="post" asp-page="/Keys/Create" class="row row-cols-lg-auto g-3 align-items-center">
-    <div class="col-4">
-        <button type="submit" class="btn btn-primary">Create new user</button>
+@if (TempData.ContainsKey("SuccessMessage"))
+{
+    <div class="alert alert-success" role="alert">@TempData["SuccessMessage"].ToString()</div>
+}
+@if (TempData.ContainsKey("ErrorMessage"))
+{
+    <div class="alert alert-danger" role="alert">@TempData["ErrorMessage"].ToString()</div>
+}
+
+<div class="row">
+    <div class="col-md-3">
+        <form method="post">
+            <div asp-validation-summary="All" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Input.Email"></label>
+                <input asp-for="Input.Email" class="form-control" required>
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.Password"></label>
+                <input asp-for="Input.Password" class="form-control" required>
+                <span asp-validation-for="Input.Password" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Create new user</button>
+            </div>
+        </form>
     </div>
-</form>
+</div>
 
 <div class="row">
     <div class="col-md-3">

--- a/Portal/Pages/Users/Index.cshtml
+++ b/Portal/Pages/Users/Index.cshtml
@@ -63,7 +63,12 @@
                         <td>@m.Email</td>
                         <td>@m.Created</td>
                         <td>@m.Enabled</td>
-                        <td></td>
+                        <td>
+                            <a asp-controller="User" asp-action="Delete" asp-route-id="@m.Id"
+                               class="delete-user" data-toggle="tooltip" title="Delete user @m.Email">
+                                <span data-feather="x">delete @m.Email</span>
+                            </a>
+                        </td>
                     </tr>
                 }
                 </tbody>
@@ -71,3 +76,30 @@
         }
     </div>
 </div>
+
+@section Scripts {
+    <script type="text/javascript">
+        
+        function deleteUser(evt){            
+            if (window.confirm("Delete user? Are you sure?")){
+                let url = this.getAttribute("href");
+                let row = this.closest('tr');
+                
+                fetch(url, {method: 'DELETE',})
+                    .then(r => r.json())
+                    .then(data => {
+                        console.log(data);
+                        row.remove() 
+                    })                        
+                    .catch(err => alert(err));
+            }
+            
+            evt.preventDefault();
+        }
+        
+        let deleteLink = document.getElementsByClassName("delete-user");
+        for (let i = 0; i < deleteLink.length; i++) {
+            deleteLink[i].addEventListener('click', deleteUser, false);
+        }
+    </script>
+}

--- a/Portal/Pages/Users/Index.cshtml.cs
+++ b/Portal/Pages/Users/Index.cshtml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DLCS.Core.Collections;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Portal.Features.Users.Requests;
+
+namespace Portal.Pages.Users
+{
+    public class IndexModel : PageModel
+    {
+        private readonly IMediator mediator;
+
+        [BindProperty]
+        public IEnumerable<PortalUserModel> PortalUsers { get; set; } = Enumerable.Empty<PortalUserModel>();
+        
+        public class PortalUserModel
+        {
+            public string Email { get; set; }
+            public DateTime Created { get; set; }
+            public bool Enabled { get; set; }
+        }
+        
+        public IndexModel(IMediator mediator)
+        {
+            this.mediator = mediator;
+        }
+        
+        public async Task OnGetAsync()
+        {
+            var portalUsers = await mediator.Send(new GetPortalUsers());
+            if (!portalUsers.Member.IsNullOrEmpty())
+            {
+                PortalUsers = portalUsers.Member.Select(pu => new PortalUserModel
+                {
+                    Created = pu.Created,
+                    Email = pu.Email,
+                    Enabled = pu.Enabled
+                });
+            }
+        }
+    }
+}

--- a/Portal/Pages/Users/Index.cshtml.cs
+++ b/Portal/Pages/Users/Index.cshtml.cs
@@ -55,9 +55,9 @@ namespace Portal.Pages.Users
         public async Task OnGetAsync()
         {
             var portalUsers = await mediator.Send(new GetPortalUsers());
-            if (!portalUsers.Member.IsNullOrEmpty())
+            if (!portalUsers.Members.IsNullOrEmpty())
             {
-                PortalUsers = portalUsers.Member.Select(pu => new PortalUserModel
+                PortalUsers = portalUsers.Members.Select(pu => new PortalUserModel
                 {
                     Id = pu.GetLastPathElement(),
                     Created = pu.Created,
@@ -81,26 +81,6 @@ namespace Portal.Pages.Users
                 SuccessMessage = $"New Portal user '{newPortalUser.Email}' created";
             }
 
-            return RedirectToPage("/Users/Index");
-        }
-
-        public async Task<IActionResult> OnPostDeleteAsync(string id)
-        {
-            if (string.IsNullOrEmpty(id))
-            {
-                ModelState.AddModelError(string.Empty, "PortalUserId must be specified");
-            }
-
-            var deleteSuccess = await mediator.Send(new DeletePortalUser(id));
-            if (deleteSuccess)
-            {
-                SuccessMessage = $"Portal user '{id}' deleted";
-            }
-            else
-            {
-                ErrorMessage = "Error deleting portal user";
-            }
-            
             return RedirectToPage("/Users/Index");
         }
     }

--- a/Portal/Pages/Users/Index.cshtml.cs
+++ b/Portal/Pages/Users/Index.cshtml.cs
@@ -30,6 +30,7 @@ namespace Portal.Pages.Users
         
         public class PortalUserModel
         {
+            public string Id { get; set; }
             public string Email { get; set; }
             public DateTime? Created { get; set; }
             public bool Enabled { get; set; }
@@ -58,6 +59,7 @@ namespace Portal.Pages.Users
             {
                 PortalUsers = portalUsers.Member.Select(pu => new PortalUserModel
                 {
+                    Id = pu.GetLastPathElement(),
                     Created = pu.Created,
                     Email = pu.Email,
                     Enabled = pu.Enabled
@@ -79,6 +81,26 @@ namespace Portal.Pages.Users
                 SuccessMessage = $"New Portal user '{newPortalUser.Email}' created";
             }
 
+            return RedirectToPage("/Users/Index");
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                ModelState.AddModelError(string.Empty, "PortalUserId must be specified");
+            }
+
+            var deleteSuccess = await mediator.Send(new DeletePortalUser(id));
+            if (deleteSuccess)
+            {
+                SuccessMessage = $"Portal user '{id}' deleted";
+            }
+            else
+            {
+                ErrorMessage = "Error deleting portal user";
+            }
+            
             return RedirectToPage("/Users/Index");
         }
     }

--- a/Portal/Pages/Users/Index.cshtml.cs
+++ b/Portal/Pages/Users/Index.cshtml.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Portal.Features.Users.Commands;
 using Portal.Features.Users.Requests;
 
 namespace Portal.Pages.Users
@@ -17,11 +19,31 @@ namespace Portal.Pages.Users
         [BindProperty]
         public IEnumerable<PortalUserModel> PortalUsers { get; set; } = Enumerable.Empty<PortalUserModel>();
         
+        [TempData]
+        public string ErrorMessage { get; set; }
+        
+        [TempData]
+        public string SuccessMessage { get; set; }
+        
+        [BindProperty]
+        public NewUserModel Input { get; set; }
+        
         public class PortalUserModel
         {
             public string Email { get; set; }
-            public DateTime Created { get; set; }
+            public DateTime? Created { get; set; }
             public bool Enabled { get; set; }
+        }
+
+        public class NewUserModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; }
+
+            [Required]
+            [DataType(DataType.Password)]
+            public string Password { get; set; }
         }
         
         public IndexModel(IMediator mediator)
@@ -41,6 +63,23 @@ namespace Portal.Pages.Users
                     Enabled = pu.Enabled
                 });
             }
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid) return Page();
+
+            var newPortalUser = await mediator.Send(new CreatePortalUser(Input.Email, Input.Password));
+            if (newPortalUser == null)
+            {
+                ErrorMessage = "Error creating portal user - does the email address already exist?";
+            }
+            else
+            {
+                SuccessMessage = $"New Portal user '{newPortalUser.Email}' created";
+            }
+
+            return RedirectToPage("/Users/Index");
         }
     }
 }

--- a/Portal/Pages/Users/_ViewImports.cshtml
+++ b/Portal/Pages/Users/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+@using Portal.Pages.Users

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -12,6 +12,7 @@
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.6" />
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.6" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />
       <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />

--- a/Portal/Properties/launchSettings.json
+++ b/Portal/Properties/launchSettings.json
@@ -21,7 +21,8 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
       }
     }
   }

--- a/Portal/Startup.cs
+++ b/Portal/Startup.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Portal.Behaviours;
 using Portal.Legacy;
 using Portal.Settings;
 
@@ -43,7 +44,7 @@ namespace Portal
                 opts.Conventions.AllowAnonymousToPage("/Index");
                 opts.Conventions.AuthorizeFolder("/Admin", "Administrators");
             });
-            
+
             // Add auth to everywhere - with the exception of those configured in AddRazorPages
             services.AddAuthorization(opts =>
             {
@@ -66,7 +67,8 @@ namespace Portal
                 .AddSingleton<IEncryption, SHA256>()
                 .AddTransient<ClaimsPrincipal>(s => s.GetService<IHttpContextAccessor>().HttpContext.User)
                 .AddMediatR(typeof(Startup))
-                .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+                .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>))
+                .AddScoped(typeof(IPipelineBehavior<,>), typeof(AuditBehaviour<,>));
 
             services.AddDbContext<DlcsContext>(opts =>
                 opts.UseNpgsql(configuration.GetConnectionString("PostgreSQLConnection"))

--- a/Portal/appSettings-Development-Example.json
+++ b/Portal/appSettings-Development-Example.json
@@ -30,7 +30,7 @@
     "loginSalt": "a-salt-value"
   },
   "DLCS": {
-    "Root": "https://api.dlcs",
+    "ApiRoot": "https://api.dlcs",
     "OriginBucket": "-bucket-name-"
   }
 }


### PR DESCRIPTION
Add view that lists current Portal users. From here users can be deleted + created.

Viewing individual users is not supported as this isn't supported in API.

Also added `IAuditable` and `AuditBehaviour` to portal. Any `IRequests` that implement `IAuditable` marker interface will have destructured request/response logged alongside userid. _Need to be careful not to log any sensitive data with this_