### PR TITLE
Tweaks to generated manifests

### DIFF
--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -111,7 +111,7 @@ namespace Orchestrator.Tests.Integration
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
             jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
-                .Should().Be($"http://localhost/thumbs/{id}");
+                .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.Headers.CacheControl.Public.Should().BeTrue();
@@ -135,7 +135,7 @@ namespace Orchestrator.Tests.Integration
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
             jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
-                .Should().Be($"http://localhost/thumbs/{id}");
+                .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             response.Headers.CacheControl.Public.Should().BeTrue();

--- a/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -86,7 +86,7 @@ namespace Orchestrator.Infrastructure.IIIF
                 {
                     canvas.Thumbnail = new IIIF3.Content.Image
                     {
-                        Id = GetFullQualifiedThumbServicePath(i, customerPathElement),
+                        Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
                         Format = "image/jpeg",
                         Service = GetImageServiceForThumbnail(i, customerPathElement,
                             thumbnailSizes.OpenThumbnails)
@@ -144,9 +144,8 @@ namespace Orchestrator.Infrastructure.IIIF
                 {
                     canvas.Thumbnail = new IIIF2.Thumbnail
                     {
-                        Id = GetFullQualifiedThumbServicePath(i, customerPathElement),
-                        Service = GetImageServiceForThumbnail(i, customerPathElement,
-                            thumbnailSizes.OpenThumbnails)
+                        Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
+                        Service = GetImageServiceForThumbnail(i, customerPathElement, thumbnailSizes.OpenThumbnails)
                     }.AsList();
                 }
 
@@ -160,7 +159,7 @@ namespace Orchestrator.Infrastructure.IIIF
             List<Size> thumbnailSizes) =>
             new ImageService2
             {
-                Id = GetFullQualifiedThumbPath(asset, customerPathElement, thumbnailSizes),
+                Id = GetFullQualifiedThumbServicePath(asset, customerPathElement),
                 Profile = ImageService2.Level0Profile,
                 Sizes = thumbnailSizes,
                 Context = ImageService2.Image2Context,

--- a/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -10,6 +10,7 @@ using DLCS.Web.Response;
 using IIIF;
 using IIIF.ImageApi.Service;
 using IIIF.Presentation.V2.Annotation;
+using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Microsoft.Extensions.Options;
@@ -63,6 +64,7 @@ namespace Orchestrator.Infrastructure.IIIF
                         Id = $"{canvasId}/page",
                         Items = new PaintingAnnotation
                         {
+                            Target = new IIIF3.Canvas { Id = canvasId },
                             Id = $"{canvasId}/page/image",
                             Body = new Image
                             {
@@ -116,6 +118,7 @@ namespace Orchestrator.Infrastructure.IIIF
                 var canvas = new IIIF2.Canvas
                 {
                     Id = canvasId,
+                    Label = new MetaDataValue($"Canvas {counter}"),
                     Width = i.Width,
                     Height = i.Height,
                     Images = new ImageAnnotation


### PR DESCRIPTION
Couple of tweaks to manifests:

* v2 - add required "Label" property to canvas (label is `$"Canvas {counter}"`)
* v3 - add required "Target" to PaintingAnnotation
* both - swap Thumbnail.Id and Thumbnail.Service.Id as these were round the wrong way.