### PR TITLE
Orchestrate images on info.json request via channels

### DIFF
--- a/Orchestrator/Features/Images/Orchestration/IOrchestrationQueue.cs
+++ b/Orchestrator/Features/Images/Orchestration/IOrchestrationQueue.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Orchestrator.Assets;
+
+namespace Orchestrator.Features.Images.Orchestration
+{
+    /// <summary>
+    /// Interface for operations related to queueing/dequeueing asynchronous orchestration requests.
+    /// </summary>
+    public interface IOrchestrationQueue
+    {
+        /// <summary>
+        /// Queue orchestration request.
+        /// </summary>
+        ValueTask QueueRequest(OrchestrationImage orchestrationImage, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get next waiting image to be orchestrated.
+        /// </summary>
+        ValueTask<OrchestrationImage> DequeueRequest(CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IOrchestrationQueue"/> using a bounded channel for read/writing
+    /// </summary>
+    public class BoundedChannelOrchestrationQueue : IOrchestrationQueue
+    {
+        private readonly Channel<OrchestrationImage> queue;
+
+        public BoundedChannelOrchestrationQueue(int capacity)
+        {
+            var options = new BoundedChannelOptions(capacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+            };
+            queue = Channel.CreateBounded<OrchestrationImage>(options);
+        }
+
+        public ValueTask QueueRequest(OrchestrationImage orchestrationImage, CancellationToken cancellationToken)
+            => queue.Writer.WriteAsync(orchestrationImage, cancellationToken);
+
+        public ValueTask<OrchestrationImage> DequeueRequest(CancellationToken cancellationToken)
+            => queue.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/Orchestrator/Features/Images/Orchestration/OrchestrationQueueMonitor.cs
+++ b/Orchestrator/Features/Images/Orchestration/OrchestrationQueueMonitor.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Orchestrator.Features.Images.Orchestration
+{
+    /// <summary>
+    /// BackgroundService that monitors queue for requests to orchestrate images.
+    /// </summary>
+    public class OrchestrationQueueMonitor : BackgroundService
+    {
+        private readonly IOrchestrationQueue orchestrationQueue;
+        private readonly IImageOrchestrator imageOrchestrator;
+        private readonly ILogger<OrchestrationQueueMonitor> logger;
+
+        public OrchestrationQueueMonitor(IOrchestrationQueue orchestrationQueue, IImageOrchestrator imageOrchestrator,
+            ILogger<OrchestrationQueueMonitor> logger)
+        {
+            this.orchestrationQueue = orchestrationQueue;
+            this.imageOrchestrator = imageOrchestrator;
+            this.logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            logger.LogInformation("Starting OrchestrationQueueMonitor");
+
+            await BackgroundProcessor(stoppingToken);
+        }
+        
+        private async Task BackgroundProcessor(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var orchestrationImage = await orchestrationQueue.DequeueRequest(stoppingToken);
+
+                try
+                {
+                    logger.LogDebug("Orchestrating {AssetId}", orchestrationImage.AssetId);
+                    await imageOrchestrator.OrchestrateImage(orchestrationImage, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Error occurred orchestrating image {AssetId}", orchestrationImage.AssetId);
+                }
+            }
+        }
+    }
+}

--- a/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/Orchestrator/Settings/OrchestratorSettings.cs
@@ -25,7 +25,7 @@ namespace Orchestrator.Settings
         public string AuthServicesUriTemplate { get; set; }
 
         /// <summary>
-        /// Timeout for critical orchestration path. How long to wait to acheive lock when orchestrating asset.
+        /// Timeout for critical orchestration path. How long to wait to achieve lock when orchestrating asset.
         /// If timeout breached, multiple orchestrations can happen for same item.
         /// </summary>
         public int CriticalPathTimeoutMs { get; set; } = 10000;
@@ -44,6 +44,11 @@ namespace Orchestrator.Settings
         /// If true, requests for info.json will cause image to be orchestrated.
         /// </summary>
         public bool OrchestrateOnInfoJson { get; set; }
+
+        /// <summary>
+        /// If <see cref="OrchestrateOnInfoJson"/> is true, this is the max number of requests that will be honoured
+        /// </summary>
+        public int OrchestrateOnInfoJsonMaxCapacity { get; set; } = 50;
         
         /// <summary>
         /// String used for salting requests to API


### PR DESCRIPTION
Change "orchestrate on info.json" behaviour to use channels to asynchronously queue the asset rather than holding up request.

New classes:
* `IOrchestrationQueue`: interface for queuing orchestration requests (in future may back with distributed queue)
* `BoundedChannelOrchestrationQueue`: implementation of above using a `BoundedQueue`. When capacity hit oldest items are dropped.
* `OrchestrationQueueMonitor`: `BackgroundWorker` implementation, subscribes to above queue and handles orchestration.

See ticket: #239 