### PR TITLE
Initial api.client refactor; move json classes into client

### DIFF
--- a/API.Client/API.Client.csproj
+++ b/API.Client/API.Client.csproj
@@ -8,6 +8,11 @@
     <ItemGroup>
       <ProjectReference Include="..\DLCS.Core\DLCS.Core.csproj" />
       <ProjectReference Include="..\DLCS.Model\DLCS.Model.csproj" />
+      <ProjectReference Include="..\DLCS.Web\DLCS.Web.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/API.Client/ClaimsPrincipalUtils.cs
+++ b/API.Client/ClaimsPrincipalUtils.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Security.Claims;
 
-namespace Portal
+namespace API.Client
 {
     /// <summary>
     /// A collection of extension methods for dealing with <see cref="ClaimsPrincipal"/>

--- a/API.Client/DeliveratorApiAuth.cs
+++ b/API.Client/DeliveratorApiAuth.cs
@@ -19,7 +19,7 @@ namespace API.Client
         }
 
         /// <summary>
-        /// Get base-64 encoded string containins basic authentication details for customer.
+        /// Get base-64 encoded string contains basic authentication details for customer.
         /// </summary>
         /// <param name="customer"><see cref="Customer"/> to get credentials for.</param>
         /// <param name="salt">ApiSalt for generating API key.</param>

--- a/API.Client/DlcsClient.cs
+++ b/API.Client/DlcsClient.cs
@@ -147,7 +147,12 @@ namespace API.Client
             var patched = await response.ReadAsJsonAsync<HydraImageCollection>(true, jsonSerializerSettings);
             return patched;
         }
-        
+
+        public Task<bool> ReingestAsset(int requestSpaceId, string requestImageId)
+        {
+            throw new NotImplementedException();
+        }
+
         private HttpContent ApiBody(JsonLdBase apiObject)
         {
             var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);

--- a/API.Client/DlcsClient.cs
+++ b/API.Client/DlcsClient.cs
@@ -6,14 +6,13 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
-using API.Features.Image.Models;
-using API.JsonLd;
+using API.Client.JsonLd;
 using DLCS.Web.Response;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace Portal.Legacy
+namespace API.Client
 {
     /// <summary>
     /// Client for Dlcs API

--- a/API.Client/DlcsClient.cs
+++ b/API.Client/DlcsClient.cs
@@ -17,7 +17,7 @@ namespace API.Client
     /// <summary>
     /// Client for Dlcs API
     /// </summary>
-    public class DlcsClient
+    public class DlcsClient : IDlcsClient
     {
         private readonly ILogger<DlcsClient> logger;
         private readonly HttpClient httpClient;
@@ -134,12 +134,6 @@ namespace API.Client
             var response = await httpClient.PutAsync(uri, ApiBody(asset));
             return await response.ReadAsJsonAsync<AssetJsonLD>(true, jsonSerializerSettings);
         }
-        
-        private HttpContent ApiBody(JsonLdBase apiObject)
-        {
-            var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);
-            return new StringContent(jsonString, Encoding.UTF8, "application/json");
-        }
 
         public async Task<HydraImageCollection> PatchImages(HydraImageCollection images, int spaceId)
         {
@@ -152,6 +146,12 @@ namespace API.Client
             var response = await httpClient.PatchAsync(uri, ApiBody(images));
             var patched = await response.ReadAsJsonAsync<HydraImageCollection>(true, jsonSerializerSettings);
             return patched;
+        }
+        
+        private HttpContent ApiBody(JsonLdBase apiObject)
+        {
+            var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);
+            return new StringContent(jsonString, Encoding.UTF8, "application/json");
         }
     }
 }

--- a/API.Client/IDlcsClient.cs
+++ b/API.Client/IDlcsClient.cs
@@ -17,5 +17,8 @@ namespace API.Client
         Task<bool> DeletePortalUser(string portalUserId);
         Task<AssetJsonLD?> DirectIngestImage(int spaceId, string imageId, AssetJsonLD asset);
         Task<HydraImageCollection> PatchImages(HydraImageCollection images, int spaceId);
+        
+        
+        Task<bool> ReingestAsset(int requestSpaceId, string requestImageId);
     }
 }

--- a/API.Client/IDlcsClient.cs
+++ b/API.Client/IDlcsClient.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using API.Client.JsonLd;
+
+namespace API.Client
+{
+    public interface IDlcsClient
+    {
+        Task<Space?> GetSpaceDetails(int spaceId);
+        Task<HydraImageCollection> GetSpaceImages(int spaceId);
+        Task<Space?> CreateSpace(Space newSpace);
+        Task<IEnumerable<string>?> GetApiKeys();
+        Task<ApiKey> CreateNewApiKey();
+        Task<Image> GetImage(int requestSpaceId, string requestImageId);
+        Task<SimpleCollection<PortalUser>?> GetPortalUsers();
+        Task<PortalUser> CreatePortalUser(PortalUser portalUser);
+        Task<bool> DeletePortalUser(string portalUserId);
+        Task<AssetJsonLD?> DirectIngestImage(int spaceId, string imageId, AssetJsonLD asset);
+        Task<HydraImageCollection> PatchImages(HydraImageCollection images, int spaceId);
+    }
+}

--- a/API.Client/JsonLd/ApiKey.cs
+++ b/API.Client/JsonLd/ApiKey.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class ApiKey : JsonLdBase
     {

--- a/API.Client/JsonLd/AssetJsonLD.cs
+++ b/API.Client/JsonLd/AssetJsonLD.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using API.JsonLd;
-using Newtonsoft.Json;
 
-namespace API.Features.Image.Models
+namespace API.Client.JsonLd
 {
-    // NOTE - these classes will be worked on when 'real' implementation of API is added. These are passed directly
-    // to API for now.
-    // TODO - Ideally we could inherit from DLCS.Model.Assets.Asset here but would need to make all props nullable
-    // and I'm unsure of side effects
+    // TODO - as a result of refactoring from two different directions into API.Client, we now have this class AND Image.
+    // need to get rid of one of them!
 
     public class AssetJsonLD  : JsonLdBase
     {

--- a/API.Client/JsonLd/Batch.cs
+++ b/API.Client/JsonLd/Batch.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class Batch : JsonLdBase
     {

--- a/API.Client/JsonLd/HydraCollectionBase.cs
+++ b/API.Client/JsonLd/HydraCollectionBase.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class HydraCollectionBase : JsonLdBase
     {

--- a/API.Client/JsonLd/HydraImageCollection.cs
+++ b/API.Client/JsonLd/HydraImageCollection.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class HydraImageCollection : HydraCollectionBase
     {

--- a/API.Client/JsonLd/Image.cs
+++ b/API.Client/JsonLd/Image.cs
@@ -1,7 +1,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class Image : JsonLdBase
     {

--- a/API.Client/JsonLd/JsonLdBase.cs
+++ b/API.Client/JsonLd/JsonLdBase.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     /// <summary>
     /// Base class for all JsonLd objects

--- a/API.Client/JsonLd/PartialCollectionView.cs
+++ b/API.Client/JsonLd/PartialCollectionView.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class PartialCollectionView : JsonLdBase
     {

--- a/API.Client/JsonLd/PortalUser.cs
+++ b/API.Client/JsonLd/PortalUser.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     /// <summary>
     /// Hydra entity representing User of Portal UI.

--- a/API.Client/JsonLd/SimpleCollection.cs
+++ b/API.Client/JsonLd/SimpleCollection.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     /// <summary>
     /// Base class for JsonLd collections

--- a/API.Client/JsonLd/Space.cs
+++ b/API.Client/JsonLd/Space.cs
@@ -1,7 +1,7 @@
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace API.JsonLd
+namespace API.Client.JsonLd
 {
     public class Space : JsonLdBase
     {

--- a/API.Tests/JsonLd/ApiKeyTests.cs
+++ b/API.Tests/JsonLd/ApiKeyTests.cs
@@ -1,4 +1,4 @@
-﻿using API.JsonLd;
+﻿using API.Client.JsonLd;
 using FluentAssertions;
 using Xunit;
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -19,9 +19,14 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\API.Client\API.Client.csproj" />
       <ProjectReference Include="..\DLCS.Mediatr\DLCS.Mediatr.csproj" />
       <ProjectReference Include="..\DLCS.Repository\DLCS.Repository.csproj" />
       <ProjectReference Include="..\DLCS.Web\DLCS.Web.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Features\Image\Models" />
     </ItemGroup>
 
 </Project>

--- a/API/Features/Image/Commands/IngestImageFromFile.cs
+++ b/API/Features/Image/Commands/IngestImageFromFile.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using API.Features.Image.Models;
+using API.Client.JsonLd;
 using API.Settings;
 using DLCS.Core;
 using DLCS.Model.Storage;

--- a/API/Features/Image/ImageController.cs
+++ b/API/Features/Image/ImageController.cs
@@ -2,8 +2,8 @@
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using API.Client.JsonLd;
 using API.Features.Image.Commands;
-using API.Features.Image.Models;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 

--- a/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -10,6 +10,7 @@ using DLCS.Repository.Strategy.Utils;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
+using Orchestrator.Infrastructure.Deliverator;
 using Orchestrator.Settings;
 
 namespace Orchestrator.Features.Images.Orchestration

--- a/Orchestrator/Infrastructure/Deliverator/IDlcsApiClient.cs
+++ b/Orchestrator/Infrastructure/Deliverator/IDlcsApiClient.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using DLCS.Core.Types;
 
-namespace API.Client
+namespace Orchestrator.Infrastructure.Deliverator
 {
     public interface IDlcsApiClient
     {

--- a/Portal.Tests/ClaimsPrincipalXTests.cs
+++ b/Portal.Tests/ClaimsPrincipalXTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Security.Claims;
+using API.Client;
 using FluentAssertions;
 using Xunit;
 

--- a/Portal.Tests/Integration/Infrastructure/TestAuthHandler.cs
+++ b/Portal.Tests/Integration/Infrastructure/TestAuthHandler.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using API.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/Portal/Behaviours/AuditBehaviour.cs
+++ b/Portal/Behaviours/AuditBehaviour.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using API.Client;
 using DLCS.Mediatr.Behaviours;
 using MediatR;
 using Microsoft.Extensions.Logging;

--- a/Portal/Features/Images/Commands/IngestSingleImage.cs
+++ b/Portal/Features/Images/Commands/IngestSingleImage.cs
@@ -2,14 +2,14 @@
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using API.Features.Image.Models;
+using API.Client;
+using API.Client.JsonLd;
 using DLCS.Core.Settings;
 using DLCS.Model.Storage;
 using DLCS.Repository.Spaces;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Portal.Legacy;
 
 namespace Portal.Features.Images.Commands
 {

--- a/Portal/Features/Images/Commands/IngestSingleImage.cs
+++ b/Portal/Features/Images/Commands/IngestSingleImage.cs
@@ -34,7 +34,7 @@ namespace Portal.Features.Images.Commands
         private readonly ClaimsPrincipal claimsPrincipal;
         private readonly IBucketReader bucketReader;
         private readonly DlcsSettings settings;
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
         private readonly ILogger<IngestImageFromFileHandler> logger;
         private readonly ISpaceRepository spaceRepository;
 
@@ -42,7 +42,7 @@ namespace Portal.Features.Images.Commands
             ClaimsPrincipal claimsPrincipal,
             IBucketReader bucketReader,
             IOptions<DlcsSettings> settings,
-            DlcsClient dlcsClient,
+            IDlcsClient dlcsClient,
             ILogger<IngestImageFromFileHandler> logger,
             ISpaceRepository spaceRepository)
         {

--- a/Portal/Features/Keys/Commands/CreateNewApiKey.cs
+++ b/Portal/Features/Keys/Commands/CreateNewApiKey.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using MediatR;
-using Portal.Legacy;
 
 namespace Portal.Features.Keys.Commands
 {

--- a/Portal/Features/Keys/Commands/CreateNewApiKey.cs
+++ b/Portal/Features/Keys/Commands/CreateNewApiKey.cs
@@ -15,9 +15,9 @@ namespace Portal.Features.Keys.Commands
     
     public class CreateNewApiKeyHandler : IRequestHandler<CreateNewApiKey, ApiKey>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public CreateNewApiKeyHandler(DlcsClient dlcsClient)
+        public CreateNewApiKeyHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Features/Keys/Requests/GetCustomerApiKeys.cs
+++ b/Portal/Features/Keys/Requests/GetCustomerApiKeys.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using API.Client;
 using MediatR;
-using Portal.Legacy;
 
 namespace Portal.Features.Keys.Requests
 {

--- a/Portal/Features/Keys/Requests/GetCustomerApiKeys.cs
+++ b/Portal/Features/Keys/Requests/GetCustomerApiKeys.cs
@@ -15,9 +15,9 @@ namespace Portal.Features.Keys.Requests
 
     public class GetCustomerApiKeysHandler : IRequestHandler<GetCustomerApiKeys, IEnumerable<string>?>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public GetCustomerApiKeysHandler(DlcsClient dlcsClient)
+        public GetCustomerApiKeysHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Features/Spaces/DropzoneController.cs
+++ b/Portal/Features/Spaces/DropzoneController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using API.Client;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/Portal/Features/Spaces/Models/SpacePageModel.cs
+++ b/Portal/Features/Spaces/Models/SpacePageModel.cs
@@ -1,5 +1,5 @@
 using System;
-using API.JsonLd;
+using API.Client.JsonLd;
 
 namespace Portal.Features.Spaces.Models
 {

--- a/Portal/Features/Spaces/Requests/CreateNewSpace.cs
+++ b/Portal/Features/Spaces/Requests/CreateNewSpace.cs
@@ -18,10 +18,10 @@ namespace Portal.Features.Spaces.Requests
         {
             private readonly ClaimsPrincipal principal;
             private readonly ILogger logger;
-            private readonly DlcsClient dlcsClient;
+            private readonly IDlcsClient dlcsClient;
 
             public CreateNewSpaceHandler(
-                DlcsClient dlcsClient, 
+                IDlcsClient dlcsClient, 
                 ClaimsPrincipal principal,
                 ILogger<GetAllSpacesHandler> logger)
             {

--- a/Portal/Features/Spaces/Requests/CreateNewSpace.cs
+++ b/Portal/Features/Spaces/Requests/CreateNewSpace.cs
@@ -2,10 +2,10 @@ using System;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Portal.Legacy;
 
 namespace Portal.Features.Spaces.Requests
 {

--- a/Portal/Features/Spaces/Requests/GetAllSpaces.cs
+++ b/Portal/Features/Spaces/Requests/GetAllSpaces.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using API.Client;
 using DLCS.Repository;
 using DLCS.Repository.Entities;
 using MediatR;

--- a/Portal/Features/Spaces/Requests/GetImage.cs
+++ b/Portal/Features/Spaces/Requests/GetImage.cs
@@ -1,9 +1,9 @@
 using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using MediatR;
 using Portal.Features.Spaces.Models;
-using Portal.Legacy;
 
 namespace Portal.Features.Spaces.Requests
 {

--- a/Portal/Features/Spaces/Requests/GetImage.cs
+++ b/Portal/Features/Spaces/Requests/GetImage.cs
@@ -15,9 +15,9 @@ namespace Portal.Features.Spaces.Requests
     
     public class GetImageHandler : IRequestHandler<GetImage, Image>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public GetImageHandler(DlcsClient dlcsClient)
+        public GetImageHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
+++ b/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
@@ -4,13 +4,13 @@ using System.Linq.Dynamic.Core;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using DLCS.Core;
 using DLCS.Core.Settings;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Portal.Legacy;
 using Portal.Features.Spaces.Models;
 using Portal.Settings;
 

--- a/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
+++ b/Portal/Features/Spaces/Requests/GetSpaceDetails.cs
@@ -40,14 +40,14 @@ namespace Portal.Features.Spaces.Requests
 
     public class GetSpaceDetailsHandler : IRequestHandler<GetSpaceDetails, SpacePageModel>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
         private readonly ClaimsPrincipal claimsPrincipal;
         private readonly PortalSettings portalSettings;
         private readonly DlcsSettings dlcsSettings;
         private readonly ILogger<GetSpaceDetailsHandler> logger;
 
         public GetSpaceDetailsHandler(
-            DlcsClient dlcsClient, 
+            IDlcsClient dlcsClient, 
             IOptions<PortalSettings> portalSettings,
             IOptions<DlcsSettings> dlcsSettings,
             ClaimsPrincipal claimsPrincipal,

--- a/Portal/Features/Spaces/Requests/PatchImages.cs
+++ b/Portal/Features/Spaces/Requests/PatchImages.cs
@@ -14,9 +14,9 @@ namespace Portal.Features.Spaces.Requests
 
     public class PatchImagesHandler : IRequestHandler<PatchImages, HydraImageCollection>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public PatchImagesHandler(DlcsClient dlcsClient)
+        public PatchImagesHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Features/Spaces/Requests/PatchImages.cs
+++ b/Portal/Features/Spaces/Requests/PatchImages.cs
@@ -1,8 +1,8 @@
 using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using MediatR;
-using Portal.Legacy;
 
 namespace Portal.Features.Spaces.Requests
 {

--- a/Portal/Features/Spaces/Requests/ToggleManifestMode.cs
+++ b/Portal/Features/Spaces/Requests/ToggleManifestMode.cs
@@ -1,11 +1,13 @@
 ﻿using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using API.Client;
 using DLCS.Repository;
 using DLCS.Repository.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Portal.Behaviours;
+using SpaceX = API.Client.JsonLd.SpaceX;
 
 namespace Portal.Features.Spaces.Requests
 {
@@ -54,11 +56,11 @@ namespace Portal.Features.Spaces.Requests
         {
             if (toggleOn)
             {
-                dbSpace.AddTag(API.JsonLd.SpaceX.ManifestTag);
+                dbSpace.AddTag(SpaceX.ManifestTag);
             }
             else
             {
-                dbSpace.RemoveTag(API.JsonLd.SpaceX.ManifestTag);
+                dbSpace.RemoveTag(SpaceX.ManifestTag);
             }
 
             var changeCount = await dbContext.SaveChangesAsync(cancellationToken);

--- a/Portal/Features/Users/Commands/CreatePortalUser.cs
+++ b/Portal/Features/Users/Commands/CreatePortalUser.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using Destructurama.Attributed;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Portal.Behaviours;
-using Portal.Legacy;
 
 namespace Portal.Features.Users.Commands
 {

--- a/Portal/Features/Users/Commands/CreatePortalUser.cs
+++ b/Portal/Features/Users/Commands/CreatePortalUser.cs
@@ -29,11 +29,11 @@ namespace Portal.Features.Users.Commands
     
     public class CreatePortalUserHandler : IRequestHandler<CreatePortalUser, PortalUser?>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
         private readonly ILogger<CreatePortalUserHandler> logger;
 
         public CreatePortalUserHandler(
-            DlcsClient dlcsClient, 
+            IDlcsClient dlcsClient, 
             ILogger<CreatePortalUserHandler> logger)
         {
             this.dlcsClient = dlcsClient;

--- a/Portal/Features/Users/Commands/DeletePortalUser.cs
+++ b/Portal/Features/Users/Commands/DeletePortalUser.cs
@@ -21,9 +21,9 @@ namespace Portal.Features.Users.Commands
     
     public class DeletePortalUserHandler : IRequestHandler<DeletePortalUser, bool>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public DeletePortalUserHandler(DlcsClient dlcsClient)
+        public DeletePortalUserHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Features/Users/Commands/DeletePortalUser.cs
+++ b/Portal/Features/Users/Commands/DeletePortalUser.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using API.Client;
 using MediatR;
 using Portal.Behaviours;
-using Portal.Legacy;
 
 namespace Portal.Features.Users.Commands
 {

--- a/Portal/Features/Users/Requests/GetPortalUsers.cs
+++ b/Portal/Features/Users/Requests/GetPortalUsers.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client;
+using API.Client.JsonLd;
 using MediatR;
-using Portal.Legacy;
 
 namespace Portal.Features.Users.Requests
 {

--- a/Portal/Features/Users/Requests/GetPortalUsers.cs
+++ b/Portal/Features/Users/Requests/GetPortalUsers.cs
@@ -15,9 +15,9 @@ namespace Portal.Features.Users.Requests
     
     public class GetPortalUsersHandler : IRequestHandler<GetPortalUsers, SimpleCollection<PortalUser>?>
     {
-        private readonly DlcsClient dlcsClient;
+        private readonly IDlcsClient dlcsClient;
 
-        public GetPortalUsersHandler(DlcsClient dlcsClient)
+        public GetPortalUsersHandler(IDlcsClient dlcsClient)
         {
             this.dlcsClient = dlcsClient;
         }

--- a/Portal/Pages/Images/Index.cshtml.cs
+++ b/Portal/Pages/Images/Index.cshtml.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
-using API.JsonLd;
+using API.Client.JsonLd;
 using DLCS.Core.Settings;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;

--- a/Portal/Pages/Spaces/Details.cshtml
+++ b/Portal/Pages/Spaces/Details.cshtml
@@ -1,5 +1,4 @@
 ﻿@page "{id}"
-@using API.JsonLd
 @model Portal.Pages.Spaces.Details
 
 @{

--- a/Portal/Pages/Spaces/Details.cshtml.cs
+++ b/Portal/Pages/Spaces/Details.cshtml.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using API.Client;
+using API.Client.JsonLd;
 using DLCS.Core.Settings;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -38,7 +40,7 @@ namespace Portal.Pages.Spaces
         public async Task<IActionResult> OnGetAsync(int id)
         {
             Space = id.ToString();
-            SpacePageModel = await mediator.Send(new GetSpaceDetails(id, nameof(API.JsonLd.Image.Number1)));
+            SpacePageModel = await mediator.Send(new GetSpaceDetails(id, nameof(Image.Number1)));
 
             if (SpacePageModel.Space == null)
             {
@@ -77,7 +79,7 @@ namespace Portal.Pages.Spaces
             if (images != null)
             {
                 var highest = orderDict.Values.Max();
-                foreach (API.JsonLd.Image image in images.Members)
+                foreach (Image image in images.Members)
                 {
                     if (orderDict.ContainsKey(image.Id))
                     {

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -57,4 +57,8 @@
       <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\LICENSE" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Legacy" />
+    </ItemGroup>
+
 </Project>

--- a/Portal/Startup.cs
+++ b/Portal/Startup.cs
@@ -82,7 +82,7 @@ namespace Portal
                 opts.UseNpgsql(configuration.GetConnectionString("PostgreSQLConnection"))
             );
 
-            services.AddHttpClient<DlcsClient>(client =>
+            services.AddHttpClient<IDlcsClient, DlcsClient>(client =>
             {
                 var dlcsSection = configuration.GetSection("DLCS");
                 var dlcsOptions = dlcsSection.Get<DlcsSettings>();

--- a/Portal/Startup.cs
+++ b/Portal/Startup.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Portal.Behaviours;
-using Portal.Legacy;
 using Portal.Settings;
 
 namespace Portal

--- a/Portal/TagHelpers/DlcsIIIFThumbnailTagHelper.cs
+++ b/Portal/TagHelpers/DlcsIIIFThumbnailTagHelper.cs
@@ -1,5 +1,5 @@
 using System;
-using API.JsonLd;
+using API.Client.JsonLd;
 using DLCS.Core.Settings;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 


### PR DESCRIPTION
This was going to be for signup but we can merge the organisation changes before adding new functionality.

* JSON-LD classes consolidated into API.Client
* Introduced IDlcsClient interface and refactored portal to use API through this interface
* API.Client IDlcsApiClient interface used only for asset reingesting moved into Orchestrator alongside its implementation 