### PR TITLE
Support multiple "order by" params for NQ

### DIFF
--- a/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
+++ b/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.Core.Guard;
+﻿using System.Collections.Generic;
+using DLCS.Core.Guard;
 using DLCS.Model.PathElements;
 
 namespace DLCS.Model.Assets.NamedQueries
@@ -10,10 +11,9 @@ namespace DLCS.Model.Assets.NamedQueries
     public class ParsedNamedQuery
     {
         /// <summary>
-        /// Which Asset property to use for specifying Canvas ordering 
+        /// Collection of OrderBy clauses to apply to assets.
         /// </summary>
-        /// <remarks>This property is used for PDFs also so should be renamed.</remarks>
-        public QueryMapping Canvas { get; set; } = QueryMapping.Unset;
+        public List<QueryOrder> AssetOrdering { get; set; } = new() { new QueryOrder(QueryMapping.Unset) };
         
         /// <summary>
         /// Value of "space" parameter after parsing
@@ -106,6 +106,27 @@ namespace DLCS.Model.Assets.NamedQueries
             Number1,
             Number2,
             Number3
+        }
+
+        public enum OrderDirection
+        {
+            Ascending,
+            Descending
+        }
+
+        /// <summary>
+        /// Represents an ordering for a NQ, specifying field and direction
+        /// </summary>
+        public class QueryOrder
+        {
+            public QueryMapping QueryMapping { get; }
+            public OrderDirection OrderDirection { get; }
+
+            public QueryOrder(QueryMapping queryMapping, OrderDirection orderDirection = OrderDirection.Ascending)
+            {
+                QueryMapping = queryMapping;
+                OrderDirection = orderDirection;
+            }
         }
     }
 }

--- a/Orchestrator.Tests/Infrastructure/NamedQueries/Manifest/IIIFNamedQueryParserTests.cs
+++ b/Orchestrator.Tests/Infrastructure/NamedQueries/Manifest/IIIFNamedQueryParserTests.cs
@@ -128,7 +128,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.Manifest
                 new IIIFParsedNamedQuery(Customer)
                 {
                     String1 = "string-1", Number1 = 40, Space = 1, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                    Canvas = ParsedNamedQuery.QueryMapping.Number2, NamedQueryName = "my-query"
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                    NamedQueryName = "my-query"
                 },
                 "All params"
             },
@@ -138,7 +139,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.Manifest
                 new IIIFParsedNamedQuery(Customer)
                 {
                     String1 = "string-1", Number1 = 40, Space = 10, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                    Canvas = ParsedNamedQuery.QueryMapping.Number2, NamedQueryName = "my-query"
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                    NamedQueryName = "my-query"
                 },
                 "Extra args are ignored"
             },
@@ -148,7 +150,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.Manifest
                 new IIIFParsedNamedQuery(Customer)
                 {
                     String1 = "string-1", Number1 = 40, Space = 1, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                    Canvas = ParsedNamedQuery.QueryMapping.Number2, NamedQueryName = "my-query"
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                    NamedQueryName = "my-query"
                 },
                 "Incorrect template pairs are ignored"
             },

--- a/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/PdfNamedQueryParserTests.cs
+++ b/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/PdfNamedQueryParserTests.cs
@@ -154,8 +154,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF
                 new PdfParsedNamedQuery(Customer)
                 {
                     String1 = "string-1", Number1 = 40, Space = 1, RedactedMessage = "you cannot view",
-                    Canvas = ParsedNamedQuery.QueryMapping.String1, Args = new List<string> { "string-1", "40", "1" },
-                    NamedQueryName = "my-query",
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.String1)}, 
+                    Args = new List<string> { "string-1", "40", "1" }, NamedQueryName = "my-query",
                 },
                 "All params except format"
             },
@@ -164,7 +164,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF
                 "canvas=n2&s1=p1&n1=p2&space=p3&#=1", "string-1/40/10/100",
                 new PdfParsedNamedQuery(Customer)
                 {
-                    String1 = "string-1", Number1 = 40, Space = 10, Canvas = ParsedNamedQuery.QueryMapping.Number2,
+                    String1 = "string-1", Number1 = 40, Space = 10,
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
                     Args = new List<string> { "string-1", "40", "10", "100", "1" }, NamedQueryName = "my-query",
                 },
                 "Extra args are ignored"
@@ -174,7 +175,8 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF
                 "manifest=s1&&n3=&canvas=n2&=10&s1=p1&n1=p2&space=p3&#=1", "string-1/40",
                 new PdfParsedNamedQuery(Customer)
                 {
-                    String1 = "string-1", Number1 = 40, Space = 1, Canvas = ParsedNamedQuery.QueryMapping.Number2,
+                    String1 = "string-1", Number1 = 40, Space = 1, 
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
                     Args = new List<string> { "string-1", "40", "1" }, NamedQueryName = "my-query",
                 },
                 "Incorrect template pairs are ignored"
@@ -210,6 +212,20 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF
                     ObjectNameFormat = "{s3}_{n1}.pdf", ObjectName = "foo_.pdf", NamedQueryName = "my-query",
                 },
                 "Replacements removed if no provided"
+            },
+            new object[]
+            {
+                "assetOrder=n2;s1 desc", "",
+                new PdfParsedNamedQuery(Customer)
+                {
+                    AssetOrdering = new List<ParsedNamedQuery.QueryOrder>
+                    {
+                        new(ParsedNamedQuery.QueryMapping.Number2),
+                        new(ParsedNamedQuery.QueryMapping.String1, ParsedNamedQuery.OrderDirection.Descending)
+                    },
+                    NamedQueryName = "my-query",
+                },
+                "Asset Ordering"
             },
         };
     }

--- a/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -32,7 +32,7 @@ namespace Orchestrator.Tests.Integration
             dbFixture.DbContext.NamedQueries.Add(new NamedQuery
             {
                 Customer = 99, Global = false, Id = Guid.NewGuid().ToString(), Name = "test-named-query",
-                Template = "canvas=n1&s1=p1&space=p2"
+                Template = "assetOrdering=n1&s1=p1&space=p2"
             });
 
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-1", num1: 2, ref1: "my-ref");
@@ -173,6 +173,39 @@ namespace Orchestrator.Tests.Integration
             response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
             var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
             jsonResponse.SelectToken("items").Count().Should().Be(3);
+        }
+        
+        [Fact]
+        public async Task Get_ReturnsManifestWithCorrectlyOrderedItems()
+        {
+            // Arrange
+            dbFixture.DbContext.NamedQueries.Add(new NamedQuery
+            {
+                Customer = 99, Global = false, Id = Guid.NewGuid().ToString(), Name = "ordered-manifest",
+                Template = "assetOrder=n1;n2 desc;s1&s2=p1"
+            });
+            
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/third", num1: 1, num2: 10, ref1: "z", ref2: "grace");
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/first", num1: 1, num2: 20, ref1: "c", ref2: "grace");
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/fourth", num1: 2, num2: 10, ref1: "a", ref2: "grace");
+            await dbFixture.DbContext.Images.AddTestAsset("99/1/second", num1: 1, num2: 10, ref1: "x", ref2: "grace");
+            await dbFixture.DbContext.SaveChangesAsync();
+
+            var expectedOrder = new[] { "99/1/first", "99/1/second", "99/1/third", "99/1/fourth" };
+
+            const string path = "iiif-resource/99/ordered-manifest/grace";
+            
+            // Act
+            var response = await httpClient.GetAsync(path);
+            
+            // Assert
+            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+            var count = 0;
+            foreach (var token in jsonResponse.SelectToken("items"))
+            {
+                token["id"].Value<string>().Should().Contain(expectedOrder[count++]);
+            }
         }
     }
 }

--- a/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -80,6 +80,16 @@ namespace Orchestrator.Tests.Integration
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         }
+        
+        [Fact]
+        public async Task Get_Returns404_IfNoMatchingAssets()
+        {
+            // Act
+            var response = await httpClient.GetAsync("iiif-resource/99/test-named-query/not-found-ref/1");
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
 
         [Fact]
         public async Task Get_ReturnsV2ManifestWithCorrectCount_ViaConneg()

--- a/Orchestrator.Tests/Orchestrator.Tests.csproj
+++ b/Orchestrator.Tests/Orchestrator.Tests.csproj
@@ -42,7 +42,6 @@
 
     <ItemGroup>
       <Folder Include="Features\PDF" />
-      <Folder Include="Infrastructure\NamedQueries\Parsing" />
     </ItemGroup>
 
 </Project>

--- a/Orchestrator.Tests/Orchestrator.Tests.csproj
+++ b/Orchestrator.Tests/Orchestrator.Tests.csproj
@@ -40,8 +40,4 @@
       <None Remove="Integration\Files\dummy.pdf" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Features\PDF" />
-    </ItemGroup>
-
 </Project>

--- a/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
+++ b/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
@@ -43,15 +43,14 @@ namespace Orchestrator.Features.Manifests
         {
             var parsedNamedQuery = namedQueryResult.ParsedQuery.ThrowIfNull(nameof(request.Query))!;
 
-            var imageResults = (await namedQueryResult.Results.ToListAsync(cancellationToken))
-                .OrderBy(i => NamedQueryProjections.GetCanvasOrderingElement(i, namedQueryResult.ParsedQuery!))
-                .ToList();
+            var assets = await namedQueryResult.Results.ToListAsync(cancellationToken);
+            if (assets.Count == 0) return null;
 
-            if (imageResults.Count == 0) return null;
+            var orderedImages = NamedQueryProjections.GetOrderedAssets(assets, parsedNamedQuery).ToList();
 
             return iiifPresentationVersion == Version.V2
-                ? await GenerateV2Manifest(parsedNamedQuery, imageResults, request)
-                : await GenerateV3Manifest(parsedNamedQuery, imageResults, request);
+                ? await GenerateV2Manifest(parsedNamedQuery, orderedImages, request)
+                : await GenerateV3Manifest(parsedNamedQuery, orderedImages, request);
         }
 
         private async Task<JsonLdBase> GenerateV2Manifest(IIIFParsedNamedQuery parsedNamedQuery, List<Asset> results,

--- a/Orchestrator/Features/Manifests/Requests/GetNamedQueryResults.cs
+++ b/Orchestrator/Features/Manifests/Requests/GetNamedQueryResults.cs
@@ -61,7 +61,9 @@ namespace Orchestrator.Features.Manifests.Requests
                 httpContextAccessor.HttpContext.Request,
                 request.IIIFPresentationVersion, cancellationToken);
 
-            return DescriptionResourceResponse.Open(manifest.AsJson());
+            return manifest == null 
+                ? DescriptionResourceResponse.Empty
+                : DescriptionResourceResponse.Open(manifest.AsJson());
         }
     }
 }

--- a/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -13,6 +13,7 @@ using IIIF.Presentation.V2.Annotation;
 using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Options;
 using Orchestrator.Settings;
 using IIIF2 = IIIF.Presentation.V2;
@@ -57,6 +58,7 @@ namespace Orchestrator.Infrastructure.IIIF
                 var canvas = new IIIF3.Canvas
                 {
                     Id = canvasId,
+                    Label = new LanguageMap("en", $"Canvas {counter}"),
                     Width = i.Width,
                     Height = i.Height,
                     Items = new AnnotationPage

--- a/Orchestrator/Infrastructure/NamedQueries/NamedQueryProjections.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/NamedQueryProjections.cs
@@ -48,5 +48,10 @@ namespace Orchestrator.Infrastructure.NamedQueries
             => queryOrder.OrderDirection == OrderDirection.Ascending
                 ? assets.OrderBy(a => GetOrderingElement(a, queryOrder.QueryMapping))
                 : assets.OrderByDescending(a => GetOrderingElement(a, queryOrder.QueryMapping));
+        
+        private static IOrderedEnumerable<Asset> AddOrderBy(IOrderedEnumerable<Asset> assets, QueryOrder queryOrder)
+            => queryOrder.OrderDirection == OrderDirection.Ascending
+                ? assets.ThenBy(a => GetOrderingElement(a, queryOrder.QueryMapping))
+                : assets.ThenByDescending(a => GetOrderingElement(a, queryOrder.QueryMapping));
     }
 }

--- a/Orchestrator/Infrastructure/NamedQueries/NamedQueryProjections.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/NamedQueryProjections.cs
@@ -1,20 +1,52 @@
-﻿using DLCS.Model.Assets;
+﻿using System.Collections.Generic;
+using System.Linq;
+using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
+using QueryMapping = DLCS.Model.Assets.NamedQueries.ParsedNamedQuery.QueryMapping;
+using OrderDirection = DLCS.Model.Assets.NamedQueries.ParsedNamedQuery.OrderDirection;
+using QueryOrder = DLCS.Model.Assets.NamedQueries.ParsedNamedQuery.QueryOrder;
 
 namespace Orchestrator.Infrastructure.NamedQueries
 {
+    /// <summary>
+    /// Utility methods for projecting named queries
+    /// </summary>
     internal static class NamedQueryProjections
     {
-        public static object GetCanvasOrderingElement(Asset image, ParsedNamedQuery query)
-            => query.Canvas switch
+        /// <summary>
+        /// Get assets with correct ordering applied
+        /// </summary>
+        /// <param name="assets">Collection of assets</param>
+        /// <param name="query">Parsed NQ containing appropriate order parameters</param>
+        /// <returns>Initial assets ordered appropriately </returns>
+        public static IOrderedEnumerable<Asset> GetOrderedAssets(IEnumerable<Asset> assets, ParsedNamedQuery query)
+        {
+            var assetOrdering = query.AssetOrdering;
+            var orderedEnumerable = AddOrderBy(assets, assetOrdering.First());
+            
+            foreach (var queryOrder in assetOrdering.Skip(1))
             {
-                ParsedNamedQuery.QueryMapping.Number1 => image.NumberReference1,
-                ParsedNamedQuery.QueryMapping.Number2 => image.NumberReference2,
-                ParsedNamedQuery.QueryMapping.Number3 => image.NumberReference3,
-                ParsedNamedQuery.QueryMapping.String1 => image.Reference1,
-                ParsedNamedQuery.QueryMapping.String2 => image.Reference2,
-                ParsedNamedQuery.QueryMapping.String3 => image.Reference3,
+                orderedEnumerable = AddOrderBy(orderedEnumerable, queryOrder);
+            }
+
+            return orderedEnumerable;
+        }
+        
+        public static object GetOrderingElement(Asset image, QueryMapping queryMapping)
+            => queryMapping switch
+            {
+                QueryMapping.Number1 => image.NumberReference1,
+                QueryMapping.Number2 => image.NumberReference2,
+                QueryMapping.Number3 => image.NumberReference3,
+                QueryMapping.String1 => image.Reference1,
+                QueryMapping.String2 => image.Reference2,
+                QueryMapping.String3 => image.Reference3,
                 _ => 0
             };
+
+        private static IOrderedEnumerable<Asset> AddOrderBy(IEnumerable<Asset> assets, QueryOrder queryOrder)
+            => queryOrder.OrderDirection == OrderDirection.Ascending
+                ? assets.OrderBy(a => GetOrderingElement(a, queryOrder.QueryMapping))
+                : assets.OrderByDescending(a => GetOrderingElement(a, queryOrder.QueryMapping));
     }
 }

--- a/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
@@ -72,8 +72,8 @@ namespace Orchestrator.Infrastructure.NamedQueries.PDF
             return new CreateProjectionResult();
         }
 
-        private FireballPlaybook GeneratePlaybook(string? pdfKey, PdfParsedNamedQuery? parsedNamedQuery,
-            List<Asset>? assets)
+        private FireballPlaybook GeneratePlaybook(string? pdfKey, PdfParsedNamedQuery parsedNamedQuery,
+            List<Asset> assets)
         {
             var playbook = new FireballPlaybook
             {
@@ -88,8 +88,7 @@ namespace Orchestrator.Infrastructure.NamedQueries.PDF
             playbook.Pages.Add(FireballPage.Download(parsedNamedQuery.CoverPageUrl));
 
             int pageNumber = 0;
-            foreach (var i in assets.OrderBy(i =>
-                NamedQueryProjections.GetCanvasOrderingElement(i, parsedNamedQuery)))
+            foreach (var i in NamedQueryProjections.GetOrderedAssets(assets, parsedNamedQuery))
             {
                 Logger.LogDebug("Adding PDF page {PdfPage} to {PdfS3Key} for {Image}", pageNumber++, pdfKey, i.Id);
                 if (i.Roles.HasText())

--- a/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
@@ -79,8 +79,7 @@ namespace Orchestrator.Infrastructure.NamedQueries.Zip
             using var zipArchive = new ZipArchive(zipToOpen, ZipArchiveMode.Create);
 
             int imageCount = 0;
-            foreach (var i in assets.OrderBy(i =>
-                NamedQueryProjections.GetCanvasOrderingElement(i, parsedNamedQuery)))
+            foreach (var i in NamedQueryProjections.GetOrderedAssets(assets, parsedNamedQuery))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {

--- a/Orchestrator/Models/DescriptionResourceResponse.cs
+++ b/Orchestrator/Models/DescriptionResourceResponse.cs
@@ -1,4 +1,6 @@
-﻿namespace Orchestrator.Models
+﻿using DLCS.Core.Guard;
+
+namespace Orchestrator.Models
 {
     /// <summary>
     /// Represents the results of a call to get a IIIF DescriptionResource (manifest, info.json etc)
@@ -23,7 +25,7 @@
         public static DescriptionResourceResponse Open(string resource) 
             => new()
             {
-                DescriptionResource = resource,
+                DescriptionResource = resource.ThrowIfNullOrEmpty(resource),
                 RequiresAuth = false,
                 HasResource = true,
                 IsUnauthorised = false
@@ -35,7 +37,7 @@
         public static DescriptionResourceResponse Restricted(string resource) 
             => new()
             {
-                DescriptionResource = resource,
+                DescriptionResource = resource.ThrowIfNullOrEmpty(resource),
                 RequiresAuth = true,
                 HasResource = true,
                 IsUnauthorised = false
@@ -47,7 +49,7 @@
         public static DescriptionResourceResponse Unauthorised(string resource) 
             => new()
             {
-                DescriptionResource = resource,
+                DescriptionResource = resource.ThrowIfNullOrEmpty(resource),
                 RequiresAuth = true,
                 HasResource = true,
                 IsUnauthorised = true


### PR DESCRIPTION
NamedQueries previously supported `canvas=s*/n*` syntax for ordering. This has been maintained for backwards compat but marked as obsolete, replaced by new `assetOrder` field. This supports multiple semi-colon delimited fields and asc/desc (defaults to ascending). Order of precedence left -> right. Implements #227. e.g.:

* `&assetOrder=s1` - `OrderBy(i => i.Reference1)`
* `&assetOrder=s1 asc` - `OrderBy(i => i.Reference1)`
* `&assetOrder=s1 desc` - `OrderByDescending(i => i.Reference1)`
* `&assetOrder=s1;n1 desc` - `OrderBy(i => i.Reference1).ThenByDescending(i => i.Number1)`

Also fixed #228 to avoid returning 200 with "null" body if assets match NQ asset.