### PR TITLE
Add route for favicon.ico requests

### DIFF
--- a/Orchestrator.Tests/Integration/FallbackProxyTests.cs
+++ b/Orchestrator.Tests/Integration/FallbackProxyTests.cs
@@ -41,11 +41,10 @@ namespace Orchestrator.Tests.Integration
         {
             // NOTE: This is everything except iiif-img and iiif-av routes
             // Arrange
-            var message = new HttpRequestMessage(HttpMethod.Get, path);
             var expectedPath = new Uri($"http://deliverator{path}");
             
             // Act
-            var response = await httpClient.SendAsync(message);
+            var response = await httpClient.GetAsync(path);
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -53,6 +52,16 @@ namespace Orchestrator.Tests.Integration
 
             proxyResponse.Uri.Should().Be(expectedPath);
             proxyResponse.Method.Should().Be(HttpMethod.Get);
+        }
+
+        [Fact]
+        public async Task Favicon_Returns404()
+        {
+            // Act
+            var response = await httpClient.GetAsync("favicon.ico");
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
     }
 }

--- a/Orchestrator/Startup.cs
+++ b/Orchestrator/Startup.cs
@@ -1,4 +1,5 @@
 using System.Net.Http;
+using System.Threading.Tasks;
 using Amazon.S3;
 using API.Client;
 using DLCS.Core.Encryption;
@@ -163,6 +164,11 @@ namespace Orchestrator
                 .UseAuthorization()
                 .UseEndpoints(endpoints =>
                 {
+                    endpoints.MapGet("favicon.ico", context =>
+                    {
+                        context.Response.StatusCode = 404;
+                        return Task.CompletedTask;
+                    });
                     endpoints.MapControllers();
                     endpoints.MapReverseProxy();
                     endpoints.MapImageHandling();


### PR DESCRIPTION
Default handling is that Yarp kicks in and attempts to send to downstream target