### PR TITLE
Add Vary:Accepts header to manifest and NQ results

### DIFF
--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -160,6 +160,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
@@ -181,6 +182,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
@@ -205,6 +207,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
@@ -226,6 +229,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
@@ -247,6 +251,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");

--- a/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -95,6 +95,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(3);
@@ -112,6 +113,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(3);
@@ -131,6 +133,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("items").Count().Should().Be(3);
@@ -148,6 +151,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("items").Count().Should().Be(3);
@@ -165,6 +169,7 @@ namespace Orchestrator.Tests.Integration
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Vary.Should().Contain("Accept");
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("items").Count().Should().Be(3);

--- a/Orchestrator/Infrastructure/IIIFAssetControllerBase.cs
+++ b/Orchestrator/Infrastructure/IIIFAssetControllerBase.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using Orchestrator.Infrastructure.Mediatr;
 using Orchestrator.Models;
@@ -65,7 +66,7 @@ namespace Orchestrator.Infrastructure
                 }
 
                 SetCacheControl(descriptionResource.RequiresAuth);
-                HttpContext.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding" };
+                HttpContext.Response.Headers[HeaderNames.Vary] = new[] { "Accept-Encoding", "Accept" };
                 return Content(descriptionResource.DescriptionResource, contentType);
             }
             catch (KeyNotFoundException ex)


### PR DESCRIPTION
This avoids issues where cached copies of wrong version are served