### PR TITLE
Tidy healthchecks for orchestrator

### DIFF
--- a/Orchestrator/Infrastructure/EndpointRouteBuilderX.cs
+++ b/Orchestrator/Infrastructure/EndpointRouteBuilderX.cs
@@ -1,0 +1,49 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Orchestrator.Infrastructure
+{
+    public static class EndpointRouteBuilderX
+    {
+        public static IEndpointRouteBuilder MapConfiguredHealthChecks(this IEndpointRouteBuilder endpoints)
+        {
+            endpoints.MapHealthChecks("/health/imageserver", new HealthCheckOptions
+            {
+                AllowCachingResponses = false,
+                Predicate = registration => registration.Name == "Image Server",
+            });
+            endpoints.MapHealthChecks("/health/detail", new HealthCheckOptions
+            {
+                AllowCachingResponses = false,
+                ResponseWriter = WriteJsonResponse,
+            });
+            endpoints.MapHealthChecks("/health", new HealthCheckOptions
+            {
+                AllowCachingResponses = false,
+                Predicate = registration => !registration.Tags.Contains("detail-only"),
+            });
+            return endpoints;
+        }
+        
+        private static Task WriteJsonResponse(HttpContext context, HealthReport result)
+        {
+            context.Response.ContentType = "application/json";
+
+            var json = new JObject(
+                new JProperty("status", result.Status.ToString()),
+                new JProperty("results", new JObject(result.Entries.Select(pair =>
+                    new JProperty(pair.Key, new JObject(
+                        new JProperty("status", pair.Value.Status.ToString())))))));
+
+            return context.Response.WriteAsync(
+                json.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/Orchestrator/Orchestrator.csproj
+++ b/Orchestrator/Orchestrator.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="5.0.2" />
+        <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
         <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
         <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.18" />

--- a/Orchestrator/Startup.cs
+++ b/Orchestrator/Startup.cs
@@ -30,7 +30,6 @@ using Orchestrator.Features.Images.Orchestration.Status;
 using Orchestrator.Features.TimeBased;
 using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.Auth;
-using Orchestrator.Infrastructure.Deliverator;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.Mediatr;
 using Orchestrator.Infrastructure.NamedQueries;
@@ -85,7 +84,8 @@ namespace Orchestrator
                 .AddMediatR()
                 .AddHttpContextAccessor()
                 .AddNamedQueries(configuration)
-                .AddApiClient(configuration.Get<OrchestratorSettings>());
+                .AddApiClient(configuration.Get<OrchestratorSettings>())
+                .ConfigureHealthChecks(reverseProxySection, configuration);
             
             // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
             services.Configure<ForwardedHeadersOptions>(opts =>
@@ -116,11 +116,6 @@ namespace Orchestrator
                 });
             
             DapperMappings.Register();
-            
-            // TODO expand healthchecks
-            services
-                .AddHealthChecks()
-                .AddNpgSql(configuration.GetPostgresSqlConnection());
             
             // Add the reverse proxy to capability to the server
             services
@@ -156,7 +151,7 @@ namespace Orchestrator
                     endpoints.MapReverseProxy();
                     endpoints.MapImageHandling();
                     endpoints.MapTimeBasedHandling();
-                    endpoints.MapHealthChecks("/health");
+                    endpoints.MapConfiguredHealthChecks();
                 });
         }
     }


### PR DESCRIPTION
Implementation for #218 

Added 4 healthchecks - database, image-server, thumbs and thumbs-resize.

Added 3 healthcheck endpoints:
- `/health` - main check, will be unhealthy of database or image-server unhealthy.
- `/health/imageserver` - returns status of image-server only.
- `/health/detail` - returns status for all 4 checks as detailed JSON output.