### PR TITLE
Single asset generation from /iiif-manifest/ route

### DIFF
--- a/DLCS.Core.Tests/Collections/CollectionXTests.cs
+++ b/DLCS.Core.Tests/Collections/CollectionXTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
 using FluentAssertions;
@@ -54,6 +55,36 @@ namespace DLCS.Core.Tests.Collections
             var coll = new List<int> {2};
 
             coll.IsNullOrEmpty().Should().BeFalse();
+        }
+
+        [Fact]
+        public void AsList_ReturnsExpected()
+        {
+            var item = DateTime.Now;
+
+            var list = item.AsList();
+
+            list.Should().ContainSingle(i => i == item);
+        }
+        
+        [Fact]
+        public void AsListOf_ThrowsIfCastInvalid()
+        {
+            var item = DateTime.Now;
+
+            Action action = () => item.AsListOf<Exception>();
+
+            action.Should().Throw<InvalidCastException>();
+        }
+        
+        [Fact]
+        public void AsListOf_ReturnsExpected()
+        {
+            var item = DateTime.Now;
+
+            var list = item.AsListOf<object>();
+
+            list.Should().ContainSingle(i => (DateTime)i == item);
         }
     }
 }

--- a/DLCS.Core/Collections/CollectionX.cs
+++ b/DLCS.Core/Collections/CollectionX.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace DLCS.Core.Collections
@@ -16,5 +17,31 @@ namespace DLCS.Core.Collections
         /// </summary>
         /// <returns>true if null or empty, else false</returns>
         public static bool IsNullOrEmpty<T>(this IList<T>? collection) => collection == null || collection.Count == 0;
+
+        /// <summary>
+        /// Return a List{T} containing single item.
+        /// </summary>
+        /// <param name="item">Item to add to list</param>
+        /// <typeparam name="T">Type of item</typeparam>
+        /// <returns>List of one item</returns>
+        public static List<T> AsList<T>(this T item)
+            => new() { item };
+
+        /// <summary>
+        /// Return a List{TList} containing single item of derived type
+        /// </summary>
+        /// <param name="item"></param>
+        /// <typeparam name="TList">Type of returned list</typeparam>
+        /// <returns>List containing single item</returns>
+        public static List<TList> AsListOf<TList>(this object item) 
+            where TList : class
+        {
+            if (item is not TList list)
+            {
+                throw new InvalidCastException($"Cannot cast {item.GetType().Name} to {typeof(TList).Name}");
+            }
+
+            return new() { list };
+        }
     }
 }

--- a/DLCS.Model.Tests/Assets/InfoJsonBuilderTests.cs
+++ b/DLCS.Model.Tests/Assets/InfoJsonBuilderTests.cs
@@ -6,13 +6,13 @@ using Xunit;
 
 namespace DLCS.Model.Tests.Assets
 {
-    public class InfoJsonBuilderTests
+  public class InfoJsonBuilderTests
+  {
+    [Fact]
+    public void GetImageApi2_1Level0_ReturnsExpected()
     {
-        [Fact]
-        public void GetImageApi2_1Level0_ReturnsExpected()
-        {
-            // Arrange
-            var expected = @"{
+      // Arrange
+      var expected = @"{
   ""@context"": ""http://iiif.io/api/image/2/context.json"",
   ""@id"": ""https://test.example.com/iiif-img/2/1/jackal"",
   ""profile"": [
@@ -31,21 +31,21 @@ namespace DLCS.Model.Tests.Assets
     {""width"":400,""height"":800}
   ]
 }";
-            // Act
-            var actual = InfoJsonBuilder.GetImageApi2_1Level0(
-                "https://test.example.com/iiif-img/2/1/jackal",
-                new List<int[]> { new[] { 400, 800 }, new[] { 100, 200 } });
-            
-            // Assert
-            var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
-            normalisedJson.Should().BeEquivalentTo(expected);
-        }
-        
-        [Fact]
-        public void GetImageApi2_1Level1_ReturnsExpected()
-        {
-            // Arrange
-            var expected = @"{
+      // Act
+      var actual = InfoJsonBuilder.GetImageApi2_1Level0(
+        "https://test.example.com/iiif-img/2/1/jackal",
+        new List<int[]> { new[] { 400, 800 }, new[] { 100, 200 } });
+
+      // Assert
+      var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
+      normalisedJson.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void GetImageApi2_1Level1_ReturnsExpected()
+    {
+      // Arrange
+      var expected = @"{
   ""@context"": ""http://iiif.io/api/image/2/context.json"",
   ""@id"": ""https://test.example.com/iiif-img/2/1/jackal"",
   ""profile"": [
@@ -92,15 +92,15 @@ namespace DLCS.Model.Tests.Assets
     }
   ]
 }";
-            // Act
-            var actual = InfoJsonBuilder.GetImageApi2_1Level1(
-                "https://test.example.com/iiif-img/2/1/jackal",
-                4200, 8400,
-                new List<int[]> {  new[] { 1000, 2000 }, new[] { 400, 800 }, new[] { 100, 200 } });
-            
-            // Assert
-            var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
-            normalisedJson.Should().BeEquivalentTo(expected);
-        }
+      // Act
+      var actual = InfoJsonBuilder.GetImageApi2_1Level1(
+        "https://test.example.com/iiif-img/2/1/jackal",
+        4200, 8400,
+        new List<int[]> { new[] { 1000, 2000 }, new[] { 400, 800 }, new[] { 100, 200 } });
+
+      // Assert
+      var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
+      normalisedJson.Should().BeEquivalentTo(expected);
     }
+  }
 }

--- a/DLCS.Model.Tests/Assets/InfoJsonBuilderTests.cs
+++ b/DLCS.Model.Tests/Assets/InfoJsonBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using DLCS.Model.Assets;
 using FluentAssertions;
+using IIIF.Serialisation;
 using Xunit;
 
 namespace DLCS.Model.Tests.Assets
@@ -12,31 +13,32 @@ namespace DLCS.Model.Tests.Assets
         {
             // Arrange
             var expected = @"{
-""@context"":""http://iiif.io/api/image/2/context.json"",
-""@id"":""https://test.example.com/iiif-img/2/1/jackal"",
-""protocol"": ""http://iiif.io/api/image"",
-""profile"": [
-  ""http://iiif.io/api/image/2/level0.json"",
-  {
-    ""formats"": [ ""jpg"" ],
-    ""qualities"": [ ""color"" ],
-    ""supports"": [ ""sizeByWhListed"" ]
-  }
+  ""@context"": ""http://iiif.io/api/image/2/context.json"",
+  ""@id"": ""https://test.example.com/iiif-img/2/1/jackal"",
+  ""profile"": [
+    ""http://iiif.io/api/image/2/level0.json"",
+    {
+      ""formats"": [""jpg""],
+      ""qualities"": [""color""],
+      ""supports"": [""sizeByWhListed""]
+    }
   ],
+  ""protocol"": ""http://iiif.io/api/image"",
   ""width"": 400,
   ""height"": 800,
   ""sizes"": [
-    { ""width"": 100, ""height"": 200 }, { ""width"": 400, ""height"": 800 }
+    {""width"":100,""height"":200},
+    {""width"":400,""height"":800}
   ]
-}
-";
+}";
             // Act
             var actual = InfoJsonBuilder.GetImageApi2_1Level0(
                 "https://test.example.com/iiif-img/2/1/jackal",
                 new List<int[]> { new[] { 400, 800 }, new[] { 100, 200 } });
             
             // Assert
-            actual.Should().BeEquivalentTo(expected);
+            var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
+            normalisedJson.Should().BeEquivalentTo(expected);
         }
         
         [Fact]
@@ -44,27 +46,52 @@ namespace DLCS.Model.Tests.Assets
         {
             // Arrange
             var expected = @"{
-""@context"":""http://iiif.io/api/image/2/context.json"",
-""@id"":""https://test.example.com/iiif-img/2/1/jackal"",
-""protocol"": ""http://iiif.io/api/image"",
-""profile"": [
-  ""http://iiif.io/api/image/2/level1.json"",
-  {
-    ""formats"": [ ""jpg"" ],
-    ""qualities"": [ ""native"",""color"",""gray"" ],
-    ""supports"": [ ""regionByPct"",""sizeByForcedWh"",""sizeByWh"",""sizeAboveFull"",""rotationBy90s"",""mirroring"",""gray"" ]
-  }
+  ""@context"": ""http://iiif.io/api/image/2/context.json"",
+  ""@id"": ""https://test.example.com/iiif-img/2/1/jackal"",
+  ""profile"": [
+    ""http://iiif.io/api/image/2/level1.json"",
+    {
+      ""formats"": [""jpg""],
+      ""qualities"": [
+        ""native"",
+        ""color"",
+        ""gray""
+      ],
+      ""supports"": [
+        ""regionByPct"",
+        ""sizeByForcedWh"",
+        ""sizeByWh"",
+        ""sizeAboveFull"",
+        ""rotationBy90s"",
+        ""mirroring"",
+        ""gray""
+      ]
+    }
   ],
+  ""protocol"": ""http://iiif.io/api/image"",
   ""width"": 4200,
   ""height"": 8400,
-  ""tiles"": [
-    { ""width"": 256, ""height"": 256, ""scaleFactors"": [ 1, 2, 4, 8, 16, 32, 64 ] }
-  ],
   ""sizes"": [
-    { ""width"": 100, ""height"": 200 }, { ""width"": 400, ""height"": 800 }, { ""width"": 1000, ""height"": 2000 }
+    {""width"":100,""height"":200},
+    {""width"":400,""height"":800},
+    {""width"":1000,""height"":2000}
+  ],
+  ""tiles"": [
+    {
+      ""width"": 256,
+      ""height"": 256,
+      ""scaleFactors"": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64
+      ]
+    }
   ]
-}
-";
+}";
             // Act
             var actual = InfoJsonBuilder.GetImageApi2_1Level1(
                 "https://test.example.com/iiif-img/2/1/jackal",
@@ -72,7 +99,8 @@ namespace DLCS.Model.Tests.Assets
                 new List<int[]> {  new[] { 1000, 2000 }, new[] { 400, 800 }, new[] { 100, 200 } });
             
             // Assert
-            actual.Should().BeEquivalentTo(expected);
+            var normalisedJson = actual.AsJson().Replace("\r\n", "\n");
+            normalisedJson.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/DLCS.Model/Assets/Asset.cs
+++ b/DLCS.Model/Assets/Asset.cs
@@ -34,7 +34,7 @@ namespace DLCS.Model.Assets
         public bool Ingesting { get; set; }
         public string ImageOptimisationPolicy { get; set; } = "";
         public string ThumbnailPolicy { get; set; }
-        public char Family { get; set; }
+        public AssetFamily Family { get; set; }
         public string MediaType { get; set; }
         public long Duration { get; set; }
 

--- a/DLCS.Model/Assets/AssetFamily.cs
+++ b/DLCS.Model/Assets/AssetFamily.cs
@@ -1,0 +1,23 @@
+﻿namespace DLCS.Model.Assets
+{
+    /// <summary>
+    /// Represents the family of an asset in DLCS.
+    /// </summary>
+    public enum AssetFamily
+    {
+        /// <summary>
+        /// Represents an image asset.
+        /// </summary>
+        Image = 'I',
+        
+        /// <summary>
+        /// Represents a time based asset (audio or video).
+        /// </summary>
+        Timebased = 'T',
+        
+        /// <summary>
+        /// Represents a file asset (pdf, docx etc).
+        /// </summary>
+        File = 'F'
+    }
+}

--- a/DLCS.Model/Assets/InfoJsonBuilder.cs
+++ b/DLCS.Model/Assets/InfoJsonBuilder.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using IIIF;
 using IIIF.ImageApi.Service;
-using IIIF.Presentation.V2;
 
 namespace DLCS.Model.Assets
 {
@@ -19,7 +18,7 @@ namespace DLCS.Model.Assets
         /// <param name="serviceEndpoint">URI for image</param>
         /// <param name="sizes">List of sizes image is available in.</param>
         /// <returns>info.json object</returns>
-        public static JsonLdBase GetImageApi2_1Level0(string serviceEndpoint, List<int[]> sizes)
+        public static ImageService2 GetImageApi2_1Level0(string serviceEndpoint, List<int[]> sizes)
         {
             var imageService = new ImageService2
             {
@@ -47,7 +46,7 @@ namespace DLCS.Model.Assets
         /// <param name="width">Width of image</param>
         /// <param name="height">Height of image</param>
         /// <returns>info.json string</returns>
-        public static JsonLdBase GetImageApi2_1Level1(string serviceEndpoint, int width, int height,
+        public static ImageService2 GetImageApi2_1Level1(string serviceEndpoint, int width, int height,
             List<int[]> sizes)
         {
             var imageService = new ImageService2

--- a/DLCS.Model/Assets/InfoJsonBuilder.cs
+++ b/DLCS.Model/Assets/InfoJsonBuilder.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using IIIF;
+using IIIF.ImageApi.Service;
+using IIIF.Presentation.V2;
 
 namespace DLCS.Model.Assets
 {
@@ -15,31 +18,27 @@ namespace DLCS.Model.Assets
         /// </summary>
         /// <param name="serviceEndpoint">URI for image</param>
         /// <param name="sizes">List of sizes image is available in.</param>
-        /// <returns>info.json string</returns>
-        public static string GetImageApi2_1Level0(string serviceEndpoint, List<int[]> sizes)
+        /// <returns>info.json object</returns>
+        public static JsonLdBase GetImageApi2_1Level0(string serviceEndpoint, List<int[]> sizes)
         {
-            const string template = @"{
-""@context"":""http://iiif.io/api/image/2/context.json"",
-""@id"":""$id$"",
-""protocol"": ""http://iiif.io/api/image"",
-""profile"": [
-  ""http://iiif.io/api/image/2/level0.json"",
-  {
-    ""formats"": [ ""jpg"" ],
-    ""qualities"": [ ""color"" ],
-    ""supports"": [ ""sizeByWhListed"" ]
-  }
-  ],
-  ""width"": $width$,
-  ""height"": $height$,
-  ""sizes"": [
-    $sizes$
-  ]
-}
-";
-            return InfoJson(serviceEndpoint, sizes, template);
+            var imageService = new ImageService2
+            {
+                Context = ImageService2.Image2Context,
+                Id = serviceEndpoint,
+                Type = null,
+                Protocol = ImageService2.Image2Protocol,
+                Profile = ImageService2.Level0Profile,
+                ProfileDescription = new ProfileDescription
+                {
+                    Formats = new[] { "jpg" },
+                    Qualities = new[] { "color" },
+                    Supports = new[] { "sizeByWhListed" }
+                }
+            };
+            SetSizes(imageService, sizes);
+            return imageService;
         }
-        
+
         /// <summary>
         /// Get full info.json for use by image-services
         /// </summary>
@@ -48,31 +47,26 @@ namespace DLCS.Model.Assets
         /// <param name="width">Width of image</param>
         /// <param name="height">Height of image</param>
         /// <returns>info.json string</returns>
-        public static string GetImageApi2_1Level1(string serviceEndpoint, int width, int height, List<int[]> sizes)
+        public static JsonLdBase GetImageApi2_1Level1(string serviceEndpoint, int width, int height,
+            List<int[]> sizes)
         {
-            const string template = @"{
-""@context"":""http://iiif.io/api/image/2/context.json"",
-""@id"":""$id$"",
-""protocol"": ""http://iiif.io/api/image"",
-""profile"": [
-  ""http://iiif.io/api/image/2/level1.json"",
-  {
-    ""formats"": [ ""jpg"" ],
-    ""qualities"": [ ""native"",""color"",""gray"" ],
-    ""supports"": [ ""regionByPct"",""sizeByForcedWh"",""sizeByWh"",""sizeAboveFull"",""rotationBy90s"",""mirroring"",""gray"" ]
-  }
-  ],
-  ""width"": $width$,
-  ""height"": $height$,
-  ""tiles"": [
-    { ""width"": 256, ""height"": 256, ""scaleFactors"": [ $scaleFactors$ ] }
-  ],
-  ""sizes"": [
-    $sizes$
-  ]
-}
-";
-            return InfoJson(serviceEndpoint, sizes, template, width, height);
+            var imageService = new ImageService2
+            {
+                Context = ImageService2.Image2Context,
+                Id = serviceEndpoint,
+                Type = null,
+                Protocol = ImageService2.Image2Protocol,
+                Profile = ImageService2.Level1Profile,
+                ProfileDescription = new ProfileDescription
+                {
+                    Formats = new[] { "jpg" },
+                    Qualities = new[] { "native", "color", "gray" },
+                    Supports = new[] { "regionByPct","sizeByForcedWh","sizeByWh","sizeAboveFull","rotationBy90s","mirroring","gray" }
+                }
+            };
+            SetSizes(imageService, sizes, width, height);
+            SetScaleFactors(imageService);
+            return imageService;
         }
         
         public static string GetImageApi2_1Level1Auth(string serviceEndpoint, int width, int height, List<int[]> sizes, string services)
@@ -124,6 +118,45 @@ namespace DLCS.Model.Assets
 ";
             return InfoJson(serviceEndpoint, sizes, template);
         }
+        
+        private static void SetSizes(
+            ImageService2 imageService2,
+            List<int[]> sizes,
+            int? width = null,
+            int? height = null)
+        {
+            int workingWidth = 0;
+            int workingHeight = 0;
+            var imageSizes = sizes.OrderBy(wh => wh[0]).Select(wh => Size.FromArray(wh)).ToList();
+
+            imageService2.Width = width ?? imageSizes[^1].Width;
+            imageService2.Height = height ?? imageSizes[^1].Height;
+            imageService2.Sizes = imageSizes;
+        }
+
+        private static void SetScaleFactors(ImageService2 imageService2, int tileSize = 256)
+        {
+            var scaleFactors = GetScaleFactors(imageService2.Width, imageService2.Height, tileSize);
+            imageService2.Tiles = new List<Tile>
+            {
+                new()
+                {
+                    Height = tileSize, Width = tileSize, ScaleFactors = scaleFactors.ToArray()
+                }
+            };
+        }
+        
+        private static IEnumerable<int> GetScaleFactors(int width, int height, int tileSize)
+        {
+            var max = Math.Max(width, height);
+            var factors = new List<int> { 1 };
+            while (max > tileSize)
+            {
+                max /= 2;
+                factors.Add(factors[^1] * 2);
+            }
+            return factors;
+        }
 
         private static string InfoJson(
             string serviceEndpoint, 
@@ -156,21 +189,9 @@ namespace DLCS.Model.Assets
                 .Replace("$width$", imgWidth.ToString())
                 .Replace("$height$", imgHeight.ToString())
                 .Replace("$sizes$", sizeStr.ToString())
-                .Replace("$scaleFactors$", GetScaleFactors(imgWidth, imgHeight, tileSize));
+                .Replace("$scaleFactors$",  string.Join(", ", GetScaleFactors(imgWidth, imgHeight, tileSize)));
             
             return infoJson;
-        }
-
-        private static string GetScaleFactors(int width, int height, int tileSize)
-        {
-            var max = Math.Max(width, height);
-            var factors = new List<int> { 1 };
-            while (max > tileSize)
-            {
-                max /= 2;
-                factors.Add(factors[^1] * 2);
-            }
-            return string.Join(", ", factors);
         }
     }
 }

--- a/DLCS.Model/DLCS.Model.csproj
+++ b/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-4-0001" />
   </ItemGroup>
 
 </Project>

--- a/DLCS.Model/DLCS.Model.csproj
+++ b/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-3-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
   </ItemGroup>
 
 </Project>

--- a/DLCS.Repository/Assets/ThumbReorganiser.cs
+++ b/DLCS.Repository/Assets/ThumbReorganiser.cs
@@ -57,7 +57,6 @@ namespace DLCS.Repository.Assets
             // trouble is we do not know how big it is!
             // we'll need to fetch the image dimensions from the database, the Thumbnail policy the image was created with, and compute the sizes.
             // Then sanity check them against the known sizes.
-
             var asset = await assetRepository.GetAsset(rootKey.Key.TrimEnd('/'));
 
             // 404 Not Found Asset

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
     <PackageReference Include="Dapper" Version="2.0.90" />
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-4-0001" />
     <PackageReference Include="LazyCache" Version="2.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
     <PackageReference Include="Dapper" Version="2.0.90" />
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-3-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
     <PackageReference Include="LazyCache" Version="2.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
       <PrivateAssets>all</PrivateAssets>

--- a/DLCS.Repository/DlcsContext.cs
+++ b/DLCS.Repository/DlcsContext.cs
@@ -271,7 +271,10 @@ namespace DLCS.Repository
                 entity.Property(e => e.Family)
                     .IsRequired()
                     //.HasColumnType("char")
-                    .HasDefaultValueSql("'I'::\"char\"");
+                    .HasDefaultValueSql("'I'::\"char\"")
+                    .HasConversion(
+                        v => (char)v,
+                        v => (AssetFamily)v);
 
                 entity.Property(e => e.Finished).HasColumnType("timestamp with time zone");
 

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-3-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-4-0001" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />

--- a/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -50,10 +50,10 @@ namespace Orchestrator.Tests.Assets
         }
 
         [Theory]
-        [InlineData('I', typeof(OrchestrationImage))]
+        [InlineData(AssetFamily.Image, typeof(OrchestrationImage))]
         //[InlineData('T', typeof(OrchestrationAsset))]
         //[InlineData('F', typeof(OrchestrationFile))]
-        public async Task GetOrchestrationAsset_ReturnsCorrectType(char family, Type expectedType)
+        public async Task GetOrchestrationAsset_ReturnsCorrectType(AssetFamily family, Type expectedType)
         {
             // Arrange
             var assetId = new AssetId(1, 1, "go!");
@@ -96,9 +96,9 @@ namespace Orchestrator.Tests.Assets
         }
         
         [Theory]
-        [InlineData('T')]
-        [InlineData('F')]
-        public async Task GetOrchestrationAssetT_ReturnsOrchestrationAsset(char family)
+        [InlineData(AssetFamily.Timebased)]
+        [InlineData(AssetFamily.File)]
+        public async Task GetOrchestrationAssetT_ReturnsOrchestrationAsset(AssetFamily family)
         {
             // Arrange
             var assetId = new AssetId(1, 1, "go!");
@@ -118,7 +118,7 @@ namespace Orchestrator.Tests.Assets
             // Arrange
             var assetId = new AssetId(1, 1, "go!");
             var sizes = new List<int[]> { new[] { 100, 200 } };
-            A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset { Family = 'I' });
+            A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset { Family = AssetFamily.Image });
             A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns(sizes);
 
             // Act
@@ -130,9 +130,9 @@ namespace Orchestrator.Tests.Assets
         }
         
         [Theory]
-        [InlineData('T')]
-        [InlineData('F')]
-        public async Task GetOrchestrationAssetT_Null_IfWrongTypeAskedFor(char family)
+        [InlineData(AssetFamily.Timebased)]
+        [InlineData(AssetFamily.File)]
+        public async Task GetOrchestrationAssetT_Null_IfWrongTypeAskedFor(AssetFamily family)
         {
             // Arrange
             var assetId = new AssetId(1, 1, "go!");

--- a/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.S3;
@@ -84,12 +83,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_NotFoundHttOrigin_Returns404()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_NotFoundHttOrigin_Returns404",
-                Origin = $"{stubAddress}/not-found", Family = AssetFamily.File, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            var id = "99/1/Get_NotFoundHttOrigin_Returns404";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
+                origin: $"{stubAddress}/not-found");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
@@ -103,12 +99,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_HttpOrigin_ReturnsFile()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_HttpOrigin_ReturnsFile",
-                Origin = $"{stubAddress}/testfile", Family = AssetFamily.File, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            var id = "99/1/Get_HttpOrigin_ReturnsFile";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
+                origin: $"{stubAddress}/testfile");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
@@ -123,12 +116,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_BasicAuthHttpOrigin_ReturnsFile()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_BasicAuthHttpOrigin_ReturnsFile",
-                Origin = $"{stubAddress}/authfile", Family = AssetFamily.File, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            var id = "99/1/Get_BasicAuthHttpOrigin_ReturnsFile";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
+                origin: $"{stubAddress}/authfile");
             await dbFixture.DbContext.CustomerOriginStrategies.AddRangeAsync(new CustomerOriginStrategy
             {
                 Credentials = orchestratorFixture.ValidCreds, Customer = 99, Id = "basic-auth-file", 
@@ -148,12 +138,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_BasicAuthHttpOrigin_BadCredentials_Returns404()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_BasicAuthHttpOrigin_BadCredentials_Returns404",
-                Origin = $"{stubAddress}/forbiddenfile", Family = AssetFamily.File, MediaType = "application/pdf",
-                ThumbnailPolicy = "default"
-            });
+            var id = "99/1/Get_BasicAuthHttpOrigin_BadCredentials_Returns404";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
+                origin: $"{stubAddress}/forbiddenfile");
             await dbFixture.DbContext.CustomerOriginStrategies.AddRangeAsync(new CustomerOriginStrategy
             {
                 Credentials = orchestratorFixture.ValidCreds, Customer = 99, Id = "basic-forbidden-file", 

--- a/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -87,7 +87,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_NotFoundHttOrigin_Returns404",
-                Origin = $"{stubAddress}/not-found", Family = 'F', MediaType = "image/jpeg",
+                Origin = $"{stubAddress}/not-found", Family = AssetFamily.File, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -106,7 +106,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_HttpOrigin_ReturnsFile",
-                Origin = $"{stubAddress}/testfile", Family = 'F', MediaType = "image/jpeg",
+                Origin = $"{stubAddress}/testfile", Family = AssetFamily.File, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -126,7 +126,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_BasicAuthHttpOrigin_ReturnsFile",
-                Origin = $"{stubAddress}/authfile", Family = 'F', MediaType = "image/jpeg",
+                Origin = $"{stubAddress}/authfile", Family = AssetFamily.File, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.CustomerOriginStrategies.AddRangeAsync(new CustomerOriginStrategy
@@ -151,7 +151,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/Get_BasicAuthHttpOrigin_BadCredentials_Returns404",
-                Origin = $"{stubAddress}/forbiddenfile", Family = 'F', MediaType = "application/pdf",
+                Origin = $"{stubAddress}/forbiddenfile", Family = AssetFamily.File, MediaType = "application/pdf",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.CustomerOriginStrategies.AddRangeAsync(new CustomerOriginStrategy

--- a/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -92,7 +92,6 @@ namespace Orchestrator.Tests.Integration
             var response = await httpClient.GetAsync($"iiif-img/{id}/info.json");
 
             // Assert
-            // TODO - improve these tests when we have IIIF models
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@id"].ToString().Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_OpenImage_Correct");
             jsonResponse["height"].ToString().Should().Be("8000");

--- a/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -82,7 +82,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = 'I', MediaType = "image/jpeg",
+                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
 
@@ -116,7 +116,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = 'I', MediaType = "image/jpeg",
+                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
 
@@ -143,7 +143,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = 'I', MediaType = "image/jpeg",
+                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
 
@@ -170,7 +170,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = 'I', MediaType = "image/jpeg",
+                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
 
@@ -209,7 +209,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "", MaxUnauthorised = 500,
-                Width = 8000, Height = 8000, Roles = roleName, Family = 'I', MediaType = "image/jpeg",
+                Width = 8000, Height = 8000, Roles = roleName, Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.Roles.AddAsync(new Role
@@ -304,7 +304,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = $"99/1/test-auth{type}", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -331,7 +331,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-uv-thumb",
-                Origin = "/test/space", Family = 'I', MediaType = "image/jpeg", ThumbnailPolicy = "default"
+                Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg", ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri("http://thumbs/thumbs/99/1/test-uv-thumb/full/!200,200/0/default.jpg");
@@ -358,7 +358,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/known-thumb", Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -388,7 +388,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -418,7 +418,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -447,7 +447,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -476,7 +476,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -505,7 +505,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();
@@ -537,7 +537,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = $"99/1/{imageName}", Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = 'I', MediaType = "image/jpeg",
+                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
                 ThumbnailPolicy = "default"
             });
             await dbFixture.DbContext.SaveChangesAsync();

--- a/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Amazon.S3;
 using Amazon.S3.Model;
 using DLCS.Core.Types;
-using DLCS.Model.Assets;
 using DLCS.Model.Security;
 using DLCS.Repository.Entities;
 using FluentAssertions;
@@ -79,12 +78,7 @@ namespace Orchestrator.Tests.Integration
         {
             // Arrange
             var id = $"99/1/{nameof(GetInfoJson_OpenImage_Correct)}";
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id);
 
             await amazonS3.PutObjectAsync(new PutObjectRequest
             {
@@ -113,12 +107,7 @@ namespace Orchestrator.Tests.Integration
         {
             // Arrange
             var id = $"99/1/{nameof(GetInfoJson_OrchestratesImage)}";
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id);
 
             await amazonS3.PutObjectAsync(new PutObjectRequest
             {
@@ -140,12 +129,7 @@ namespace Orchestrator.Tests.Integration
         {
             // Arrange
             var id = $"99/1/{nameof(GetInfoJson_DoesNotOrchestratesImage_IfQueryParamPassed)}";
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id);
 
             await amazonS3.PutObjectAsync(new PutObjectRequest
             {
@@ -167,12 +151,7 @@ namespace Orchestrator.Tests.Integration
         {
             // Arrange
             var id = $"99/1/{nameof(GetInfoJson_OpenImage_ForwardedFor_Correct)}";
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "",
-                Width = 8000, Height = 8000, Roles = "", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id);
 
             await amazonS3.PutObjectAsync(new PutObjectRequest
             {
@@ -206,12 +185,7 @@ namespace Orchestrator.Tests.Integration
             var id = $"99/1/{nameof(GetInfoJson_RestrictedImage_Correct)}";
             const string roleName = "my-test-role";
             const string authServiceName = "my-auth-service";
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Origin = "", MaxUnauthorised = 500,
-                Width = 8000, Height = 8000, Roles = roleName, Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500);
             await dbFixture.DbContext.Roles.AddAsync(new Role
             {
                 Customer = 99, Id = roleName, Name = "test-role", AuthService = authServiceName
@@ -301,12 +275,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_ImageRequiresAuth_RedirectsToDeliverator(string path, string type)
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = $"99/1/test-auth{type}", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset($"99/1/test-auth{type}", roles: "basic", maxUnauthorised: 100);
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri($"http://deliverator/iiif-img/99/1/test-auth{type}/full/!200,200/0/default.jpg");
             
@@ -328,11 +297,7 @@ namespace Orchestrator.Tests.Integration
                 BucketName = "protagonist-thumbs",
                 ContentBody = "{\"o\": [[200,200]]}",
             });
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-uv-thumb",
-                Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg", ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/test-uv-thumb", origin: "/test/space");
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri("http://thumbs/thumbs/99/1/test-uv-thumb/full/!200,200/0/default.jpg");
             
@@ -355,12 +320,8 @@ namespace Orchestrator.Tests.Integration
                 ContentBody = "{\"o\": [[200,200]]}",
             });
 
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/known-thumb", Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/known-thumb", origin: "/test/space", width: 1000,
+                height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri("http://thumbs/thumbs/99/1/known-thumb/full/!200,200/0/default.jpg");
             
@@ -384,13 +345,7 @@ namespace Orchestrator.Tests.Integration
                 BucketName = "protagonist-thumbs",
                 ContentBody = "{\"o\": [[400,400], [200,200]]}",
             });
-
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!123,123/0/default.jpg");
             
@@ -414,13 +369,7 @@ namespace Orchestrator.Tests.Integration
                 BucketName = "protagonist-thumbs",
                 ContentBody = "{\"o\": [[400,400], [200,200]]}",
             });
-
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             
             // Act
@@ -444,12 +393,7 @@ namespace Orchestrator.Tests.Integration
                 ContentBody = "{\"o\": []}",
             });
 
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             
             // Act
@@ -473,12 +417,7 @@ namespace Orchestrator.Tests.Integration
                 ContentBody = "{\"o\": [[300,300]]}",
             });
 
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             
             // Act
@@ -502,12 +441,7 @@ namespace Orchestrator.Tests.Integration
                 ContentBody = "{\"o\": [[300,300]]}",
             });
 
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = id, Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!600,600/0/default.jpg");
             
@@ -533,13 +467,9 @@ namespace Orchestrator.Tests.Integration
                 BucketName = "protagonist-thumbs",
                 ContentBody = "{\"o\": []}",
             });
-            
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = $"99/1/{imageName}", Width = 1000,
-                Height = 1000, Origin = "/test/space", Family = AssetFamily.Image, MediaType = "image/jpeg",
-                ThumbnailPolicy = "default"
-            });
+
+            await dbFixture.DbContext.Images.AddTestAsset($"99/1/{imageName}", origin: "/test/space", width: 1000,
+                height: 1000);
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act

--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -1,0 +1,71 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Orchestrator.Tests.Integration.Infrastructure;
+using Test.Helpers.Integration;
+using Xunit;
+
+namespace Orchestrator.Tests.Integration
+{
+    /// <summary>
+    /// Test of all iiif-manifest handling
+    /// </summary>
+    [Trait("Category", "Integration")]
+    [Collection(StorageCollection.CollectionName)]
+    public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
+    {
+        private readonly DlcsDatabaseFixture dbFixture;
+        private readonly HttpClient httpClient;
+        
+        public ManifestHandlingTests(ProtagonistAppFactory<Startup> factory, StorageFixture storageFixture)
+        {
+            dbFixture = storageFixture.DbFixture;
+            
+            httpClient = factory
+                .WithConnectionString(dbFixture.ConnectionString)
+                .CreateClient();
+            
+            dbFixture.CleanUp();
+        }
+        
+        [Fact]
+        public async Task Get_UnknownCustomer_Returns404()
+        {
+            // Arrange
+            const string path = "iiif-manifest/1/1/my-asset";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        
+        [Fact]
+        public async Task Get_UnknownSpace_Returns404()
+        {
+            // Arrange
+            const string path = "iiif-manifest/99/5/my-asset";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        
+        [Fact]
+        public async Task Get_UnknownImage_Returns404()
+        {
+            // Arrange
+            const string path = "iiif-manifest/99/1/my-asset";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+    }
+}

--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -1,7 +1,13 @@
-﻿using System.Net;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Amazon.S3;
+using DLCS.Model.Assets;
+using DLCS.Repository.Assets;
 using FluentAssertions;
+using Newtonsoft.Json.Linq;
 using Orchestrator.Tests.Integration.Infrastructure;
 using Test.Helpers.Integration;
 using Xunit;
@@ -17,13 +23,16 @@ namespace Orchestrator.Tests.Integration
     {
         private readonly DlcsDatabaseFixture dbFixture;
         private readonly HttpClient httpClient;
-        
+        private readonly IAmazonS3 amazonS3;
+
         public ManifestHandlingTests(ProtagonistAppFactory<Startup> factory, StorageFixture storageFixture)
         {
             dbFixture = storageFixture.DbFixture;
+            amazonS3 = storageFixture.LocalStackFixture.AmazonS3;
             
             httpClient = factory
                 .WithConnectionString(dbFixture.ConnectionString)
+                .WithLocalStack(storageFixture.LocalStackFixture)
                 .CreateClient();
             
             dbFixture.CleanUp();
@@ -66,6 +75,75 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        
+        [Theory]
+        [InlineData(AssetFamily.File)]
+        [InlineData(AssetFamily.Timebased)]
+        public async Task Get_NonImage_Returns404(AssetFamily family)
+        {
+            // Arrange
+            var id = $"99/1/{nameof(Get_NonImage_Returns404)}:{family}";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: family);
+            await dbFixture.DbContext.SaveChangesAsync();
+            
+            var path = $"iiif-manifest/{id}";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        
+        [Fact]
+        public async Task Get_ManifestForImage_HandlesNoAvailableThumbs()
+        {
+            // Arrange
+            var id = $"99/1/{nameof(Get_ManifestForImage_HandlesNoAvailableThumbs)}";
+            await dbFixture.DbContext.Images.AddTestAsset(id);
+            await dbFixture.DbContext.SaveChangesAsync();
+            
+            var path = $"iiif-manifest/{id}";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+            jsonResponse["@id"].ToString().Should().Be("http://localhost/iiif-img/99/1/Get_ManifestForImage_HandlesNoAvailableThumbs");
+            jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail").Should().BeNull();
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.CacheControl.Public.Should().BeTrue();
+            response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+        }
+        
+        [Fact]
+        public async Task Get_ManifestForImage_ReturnsManifest()
+        {
+            // Arrange
+            var id = $"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}";
+            await dbFixture.DbContext.Images.AddTestAsset(id);
+            await dbFixture.DbContext.SaveChangesAsync();
+
+            var openSizes = new List<int[]> { new[] { 100, 100 }, new[] { 200, 200 } };
+            await amazonS3.AddSizesJson(id, new ThumbnailSizes(openSizes, null));
+
+            var path = $"iiif-manifest/{id}";
+
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+            jsonResponse["@id"].ToString().Should().Be("http://localhost/iiif-img/99/1/Get_ManifestForImage_ReturnsManifest");
+            jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>().Should().Be(
+                "http://localhost/thumbs/99/1/Get_ManifestForImage_ReturnsManifest/full/100,100/0/default.jpg");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.CacheControl.Public.Should().BeTrue();
+            response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         }
     }
 }

--- a/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -92,7 +92,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-noauth", Roles = "",
-                MaxUnauthorised = -1, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = -1, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath =
@@ -114,7 +114,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-auth", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -132,7 +132,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-fail", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
             const string bearerToken = "ababababab";
@@ -154,7 +154,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-pass", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -180,7 +180,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-head", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -201,7 +201,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-fail", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -222,7 +222,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-pass", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -248,7 +248,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.Images.AddAsync(new Asset
             {
                 Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-head", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = 'F', MediaType = "video/mpeg"
+                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
             });
             await dbFixture.DbContext.SaveChangesAsync();
 

--- a/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -89,11 +89,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetDoesNotRequireAuth_Returns302ToS3Location()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-noauth", Roles = "",
-                MaxUnauthorised = -1, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/test-noauth";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: -1, origin: "/test/space");
             await dbFixture.DbContext.SaveChangesAsync();
             var expectedPath =
                 new Uri(
@@ -111,11 +109,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetRequiresAuth_Returns401_IfNoAuthProvided()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/test-auth", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            string id = "99/1/test-auth";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
@@ -129,11 +125,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetRequiresAuth_Returns401_IfBearerTokenProvided_ButInvalid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-fail", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/bearer-fail";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
             const string bearerToken = "ababababab";
 
@@ -151,11 +145,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetRequiresAuth_ProxiesToS3_IfBearerTokenValid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-pass", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/bearer-pass";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
             
             var expectedPath =
@@ -177,11 +169,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Head_AssetRequiresAuth_Returns200_IfBearerTokenValid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/bearer-head", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/bearer-head";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
@@ -198,11 +188,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetRequiresAuth_Returns401_IfCookieProvided_ButInvalid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-fail", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/cookie-fail";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
@@ -219,11 +207,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_AssetRequiresAuth_ProxiesToS3_IfCookieTokenValid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-pass", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/cookie-pass";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
             
             var expectedPath =
@@ -245,11 +231,9 @@ namespace Orchestrator.Tests.Integration
         public async Task Head_AssetRequiresAuth_Returns200_IfCookieValid()
         {
             // Arrange
-            await dbFixture.DbContext.Images.AddAsync(new Asset
-            {
-                Created = DateTime.Now, Customer = 99, Space = 1, Id = "99/1/cookie-head", Roles = "basic",
-                MaxUnauthorised = 100, Origin = "/test/space", Family = AssetFamily.Timebased, MediaType = "video/mpeg"
-            });
+            var id = "99/1/cookie-head";
+            await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.Timebased, mediaType: "video/mpeg",
+                maxUnauthorised: 100, origin: "/test/space", roles: "basic");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act

--- a/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -137,7 +137,7 @@ namespace Orchestrator.Assets
         {
             switch (asset.Family)
             {
-                case 'I':
+                case AssetFamily.Image:
                     var getImageLocation = assetRepository.GetImageLocation(assetId);
                     var getOpenThumbs = thumbRepository.GetOpenSizes(assetId);
                     var getOrchestrationStatus = statusProvider.GetOrchestrationStatus(assetId);
@@ -154,7 +154,7 @@ namespace Orchestrator.Assets
                         OpenThumbs = getOpenThumbs.Result, // TODO - reorganise thumb layout + create missing eventually
                         Status = getOrchestrationStatus.Result
                     };
-                case 'F':
+                case AssetFamily.File:
                     return new OrchestrationFile
                     {
                         AssetId = assetId, RequiresAuth = asset.RequiresAuth, Origin = asset.Origin,

--- a/Orchestrator/Features/Images/ImageController.cs
+++ b/Orchestrator/Features/Images/ImageController.cs
@@ -41,7 +41,7 @@ namespace Orchestrator.Features.Images
         /// Optional query parameter, if true then info.json request will not trigger orchestration
         /// </param>
         /// <param name="cancellationToken">Async cancellation token</param>
-        /// <returns></returns>
+        /// <returns>IIIF info.json for specified manifest.</returns>
         [Route("info.json", Name = "info_json")]
         [HttpGet]
         public Task<IActionResult> InfoJson([FromQuery] bool noOrchestrate = false,

--- a/Orchestrator/Features/Images/ImageController.cs
+++ b/Orchestrator/Features/Images/ImageController.cs
@@ -1,36 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Repository.Caching;
-using DLCS.Repository.Settings;
 using MediatR;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Net.Http.Headers;
 using Orchestrator.Features.Images.Requests;
+using Orchestrator.Infrastructure;
 
 namespace Orchestrator.Features.Images
 {
     [Route("iiif-img/{customer}/{space}/{image}")]
     [ApiController]
-    public class ImageController : Controller
+    public class ImageController : IIIFAssetControllerBase
     {
-        private readonly IMediator mediator;
-        private readonly ILogger<ImageController> logger;
-        private readonly CacheSettings cacheSettings;
-
         public ImageController(
             IMediator mediator, 
             IOptions<CacheSettings> cacheSettings,
-            ILogger<ImageController> logger)
+            ILogger<ImageController> logger) : base(mediator, cacheSettings, logger)
         {
-            this.mediator = mediator;
-            this.logger = logger;
-            this.cacheSettings = cacheSettings.Value;
         }
 
         /// <summary>
@@ -56,46 +44,9 @@ namespace Orchestrator.Features.Images
         /// <returns></returns>
         [Route("info.json", Name = "info_json")]
         [HttpGet]
-        public async Task<IActionResult> InfoJson([FromQuery] bool noOrchestrate = false, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                var infoJsonResponse =
-                    await mediator.Send(new GetImageInfoJson(HttpContext.Request.Path, noOrchestrate),
-                        cancellationToken);
-                if (!infoJsonResponse.HasInfoJson) return NotFound();
-
-                if (infoJsonResponse.RequiresAuth)
-                {
-                    Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-                }
-
-                SetCacheControl(infoJsonResponse.RequiresAuth);
-                HttpContext.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding" };
-                return Content(infoJsonResponse.InfoJson, "application/json");
-            }
-            catch (KeyNotFoundException ex)
-            {
-                // TODO - this error handling duplicates same in RequestHandlerBase
-                logger.LogError(ex, "Could not find Customer/Space from '{Path}'", HttpContext.Request.Path);
-                return NotFound();
-            }
-            catch (FormatException ex)
-            {
-                logger.LogError(ex, "Error parsing path '{Path}'", HttpContext.Request.Path);
-                return BadRequest();
-            }
-        }
-        
-        private void SetCacheControl(bool requiresAuth)
-        {
-            HttpContext.Response.GetTypedHeaders().CacheControl =
-                new CacheControlHeaderValue
-                {
-                    Public = !requiresAuth,
-                    Private = requiresAuth,
-                    MaxAge = TimeSpan.FromSeconds(cacheSettings.GetTtl(CacheDuration.Default, CacheSource.Http))
-                };
-        }
+        public Task<IActionResult> InfoJson([FromQuery] bool noOrchestrate = false,
+            CancellationToken cancellationToken = default)
+            => GenerateIIIFJsonResponse(() => new GetImageInfoJson(HttpContext.Request.Path, noOrchestrate),
+                cancellationToken);
     }
 }

--- a/Orchestrator/Features/Manifests/GetManifestForAsset.cs
+++ b/Orchestrator/Features/Manifests/GetManifestForAsset.cs
@@ -1,9 +1,23 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core;
+using DLCS.Core.Collections;
+using DLCS.Model.Assets;
 using DLCS.Web.Requests.AssetDelivery;
+using DLCS.Web.Response;
+using IIIF;
+using IIIF.ImageApi.Service;
+using IIIF.Presentation.V2;
+using IIIF.Presentation.V2.Annotation;
+using IIIF.Presentation.V2.Strings;
+using IIIF.Serialisation;
 using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.Mediatr;
 using Orchestrator.Models;
+using Orchestrator.Settings;
 
 namespace Orchestrator.Features.Manifests
 {
@@ -24,9 +38,124 @@ namespace Orchestrator.Features.Manifests
     
     public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, IIIFJsonResponse>
     {
-        public Task<IIIFJsonResponse> Handle(GetManifestForAsset request, CancellationToken cancellationToken)
+        private readonly IAssetRepository assetRepository;
+        private readonly IAssetPathGenerator assetPathGenerator;
+        private readonly IThumbRepository thumbRepository;
+        private readonly ILogger<GetManifestForAssetHandler> logger;
+        private readonly OrchestratorSettings orchestratorSettings;
+
+        public GetManifestForAssetHandler(
+            IAssetRepository assetRepository,
+            IAssetPathGenerator assetPathGenerator,
+            IThumbRepository thumbRepository,
+            IOptions<OrchestratorSettings> orchestratorSettings,
+            ILogger<GetManifestForAssetHandler> logger)
         {
-            return Task.FromResult(IIIFJsonResponse.Empty);
+            this.assetRepository = assetRepository;
+            this.assetPathGenerator = assetPathGenerator;
+            this.thumbRepository = thumbRepository;
+            this.orchestratorSettings = orchestratorSettings.Value;
+            this.logger = logger;
         }
+
+        public async Task<IIIFJsonResponse> Handle(GetManifestForAsset request, CancellationToken cancellationToken)
+        {
+            var assetId = request.AssetRequest.GetAssetId();
+            var asset = await assetRepository.GetAsset(assetId);
+            if (asset is not { Family: AssetFamily.Image })
+            {
+                logger.LogDebug("Request iiif-manifest for asset {AssetId} but is not found or not an image", assetId);
+                return IIIFJsonResponse.Empty;
+            }
+
+            var openThumbs = await thumbRepository.GetOpenSizes(assetId);
+            var manifest = GenerateV2Manifest(request.AssetRequest, asset, openThumbs);
+
+            return IIIFJsonResponse.Open(manifest.AsJson());
+        }
+
+        private Manifest GenerateV2Manifest(BaseAssetRequest assetRequest, Asset asset, List<int[]>? openThumbs)
+        {
+            var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ImagePath);
+            var manifest = new Manifest
+            {
+                Id = fullyQualifiedImageId,
+                Context = IIIF.Presentation.Context.V2,
+                Metadata = new Metadata
+                    {
+                        Label = new MetaDataValue("origin"),
+                        Value = new MetaDataValue(asset.Origin)
+                    }
+                    .AsList(),
+                Sequences = new Sequence
+                {
+                    Id = string.Concat(fullyQualifiedImageId, "/sequence/s0"),
+                    Label = new MetaDataValue("Sequence 0"),
+                    ViewingHint = "paged",
+                    Canvases = CreateCanvases(fullyQualifiedImageId, assetRequest, asset, openThumbs)
+                }.AsList()
+            };
+
+            return manifest;
+        }
+
+        private List<Canvas> CreateCanvases(string fullyQualifiedImageId, BaseAssetRequest assetRequest, Asset asset, List<int[]>? openThumbs)
+        {
+            var fullyQualifiedThumbId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ThumbsPath);
+
+            string thumbExample = string.Empty;
+            if (!openThumbs.IsNullOrEmpty())
+            {
+                var smallestThumb = Size.FromArray(openThumbs[^1]);
+                thumbExample = $"{fullyQualifiedThumbId}/full/{smallestThumb.Width},{smallestThumb.Height}/0/default.jpg";
+            }
+
+            var imageExample = $"{fullyQualifiedImageId}/full/{asset.Width},{asset.Height}/0/default.jpg";
+
+            var canvasId = string.Concat(fullyQualifiedImageId, "/canvas/c/0");
+            var canvas = new Canvas
+            {
+                Id = canvasId,
+                Label = new MetaDataValue($"Image - {assetRequest.GetAssetId()}"),
+                Thumbnail = new Thumbnail
+                {
+                    Id = thumbExample,
+                    Service = (InfoJsonBuilder.GetImageApi2_1Level0(fullyQualifiedThumbId, openThumbs) as IService)
+                        .AsList()
+                }.AsList(),
+                Height = asset.Height,
+                Width = asset.Width,
+                Images = new ImageAnnotation
+                {
+                    Id = string.Concat(fullyQualifiedImageId, "/imageanno/0"),
+                    On = canvasId,
+                    Resource = new ImageResource
+                    {
+                        Id = imageExample,
+                        Width = asset.Width,
+                        Height = asset.Height,
+                        Service = new ImageService2
+                        {
+                            Id = fullyQualifiedImageId,
+                            Profile = ImageService2.Level1Profile,
+                            Width = asset.Width,
+                            Height = asset.Height,
+                        }.AsListOf<IService>()
+                    }
+                }.AsList()
+            };
+
+            return canvas.AsList();
+        }
+        
+        private string GetFullyQualifiedId(BaseAssetRequest baseAssetRequest, string prefix)
+            => assetPathGenerator.GetFullPathForRequest(
+                baseAssetRequest,
+                (assetRequest, template) => DlcsPathHelpers.GeneratePathFromTemplate(
+                    template,
+                    prefix,
+                    assetRequest.CustomerPathValue,
+                    assetRequest.Space.ToString(),
+                    assetRequest.AssetId));
     }
 }

--- a/Orchestrator/Features/Manifests/GetManifestForAsset.cs
+++ b/Orchestrator/Features/Manifests/GetManifestForAsset.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Web.Requests.AssetDelivery;
+using MediatR;
+using Orchestrator.Infrastructure.Mediatr;
+using Orchestrator.Models;
+
+namespace Orchestrator.Features.Manifests
+{
+    /// <summary>
+    /// Mediatr request for generating basic single-item manifest for specified image
+    /// </summary>
+    public class GetManifestForAsset : IRequest<IIIFJsonResponse>, IGenericAssetRequest
+    {
+        public string FullPath { get; }
+        
+        public BaseAssetRequest AssetRequest { get; set; }
+
+        public GetManifestForAsset(string path)
+        {
+            FullPath = path;
+        }
+    }
+    
+    public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, IIIFJsonResponse>
+    {
+        public Task<IIIFJsonResponse> Handle(GetManifestForAsset request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(IIIFJsonResponse.Empty);
+        }
+    }
+}

--- a/Orchestrator/Features/Manifests/ManifestController.cs
+++ b/Orchestrator/Features/Manifests/ManifestController.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Repository.Caching;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orchestrator.Infrastructure;
+
+namespace Orchestrator.Features.Manifests
+{
+    [Route("iiif-manifest")]
+    [ApiController]
+    public class ManifestController : IIIFAssetControllerBase
+    {
+        public ManifestController(
+            IMediator mediator, 
+            IOptions<CacheSettings> cacheSettings,
+            ILogger<ManifestController> logger
+            ) : base(mediator, cacheSettings, logger)
+        {
+        }
+
+        /// <summary>
+        /// Get single-item manifest for specified asset
+        /// </summary>
+        /// <param name="cancellationToken">Async cancellation token</param>
+        /// <returns>IIIF manifest containing specified item</returns>
+        [Route("{customer}/{space}/{image}")]
+        [HttpGet]
+        public Task<IActionResult> Index(CancellationToken cancellationToken = default)
+            => GenerateIIIFJsonResponse(() => new GetManifestForAsset(HttpContext.Request.Path), cancellationToken);
+    }
+}

--- a/Orchestrator/Infrastructure/IIIFAssetControllerBase.cs
+++ b/Orchestrator/Infrastructure/IIIFAssetControllerBase.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Repository.Caching;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Orchestrator.Infrastructure.Mediatr;
+using Orchestrator.Models;
+
+namespace Orchestrator.Infrastructure
+{
+    /// <summary>
+    /// Base class for controllers that generate <see cref="IIIFJsonResponse"/> from <see cref="IAssetRequest"/> request 
+    /// </summary>
+    public abstract class IIIFAssetControllerBase : Controller
+    {
+        protected readonly IMediator mediator;
+        protected readonly ILogger<IIIFAssetControllerBase> logger;
+        protected readonly CacheSettings cacheSettings;
+
+        protected IIIFAssetControllerBase(
+            IMediator mediator,
+            IOptions<CacheSettings> cacheSettings,
+            ILogger<IIIFAssetControllerBase> logger
+        )
+        {
+            this.mediator = mediator;
+            this.logger = logger;
+            this.cacheSettings = cacheSettings.Value;
+        }
+
+        /// <summary>
+        /// Generate <see cref="IIIFJsonResponse"/> from <see cref="IAssetRequest"/> request. Handles known issues
+        /// parsing asset request and sets appropriate headers on response.
+        /// </summary>
+        /// <param name="generateRequest">Function to generate mediatr request.</param>
+        /// <param name="cancellationToken">Current cancellation token.</param>
+        /// <typeparam name="T">
+        /// Type of mediatr request, must be <see cref="IAssetRequest"/> and return <see cref="IIIFJsonResponse"/>
+        /// </typeparam>
+        /// <returns>IActionResult, will be NotFoundResult ,BadRequestResult or ContentResult if successful</returns>
+        protected async Task<IActionResult> GenerateIIIFJsonResponse<T>(Func<T> generateRequest,
+            CancellationToken cancellationToken = default)
+            where T : IRequest<IIIFJsonResponse>, IAssetRequest
+        {
+            try
+            {
+                var request = generateRequest();
+                var infoJsonResponse = await mediator.Send(request, cancellationToken);
+                if (!infoJsonResponse.HasInfoJson) return NotFound();
+
+                if (infoJsonResponse.RequiresAuth)
+                {
+                    Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+                }
+
+                SetCacheControl(infoJsonResponse.RequiresAuth);
+                HttpContext.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding" };
+                return Content(infoJsonResponse.InfoJson, "application/json");
+            }
+            catch (KeyNotFoundException ex)
+            {
+                // TODO - this error handling duplicates same in RequestHandlerBase
+                logger.LogError(ex, "Could not find Customer/Space from '{Path}'", HttpContext.Request.Path);
+                return NotFound();
+            }
+            catch (FormatException ex)
+            {
+                logger.LogError(ex, "Error parsing path '{Path}'", HttpContext.Request.Path);
+                return BadRequest();
+            }
+        }
+
+        private void SetCacheControl(bool requiresAuth)
+        {
+            var maxAge = TimeSpan.FromSeconds(cacheSettings.GetTtl(CacheDuration.Default, CacheSource.Http));
+            HttpContext.Response.GetTypedHeaders().CacheControl =
+                new CacheControlHeaderValue
+                {
+                    Public = !requiresAuth,
+                    Private = requiresAuth,
+                    MaxAge = maxAge,
+                    SharedMaxAge = requiresAuth ? null : maxAge
+                };
+        }
+    }
+}

--- a/Orchestrator/Infrastructure/Mediatr/AssetRequestParsingBehavior.cs
+++ b/Orchestrator/Infrastructure/Mediatr/AssetRequestParsingBehavior.cs
@@ -23,19 +23,25 @@ namespace Orchestrator.Infrastructure.Mediatr
         public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken,
             RequestHandlerDelegate<TResponse> next)
         {
-            if (request is IImageRequest imageRequest)
+            switch (request)
             {
-                imageRequest.AssetRequest =
-                    await assetDeliveryPathParser.Parse<ImageAssetDeliveryRequest>(request.FullPath);
+                case IImageRequest imageRequest:
+                    imageRequest.AssetRequest =
+                        await assetDeliveryPathParser.Parse<ImageAssetDeliveryRequest>(request.FullPath);
+                    break;
+                case IFileRequest fileRequest:
+                    fileRequest.AssetRequest =
+                        await assetDeliveryPathParser.Parse<FileAssetDeliveryRequest>(request.FullPath);
+                    break;
+                case IGenericAssetRequest genericRequest:
+                    genericRequest.AssetRequest =
+                        await assetDeliveryPathParser.Parse<BaseAssetRequest>(request.FullPath);
+                    break;
             }
-            else if (request is IFileRequest fileRequest)
-            {
-                fileRequest.AssetRequest =
-                    await assetDeliveryPathParser.Parse<FileAssetDeliveryRequest>(request.FullPath);
-            }
+
             // TODO - error handling
-            // TODO - image and TimeBased handling
-            return await next(); // Thing that we implement
+            // TODO - timeBased handling
+            return await next();
         }
     }
 }

--- a/Orchestrator/Infrastructure/Mediatr/IAssetRequest.cs
+++ b/Orchestrator/Infrastructure/Mediatr/IAssetRequest.cs
@@ -11,7 +11,7 @@ namespace Orchestrator.Infrastructure.Mediatr
     {
         string FullPath { get; }
     }
-    
+
     /// <summary>
     /// Marker interface for any File asset requests
     /// </summary>
@@ -26,5 +26,13 @@ namespace Orchestrator.Infrastructure.Mediatr
     public interface IImageRequest : IAssetRequest
     {
         ImageAssetDeliveryRequest AssetRequest { set; }
+    }
+    
+    /// <summary>
+    /// Marker interface for any asset requests
+    /// </summary>
+    public interface IGenericAssetRequest : IAssetRequest
+    {
+        BaseAssetRequest AssetRequest { set; }
     }
 }

--- a/Orchestrator/Models/IIIFJsonResponse.cs
+++ b/Orchestrator/Models/IIIFJsonResponse.cs
@@ -1,0 +1,28 @@
+﻿namespace Orchestrator.Models
+{
+    public class IIIFJsonResponse
+    {
+        // TODO - use JsonLdBase, rather than string
+        public string? InfoJson { get; private init; }
+        public bool HasInfoJson { get; private init; }
+        public bool RequiresAuth { get; private init; }
+
+        public static IIIFJsonResponse Empty = new();
+
+        public static IIIFJsonResponse Open(string infoJson) 
+            => new()
+            {
+                InfoJson = infoJson,
+                RequiresAuth = false,
+                HasInfoJson = true
+            };
+
+        public static IIIFJsonResponse Restricted(string infoJson) 
+            => new()
+            {
+                InfoJson = infoJson,
+                RequiresAuth = true,
+                HasInfoJson = true
+            };
+    }
+}

--- a/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/Orchestrator/Settings/OrchestratorSettings.cs
@@ -111,6 +111,11 @@ namespace Orchestrator.Settings
         /// Get the root path that thumb handler is listening on
         /// </summary>
         public string ThumbResizePath { get; set; } = "thumbs";
+        
+        /// <summary>
+        /// Get the root path for serving images
+        /// </summary>
+        public string ImagePath { get; set; } = "iiif-img";
 
         /// <summary>
         /// A collection of resize config for serving resized thumbs rather than handling requests via image-server

--- a/Orchestrator/appsettings.json
+++ b/Orchestrator/appsettings.json
@@ -22,6 +22,7 @@
   },
   "Proxy": {
     "ThumbsPath": "thumbs",
+    "ImagePath": "iiif-img",
     "CheckUVThumbs": true,
     "UVThumbReplacementPath": "!200,200",
     "CanResizeThumbs": true

--- a/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using DLCS.Model.Assets;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace Test.Helpers.Integration
+{
+    public static class DatabaseTestDataPopulation
+    {
+        public static ValueTask<EntityEntry<Asset>> AddTestAsset(this DbSet<Asset> assets, 
+            string id, 
+            AssetFamily family = AssetFamily.Image,
+            int customer = 99,
+            int space = 1,
+            string origin = "",
+            string roles = "",
+            string mediaType = "imag/jpeg",
+            int maxUnauthorised = 0,
+            int width = 8000,
+            int height = 8000) 
+            =>
+            assets.AddAsync(new Asset
+            {
+                Created = DateTime.Now, Customer = customer, Space = space, Id = id, Origin = origin,
+                Width = width, Height = height, Roles = roles, Family = family, MediaType = mediaType,
+                ThumbnailPolicy = "default", MaxUnauthorised = maxUnauthorised
+            });
+    }
+}

--- a/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -15,7 +15,7 @@ namespace Test.Helpers.Integration
             int space = 1,
             string origin = "",
             string roles = "",
-            string mediaType = "imag/jpeg",
+            string mediaType = "image/jpeg",
             int maxUnauthorised = 0,
             int width = 8000,
             int height = 8000) 

--- a/Test.Helpers/Integration/S3TestDataPopulation.cs
+++ b/Test.Helpers/Integration/S3TestDataPopulation.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Amazon.S3;
+using Amazon.S3.Model;
+using DLCS.Repository.Assets;
+using Newtonsoft.Json;
+
+namespace Test.Helpers.Integration
+{
+    public static class S3TestDataPopulation
+    {
+        public static Task AddSizesJson(this IAmazonS3 amazonS3, string assetId, ThumbnailSizes thumbnailSizes)
+        {
+            return amazonS3.PutObjectAsync(new PutObjectRequest
+            {
+                Key = $"{assetId}/s.json",
+                BucketName = "protagonist-thumbs",
+                ContentBody = JsonConvert.SerializeObject(thumbnailSizes)
+            });
+        }
+    }
+}

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.0.45" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-4-0001" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AWSSDK.Core" Version="3.7.0.45" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
-    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-3-0001" />
+    <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-5-0001" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -4,6 +4,7 @@ using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
+using IIIF.Serialisation;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -119,7 +120,7 @@ namespace Thumbs
             
             var id = displayUrl.Substring(0, displayUrl.LastIndexOf("/", StringComparison.CurrentCultureIgnoreCase));
             var infoJsonText = InfoJsonBuilder.GetImageApi2_1Level0(id, sizes);
-            await context.Response.WriteAsync(infoJsonText);
+            await context.Response.WriteAsync(infoJsonText.AsJson());
         }
 
         private Task RedirectToInfoJson(HttpContext context, ImageAssetDeliveryRequest imageAssetDeliveryRequest)


### PR DESCRIPTION
Add new route for `/iiif-manifest/{cust}/{space}/{asset}` which will generate a single asset manifest. This only works for Image assets, as per current version. Refactored `ImageController` and introduced `IIIFAssetControllerBase` base class as the error handling/response handling for info.json and manifests are very similar.

Took this opportunity to update info.json generation to use models from `iiif-net` nuget package, rather than string manipulation. This is still a WiP, only those methods called have been updated.

Updated `Asset` entity to store `AssetFamily` enum, rather than just a char.

> Note - this is merging into branch for #112 as that's required to use iiif-net nuget package.