### PR TITLE
Upgrade yarp to rc-1

### DIFF
--- a/Orchestrator/Features/Images/ImageRouteHandlers.cs
+++ b/Orchestrator/Features/Images/ImageRouteHandlers.cs
@@ -39,7 +39,7 @@ namespace Orchestrator.Features.Images
             DefaultTransformer = HttpTransformer.Default;
             
             // TODO - make this configurable, potentially by target
-            RequestOptions = new ForwarderRequestConfig {Timeout = TimeSpan.FromSeconds(100)};  
+            RequestOptions = new ForwarderRequestConfig {ActivityTimeout = TimeSpan.FromSeconds(60)};  
         }
 
         /// <summary>

--- a/Orchestrator/Features/TimeBased/TimeBasedRouteHandlers.cs
+++ b/Orchestrator/Features/TimeBased/TimeBasedRouteHandlers.cs
@@ -35,7 +35,7 @@ namespace Orchestrator.Features.TimeBased
             });
 
             DefaultTransformer = HttpTransformer.Default;
-            RequestOptions = new ForwarderRequestConfig {Timeout = TimeSpan.FromSeconds(100)};
+            RequestOptions = new ForwarderRequestConfig {ActivityTimeout = TimeSpan.FromSeconds(60)};
         }
         
         /// <summary>

--- a/Orchestrator/Orchestrator.csproj
+++ b/Orchestrator/Orchestrator.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.10" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-        <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.12.21328.2" />
+        <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-rc.1.21520.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Test.Helpers/Test.Helpers.csproj
+++ b/Test.Helpers/Test.Helpers.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
-      <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-preview.12.21328.2" />
+      <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-rc.1.21520.4" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Only breaking change was `ForwarderRequestConfig.Timeout` becoming `ActivityTimeout` (see breaking changes https://github.com/microsoft/reverse-proxy/releases/tag/v1.0.0-rc.1).

All tests passing.