### PR TITLE
Remove https-redirection as handled at load balancer

### DIFF
--- a/Orchestrator/Startup.cs
+++ b/Orchestrator/Startup.cs
@@ -137,13 +137,8 @@ namespace Orchestrator
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                
             }
-
-            if (env.IsProduction())
-            {
-                app.UseHttpsRedirection();
-            }
-
             app
                 .HandlePathBase(pathBase, logger)
                 .UseForwardedHeaders()


### PR DESCRIPTION
When running in production we sit behind an load balancer that handles tls and redirections so there's no need to run the middleware here.

Can be added back in at a later date if required.