### PR TITLE
Upgrade to dotnet 6

### DIFF
--- a/.build/Jenkinsfile.BuildPush
+++ b/.build/Jenkinsfile.BuildPush
@@ -34,7 +34,7 @@ pipeline {
       sh "apt-get update"
       sh "apt install -y libunwind8 gettext apt-transport-https python3-pip"
       sh "pip3 install awscli"
-      sh "curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 5.0"
+      sh "curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 6.0"
     }
   }
   stage('Test') {

--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -21,7 +21,7 @@ jobs:
       - id: setup-dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "5.0.x"
+          dotnet-version: "6.0.x"
       - id: restore-dotnet-dependencies
         run: dotnet restore $SOLUTION
       - id: build-dotnet

--- a/API.Client/API.Client.csproj
+++ b/API.Client/API.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     </ItemGroup>
 
 </Project>

--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/API.Tests/API.Tests.csproj
+++ b/API.Tests/API.Tests.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <LangVersion>default</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
+      <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
       <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
       <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.8" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
-      <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
     </ItemGroup>
 

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -9,11 +9,11 @@
 
     <ItemGroup>
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
-      <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-      <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+      <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
+      <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
+      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+      <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
             <PrivateAssets>all</PrivateAssets>
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DLCS.Core.Tests/DLCS.Core.Tests.csproj
+++ b/DLCS.Core.Tests/DLCS.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/DLCS.Core.Tests/DLCS.Core.Tests.csproj
+++ b/DLCS.Core.Tests/DLCS.Core.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DLCS.Core/DLCS.Core.csproj
+++ b/DLCS.Core/DLCS.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
     </PropertyGroup>

--- a/DLCS.HydraModel/DLCS.HydraModel.csproj
+++ b/DLCS.HydraModel/DLCS.HydraModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
+++ b/DLCS.Mediatr/Behaviours/LoggingBehaviour.cs
@@ -11,7 +11,7 @@ namespace DLCS.Mediatr.Behaviours
     /// Will use ToString() property to log details
     /// </summary>
     public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : ITimedRequest
+        where TRequest : IRequest<TResponse>, ITimedRequest
     {
         private readonly ILogger<LoggingBehavior<TRequest, TResponse>> logger;
 

--- a/DLCS.Mediatr/DLCS.Mediatr.csproj
+++ b/DLCS.Mediatr/DLCS.Mediatr.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="MediatR" Version="9.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     </ItemGroup>
 
 </Project>

--- a/DLCS.Mediatr/DLCS.Mediatr.csproj
+++ b/DLCS.Mediatr/DLCS.Mediatr.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="9.0.0" />
+      <PackageReference Include="MediatR" Version="10.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     </ItemGroup>
 

--- a/DLCS.Mock/Controllers/CustomersController.cs
+++ b/DLCS.Mock/Controllers/CustomersController.cs
@@ -144,7 +144,7 @@ namespace DLCS.Mock.Controllers
             // obviously not thread safe..
             var modelId = model.Spaces.Select(s => s.ModelId).Max() + 1;
             var newSpace = MockHelp.MakeSpace(model.BaseUrl, modelId, customerId,
-                space.Name, DateTime.Now, space.DefaultTags, space.DefaultMaxUnauthorised);
+                space.Name, DateTime.UtcNow, space.DefaultTags, space.DefaultMaxUnauthorised);
             model.Spaces.Add(newSpace);
             return Created(newSpace.Id, space);
         }

--- a/DLCS.Mock/Controllers/QueueController.cs
+++ b/DLCS.Mock/Controllers/QueueController.cs
@@ -38,12 +38,12 @@ namespace DLCS.Mock.Controllers
             List<Image> initialisedImages = new List<Image>();
 
             var newBatchId = model.Batches.Select(b => b.ModelId).Max() + 1;
-            var batch = new Batch(model.BaseUrl, newBatchId, customerId, DateTime.Now);
+            var batch = new Batch(model.BaseUrl, newBatchId, customerId, DateTime.UtcNow);
             model.Batches.Add(batch);
             foreach (var incomingImage in images.Members)
             {
                 var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, incomingImage.Space, incomingImage.ModelId, 
-                    DateTime.Now, incomingImage.Origin, incomingImage.InitialOrigin,
+                    DateTime.UtcNow, incomingImage.Origin, incomingImage.InitialOrigin,
                     0, 0, incomingImage.MaxUnauthorised, null, null, null, true, null, 
                     incomingImage.Tags, incomingImage.String1, incomingImage.String2, incomingImage.String3,
                     incomingImage.Number1, incomingImage.Number2, incomingImage.Number3,

--- a/DLCS.Mock/Controllers/SpaceImagesController.cs
+++ b/DLCS.Mock/Controllers/SpaceImagesController.cs
@@ -52,7 +52,7 @@ namespace DLCS.Mock.Controllers
 
         private void AutoAdvance(List<Image> images)
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             var tenSeconds = new TimeSpan(0, 0, 10);
             foreach (var image in images)
             {
@@ -101,7 +101,7 @@ namespace DLCS.Mock.Controllers
         public Image Image(int customerId, int spaceId, string id, [FromBody]Image incomingImage)
         {
             var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, spaceId, incomingImage.ModelId,
-                    DateTime.Now, incomingImage.Origin, incomingImage.InitialOrigin,
+                    DateTime.UtcNow, incomingImage.Origin, incomingImage.InitialOrigin,
                     0, 0, incomingImage.MaxUnauthorised, null, null, null, true, null,
                     incomingImage.Tags, incomingImage.String1, incomingImage.String2, incomingImage.String3,
                     incomingImage.Number1, incomingImage.Number2, incomingImage.Number3,

--- a/DLCS.Mock/DLCS.Mock.csproj
+++ b/DLCS.Mock/DLCS.Mock.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     </ItemGroup>
 

--- a/DLCS.Mock/DLCS.Mock.csproj
+++ b/DLCS.Mock/DLCS.Mock.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.5" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DLCS.Model.Tests/DLCS.Model.Tests.csproj
+++ b/DLCS.Model.Tests/DLCS.Model.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/DLCS.Model.Tests/DLCS.Model.Tests.csproj
+++ b/DLCS.Model.Tests/DLCS.Model.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DLCS.Model/DLCS.Model.csproj
+++ b/DLCS.Model/DLCS.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
+++ b/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
@@ -9,19 +9,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
-        <PackageReference Include="FakeItEasy" Version="7.1.0" />
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
-        <PackageReference Include="LazyCache" Version="2.1.3" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.9.2" />
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="LazyCache" Version="2.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
+++ b/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 
@@ -13,8 +13,8 @@
         <PackageReference Include="FakeItEasy" Version="7.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
         <PackageReference Include="LazyCache" Version="2.1.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.10" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="6.0.4" />
     <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
-    <PackageReference Include="Dapper" Version="2.0.90" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.2" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-6-0001" />
-    <PackageReference Include="LazyCache" Version="2.1.3" />
+    <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DLCS.Repository/DLCS.Repository.csproj
+++ b/DLCS.Repository/DLCS.Repository.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
@@ -11,19 +11,19 @@
     <PackageReference Include="Dapper" Version="2.0.90" />
     <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-6-0001" />
     <PackageReference Include="LazyCache" Version="2.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="5.0.2" />
-    <PackageReference Include="Npgsql" Version="5.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="6.0.4" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
 
@@ -35,11 +35,5 @@
   <ItemGroup>
     <Folder Include="Migrations" />
   </ItemGroup>
-
-  <!--
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
-  </ItemGroup>
--->
 
 </Project>

--- a/DLCS.Web.Tests/DLCS.Web.Tests.csproj
+++ b/DLCS.Web.Tests/DLCS.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
 

--- a/DLCS.Web.Tests/DLCS.Web.Tests.csproj
+++ b/DLCS.Web.Tests/DLCS.Web.Tests.csproj
@@ -9,16 +9,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FakeItEasy" Version="7.1.0" />
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
@@ -15,7 +15,7 @@
     <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-6-0001" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
   </ItemGroup>
 

--- a/DLCS.Web/DLCS.Web.csproj
+++ b/DLCS.Web/DLCS.Web.csproj
@@ -16,11 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Content" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Dockerfile.API
+++ b/Dockerfile.API
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
 COPY ["API/API.csproj", "API/"]
@@ -17,7 +17,12 @@ RUN dotnet build "API.csproj" -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish "API.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist
+LABEL org.opencontainers.image.description="HTTP API for DLCS interactions."
+
 WORKDIR /app
 EXPOSE 80
 COPY --from=publish /app/publish .

--- a/Dockerfile.Orchestrator
+++ b/Dockerfile.Orchestrator
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
 COPY ["Orchestrator/Orchestrator.csproj", "Orchestrator/"]
@@ -20,7 +20,7 @@ RUN dotnet build "Orchestrator.csproj" --no-restore -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish "Orchestrator.csproj" --no-restore -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Portal
+++ b/Dockerfile.Portal
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
 COPY ["Portal/Portal.csproj", "Portal/"]
@@ -17,7 +17,12 @@ RUN dotnet build "Portal.csproj" -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish "Portal.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist
+LABEL org.opencontainers.image.description="DLCS Management UI."
+
 WORKDIR /app
 EXPOSE 80
 COPY --from=publish /app/publish .

--- a/Dockerfile.Thumbs
+++ b/Dockerfile.Thumbs
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim-amd64 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 
 COPY ["Thumbs/Thumbs.csproj", "Thumbs/"]
@@ -16,7 +16,7 @@ RUN dotnet build "Thumbs.csproj" -c Release -o /app/build
 FROM build AS publish
 RUN dotnet publish "Thumbs.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Hydra/Hydra.csproj
+++ b/Hydra/Hydra.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/Orchestrator.Tests/Integration/AuthHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/AuthHandlingTests.cs
@@ -172,7 +172,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_Token_Returns403_WithErrorJson_IfCookieContainsExpiredId_AndMessageIdNotPresent()
         {
             // Arrange
-            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddHours(-1));
+            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddHours(-1));
             await dbFixture.DbContext.SaveChangesAsync();
             const string path = "/auth/99/token";
             var request = new HttpRequestMessage(HttpMethod.Get, path);
@@ -193,7 +193,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_Token_Returns200_WithAccessToken_IfSuccess_AndMessageIdNotPresent()
         {
             // Arrange
-            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(10));
+            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(10));
             await dbFixture.DbContext.SaveChangesAsync();
             const string path = "/auth/99/token";
             var request = new HttpRequestMessage(HttpMethod.Get, path);
@@ -292,7 +292,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_Token_ReturnsView_WithErrorJson_IfCookieContainsExpiredId()
         {
             // Arrange
-            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddHours(-1));
+            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddHours(-1));
             await dbFixture.DbContext.SaveChangesAsync();
             const string path = "/auth/99/token?messageId=123";
             var request = new HttpRequestMessage(HttpMethod.Get, path);
@@ -313,7 +313,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_Token_ReturnsView_WithAccessToken_IfSuccess()
         {
             // Arrange
-            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(10));
+            var token = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(10));
             await dbFixture.DbContext.SaveChangesAsync();
             const string path = "/auth/99/token?messageId=123";
             var request = new HttpRequestMessage(HttpMethod.Get, path);

--- a/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -311,7 +311,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(-1),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(-1),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -344,8 +344,8 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(1),
-                sessionUserId: userSession.Entity.Id, ttl: 6000, lastChecked: DateTime.Now.AddHours(-1));
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(1),
+                sessionUserId: userSession.Entity.Id, ttl: 6000, lastChecked: DateTime.UtcNow.AddHours(-1));
             await dbFixture.DbContext.SaveChangesAsync();
             
             await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -370,7 +370,7 @@ namespace Orchestrator.Tests.Integration
             response.Headers.CacheControl.Private.Should().BeTrue();
             
             dbFixture.DbContext.AuthTokens.Single(t => t.BearerToken == bearerToken)
-                .Expires.Should().BeAfter(DateTime.Now.AddMinutes(5));
+                .Expires.Should().BeAfter(DateTime.UtcNow.AddMinutes(5));
         }
 
         [Fact]
@@ -471,7 +471,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(-1),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(-1),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -495,7 +495,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
             

--- a/Orchestrator.Tests/Integration/PdfTests.cs
+++ b/Orchestrator.Tests/Integration/PdfTests.cs
@@ -120,7 +120,7 @@ namespace Orchestrator.Tests.Integration
             // Arrange
             const string path = "pdf/99/test-pdf/my-ref/1/1";
             await AddPdfControlFile("99/pdf/test-pdf/my-ref/1/1/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = true });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = true });
 
             // Act
             var response = await httpClient.GetAsync(path);
@@ -137,7 +137,7 @@ namespace Orchestrator.Tests.Integration
             var fakePdfContent = nameof(GetPdf_Returns200_WithExistingPdf_IfPdfControlFileAndPdfExist);
             const string path = "pdf/99/test-pdf/my-ref/1/1";
             await AddPdfControlFile("99/pdf/test-pdf/my-ref/1/1/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             await AddPdf("99/pdf/test-pdf/my-ref/1/1/tester", fakePdfContent);
 
             // Act
@@ -158,7 +158,7 @@ namespace Orchestrator.Tests.Integration
             const string path = "pdf/99/test-pdf/my-ref/1/2";
             
             await AddPdfControlFile("99/pdf/test-pdf/my-ref/1/2/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             pdfCreator.AddCallbackFor(pdfStorageKey, (query, assets) =>
             {
                 AddPdf(pdfStorageKey, fakePdfContent).Wait();
@@ -182,7 +182,7 @@ namespace Orchestrator.Tests.Integration
             const string pdfStorageKey = "99/pdf/test-pdf/my-ref/1/3/tester";
             const string path = "pdf/99/test-pdf/my-ref/1/3";
             await AddPdfControlFile("99/pdf/test-pdf/my-ref/1/3/tester.json",
-                new ControlFile { Created = DateTime.Now.AddHours(-1), InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow.AddHours(-1), InProcess = false });
             
             pdfCreator.AddCallbackFor(pdfStorageKey, (query, assets) =>
             {
@@ -207,7 +207,7 @@ namespace Orchestrator.Tests.Integration
             const string pdfStorageKey = "99/pdf/test-pdf/my-ref/1/4/tester";
             
             await AddPdfControlFile("99/pdf/test-pdf/my-ref/1/4/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             
             // return True but don't create object
             pdfCreator.AddCallbackFor(pdfStorageKey, (query, assets) => true);
@@ -227,7 +227,7 @@ namespace Orchestrator.Tests.Integration
             const string pdfStorageKey = "99/pdf/test-pdf/my-ref/1/5/tester";
             
             await AddPdfControlFile("99/test-pdf/my-ref/1/5/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             
             pdfCreator.AddCallbackFor(pdfStorageKey, (query, assets) => false);
 
@@ -261,7 +261,7 @@ namespace Orchestrator.Tests.Integration
             const string pdfStorageKey = "99/pdf/ordered-pdf/possum/tester";
             
             await AddPdfControlFile("99/pdf/ordered-pdf/possum/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             
             List<Asset> savedAssets = null;
             pdfCreator.AddCallbackFor(pdfStorageKey, (query, assets) =>
@@ -337,7 +337,7 @@ namespace Orchestrator.Tests.Integration
 
             var controlFile = new ControlFile
             {
-                Created = DateTime.Now, InProcess = false, Exists = true, Key = "the-key", ItemCount = 100,
+                Created = DateTime.UtcNow, InProcess = false, Exists = true, Key = "the-key", ItemCount = 100,
                 SizeBytes = 1024
             };
             var pdfControlFile = new PdfControlFile(controlFile);

--- a/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -147,7 +147,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -171,7 +171,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -195,7 +195,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(-15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(-15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -237,7 +237,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
             
@@ -266,7 +266,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
 
@@ -290,7 +290,7 @@ namespace Orchestrator.Tests.Integration
             var userSession =
                 await dbFixture.DbContext.SessionUsers.AddTestSession(
                     DlcsDatabaseFixture.ClickThroughAuthService.AsList());
-            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.Now.AddMinutes(-15),
+            var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(-15),
                 sessionUserId: userSession.Entity.Id);
             await dbFixture.DbContext.SaveChangesAsync();
 

--- a/Orchestrator.Tests/Integration/ZipTests.cs
+++ b/Orchestrator.Tests/Integration/ZipTests.cs
@@ -119,7 +119,7 @@ namespace Orchestrator.Tests.Integration
             // Arrange
             const string path = "zip/99/test-zip/my-ref/1/1";
             await AddControlFile("99/zip/test-zip/my-ref/1/1/tester.zip.json",
-                new ControlFile { Created = DateTime.Now, InProcess = true });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = true });
 
             // Act
             var response = await httpClient.GetAsync(path);
@@ -136,7 +136,7 @@ namespace Orchestrator.Tests.Integration
             var fakeContent = nameof(GetZip_Returns200_WithExistingZip_IfControlFileAndZipExist);
             const string path = "zip/99/test-zip/my-ref/1/1";
             await AddControlFile("99/zip/test-zip/my-ref/1/1/tester.zip.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             await AddZipArchive("99/zip/test-zip/my-ref/1/1/tester.zip", fakeContent);
 
             // Act
@@ -157,7 +157,7 @@ namespace Orchestrator.Tests.Integration
             const string path = "zip/99/test-zip/my-ref/1/2";
             
             await AddControlFile("99/zip/test-zip/my-ref/1/2/tester.zip.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             zipCreator.AddCallbackFor(storageKey, (query, assets) =>
             {
                 AddZipArchive(storageKey, fakeContent).Wait();
@@ -181,7 +181,7 @@ namespace Orchestrator.Tests.Integration
             const string storageKey = "99/zip/test-zip/my-ref/1/3/tester.zip";
             const string path = "zip/99/test-zip/my-ref/1/3";
             await AddControlFile("99/zip/test-zip/my-ref/1/3/tester.json",
-                new ControlFile { Created = DateTime.Now.AddHours(-1), InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow.AddHours(-1), InProcess = false });
             
             zipCreator.AddCallbackFor(storageKey, (query, assets) =>
             {
@@ -206,7 +206,7 @@ namespace Orchestrator.Tests.Integration
             const string storageKey = "99/zip/test-zip/my-ref/1/4/tester";
             
             await AddControlFile("99/zip/test-zip/my-ref/1/4/tester.zip.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             
             // return True but don't create object in s3
             zipCreator.AddCallbackFor(storageKey, (query, assets) => true);
@@ -226,7 +226,7 @@ namespace Orchestrator.Tests.Integration
             const string storageKey = "99/zip/test-zip/my-ref/1/5/tester";
             
             await AddControlFile("99/test-zip/my-ref/1/5/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
             
             zipCreator.AddCallbackFor(storageKey, (query, assets) => false);
 
@@ -259,7 +259,7 @@ namespace Orchestrator.Tests.Integration
             const string storageKey = "99/zip/ordered-zip/ordered/tester";
             
             await AddControlFile("99/ordered-zip/ordered/tester.json",
-                new ControlFile { Created = DateTime.Now, InProcess = false });
+                new ControlFile { Created = DateTime.UtcNow, InProcess = false });
 
             List<Asset> savedAssets = null;
             zipCreator.AddCallbackFor(storageKey, (query, assets) =>
@@ -335,7 +335,7 @@ namespace Orchestrator.Tests.Integration
 
             var controlFile = new ControlFile
             {
-                Created = DateTime.Now, InProcess = false, Exists = true, Key = "the-key", ItemCount = 100,
+                Created = DateTime.UtcNow, InProcess = false, Exists = true, Key = "the-key", ItemCount = 100,
                 SizeBytes = 1024
             };
             await AddControlFile("99/zip/test-zip/any-ref/1/5/tester.zip.json", controlFile);

--- a/Orchestrator.Tests/Orchestrator.Tests.csproj
+++ b/Orchestrator.Tests/Orchestrator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -10,7 +10,7 @@
         <PackageReference Include="AngleSharp" Version="0.16.0" />
         <PackageReference Include="FakeItEasy" Version="7.1.0" />
         <PackageReference Include="FluentAssertions" Version="6.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Stubbery" Version="2.7.1" />

--- a/Orchestrator.Tests/Orchestrator.Tests.csproj
+++ b/Orchestrator.Tests/Orchestrator.Tests.csproj
@@ -7,19 +7,19 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="0.16.0" />
-        <PackageReference Include="FakeItEasy" Version="7.1.0" />
-        <PackageReference Include="FluentAssertions" Version="6.1.0" />
+        <PackageReference Include="AngleSharp" Version="0.16.1" />
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="Stubbery" Version="2.7.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Orchestrator/Features/Auth/SessionAuthService.cs
+++ b/Orchestrator/Features/Auth/SessionAuthService.cs
@@ -215,17 +215,17 @@ namespace Orchestrator.Features.Auth
                 return null;
             }
 
-            if (authToken.Expires <= DateTime.Now)
+            if (authToken.Expires <= DateTime.UtcNow)
             {
                 logger.LogDebug("AuthToken expired, customer:'{Customer}'", customer);
                 return null;
             }
 
             // Token was last checked in the past and threshold has passed
-            if (authToken.LastChecked.HasValue && authToken.LastChecked.Value.Add(RefreshThreshold) < DateTime.Now)
+            if (authToken.LastChecked.HasValue && authToken.LastChecked.Value.Add(RefreshThreshold) < DateTime.UtcNow)
             {
-                authToken.LastChecked = DateTime.Now;
-                authToken.Expires = DateTime.Now.AddSeconds(authToken.Ttl);
+                authToken.LastChecked = DateTime.UtcNow;
+                authToken.Expires = DateTime.UtcNow.AddSeconds(authToken.Ttl);
                 await dbContext.SaveChangesAsync(cancellationToken);
             }
 
@@ -238,7 +238,7 @@ namespace Orchestrator.Features.Auth
         {
             var sessionUser = new SessionUser
             {
-                Created = DateTime.Now,
+                Created = DateTime.UtcNow,
                 Id = Guid.NewGuid().ToString(),
                 Roles = new Dictionary<int, List<string>>
                 {
@@ -255,13 +255,13 @@ namespace Orchestrator.Features.Auth
             var authToken = new AuthToken
             {
                 Id = Guid.NewGuid().ToString(),
-                Created = DateTime.Now,
-                LastChecked = DateTime.Now,
+                Created = DateTime.UtcNow,
+                LastChecked = DateTime.UtcNow,
                 CookieId = Guid.NewGuid().ToString(),
                 SessionUserId = sessionUser.Id,
                 BearerToken = Guid.NewGuid().ToString().Replace("-", string.Empty),
                 Customer = authService.Customer,
-                Expires = DateTime.Now.AddSeconds(authService.Ttl),
+                Expires = DateTime.UtcNow.AddSeconds(authService.Ttl),
                 Ttl = authService.Ttl
             };
             await dbContext.AuthTokens.AddAsync(authToken);

--- a/Orchestrator/Infrastructure/Mediatr/AssetRequestParsingBehavior.cs
+++ b/Orchestrator/Infrastructure/Mediatr/AssetRequestParsingBehavior.cs
@@ -11,7 +11,7 @@ namespace Orchestrator.Infrastructure.Mediatr
     /// <typeparam name="TRequest">Type of mediatr request</typeparam>
     /// <typeparam name="TResponse">Type of response</typeparam>
     public class AssetRequestParsingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : IAssetRequest
+        where TRequest : IRequest<TResponse>, IAssetRequest
     {
         private readonly IAssetDeliveryPathParser assetDeliveryPathParser;
 

--- a/Orchestrator/Infrastructure/NamedQueries/Persistence/BaseProjectionCreator.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/Persistence/BaseProjectionCreator.cs
@@ -63,7 +63,7 @@ namespace Orchestrator.Infrastructure.NamedQueries.Persistence
             Logger.LogInformation("Creating new control file: {ControlS3Key}", parsedNamedQuery.ControlFileStorageKey);
             var controlFile = new ControlFile
             {
-                Created = DateTime.Now,
+                Created = DateTime.UtcNow,
                 Key = parsedNamedQuery.StorageKey,
                 Exists = false,
                 InProcess = true,

--- a/Orchestrator/Infrastructure/NamedQueries/Persistence/Models/ControlFile.cs
+++ b/Orchestrator/Infrastructure/NamedQueries/Persistence/Models/ControlFile.cs
@@ -48,6 +48,6 @@ namespace Orchestrator.Infrastructure.NamedQueries.Persistence.Models
         /// Check if this is control file is stale (in process for longer than X secs)
         /// </summary>
         public bool IsStale(int staleSecs)
-            => InProcess && DateTime.Now.Subtract(Created).TotalSeconds > staleSecs;
+            => InProcess && DateTime.UtcNow.Subtract(Created).TotalSeconds > staleSecs;
     }
 }

--- a/Orchestrator/Orchestrator.csproj
+++ b/Orchestrator/Orchestrator.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
-        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="5.0.2" />
-        <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
+        <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
+        <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
         <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
         <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.18" />
@@ -16,9 +16,9 @@
         <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
         <PackageReference Include="MediatR" Version="9.0.0" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.10" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
-        <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+        <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-rc.1.21520.4" />
     </ItemGroup>
 

--- a/Orchestrator/Orchestrator.csproj
+++ b/Orchestrator/Orchestrator.csproj
@@ -9,13 +9,13 @@
         <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
         <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-        <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-        <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
-        <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.18" />
-        <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-        <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
-        <PackageReference Include="MediatR" Version="9.0.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.9.2" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
+        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+        <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
+        <PackageReference Include="MediatR" Version="10.0.1" />
+        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/Orchestrator/Startup.cs
+++ b/Orchestrator/Startup.cs
@@ -97,8 +97,7 @@ namespace Orchestrator
 
             services
                 .AddFeatureFolderViews()
-                .AddControllersWithViews()
-                .SetCompatibilityVersion(CompatibilityVersion.Latest);
+                .AddControllersWithViews();
 
             services
                 .AddCors(options =>

--- a/Portal.Tests/Integration/SpacesTests.cs
+++ b/Portal.Tests/Integration/SpacesTests.cs
@@ -65,9 +65,9 @@ namespace Portal.Tests.Integration
             // Arrange
             // Add 3 spaces - 2 for this customer and 1 for another
             await dbContext.Spaces.AddRangeAsync(
-                new Space {Customer = 1, Id = 1, Created = DateTime.Now, Name = "space1"},
-                new Space {Customer = 2, Id = 2, Created = DateTime.Now, Name = "space2"},
-                new Space {Customer = 2, Id = 3, Created = DateTime.Now, Name = "space3"}
+                new Space {Customer = 1, Id = 1, Created = DateTime.UtcNow, Name = "space1"},
+                new Space {Customer = 2, Id = 2, Created = DateTime.UtcNow, Name = "space2"},
+                new Space {Customer = 2, Id = 3, Created = DateTime.UtcNow, Name = "space3"}
             );
             
             await dbContext.SaveChangesAsync();

--- a/Portal.Tests/Portal.Tests.csproj
+++ b/Portal.Tests/Portal.Tests.csproj
@@ -8,15 +8,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AngleSharp" Version="0.16.0" />
+      <PackageReference Include="AngleSharp" Version="0.16.1" />
       <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
-      <PackageReference Include="FluentAssertions" Version="6.1.0" />
+      <PackageReference Include="FluentAssertions" Version="6.6.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/Portal.Tests/Portal.Tests.csproj
+++ b/Portal.Tests/Portal.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
 
         <LangVersion>default</LangVersion>
@@ -11,9 +11,9 @@
       <PackageReference Include="AngleSharp" Version="0.16.0" />
       <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
       <PackageReference Include="FluentAssertions" Version="6.1.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Portal/Behaviours/AuditBehaviour.cs
+++ b/Portal/Behaviours/AuditBehaviour.cs
@@ -12,7 +12,7 @@ namespace Portal.Behaviours
     /// Audits request by logging message type/contents and UserId
     /// </summary>
     public class AuditBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : IAuditable
+        where TRequest : IRequest<TResponse>, IAuditable
     {
         private readonly ILogger<AuditBehaviour<TRequest, TResponse>> logger;
         private readonly ClaimsPrincipal claimsPrincipal;

--- a/Portal/Features/Admin/AdminController.cs
+++ b/Portal/Features/Admin/AdminController.cs
@@ -27,9 +27,9 @@ namespace Portal.Features.Admin
         
         public async Task<IActionResult> CreateSignUp([FromForm] string? note, [FromForm] DateTime? expires = null)
         {
-            if(expires == null || expires.Value < DateTime.Now)
+            if(expires == null || expires.Value < DateTime.UtcNow)
             {
-                expires = DateTime.Now.AddDays(14);
+                expires = DateTime.UtcNow.AddDays(14);
             }
             var signUpLink = await mediator.Send(new CreateSignupLink{Note = note, Expires = expires.Value});
             TempData["new-signup-id"] = signUpLink.Id;

--- a/Portal/Features/Admin/Requests/CreateSignupLink.cs
+++ b/Portal/Features/Admin/Requests/CreateSignupLink.cs
@@ -41,7 +41,7 @@ namespace Portal.Features.Admin.Requests
                 var newLink = new SignupLink
                 {
                     Id = KeyGenerator.GetUniqueKey(24),
-                    Created = DateTime.Now,
+                    Created = DateTime.UtcNow,
                     Expires = request.Expires,
                     Note = request.Note
                 };

--- a/Portal/Pages/Account/SignupFromLink.cshtml.cs
+++ b/Portal/Pages/Account/SignupFromLink.cshtml.cs
@@ -118,7 +118,7 @@ namespace Portal.Pages.Account
             var signups = await dbContext.SignupLinks.Where(link => link.Id == signupCode).ToListAsync();
             if (signups.Count == 1)
             {
-                if (signups[0].CustomerId == null && signups[0].Expires > DateTime.Now)
+                if (signups[0].CustomerId == null && signups[0].Expires > DateTime.UtcNow)
                 {
                     return true;
                 }

--- a/Portal/Pages/Admin/Signups.cshtml.cs
+++ b/Portal/Pages/Admin/Signups.cshtml.cs
@@ -31,7 +31,7 @@ namespace Portal.Pages.Admin
                 {
                     signup.CssClass = "table-success";
                 }
-                else if (signup.Expires < DateTime.Now)
+                else if (signup.Expires < DateTime.UtcNow)
                 {
                     signup.CssClass = "table-danger";
                 }

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -8,11 +8,11 @@
     <ItemGroup>
       <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
-      <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.17" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.9.2" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-      <PackageReference Include="MediatR" Version="9.0.0" />
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+      <PackageReference Include="MediatR" Version="10.0.1" />
+      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
         <PrivateAssets>all</PrivateAssets>
@@ -21,7 +21,7 @@
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-      <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.10" />
+      <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.18" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Portal/Portal.csproj
+++ b/Portal/Portal.csproj
@@ -1,26 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
-      <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="5.0.1" />
+      <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
       <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.17" />
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.6" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.10">
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.10" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
-      <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.10" />
     </ItemGroup>
 

--- a/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -31,7 +31,7 @@ namespace Test.Helpers.Integration
             int num3 = 0)
             => assets.AddAsync(new Asset
             {
-                Created = DateTime.Now, Customer = customer, Space = space, Id = id, Origin = origin,
+                Created = DateTime.UtcNow, Customer = customer, Space = space, Id = id, Origin = origin,
                 Width = width, Height = height, Roles = roles, Family = family, MediaType = mediaType,
                 ThumbnailPolicy = "default", MaxUnauthorised = maxUnauthorised, Reference1 = ref1,
                 Reference2 = ref2, Reference3 = ref3, NumberReference1 = num1, NumberReference2 = num2,
@@ -45,13 +45,13 @@ namespace Test.Helpers.Integration
                 new AuthToken
                 {
                     Id = Guid.NewGuid().ToString(),
-                    Created = DateTime.Now,
-                    LastChecked = lastChecked ?? DateTime.Now,
+                    Created = DateTime.UtcNow,
+                    LastChecked = lastChecked ?? DateTime.UtcNow,
                     CookieId = Guid.NewGuid().ToString(),
                     SessionUserId = sessionUserId ?? Guid.NewGuid().ToString(),
                     BearerToken = Guid.NewGuid().ToString().Replace("-", string.Empty),
                     Customer = customer,
-                    Expires = expires ?? DateTime.Now.AddSeconds(ttl),
+                    Expires = expires ?? DateTime.UtcNow.AddSeconds(ttl),
                     Ttl = ttl
                 });
 
@@ -61,7 +61,7 @@ namespace Test.Helpers.Integration
                 new SessionUser
                 {
                     Id = Guid.NewGuid().ToString(),
-                    Created = DateTime.Now,
+                    Created = DateTime.UtcNow,
                     Roles = new Dictionary<int, List<string>>
                     {
                         [customer] = roles

--- a/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -72,14 +72,14 @@ namespace Test.Helpers.Integration
 
             await DbContext.Customers.AddAsync(new Customer
             {
-                Created = DateTime.Now,
+                Created = DateTime.UtcNow,
                 Id = customer,
                 DisplayName = "TestUser",
                 Name = "test",
                 Keys = Array.Empty<string>()
             });
             await DbContext.Spaces.AddAsync(new Space
-                { Created = DateTime.Now, Id = 1, Customer = customer, Name = "space-1" });
+                { Created = DateTime.UtcNow, Id = 1, Customer = customer, Name = "space-1" });
             await DbContext.ThumbnailPolicies.AddAsync(new ThumbnailPolicy
                 { Id = "default", Name = "default", Sizes = "800,400,200" });
             await DbContext.AuthServices.AddAsync(new AuthService

--- a/Test.Helpers/Test.Helpers.csproj
+++ b/Test.Helpers/Test.Helpers.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
       <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.8" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="Yarp.ReverseProxy" Version="1.0.0-rc.1.21520.4" />

--- a/Test.Helpers/Test.Helpers.csproj
+++ b/Test.Helpers/Test.Helpers.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AWSSDK.S3" Version="3.7.1.15" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.9.2" />
       <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <Nullable>enable</Nullable>
     <LangVersion>default</LangVersion>
@@ -9,16 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="5.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.0.45" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
     <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-6-0001" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
   </ItemGroup>
 

--- a/Thumbs/Thumbs.csproj
+++ b/Thumbs/Thumbs.csproj
@@ -10,14 +10,12 @@
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0.45" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0.1" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.16" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.11.2" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
     <PackageReference Include="iiif-net" Version="0.1.0-tags-v0-0-6-0001" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.1.3" />
+    <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
Ticket - #216 

Set TargetFramework for all projects to `.net6.0`, upgraded nuget packages and Dockerfiles.

Made minimal code changes, biggest change was to use `DateTime.UtcNow` due to update to how npgsql handles dates - see https://www.npgsql.org/efcore/release-notes/6.0.html?tabs=annotations.
