### PR TITLE
Upload images to DLCS / handle 'manifest' mode spaces

### DIFF
--- a/API/Features/Image/Models/AssetJsonLD.cs
+++ b/API/Features/Image/Models/AssetJsonLD.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using API.JsonLd;
 using Newtonsoft.Json;
 
 namespace API.Features.Image.Models
@@ -9,16 +10,9 @@ namespace API.Features.Image.Models
     // TODO - Ideally we could inherit from DLCS.Model.Assets.Asset here but would need to make all props nullable
     // and I'm unsure of side effects
 
-    public class AssetJsonLD 
+    public class AssetJsonLD  : JsonLdBase
     {
-        [JsonProperty("@context")]
-        public string? Context { get; set; }
-        
-        [JsonProperty("@type")]
-        public string? Type { get; set; }
-        
-        [JsonProperty("@id")]
-        public string? Id { get; set; }
+        public override string Type => "Image";
         public DateTime? Created { get; set; }
         public string? Origin { get; set; }
         public List<string>? Tags { get; set; }

--- a/API/JsonLd/Space.cs
+++ b/API/JsonLd/Space.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace API.JsonLd
@@ -15,5 +16,18 @@ namespace API.JsonLd
 
         [JsonProperty(Order = 14, PropertyName = "defaultMaxUnauthorised")]
         public int DefaultMaxUnauthorised { get; set; }
+    }
+
+    public static class SpaceX
+    {
+        public static string ManifestTag = "dlcs:manifestSpace";
+        
+        /// <summary>
+        /// Check 
+        /// </summary>
+        /// <param name="space"></param>
+        /// <returns></returns>
+        public static bool IsManifestSpace(this Space space) 
+            => space.DefaultTags.Contains(ManifestTag);
     }
 }

--- a/API/Startup.cs
+++ b/API/Startup.cs
@@ -43,7 +43,7 @@ namespace API
                 .ConfigureMediatR()
                 .ConfigureSwagger()
                 .AddAWSService<IAmazonS3>()
-                .AddSingleton<IBucketReader, BucketReader>();;
+                .AddSingleton<IBucketReader, BucketReader>();
 
             services.AddDlcsDelegatedBasicAuth(options => options.Realm = "DLCS-API");
             

--- a/DLCS.Core/Settings/DlcsSettings.cs
+++ b/DLCS.Core/Settings/DlcsSettings.cs
@@ -29,5 +29,7 @@ namespace DLCS.Core.Settings
         /// TODO - the DLCS API's returned Image resource should have this kind of information
         /// </summary>
         public int PortalThumb { get; set; }
+
+        public string Region { get; set; } = "eu-west-1";
     }
 }

--- a/DLCS.Repository.Tests/Entities/SpaceXTests.cs
+++ b/DLCS.Repository.Tests/Entities/SpaceXTests.cs
@@ -1,0 +1,91 @@
+﻿using DLCS.Repository.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace DLCS.Repository.Tests.Entities
+{
+    public class SpaceXTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AddTag_Adds_IfTagEmpty(string tags)
+        {
+            // Arrange
+            var space = new Space {Tags = tags};
+            
+            // Arrange
+            space.AddTag("foo");
+            
+            // Assert
+            space.Tags.Should().Be("foo");
+        }
+
+        [Fact]
+        public void AddTag_Adds_IfTagHasValues()
+        {
+            // Arrange
+            var space = new Space {Tags = "bar,baz"};
+            
+            // Arrange
+            space.AddTag("foo");
+            
+            // Assert
+            space.Tags.Should().Be("bar,baz,foo");
+        }
+
+        [Fact]
+        public void AddTag_Noop_IfTagExists()
+        {
+            // Arrange
+            var space = new Space {Tags = "bar,baz"};
+            
+            // Arrange
+            space.AddTag("bar");
+            
+            // Assert
+            space.Tags.Should().Be("bar,baz");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void RemoveTag_Noop_IfTagsEmpty(string tags)
+        {
+            // Arrange
+            var space = new Space{Tags = tags};
+            
+            // Arrange
+            space.RemoveTag("foo");
+            
+            // Assert
+            space.Tags.Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void RemoveTag_Noop_IfTagDoesntExist()
+        {
+            // Arrange
+            var space = new Space {Tags = "bar,baz"};
+            
+            // Arrange
+            space.RemoveTag("foo");
+            
+            // Assert
+            space.Tags.Should().Be("bar,baz");
+        }
+
+        [Fact]
+        public void RemoveTag_Removes_IfTagExists()
+        {
+            // Arrange
+            var space = new Space {Tags = "bar,baz"};
+            
+            // Arrange
+            space.RemoveTag("bar");
+            
+            // Assert
+            space.Tags.Should().Be("baz");
+        }
+    }
+}

--- a/DLCS.Repository/Entities/Space.cs
+++ b/DLCS.Repository/Entities/Space.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 #nullable disable
 
@@ -16,5 +17,39 @@ namespace DLCS.Repository.Entities
         public bool Keep { get; set; }
         public bool Transform { get; set; }
         public int MaxUnauthorised { get; set; }
+    }
+
+    public static class SpaceX
+    {
+        /// <summary>
+        /// Add specified tag to spaces tag list
+        /// </summary>
+        public static void AddTag(this Space space, string tag)
+        {
+            if (string.IsNullOrEmpty(space.Tags))
+            {
+                space.Tags = tag;
+                return;
+            }
+
+            var tags = space.Tags.Split(",", StringSplitOptions.RemoveEmptyEntries).ToList();
+            if (tags.Contains(tag)) return;
+            
+            tags.Add(tag);
+            space.Tags = string.Join(",", tags);
+        }
+
+        /// <summary>
+        /// Remove specified tag from spaces tag list
+        /// </summary>
+        public static void RemoveTag(this Space space, string tag)
+        {
+            if (string.IsNullOrEmpty(space.Tags)) return;
+            
+            var tags = space.Tags.Split(",", StringSplitOptions.RemoveEmptyEntries).ToList();
+            if (!tags.Contains(tag)) return;
+
+            space.Tags = string.Join(",", tags.Where(t => t != tag));
+        }
     }
 }

--- a/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace DLCS.Repository.Spaces
+{
+    public interface ISpaceRepository
+    {
+        Task<int?> GetImageCountForSpace(int customerId, int spaceId);
+    }
+
+    public class SpaceRepository : ISpaceRepository
+    {
+        private readonly DlcsContext dlcsContext;
+
+        public SpaceRepository(DlcsContext dlcsContext)
+        {
+            this.dlcsContext = dlcsContext;
+        }
+        
+        public async Task<int?> GetImageCountForSpace(int customerId, int spaceId)
+        {
+            // NOTE - this is sub-optimal but EntityCounters are not reliable when using PUT
+            var count = await dlcsContext.Images.Where(c => c.Customer == customerId && c.Space == spaceId)
+                .CountAsync();
+            return count;
+
+            /*var entity = await dlcsContext.EntityCounters.AsNoTracking()
+                .SingleOrDefaultAsync(ec => ec.Type == "space-images"
+                                            && ec.Customer == customerId
+                                            && ec.Scope == spaceId.ToString());
+
+            return entity == null ? null : (int) entity.Next;*/
+        } 
+    }
+}

--- a/Portal/Features/Images/Commands/IngestSingleImage.cs
+++ b/Portal/Features/Images/Commands/IngestSingleImage.cs
@@ -1,0 +1,93 @@
+﻿using System.IO;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Features.Image.Models;
+using DLCS.Core.Settings;
+using DLCS.Model.Storage;
+using DLCS.Repository.Spaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Portal.Legacy;
+
+namespace Portal.Features.Images.Commands
+{
+    public class IngestSingleImage : IRequest<AssetJsonLD?>
+    {
+        public int SpaceId { get; }
+        public string ImageId { get; }
+        public Stream File { get; }
+        public string MediaType { get; }
+        
+        public IngestSingleImage(int spaceId, string imageId, Stream file, string mediaType)
+        {
+            SpaceId = spaceId;
+            ImageId = imageId;
+            File = file;
+            MediaType = mediaType;
+        }
+    }
+    
+    public class IngestImageFromFileHandler : IRequestHandler<IngestSingleImage, AssetJsonLD?>
+    {
+        private readonly ClaimsPrincipal claimsPrincipal;
+        private readonly IBucketReader bucketReader;
+        private readonly DlcsSettings settings;
+        private readonly DlcsClient dlcsClient;
+        private readonly ILogger<IngestImageFromFileHandler> logger;
+        private readonly ISpaceRepository spaceRepository;
+
+        public IngestImageFromFileHandler(
+            ClaimsPrincipal claimsPrincipal,
+            IBucketReader bucketReader,
+            IOptions<DlcsSettings> settings,
+            DlcsClient dlcsClient,
+            ILogger<IngestImageFromFileHandler> logger,
+            ISpaceRepository spaceRepository)
+        {
+            this.claimsPrincipal = claimsPrincipal;
+            this.bucketReader = bucketReader;
+            this.settings = settings.Value;
+            this.dlcsClient = dlcsClient;
+            this.logger = logger;
+            this.spaceRepository = spaceRepository;
+        }
+        
+        public async Task<AssetJsonLD?> Handle(IngestSingleImage request, CancellationToken cancellationToken)
+        {
+            // Save to S3
+            var objectInBucket = GetObjectInBucket(request);
+            var bucketSuccess = await bucketReader.WriteToBucket(objectInBucket, request.File, request.MediaType);
+            
+            if (!bucketSuccess)
+            {
+                // Failed, abort
+                logger.LogError("Failed to upload file to S3, aborting ingest. Key: '{Object}'",
+                    objectInBucket);
+                return null;
+            }
+            
+            var asset = await CreateJsonBody(objectInBucket, request);
+            var ingestResponse = await dlcsClient.DirectIngestImage(request.SpaceId, request.ImageId, asset);
+            return ingestResponse;
+        }
+
+        private RegionalisedObjectInBucket GetObjectInBucket(IngestSingleImage request)
+            => new RegionalisedObjectInBucket(settings.OriginBucket,
+                $"{claimsPrincipal.GetCustomerId()}/{request.SpaceId}/{request.ImageId}", settings.Region);
+
+        private async Task<AssetJsonLD> CreateJsonBody(RegionalisedObjectInBucket objectInBucket, IngestSingleImage request)
+        {
+            var spaceCount =
+                await spaceRepository.GetImageCountForSpace(claimsPrincipal.GetCustomerId().Value, request.SpaceId);
+            var nextCount = (spaceCount ?? 0) + 1;
+            return new AssetJsonLD
+            {
+                Origin = objectInBucket.GetHttpUri(),
+                Number1 = nextCount,
+                String1 = nextCount.ToString()
+            };
+        }
+    }
+}

--- a/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
+++ b/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
@@ -9,7 +9,6 @@ namespace Portal.Features.Spaces.Requests
     /// <summary>
     /// Request to get details of space from API.
     /// </summary>
-    /// <remarks>This is temporary to verify API handling</remarks>
     public class GetSpaceDetails : IRequest<SpacePageModel>
     {
         public int SpaceId { get; set; }

--- a/Portal/Features/Spaces/Requests/ToggleManifestMode.cs
+++ b/Portal/Features/Spaces/Requests/ToggleManifestMode.cs
@@ -1,0 +1,68 @@
+﻿using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Repository;
+using DLCS.Repository.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Portal.Behaviours;
+
+namespace Portal.Features.Spaces.Requests
+{
+    /// <summary>
+    /// Convert space to normal/manifest mode
+    /// </summary>
+    public class ToggleManifestMode : IRequest<bool>, IAuditable
+    {
+        public int SpaceId { get; }
+        public bool ToggleOn { get; }
+
+        public ToggleManifestMode(int spaceId, bool toggleOn)
+        {
+            SpaceId = spaceId;
+            ToggleOn = toggleOn;
+        }
+    }
+    
+    public class ToggleManifestModeHandler : IRequestHandler<ToggleManifestMode, bool>
+    {
+        private readonly DlcsContext dbContext;
+        private readonly ClaimsPrincipal claimsPrincipal;
+
+        public ToggleManifestModeHandler(
+            DlcsContext dbContext,
+            ClaimsPrincipal claimsPrincipal)
+        {
+            this.dbContext = dbContext;
+            this.claimsPrincipal = claimsPrincipal;
+        }
+        
+        public async Task<bool> Handle(ToggleManifestMode request, CancellationToken cancellationToken)
+        {
+            // NOTE: Updating Tags is not supported in API so do directly into DB.
+            // Space tag management should go into a space repository/service rather than isolated here as it will be reusable.
+            var dbSpace = await GetSpace(request.SpaceId, claimsPrincipal.GetCustomerId() ?? 0, cancellationToken);
+
+            return await ToggleManifestMode(request.ToggleOn, dbSpace, cancellationToken);
+        }
+
+        private Task<Space> GetSpace(int spaceId, int customerId, CancellationToken cancellationToken)
+            => dbContext.Spaces.SingleAsync(s => s.Id == spaceId && s.Customer == customerId,
+                cancellationToken: cancellationToken);
+        
+        private async Task<bool> ToggleManifestMode(bool toggleOn, Space? dbSpace, CancellationToken cancellationToken)
+        {
+            if (toggleOn)
+            {
+                dbSpace.AddTag(API.JsonLd.SpaceX.ManifestTag);
+            }
+            else
+            {
+                dbSpace.RemoveTag(API.JsonLd.SpaceX.ManifestTag);
+            }
+
+            var changeCount = await dbContext.SaveChangesAsync(cancellationToken);
+            return changeCount > 0;
+        }
+    }
+}

--- a/Portal/Legacy/DlcsClient.cs
+++ b/Portal/Legacy/DlcsClient.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using API.Features.Image.Models;
 using API.JsonLd;
 using DLCS.Web.Response;
 using Microsoft.Extensions.Logging;
@@ -70,12 +71,6 @@ namespace Portal.Legacy
             return space;
         }
 
-        private HttpContent ApiBody(JsonLdBase apiObject)
-        {
-            var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);
-            return new StringContent(jsonString, Encoding.UTF8, "application/json");
-        }
-
         public async Task<IEnumerable<string>?> GetApiKeys()
         {
             var url = $"/customers/{currentUser.GetCustomerId()}/keys";
@@ -131,6 +126,20 @@ namespace Portal.Legacy
                 logger.LogError(ex, "Error deleting portalUser '{PortalUserId}'", portalUserId);
                 return false;
             }
+        }
+
+        public async Task<AssetJsonLD?> DirectIngestImage(int spaceId, string imageId, AssetJsonLD asset)
+        {
+            // TODO - error handling
+            var uri = $"/customers/{currentUser.GetCustomerId()}/spaces/{spaceId}/images/{imageId}";
+            var response = await httpClient.PutAsync(uri, ApiBody(asset));
+            return await response.ReadAsJsonAsync<AssetJsonLD>(true, jsonSerializerSettings);
+        }
+        
+        private HttpContent ApiBody(JsonLdBase apiObject)
+        {
+            var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);
+            return new StringContent(jsonString, Encoding.UTF8, "application/json");
         }
     }
 }

--- a/Portal/Pages/Account/Login.cshtml
+++ b/Portal/Pages/Account/Login.cshtml
@@ -32,7 +32,7 @@
                 <span asp-validation-for="Input.ApiSecret" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <button type="submit" class="btn btn-default">Log in</button>
+                <button type="submit" class="btn btn-primary">Log in</button>
             </div>
         </form>
     </div>

--- a/Portal/Pages/Spaces/Details.cshtml
+++ b/Portal/Pages/Spaces/Details.cshtml
@@ -30,7 +30,7 @@
     }
 </form>
 
-<form action="/dropzone/@Model.Customer/@Model.Space/local"
+<form action="/dropzone/@Model.Customer/@Model.Space/upload"
       class="dropzone"
       id="dropzoneForm">
 </form>

--- a/Portal/Pages/Spaces/Details.cshtml
+++ b/Portal/Pages/Spaces/Details.cshtml
@@ -3,13 +3,32 @@
 @model Portal.Pages.Spaces.Details
 
 @{
-    ViewData["Title"] = $"Space {Model.SpacePageModel.Space.GetLastPathElementAsInt()}: {Model.SpacePageModel.Space.Name}";
+    var spaceId = Model.SpacePageModel.Space.GetLastPathElementAsInt();
+    ViewData["Title"] = $"Space {spaceId}: {Model.SpacePageModel.Space.Name}";
 }
 
 @section header
 {
     <link href="https://cdn.jsdelivr.net/npm/dropzone@5.9.2/dist/min/dropzone.min.css" rel="stylesheet" />
 }
+
+<form method="post" asp-page-handler="Convert">
+    <input type="hidden" value="@spaceId" name="spaceId">
+    @if (Model.SpacePageModel.Space.IsManifestSpace())
+    {
+        <input type="hidden" value="false" name="manifestMode">
+        <button type="submit" class="btn btn-primary">
+            Convert to 'Normal' mode
+        </button>
+    }
+    else
+    {
+        <input type="hidden" value="true" name="manifestMode">
+        <button type="submit" class="btn btn-primary">
+            Convert to 'Manifest' mode
+        </button>
+    }
+</form>
 
 <form action="/dropzone/@Model.Customer/@Model.Space/local"
       class="dropzone"

--- a/Portal/Pages/Spaces/Details.cshtml.cs
+++ b/Portal/Pages/Spaces/Details.cshtml.cs
@@ -52,5 +52,13 @@ namespace Portal.Pages.Spaces
 
             return Page();
         }
+
+        public async Task<IActionResult> OnPostConvert(int spaceId, bool manifestMode)
+        {
+            // TODO - handle failure
+            var result = await mediator.Send(new ToggleManifestMode(spaceId, manifestMode));
+
+            return RedirectToPage("/spaces/details", new {id = spaceId});
+        }
     }
 }

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
       <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.0.29" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.17" />
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
       <PackageReference Include="MediatR" Version="9.0.0" />

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -50,8 +50,4 @@
       <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\LICENSE" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Controllers" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Add logic to toggle a space between manifest/normal mode. This updates the DLCS DB directly as the API doesn't currently support updating tags.

Added handler for uploading an image - this will upload to S3 + synchronously ingest into DLCS before returning. Handler also sets N1 + S1 to next index in sequence. Done in DB as entityCounters table not updated when using synchronous ingest.