### PR TITLE
Update image services on manifests

### DIFF
--- a/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -2,6 +2,8 @@
 using DLCS.Web.Requests;
 using DLCS.Web.Requests.AssetDelivery;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace DLCS.Web.Response
@@ -9,6 +11,11 @@ namespace DLCS.Web.Response
     /// <summary>
     /// Generate paths related to running Dlcs instance using appSettings config for rules.
     /// </summary>
+    /// <remarks>
+    /// This class uses <see cref="PathTemplateOptions"/> to determine different URL patterns for different hostnames,
+    /// this allows e.g. "id" values on manifests to use different URL structures than the default DLCS paths.
+    /// e.g. /images/{image}/ rather than default of /iiif-img/{cust}/{space}/{image} 
+    /// </remarks>
     public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
     {
         private readonly IHttpContextAccessor httpContextAccessor;

--- a/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -14,17 +14,20 @@ namespace DLCS.Web.Response
     {
         /// <summary>
         /// Generate path for specified <see cref="BaseAssetRequest"/> excluding host.
+        /// Uses default template replacements.
         /// </summary>
         string GetPathForRequest(IBasicPathElements assetRequest);
 
         /// <summary>
-        /// Generate full path for specified <see cref="BaseAssetRequest"/>, including host. 
+        /// Generate full path for specified <see cref="BaseAssetRequest"/>, including host.
+        /// Uses default template replacements. 
         /// </summary>
         string GetFullPathForRequest(IBasicPathElements assetRequest);
 
         /// <summary>
         /// Generate full path for specified <see cref="BaseAssetRequest"/>, using provided delegate to generate
-        /// path element. 
+        /// path element.
+        /// This can be useful for constructing paths that do not use the default path elements.
         /// </summary>
         string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator);
     }

--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -107,7 +107,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-manifest/v2/{id}");
         jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
             .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
@@ -131,7 +131,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-manifest/v2/{id}");
         jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
             .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
@@ -161,6 +161,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-manifest/{id}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
         jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
     }
@@ -183,6 +184,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-manifest/v2/{id}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
         jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
     }
@@ -208,6 +210,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-manifest/{id}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
         jsonResponse.SelectToken("items").Count().Should().Be(1);
     }
@@ -230,6 +233,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-manifest/{id}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
         jsonResponse.SelectToken("items").Count().Should().Be(1);
     }

--- a/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -1,261 +1,285 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Amazon.S3;
 using DLCS.Model.Assets;
-using DLCS.Repository.Assets;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using Orchestrator.Tests.Integration.Infrastructure;
 using Test.Helpers.Integration;
 using Xunit;
 
-namespace Orchestrator.Tests.Integration
+namespace Orchestrator.Tests.Integration;
+
+/// <summary>
+/// Test of all iiif-manifest handling
+/// </summary>
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 {
-    /// <summary>
-    /// Test of all iiif-manifest handling
-    /// </summary>
-    [Trait("Category", "Integration")]
-    [Collection(DatabaseCollection.CollectionName)]
-    public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
+    private readonly DlcsDatabaseFixture dbFixture;
+    private readonly HttpClient httpClient;
+    private JToken imageServices;
+
+    public ManifestHandlingTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture databaseFixture)
     {
-        private readonly DlcsDatabaseFixture dbFixture;
-        private readonly HttpClient httpClient;
+        dbFixture = databaseFixture;
+            
+        httpClient = factory
+            .WithConnectionString(dbFixture.ConnectionString)
+            .CreateClient();
+            
+        dbFixture.CleanUp();
+    }
+        
+    [Theory]
+    [InlineData("iiif-manifest/1/1/my-asset")]
+    [InlineData("iiif-manifest/v2/1/1/my-asset")]
+    [InlineData("iiif-manifest/v3/1/1/my-asset")]
+    public async Task Get_UnknownCustomer_Returns404(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+        
+    [Theory]
+    [InlineData("iiif-manifest/99/5/my-asset")]
+    [InlineData("iiif-manifest/v2/99/5/my-asset")]
+    [InlineData("iiif-manifest/v3/99/5/my-asset")]
+    public async Task Get_UnknownSpace_Returns404(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+        
+    [Theory]
+    [InlineData("iiif-manifest/99/1/my-asset")]
+    [InlineData("iiif-manifest/v2/99/1/my-asset")]
+    [InlineData("iiif-manifest/v3/99/1/my-asset")]
+    public async Task Get_UnknownImage_Returns404(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+        
+    [Theory]
+    [InlineData(AssetFamily.File)]
+    [InlineData(AssetFamily.Timebased)]
+    public async Task Get_NonImage_Returns404(AssetFamily family)
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_NonImage_Returns404)}:{family}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, family: family);
+        await dbFixture.DbContext.SaveChangesAsync();
+            
+        var path = $"iiif-manifest/{id}";
 
-        public ManifestHandlingTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture databaseFixture)
-        {
-            dbFixture = databaseFixture;
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            httpClient = factory
-                .WithConnectionString(dbFixture.ConnectionString)
-                .CreateClient();
-            
-            dbFixture.CleanUp();
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
         
-        [Theory]
-        [InlineData("iiif-manifest/1/1/my-asset")]
-        [InlineData("iiif-manifest/v2/1/1/my-asset")]
-        [InlineData("iiif-manifest/v3/1/1/my-asset")]
-        public async Task Get_UnknownCustomer_Returns404(string path)
-        {
-            // Act
-            var response = await httpClient.GetAsync(path);
+    [Fact]
+    public async Task Get_ManifestForImage_ReturnsManifest()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        }
-        
-        [Theory]
-        [InlineData("iiif-manifest/99/5/my-asset")]
-        [InlineData("iiif-manifest/v2/99/5/my-asset")]
-        [InlineData("iiif-manifest/v3/99/5/my-asset")]
-        public async Task Get_UnknownSpace_Returns404(string path)
-        {
-            // Act
-            var response = await httpClient.GetAsync(path);
-            
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        }
-        
-        [Theory]
-        [InlineData("iiif-manifest/99/1/my-asset")]
-        [InlineData("iiif-manifest/v2/99/1/my-asset")]
-        [InlineData("iiif-manifest/v3/99/1/my-asset")]
-        public async Task Get_UnknownImage_Returns404(string path)
-        {
-            // Act
-            var response = await httpClient.GetAsync(path);
-            
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        }
-        
-        [Theory]
-        [InlineData(AssetFamily.File)]
-        [InlineData(AssetFamily.Timebased)]
-        public async Task Get_NonImage_Returns404(AssetFamily family)
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_NonImage_Returns404)}:{family}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, family: family);
-            await dbFixture.DbContext.SaveChangesAsync();
-            
-            var path = $"iiif-manifest/{id}";
+        var path = $"iiif-manifest/v2/{id}";
 
-            // Act
-            var response = await httpClient.GetAsync(path);
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        }
-        
-        [Fact]
-        public async Task Get_ManifestForImage_ReturnsManifest()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            
-            var path = $"iiif-manifest/v2/{id}";
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
+        jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
+            .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
-            // Act
-            var response = await httpClient.GetAsync(path);
-            
-            // Assert
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
-            jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
-                .Should().StartWith($"http://localhost/thumbs/{id}/full");
-
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.CacheControl.Public.Should().BeTrue();
-            response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
-        }
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+    }
         
-        [Fact]
-        public async Task Get_ManifestForRestrictedImage_ReturnsManifest()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ManifestForRestrictedImage_ReturnsManifest)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
+    [Fact]
+    public async Task Get_ManifestForRestrictedImage_ReturnsManifest()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ManifestForRestrictedImage_ReturnsManifest)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
 
-            var path = $"iiif-manifest/v2/{id}";
+        var path = $"iiif-manifest/v2/{id}";
 
-            // Act
-            var response = await httpClient.GetAsync(path);
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            // Assert
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
-            jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
-                .Should().StartWith($"http://localhost/thumbs/{id}/full");
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
+        jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
+            .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.CacheControl.Public.Should().BeTrue();
-            response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
-        }
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+    }
 
-        [Fact]
-        public async Task Get_ReturnsV2Manifest_ViaConneg()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ReturnsV2Manifest_ViaConneg)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            var path = $"iiif-manifest/{id}";
+    [Fact]
+    public async Task Get_ReturnsV2Manifest_ViaConneg()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsV2Manifest_ViaConneg)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/{id}";
             
-            const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
+        const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
             
-            // Act
-            var request = new HttpRequestMessage(HttpMethod.Get, path);
-            request.Headers.Add("Accept", iiif2);
-            var response = await httpClient.SendAsync(request);
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Accept", iiif2);
+        var response = await httpClient.SendAsync(request);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.Vary.Should().Contain("Accept");
-            response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
-            jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
+        jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
+    }
         
-        [Fact]
-        public async Task Get_ReturnsV2Manifest_ViaDirectPath()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ReturnsV2Manifest_ViaDirectPath)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            var path = $"iiif-manifest/v2/{id}";
-            const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
+    [Fact]
+    public async Task Get_ReturnsV2Manifest_ViaDirectPath()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsV2Manifest_ViaDirectPath)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/v2/{id}";
+        const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
             
-            // Act
-            var response = await httpClient.GetAsync(path);
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.Vary.Should().Contain("Accept");
-            response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
-            jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/2/context.json");
+        jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(1);
+    }
         
-        [Fact]
-        public async Task Get_ReturnsV3Manifest_ViaConneg()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ReturnsV3Manifest_ViaConneg)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            var path = $"iiif-manifest/{id}";
+    [Fact]
+    public async Task Get_ReturnsV3Manifest_ViaConneg()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsV3Manifest_ViaConneg)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/{id}";
             
-            const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
+        const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
             
-            // Act
-            var request = new HttpRequestMessage(HttpMethod.Get, path);
-            request.Headers.Add("Accept", iiif3);
-            var response = await httpClient.SendAsync(request);
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Accept", iiif3);
+        var response = await httpClient.SendAsync(request);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.Vary.Should().Contain("Accept");
-            response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
-            jsonResponse.SelectToken("items").Count().Should().Be(1);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
+        jsonResponse.SelectToken("items").Count().Should().Be(1);
+    }
         
-        [Fact]
-        public async Task Get_ReturnsV3Manifest_ViaDirectPath()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ReturnsV3Manifest_ViaDirectPath)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            var path = $"iiif-manifest/{id}";
-            const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
+    [Fact]
+    public async Task Get_ReturnsV3Manifest_ViaDirectPath()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsV3Manifest_ViaDirectPath)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/{id}";
+        const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
             
-            // Act
-            var response = await httpClient.GetAsync(path);
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.Vary.Should().Contain("Accept");
-            response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
-            jsonResponse.SelectToken("items").Count().Should().Be(1);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
+        jsonResponse.SelectToken("items").Count().Should().Be(1);
+    }
         
-        [Fact]
-        public async Task Get_ReturnsV3ManifestWithCorrectCount_AsCanonical()
-        {
-            // Arrange
-            var id = $"99/1/{nameof(Get_ReturnsV3ManifestWithCorrectCount_AsCanonical)}";
-            await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
-            await dbFixture.DbContext.SaveChangesAsync();
-            var path = $"iiif-manifest/{id}";
-            const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
+    [Fact]
+    public async Task Get_ReturnsV3ManifestWithCorrectItemCount_AsCanonical()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsV3ManifestWithCorrectItemCount_AsCanonical)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/{id}";
+        const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
             
-            // Act
-            var response = await httpClient.GetAsync(path);
+        // Act
+        var response = await httpClient.GetAsync(path);
             
-            // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            response.Headers.Vary.Should().Contain("Accept");
-            response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
-            var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-            jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
-            jsonResponse.SelectToken("items").Count().Should().Be(1);
-        }
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/presentation/3/context.json");
+        jsonResponse.SelectToken("items").Count().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsMultipleImageServices()
+    {
+        // Arrange
+        var id = $"99/1/{nameof(Get_ReturnsMultipleImageServices)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"iiif-manifest/{id}";
+            
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+
+        imageServices = jsonResponse.SelectToken("items[0].items[0].items[0].body.service");
+        imageServices.Should().HaveCount(2);
+            
+        // Image2, non-canonical so Id has version in path
+        imageServices.First()["@context"].ToString().Should().Be("http://iiif.io/api/image/2/context.json");
+        imageServices.First()["@id"].ToString().Should().Be($"http://localhost/iiif-img/v2/{id}");
+                
+        // Image3, canonical so Id doesn't have version in path
+        imageServices.Last["@context"].ToString().Should().Be("http://iiif.io/api/image/3/context.json");
+        imageServices.Last()["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
     }
 }

--- a/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -48,19 +48,16 @@ namespace Orchestrator.Features.Manifests.Requests
         private readonly IAssetPathGenerator assetPathGenerator;
         private readonly IIIFCanvasFactory canvasFactory;
         private readonly ILogger<GetManifestForAssetHandler> logger;
-        private readonly OrchestratorSettings orchestratorSettings;
 
         public GetManifestForAssetHandler(
             IAssetRepository assetRepository,
             IAssetPathGenerator assetPathGenerator,
-            IOptions<OrchestratorSettings> orchestratorSettings,
             IIIFCanvasFactory canvasFactory,
             ILogger<GetManifestForAssetHandler> logger)
         {
             this.assetRepository = assetRepository;
             this.assetPathGenerator = assetPathGenerator;
             this.canvasFactory = canvasFactory;
-            this.orchestratorSettings = orchestratorSettings.Value;
             this.logger = logger;
         }
 
@@ -84,8 +81,7 @@ namespace Orchestrator.Features.Manifests.Requests
 
         private async Task<IIIF3.Manifest> GenerateV3Manifest(BaseAssetRequest assetRequest, Asset asset)
         {
-            // TODO - this shouldn't be image path
-            var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ImagePath);
+            var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest);
             var manifest = new IIIF3.Manifest
             {
                 Id = fullyQualifiedImageId,
@@ -100,8 +96,7 @@ namespace Orchestrator.Features.Manifests.Requests
 
         private async Task<IIIF2.Manifest> GenerateV2Manifest(BaseAssetRequest assetRequest, Asset asset)
         {
-            // TODO - this shouldn't be image path
-            var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ImagePath);
+            var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest);
             var manifest = new IIIF2.Manifest
             {
                 Id = fullyQualifiedImageId,
@@ -125,7 +120,7 @@ namespace Orchestrator.Features.Manifests.Requests
             return manifest;
         }
 
-        private string GetFullyQualifiedId(BaseAssetRequest baseAssetRequest, string prefix)
+        private string GetFullyQualifiedId(BaseAssetRequest baseAssetRequest)
             => assetPathGenerator.GetFullPathForRequest(
                 baseAssetRequest,
                 (assetRequest, template) =>
@@ -133,7 +128,7 @@ namespace Orchestrator.Features.Manifests.Requests
                     var request = assetRequest as BaseAssetRequest;
                     return DlcsPathHelpers.GeneratePathFromTemplate(
                         template,
-                        prefix,
+                        request.VersionedRoutePrefix,
                         request.CustomerPathValue,
                         request.Space.ToString(),
                         request.AssetId);

--- a/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -84,6 +84,7 @@ namespace Orchestrator.Features.Manifests.Requests
 
         private async Task<IIIF3.Manifest> GenerateV3Manifest(BaseAssetRequest assetRequest, Asset asset)
         {
+            // TODO - this shouldn't be image path
             var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ImagePath);
             var manifest = new IIIF3.Manifest
             {
@@ -99,6 +100,7 @@ namespace Orchestrator.Features.Manifests.Requests
 
         private async Task<IIIF2.Manifest> GenerateV2Manifest(BaseAssetRequest assetRequest, Asset asset)
         {
+            // TODO - this shouldn't be image path
             var fullyQualifiedImageId = GetFullyQualifiedId(assetRequest, orchestratorSettings.Proxy.ImagePath);
             var manifest = new IIIF2.Manifest
             {

--- a/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -9,6 +9,7 @@ using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
 using IIIF;
 using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
 using IIIF.Presentation.V2.Annotation;
 using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3.Annotation;
@@ -16,267 +17,301 @@ using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Options;
 using Orchestrator.Settings;
+using Presi = IIIF.Presentation;
+using ImageApi = IIIF.ImageApi;
 using IIIF2 = IIIF.Presentation.V2;
 using IIIF3 = IIIF.Presentation.V3;
 
-namespace Orchestrator.Infrastructure.IIIF
+namespace Orchestrator.Infrastructure.IIIF;
+
+/// <summary>
+/// Canvas factory for creating Canvases from Assets items for IIIF Manifests. 
+/// </summary>
+public class IIIFCanvasFactory
 {
-    /// <summary>
-    /// Canvas factory for creating Canvases from Assets items for IIIF Manifests. 
-    /// </summary>
-    public class IIIFCanvasFactory
+    private readonly IAssetPathGenerator assetPathGenerator;
+    private readonly IThumbnailPolicyRepository thumbnailPolicyRepository;
+    private readonly OrchestratorSettings orchestratorSettings;
+    private readonly Dictionary<string, ThumbnailPolicy> thumbnailPolicies = new();
+
+    public IIIFCanvasFactory(
+        IAssetPathGenerator assetPathGenerator,
+        IOptions<OrchestratorSettings> orchestratorSettings,
+        IThumbnailPolicyRepository thumbnailPolicyRepository)
     {
-        private readonly IAssetPathGenerator assetPathGenerator;
-        private readonly IThumbnailPolicyRepository thumbnailPolicyRepository;
-        private readonly OrchestratorSettings orchestratorSettings;
-        private readonly Dictionary<string, ThumbnailPolicy> thumbnailPolicies = new();
+        this.assetPathGenerator = assetPathGenerator;
+        this.thumbnailPolicyRepository = thumbnailPolicyRepository;
+        this.orchestratorSettings = orchestratorSettings.Value;
+    }
 
-        public IIIFCanvasFactory(
-            IAssetPathGenerator assetPathGenerator,
-            IOptions<OrchestratorSettings> orchestratorSettings,
-            IThumbnailPolicyRepository thumbnailPolicyRepository)
+    /// <summary>
+    /// Generate IIIF V3 canvases for assets.
+    /// </summary>
+    public async Task<List<IIIF3.Canvas>> CreateV3Canvases(List<Asset> results,
+        CustomerPathElement customerPathElement)
+    {
+        int counter = 0;
+        var canvases = new List<IIIF3.Canvas>(results.Count);
+        foreach (var i in results)
         {
-            this.assetPathGenerator = assetPathGenerator;
-            this.thumbnailPolicyRepository = thumbnailPolicyRepository;
-            this.orchestratorSettings = orchestratorSettings.Value;
-        }
+            var fullyQualifiedImageId = GetFullyQualifiedId(i, customerPathElement, false);
+            var canvasId = string.Concat(fullyQualifiedImageId, "/canvas/c/", ++counter);
+            var thumbnailSizes = await GetThumbnailSizesForImage(i);
 
-        /// <summary>
-        /// Generate IIIF V3 canvases for assets.
-        /// </summary>
-        public async Task<List<IIIF3.Canvas>> CreateV3Canvases(List<Asset> results,
-            CustomerPathElement customerPathElement)
-        {
-            int counter = 0;
-            var canvases = new List<IIIF3.Canvas>(results.Count);
-            foreach (var i in results)
+            var canvas = new IIIF3.Canvas
             {
-                var fullyQualifiedImageId = GetFullyQualifiedId(i, customerPathElement);
-                var canvasId = string.Concat(fullyQualifiedImageId, "/canvas/c/", ++counter);
-                var thumbnailSizes = await GetThumbnailSizesForImage(i);
-
-                var canvas = new IIIF3.Canvas
+                Id = canvasId,
+                Label = new LanguageMap("en", $"Canvas {counter}"),
+                Width = i.Width,
+                Height = i.Height,
+                Items = new AnnotationPage
                 {
-                    Id = canvasId,
-                    Label = new LanguageMap("en", $"Canvas {counter}"),
-                    Width = i.Width,
-                    Height = i.Height,
-                    Items = new AnnotationPage
+                    Id = $"{canvasId}/page",
+                    Items = new PaintingAnnotation
                     {
-                        Id = $"{canvasId}/page",
-                        Items = new PaintingAnnotation
-                        {
-                            Target = new IIIF3.Canvas { Id = canvasId },
-                            Id = $"{canvasId}/page/image",
-                            Body = new Image
-                            {
-                                Id = GetFullQualifiedImagePath(i, customerPathElement,
-                                    thumbnailSizes.MaxDerivativeSize, false),
-                                Format = "image/jpeg",
-                                Service = new ImageService2
-                                {
-                                    Id = fullyQualifiedImageId,
-                                    Profile = ImageService2.Level1Profile,
-                                    Context = ImageService2.Image2Context,
-                                    Width = i.Width,
-                                    Height = i.Height,
-                                }.AsListOf<IService>()
-                            }
-                        }.AsListOf<IAnnotation>()
-                    }.AsList()
-                };
-
-                if (!thumbnailSizes.OpenThumbnails.IsNullOrEmpty())
-                {
-                    canvas.Thumbnail = new IIIF3.Content.Image
-                    {
-                        Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
-                        Format = "image/jpeg",
-                        Service = GetImageServiceForThumbnail(i, customerPathElement,
-                            thumbnailSizes.OpenThumbnails)
-                    }.AsListOf<ExternalResource>();
-                }
-
-                canvases.Add(canvas);
-            }
-
-            return canvases;
-        }
-
-        /// <summary>
-        /// Generate IIIF V2 canvases for assets.
-        /// </summary>
-        public async Task<List<IIIF2.Canvas>> CreateV2Canvases(List<Asset> results,
-            CustomerPathElement customerPathElement)
-        {
-            int counter = 0;
-            var canvases = new List<IIIF2.Canvas>(results.Count);
-            foreach (var i in results)
-            {
-                var fullyQualifiedImageId = GetFullyQualifiedId(i, customerPathElement);
-                var canvasId = string.Concat(fullyQualifiedImageId, "/canvas/c/", ++counter);
-                var thumbnailSizes = await GetThumbnailSizesForImage(i);
-
-                var canvas = new IIIF2.Canvas
-                {
-                    Id = canvasId,
-                    Label = new MetaDataValue($"Canvas {counter}"),
-                    Width = i.Width,
-                    Height = i.Height,
-                    Images = new ImageAnnotation
-                    {
-                        Id = string.Concat(fullyQualifiedImageId, "/imageanno/0"),
-                        On = canvasId,
-                        Resource = new IIIF2.ImageResource
+                        Target = new IIIF3.Canvas { Id = canvasId },
+                        Id = $"{canvasId}/page/image",
+                        Body = new Image
                         {
                             Id = GetFullQualifiedImagePath(i, customerPathElement,
                                 thumbnailSizes.MaxDerivativeSize, false),
-                            Width = i.Width,
-                            Height = i.Height,
-                            Service = new ImageService2
-                            {
-                                Id = fullyQualifiedImageId,
-                                Profile = ImageService2.Level1Profile,
-                                Context = ImageService2.Image2Context,
-                                Width = i.Width,
-                                Height = i.Height,
-                            }.AsListOf<IService>()
+                            Format = "image/jpeg",
+                            Service = GetImageServices(i, customerPathElement)
                         }
-                    }.AsList()
-                };
+                    }.AsListOf<IAnnotation>()
+                }.AsList()
+            };
 
-                if (!thumbnailSizes.OpenThumbnails.IsNullOrEmpty())
+            if (!thumbnailSizes.OpenThumbnails.IsNullOrEmpty())
+            {
+                canvas.Thumbnail = new IIIF3.Content.Image
                 {
-                    canvas.Thumbnail = new IIIF2.Thumbnail
-                    {
-                        Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
-                        Service = GetImageServiceForThumbnail(i, customerPathElement, thumbnailSizes.OpenThumbnails)
-                    }.AsList();
-                }
-
-                canvases.Add(canvas);
+                    Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
+                    Format = "image/jpeg",
+                    Service = GetImageServiceForThumbnail(i, customerPathElement,
+                        thumbnailSizes.OpenThumbnails)
+                }.AsListOf<ExternalResource>();
             }
 
-            return canvases;
+            canvases.Add(canvas);
         }
 
-        private List<IService> GetImageServiceForThumbnail(Asset asset, CustomerPathElement customerPathElement,
-            List<Size> thumbnailSizes) =>
-            new ImageService2
+        return canvases;
+    }
+
+    /// <summary>
+    /// Generate IIIF V2 canvases for assets.
+    /// </summary>
+    public async Task<List<IIIF2.Canvas>> CreateV2Canvases(List<Asset> results,
+        CustomerPathElement customerPathElement)
+    {
+        int counter = 0;
+        var canvases = new List<IIIF2.Canvas>(results.Count);
+        foreach (var i in results)
+        {
+            var fullyQualifiedImageId = GetFullyQualifiedId(i, customerPathElement, false);
+            var canvasId = string.Concat(fullyQualifiedImageId, "/canvas/c/", ++counter);
+            var thumbnailSizes = await GetThumbnailSizesForImage(i);
+
+            var canvas = new IIIF2.Canvas
             {
-                Id = GetFullQualifiedThumbServicePath(asset, customerPathElement),
+                Id = canvasId,
+                Label = new MetaDataValue($"Canvas {counter}"),
+                Width = i.Width,
+                Height = i.Height,
+                Images = new ImageAnnotation
+                {
+                    Id = string.Concat(fullyQualifiedImageId, "/imageanno/0"),
+                    On = canvasId,
+                    Resource = new IIIF2.ImageResource
+                    {
+                        Id = GetFullQualifiedImagePath(i, customerPathElement,
+                            thumbnailSizes.MaxDerivativeSize, false),
+                        Width = i.Width,
+                        Height = i.Height,
+                        Service = GetImageServices(i, customerPathElement)
+                    }
+                }.AsList()
+            };
+
+            if (!thumbnailSizes.OpenThumbnails.IsNullOrEmpty())
+            {
+                canvas.Thumbnail = new IIIF2.Thumbnail
+                {
+                    Id = GetFullQualifiedThumbPath(i, customerPathElement, thumbnailSizes.OpenThumbnails),
+                    Service = GetImageServiceForThumbnail(i, customerPathElement, thumbnailSizes.OpenThumbnails)
+                }.AsList();
+            }
+
+            canvases.Add(canvas);
+        }
+
+        return canvases;
+    }
+    
+    private List<IService> GetImageServiceForThumbnail(Asset asset, CustomerPathElement customerPathElement,
+        List<Size> thumbnailSizes)
+    {
+        var services = new List<IService>(2);
+        if (orchestratorSettings.ImageServerConfig.VersionPathTemplates.ContainsKey(ImageApi.Version.V2))
+        {
+            services.Add(new ImageService2
+            {
+                Id = GetFullyQualifiedId(asset, customerPathElement, true, ImageApi.Version.V2),
                 Profile = ImageService2.Level0Profile,
                 Sizes = thumbnailSizes,
                 Context = ImageService2.Image2Context,
-            }.AsListOf<IService>();
+            });
+        }
 
-        private async Task<ImageSizeDetails> GetThumbnailSizesForImage(Asset image)
+        if (orchestratorSettings.ImageServerConfig.VersionPathTemplates.ContainsKey(ImageApi.Version.V3))
         {
-            var thumbnailPolicy = await GetThumbnailPolicyForImage(image);
-            var thumbnailSizesForImage = image.GetAvailableThumbSizes(thumbnailPolicy, out var maxDimensions);
-
-            if (thumbnailSizesForImage.IsNullOrEmpty())
+            services.Add(new ImageService3
             {
-                var largestThumbnail = thumbnailPolicy.SizeList.OrderByDescending(s => s).First();
+                Id = GetFullyQualifiedId(asset, customerPathElement, true, ImageApi.Version.V3),
+                Profile = ImageService3.Level0Profile,
+                Sizes = thumbnailSizes,
+                Context = ImageService3.Image3Context,
+            });
+        }
 
-                return new ImageSizeDetails
-                {
-                    OpenThumbnails = new List<Size>(0),
-                    IsDerivativeOpen = false,
-                    MaxDerivativeSize = Size.Confine(largestThumbnail, new Size(image.Width, image.Height))
-                };
-            }
+        return services;
+    }
+
+    private async Task<ImageSizeDetails> GetThumbnailSizesForImage(Asset image)
+    {
+        var thumbnailPolicy = await GetThumbnailPolicyForImage(image);
+        var thumbnailSizesForImage = image.GetAvailableThumbSizes(thumbnailPolicy, out var maxDimensions);
+
+        if (thumbnailSizesForImage.IsNullOrEmpty())
+        {
+            var largestThumbnail = thumbnailPolicy.SizeList.MaxBy(s => s);
 
             return new ImageSizeDetails
             {
-                OpenThumbnails = thumbnailSizesForImage,
-                IsDerivativeOpen = true,
-                MaxDerivativeSize = new Size(maxDimensions.maxAvailableWidth, maxDimensions.maxAvailableHeight)
+                OpenThumbnails = new List<Size>(0),
+                IsDerivativeOpen = false,
+                MaxDerivativeSize = Size.Confine(largestThumbnail, new Size(image.Width, image.Height))
             };
         }
 
-        private async Task<ThumbnailPolicy> GetThumbnailPolicyForImage(Asset image)
+        return new ImageSizeDetails
         {
-            if (thumbnailPolicies.TryGetValue(image.ThumbnailPolicy, out var thumbnailPolicy))
+            OpenThumbnails = thumbnailSizesForImage,
+            IsDerivativeOpen = true,
+            MaxDerivativeSize = new Size(maxDimensions.maxAvailableWidth, maxDimensions.maxAvailableHeight)
+        };
+    }
+
+    private async Task<ThumbnailPolicy> GetThumbnailPolicyForImage(Asset image)
+    {
+        if (thumbnailPolicies.TryGetValue(image.ThumbnailPolicy, out var thumbnailPolicy))
+        {
+            return thumbnailPolicy;
+        }
+
+        var thumbnailPolicyFromDb = await thumbnailPolicyRepository.GetThumbnailPolicy(image.ThumbnailPolicy);
+        thumbnailPolicies[image.ThumbnailPolicy] = thumbnailPolicyFromDb;
+        return thumbnailPolicyFromDb;
+    }
+
+    private string GetFullQualifiedThumbPath(Asset asset, CustomerPathElement customerPathElement,
+        List<Size> availableThumbs)
+    {
+        var targetThumb = orchestratorSettings.TargetThumbnailSize;
+
+        // Get the thumbnail size that is closest to the system-wide TargetThumbnailSize
+        var closestSize = availableThumbs
+            .OrderBy(s => s.MaxDimension)
+            .Aggregate((x, y) =>
+                Math.Abs(x.MaxDimension - targetThumb) < Math.Abs(y.MaxDimension - targetThumb) ? x : y);
+
+        return GetFullQualifiedImagePath(asset, customerPathElement, closestSize, true);
+    }
+
+    private string GetFullQualifiedImagePath(Asset asset, CustomerPathElement customerPathElement, Size size,
+        bool isThumb)
+    {
+        var request = new BasicPathElements
+        {
+            Space = asset.Space,
+            AssetPath = $"{asset.GetUniqueName()}/full/{size.Width},{size.Height}/0/default.jpg",
+            RoutePrefix = isThumb ? orchestratorSettings.Proxy.ThumbsPath : orchestratorSettings.Proxy.ImagePath,
+            CustomerPathValue = customerPathElement.Id.ToString(),
+        };
+        return assetPathGenerator.GetFullPathForRequest(request);
+    }
+
+    private string GetFullyQualifiedId(Asset asset, CustomerPathElement customerPathElement,
+        bool isThumb, ImageApi.Version imageApiVersion = ImageApi.Version.Unknown)
+    {
+        var versionPart = imageApiVersion == orchestratorSettings.DefaultIIIFImageVersion ||
+                          imageApiVersion == ImageApi.Version.Unknown
+            ? string.Empty
+            : $"/{imageApiVersion.ToString().ToLower()}";
+
+        var routePrefix = isThumb
+            ? orchestratorSettings.Proxy.ThumbsPath
+            : orchestratorSettings.Proxy.ImagePath;
+        
+        var imageRequest = new BasicPathElements
+        {
+            Space = asset.Space,
+            AssetPath = asset.GetUniqueName(),
+            RoutePrefix = $"{routePrefix}{versionPart}",
+            CustomerPathValue = customerPathElement.Id.ToString(),
+        };
+        return assetPathGenerator.GetFullPathForRequest(imageRequest);
+    }
+
+    private List<IService> GetImageServices(Asset asset, CustomerPathElement customerPathElement)
+    {
+        var services = new List<IService>(2);
+        if (orchestratorSettings.ImageServerConfig.VersionPathTemplates.ContainsKey(ImageApi.Version.V2))
+        {
+            services.Add(new ImageService2
             {
-                return thumbnailPolicy;
-            }
-
-            var thumbnailPolicyFromDb = await thumbnailPolicyRepository.GetThumbnailPolicy(image.ThumbnailPolicy);
-            thumbnailPolicies[image.ThumbnailPolicy] = thumbnailPolicyFromDb;
-            return thumbnailPolicyFromDb;
+                Id = GetFullyQualifiedId(asset, customerPathElement, false, ImageApi.Version.V2),
+                Profile = ImageService2.Level2Profile,
+                Context = ImageService2.Image2Context,
+                Width = asset.Width,
+                Height = asset.Height,
+            });
         }
 
-        private string GetFullQualifiedThumbServicePath(Asset asset, CustomerPathElement customerPathElement)
+        if (orchestratorSettings.ImageServerConfig.VersionPathTemplates.ContainsKey(ImageApi.Version.V3))
         {
-            var thumbRequest = new BasicPathElements
+            services.Add(new ImageService3
             {
-                Space = asset.Space,
-                AssetPath = asset.GetUniqueName(),
-                RoutePrefix = orchestratorSettings.Proxy.ThumbsPath,
-                CustomerPathValue = customerPathElement.Id.ToString(),
-            };
-            return assetPathGenerator.GetFullPathForRequest(thumbRequest);
+                Id = GetFullyQualifiedId(asset, customerPathElement, false, ImageApi.Version.V3),
+                Profile = ImageService3.Level2Profile,
+                Context = ImageService3.Image3Context,
+                Width = asset.Width,
+                Height = asset.Height,
+            });
         }
+        
+        return services;
+    }
 
-        private string GetFullQualifiedThumbPath(Asset asset, CustomerPathElement customerPathElement,
-            List<Size> availableThumbs)
-        {
-            var targetThumb = orchestratorSettings.TargetThumbnailSize;
-
-            // Get the thumbnail size that is closest to the system-wide TargetThumbnailSize
-            var closestSize = availableThumbs
-                .OrderBy(s => s.MaxDimension)
-                .Aggregate((x, y) =>
-                    Math.Abs(x.MaxDimension - targetThumb) < Math.Abs(y.MaxDimension - targetThumb) ? x : y);
-
-            return GetFullQualifiedImagePath(asset, customerPathElement, closestSize, true);
-        }
-
-        private string GetFullQualifiedImagePath(Asset asset, CustomerPathElement customerPathElement, Size size,
-            bool isThumb)
-        {
-            var request = new BasicPathElements
-            {
-                Space = asset.Space,
-                AssetPath = $"{asset.GetUniqueName()}/full/{size.Width},{size.Height}/0/default.jpg",
-                RoutePrefix = isThumb ? orchestratorSettings.Proxy.ThumbsPath : orchestratorSettings.Proxy.ImagePath,
-                CustomerPathValue = customerPathElement.Id.ToString(),
-            };
-            return assetPathGenerator.GetFullPathForRequest(request);
-        }
-
-        private string GetFullyQualifiedId(Asset asset, CustomerPathElement customerPathElement)
-        {
-            var thumbRequest = new BasicPathElements
-            {
-                Space = asset.Space,
-                AssetPath = asset.GetUniqueName(),
-                RoutePrefix = orchestratorSettings.Proxy.ImagePath,
-                CustomerPathValue = customerPathElement.Id.ToString(),
-            };
-            return assetPathGenerator.GetFullPathForRequest(thumbRequest);
-        }
+    /// <summary>
+    /// Class containing details of available thumbnail sizes
+    /// </summary>
+    private class ImageSizeDetails
+    {
+        /// <summary>
+        /// List of open availabel thumbnails
+        /// </summary>
+        public List<Size> OpenThumbnails { get; set; }
 
         /// <summary>
-        /// Class containing details of available thumbnail sizes
+        /// The size of the largest derivative, according to thumbnail policy.
         /// </summary>
-        private class ImageSizeDetails
-        {
-            /// <summary>
-            /// List of open availabel thumbnails
-            /// </summary>
-            public List<Size> OpenThumbnails { get; set; }
+        public Size MaxDerivativeSize { get; set; }
 
-            /// <summary>
-            /// The size of the largest derivative, according to thumbnail policy.
-            /// </summary>
-            public Size MaxDerivativeSize { get; set; }
-
-            /// <summary>
-            /// Whether the <see cref="MaxDerivativeSize"/> is open.
-            /// </summary>
-            public bool IsDerivativeOpen { get; set; }
-        }
+        /// <summary>
+        /// Whether the <see cref="MaxDerivativeSize"/> is open.
+        /// </summary>
+        public bool IsDerivativeOpen { get; set; }
     }
 }

--- a/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/Orchestrator/Settings/OrchestratorSettings.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using DLCS.Core.Types;
-using DLCS.Model.Templates;
 using DLCS.Repository.Caching;
-using Version = IIIF.ImageApi.Version;
 
 namespace Orchestrator.Settings
 {
@@ -73,7 +70,13 @@ namespace Orchestrator.Settings
         /// <summary>
         /// Default Image API Version to conform to when returning image description resources
         /// </summary>
-        public IIIF.ImageApi.Version DefaultIIIFImageVersion { get; set; } = Version.V3;
+        public IIIF.ImageApi.Version DefaultIIIFImageVersion { get; set; } = IIIF.ImageApi.Version.V3;
+
+        /// <summary>
+        /// Defines which IIIF ImageAPI version to return in Presentation description resources. 
+        /// </summary>
+        public PresentationImageServiceBehaviour PresentationImageBehaviour { get; init; } =
+            PresentationImageServiceBehaviour.UseImageDefault;
 
         /// <summary>
         /// Root URL for dlcs api
@@ -93,48 +96,6 @@ namespace Orchestrator.Settings
         public AuthSettings Auth { get; set; }
 
         public NamedQuerySettings NamedQuery { get; set; }
-
-        /// <summary>
-        /// Get the local folder path for Asset. This is where it will be orchestrated to, or found on fast disk after
-        /// orchestration.
-        /// </summary>
-        public string GetImageLocalPath(AssetId assetId)
-            => TemplatedFolders.GenerateFolderTemplate(ImageFolderTemplateOrchestrator, assetId);
-
-        /// <summary>
-        /// Get the full redirect path for ImageServer. Includes path prefix and parsed location where image-server can
-        /// access Asset file.
-        /// This will return the endpoint for highest supported ImageApiVersion 
-        /// </summary>
-        public string GetImageServerPath(AssetId assetId)
-        {
-            var imageServerConfig = ImageServerPathConfig[ImageServer];
-            return GetImageServerFilePathInternal(assetId, imageServerConfig,
-                imageServerConfig.DefaultVersionPathTemplate);
-        }
-
-        /// <summary>
-        /// Get the full redirect path for ImageServer for specified ImageApi version. Includes path prefix and parsed
-        /// location where image-server can access Asset file.
-        /// </summary>
-        /// <returns>Path for image-server if image-server can handle requested version, else null</returns>
-        public string? GetImageServerPath(AssetId assetId, Version targetVersion)
-        {
-            var imageServerConfig = ImageServerPathConfig[ImageServer];
-
-            return imageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate)
-                ? GetImageServerFilePathInternal(assetId, imageServerConfig, pathTemplate)
-                : null;
-        }
-
-        private static string GetImageServerFilePathInternal(AssetId assetId, ImageServerConfig imageServerConfig,
-            string versionTemplate)
-        {
-            var imageServerFilePath = TemplatedFolders.GenerateTemplate(imageServerConfig.PathTemplate, assetId,
-                imageServerConfig.Separator);
-
-            return $"{versionTemplate}{imageServerFilePath}";
-        }
     }
 
     public class ProxySettings
@@ -249,6 +210,22 @@ namespace Orchestrator.Settings
         /// </summary>
         IIPImage
     }
+    
+    /// <summary>
+    /// Defines which version IIIF image service should be linked to in generated manifests 
+    /// </summary>
+    public enum PresentationImageServiceBehaviour
+    {
+        /// <summary>
+        /// Image services will use the version specified in DefaultIIIFImageVersion
+        /// </summary>
+        UseImageDefault,
+        
+        /// <summary>
+        /// Image services will match the IIIF Presentation version
+        /// </summary>
+        MatchPresentationVersion
+    }
 
     /// <summary>
     /// Represents redirect configuration for redirecting ImageServer requests
@@ -274,7 +251,7 @@ namespace Orchestrator.Settings
         /// The prefix for forwarding requests to this image-server by supported Image Api version. The final URL sent
         /// to the image-server is {image-server-root}{url-prefix}{path-template}{image-request}
         /// </summary>
-        public Dictionary<Version, string> VersionPathTemplates { get; set; }
+        public Dictionary<IIIF.ImageApi.Version, string> VersionPathTemplates { get; set; }
 
         private string? defaultVersionPathTemplate;
 
@@ -291,9 +268,9 @@ namespace Orchestrator.Settings
                     // On first request find the value with highest Version
                     defaultVersionPathTemplate = VersionPathTemplates.MaxBy(t => t.Key switch
                     {
-                        Version.Unknown => 1,
-                        Version.V2 => 2,
-                        Version.V3 => 3,
+                        IIIF.ImageApi.Version.Unknown => 1,
+                        IIIF.ImageApi.Version.V2 => 2,
+                        IIIF.ImageApi.Version.V3 => 3,
                         _ => throw new ArgumentOutOfRangeException(nameof(VersionPathTemplates),
                             "Unknown IIIFImageVersion")
                     }).Value;

--- a/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/Orchestrator/Settings/OrchestratorSettings.cs
@@ -43,6 +43,11 @@ namespace Orchestrator.Settings
         public Dictionary<ImageServer, ImageServerConfig> ImageServerPathConfig { get; set; } = new();
 
         /// <summary>
+        /// The current <see cref="ImageServerConfig"/> object
+        /// </summary>
+        public ImageServerConfig ImageServerConfig => ImageServerPathConfig[ImageServer];
+
+        /// <summary>
         /// Folder template for downloading resources to.
         /// </summary>
         public string ImageFolderTemplateOrchestrator { get; set; }
@@ -71,13 +76,7 @@ namespace Orchestrator.Settings
         /// Default Image API Version to conform to when returning image description resources
         /// </summary>
         public IIIF.ImageApi.Version DefaultIIIFImageVersion { get; set; } = IIIF.ImageApi.Version.V3;
-
-        /// <summary>
-        /// Defines which IIIF ImageAPI version to return in Presentation description resources. 
-        /// </summary>
-        public PresentationImageServiceBehaviour PresentationImageBehaviour { get; init; } =
-            PresentationImageServiceBehaviour.UseImageDefault;
-
+        
         /// <summary>
         /// Root URL for dlcs api
         /// </summary>
@@ -209,22 +208,6 @@ namespace Orchestrator.Settings
         /// IIP Image Server
         /// </summary>
         IIPImage
-    }
-    
-    /// <summary>
-    /// Defines which version IIIF image service should be linked to in generated manifests 
-    /// </summary>
-    public enum PresentationImageServiceBehaviour
-    {
-        /// <summary>
-        /// Image services will use the version specified in DefaultIIIFImageVersion
-        /// </summary>
-        UseImageDefault,
-        
-        /// <summary>
-        /// Image services will match the IIIF Presentation version
-        /// </summary>
-        MatchPresentationVersion
     }
 
     /// <summary>

--- a/Orchestrator/Settings/OrchestratorSettingsX.cs
+++ b/Orchestrator/Settings/OrchestratorSettingsX.cs
@@ -1,0 +1,52 @@
+﻿using DLCS.Core.Types;
+using DLCS.Model.Templates;
+
+namespace Orchestrator.Settings;
+
+/// <summary>
+/// A collection of extension methods for OrchestratorSettings
+/// </summary>
+public static class OrchestratorSettingsX
+{
+    /// <summary>
+    /// Get the local folder path for Asset. This is where it will be orchestrated to, or found on fast disk after
+    /// orchestration.
+    /// </summary>
+    public static string GetImageLocalPath(this OrchestratorSettings settings, AssetId assetId)
+        => TemplatedFolders.GenerateFolderTemplate(settings.ImageFolderTemplateOrchestrator, assetId);
+    
+    /// <summary>
+    /// Get the full redirect path for ImageServer. Includes path prefix and parsed location where image-server can
+    /// access Asset file.
+    /// This will return the endpoint for highest supported ImageApiVersion 
+    /// </summary>
+    public static string GetImageServerPath(this OrchestratorSettings settings, AssetId assetId)
+    {
+        var imageServerConfig = settings.ImageServerPathConfig[settings.ImageServer];
+        return GetImageServerFilePathInternal(assetId, imageServerConfig,
+            imageServerConfig.DefaultVersionPathTemplate);
+    }
+
+    /// <summary>
+    /// Get the full redirect path for ImageServer for specified ImageApi version. Includes path prefix and parsed
+    /// location where image-server can access Asset file.
+    /// </summary>
+    /// <returns>Path for image-server if image-server can handle requested version, else null</returns>
+    public static string? GetImageServerPath(this OrchestratorSettings settings, AssetId assetId, IIIF.ImageApi.Version targetVersion)
+    {
+        var imageServerConfig = settings.ImageServerPathConfig[settings.ImageServer];
+
+        return imageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate)
+            ? GetImageServerFilePathInternal(assetId, imageServerConfig, pathTemplate)
+            : null;
+    }
+
+    private static string GetImageServerFilePathInternal(AssetId assetId, ImageServerConfig imageServerConfig,
+        string versionTemplate)
+    {
+        var imageServerFilePath = TemplatedFolders.GenerateTemplate(imageServerConfig.PathTemplate, assetId,
+            imageServerConfig.Separator);
+
+        return $"{versionTemplate}{imageServerFilePath}";
+    }
+}

--- a/Orchestrator/Settings/OrchestratorSettingsX.cs
+++ b/Orchestrator/Settings/OrchestratorSettingsX.cs
@@ -14,32 +14,26 @@ public static class OrchestratorSettingsX
     /// </summary>
     public static string GetImageLocalPath(this OrchestratorSettings settings, AssetId assetId)
         => TemplatedFolders.GenerateFolderTemplate(settings.ImageFolderTemplateOrchestrator, assetId);
-    
+
     /// <summary>
     /// Get the full redirect path for ImageServer. Includes path prefix and parsed location where image-server can
     /// access Asset file.
     /// This will return the endpoint for highest supported ImageApiVersion 
     /// </summary>
     public static string GetImageServerPath(this OrchestratorSettings settings, AssetId assetId)
-    {
-        var imageServerConfig = settings.ImageServerPathConfig[settings.ImageServer];
-        return GetImageServerFilePathInternal(assetId, imageServerConfig,
-            imageServerConfig.DefaultVersionPathTemplate);
-    }
+        => GetImageServerFilePathInternal(assetId, settings.ImageServerConfig,
+            settings.ImageServerConfig.DefaultVersionPathTemplate);
 
     /// <summary>
     /// Get the full redirect path for ImageServer for specified ImageApi version. Includes path prefix and parsed
     /// location where image-server can access Asset file.
     /// </summary>
     /// <returns>Path for image-server if image-server can handle requested version, else null</returns>
-    public static string? GetImageServerPath(this OrchestratorSettings settings, AssetId assetId, IIIF.ImageApi.Version targetVersion)
-    {
-        var imageServerConfig = settings.ImageServerPathConfig[settings.ImageServer];
-
-        return imageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate)
-            ? GetImageServerFilePathInternal(assetId, imageServerConfig, pathTemplate)
+    public static string? GetImageServerPath(this OrchestratorSettings settings, AssetId assetId,
+        IIIF.ImageApi.Version targetVersion)
+        => settings.ImageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate)
+            ? GetImageServerFilePathInternal(assetId, settings.ImageServerConfig, pathTemplate)
             : null;
-    }
 
     private static string GetImageServerFilePathInternal(AssetId assetId, ImageServerConfig imageServerConfig,
         string versionTemplate)


### PR DESCRIPTION
Update single-item and presentation manifests to add v2 + v3 image-services. Paths will be canonical and versioned depending on configured default image version. Majority of changes in `IIIFCanvasFactory` - this is starting to get unweildy but haven't drastically changed it yet.

Also moved methods out of `OrchestratorSettings` and into `OrchestratorSettingsX` so that the former is only storing values.

Update `"id`/`"@id"` on single-item manifests to use `/iiif-manifest/` rather than `/iiif-img/`

See: #248 