### PR TITLE
Validate requests can be handled by Thumbs service

### DIFF
--- a/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
+++ b/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
@@ -1,0 +1,83 @@
+﻿using DLCS.Web.IIIF;
+using FluentAssertions;
+using IIIF.ImageApi;
+using Xunit;
+
+namespace DLCS.Web.Tests.IIIF;
+
+public class ImageRequestXTests
+{
+    [Theory]
+    [InlineData("tif")]
+    [InlineData("png")]
+    [InlineData("gif")]
+    [InlineData("jp2")]
+    [InlineData("pdf")]
+    [InlineData("webp")]
+    public void IsCandidateForThumbHandling_False_IfNonJpgFormat(string format)
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+            { Format = format, Quality = "default", Rotation = new RotationParameter() };
+
+        // Act
+        var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
+
+        // Assert
+        canHandle.Should().BeFalse();
+        message.Should().Be($"Requested format '{format}' not supported, use 'jpg'");
+    }
+
+    [Theory]
+    [InlineData("gray")]
+    [InlineData("bitonal")]
+    public void IsCandidateForThumbHandling_False_IfNonDefaultQuality(string quality)
+    {
+        // Arrange
+        var imageRequest = new ImageRequest { Format = "jpg", Quality = quality, Rotation = new RotationParameter() };
+
+        // Act
+        var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
+
+        // Assert
+        canHandle.Should().BeFalse();
+        message.Should().Be($"Requested quality '{quality}' not supported, use 'default' or 'color'");
+    }
+    
+    [Theory]
+    [InlineData("90")]
+    [InlineData("120")]
+    [InlineData("!90")]
+    [InlineData("!120")]
+    [InlineData("!0")]
+    public void IsCandidateForThumbHandling_False_IfNonZeroRotation(string rotation)
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+            { Format = "jpg", Quality = "default", Rotation = RotationParameter.Parse(rotation) };
+
+        // Act
+        var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
+
+        // Assert
+        canHandle.Should().BeFalse();
+        message.Should().Be("Requested rotation value not supported, use '0'");
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("color")]
+    public void IsCandidateForThumbHandling_True_IfJpg_Default_NoRotation(string quality)
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+            { Format = "jpg", Quality = quality, Rotation = new RotationParameter() };
+
+        // Act
+        var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
+
+        // Assert
+        canHandle.Should().BeTrue();
+        message.Should().BeNull();
+    }
+}

--- a/DLCS.Web/IIIF/ImageRequestX.cs
+++ b/DLCS.Web/IIIF/ImageRequestX.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using IIIF.ImageApi;
+
+namespace DLCS.Web.IIIF;
+
+public static class ImageRequestX
+{
+    private const string DefaultQuality = "default";
+    public const string ColorQuality = "color";
+    private const string JpgFormat = "jpg";
+
+    /// <summary>
+    /// Check if the IIIF ImageRequest has request parameter that are able to be handled by Thumbnail service.
+    /// Note: This checks Format, Quality, Rotation etc - this check may pass but thumbs still cannot handle due to size
+    /// constraints
+    /// </summary>
+    /// <param name="request">Candidate <see cref="ImageRequest"/></param>
+    /// <param name="invalidMessage">String detailing why object cannot be handled</param>
+    /// <returns>True if object can be handled, else false</returns>
+    public static bool IsCandidateForThumbHandling(this ImageRequest request, out string? invalidMessage)
+    {
+        invalidMessage = null;
+        if (!request.Format.Equals(JpgFormat, StringComparison.OrdinalIgnoreCase))
+        {
+            invalidMessage = $"Requested format '{request.Format}' not supported, use 'jpg'";
+            return false;
+        }
+        
+        if (request.Quality is not (DefaultQuality or ColorQuality))
+        {
+            invalidMessage = $"Requested quality '{request.Quality}' not supported, use 'default' or 'color'";
+            return false;
+        }
+
+        if (request.Rotation is not { Angle: 0, Mirror: not true })
+        {
+            invalidMessage = $"Requested rotation value not supported, use '0'";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/DLCS.Web/Middleware/StatusCodeExceptionHandlerMiddleware.cs
+++ b/DLCS.Web/Middleware/StatusCodeExceptionHandlerMiddleware.cs
@@ -10,18 +10,18 @@ namespace DLCS.Web.Middleware
     /// </summary>
     public class StatusCodeExceptionHandlerMiddleware
     {
-        private readonly RequestDelegate _next;
+        private readonly RequestDelegate next;
 
         public StatusCodeExceptionHandlerMiddleware(RequestDelegate next)
         {
-            _next = next;
+            this.next = next;
         }
  
         public async Task InvokeAsync(HttpContext httpContext)
         {
             try
             {
-                await _next(httpContext);
+                await next(httpContext);
             }
             catch (HttpException ex)
             {
@@ -30,6 +30,7 @@ namespace DLCS.Web.Middleware
         }
 
         private static Task HandleExceptionAsync(HttpContext context, HttpException exception)
-            => new StatusCodeResponse(exception.StatusCode, exception.Message).WriteJsonResponse(context.Response);
+            => new StatusCodeResponse(exception.StatusCode, exception.Message)
+                .WriteJsonResponse(context.Response);
     }
 }

--- a/DLCS.Web/Response/StatusCodeResponse.cs
+++ b/DLCS.Web/Response/StatusCodeResponse.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace DLCS.Web.Response
 {
@@ -9,6 +9,8 @@ namespace DLCS.Web.Response
     {
         public HttpStatusCode StatusCode { get; }
         public string Message { get; }
+        
+        private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
 
         public StatusCodeResponse(HttpStatusCode statusCode, string message)
         {
@@ -20,19 +22,23 @@ namespace DLCS.Web.Response
         /// Create a StatusCodeResponse for 404 NotFound.
         /// </summary>
         /// <param name="message">Friendly error message explaining message.</param>
-        public static StatusCodeResponse NotFound(string message) => new StatusCodeResponse(HttpStatusCode.NotFound, message);
+        public static StatusCodeResponse NotFound(string message) => new(HttpStatusCode.NotFound, message);
+        
+        /// <summary>
+        /// Create a StatusCodeResponse for 400 NotFound.
+        /// </summary>
+        /// <param name="message">Friendly error message explaining message.</param>
+        public static StatusCodeResponse BadRequest(string message) => new(HttpStatusCode.BadRequest, message);
 
         /// <summary>
         /// Set response StatusCode and write a JSON representation of object to HttpResponse.
         /// </summary>
         /// <param name="response"></param>
-        public Task WriteJsonResponse(HttpResponse response)
+        public async Task WriteJsonResponse(HttpResponse response)
         {
             response.ContentType = "application/json";
             response.StatusCode = (int)StatusCode;
-            return response.WriteAsync(this.ToString());
+            await JsonSerializer.SerializeAsync(response.Body, this, settings);
         }
-
-        public override string ToString() => JsonConvert.SerializeObject(this);
     }
 }

--- a/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -203,6 +203,12 @@ public class ImageRequestHandlerTests
     [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg", false)] // UV without ?t=
     [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg", true)] // /full/full
     [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", true)] // /full/max
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", false)] // bitonal
     public async Task HandleRequest_ProxiesToImageServer_ForAllOtherCases(string path, bool knownThumb)
     {
         // Arrange

--- a/Thumbs.Tests/Integration/ImageRequestTests.cs
+++ b/Thumbs.Tests/Integration/ImageRequestTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Net;
+using System.Text.Json.Nodes;
+using Amazon.S3;
+using Amazon.S3.Model;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Newtonsoft.Json.Linq;
+using Test.Helpers.Integration;
+using Thumbs.Tests.Integration.Infrastructure;
+
+namespace Thumbs.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class ImageRequestTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsDatabaseFixture dbFixture;
+    private readonly HttpClient httpClient;
+
+    public ImageRequestTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture dbFixture)
+    {
+        this.dbFixture = dbFixture;
+        httpClient = factory
+            .WithConnectionString(this.dbFixture.ConnectionString)
+            .CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
+
+        this.dbFixture.CleanUp();
+    }
+    
+    [Theory]
+    [InlineData("tif")]
+    [InlineData("png")]
+    [InlineData("gif")]
+    [InlineData("jp2")]
+    [InlineData("pdf")]
+    [InlineData("webp")]
+    public async Task GetThumbnail_Returns400_IfUnsupportedFormatRequested(string format)
+    {
+        // Arrange
+        var id = $"99/1/{nameof(GetThumbnail_Returns400_IfUnsupportedFormatRequested)}";
+
+        // Act
+        var response = await httpClient.GetAsync($"thumbs/{id}/full/200,150/0/default.{format}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        responseObject["message"].ToString().Should().Be($"Requested format '{format}' not supported, use 'jpg'");
+        responseObject["statusCode"].ToString().Should().Be("400");
+    }
+
+    [Theory]
+    [InlineData("bitonal")]
+    [InlineData("gray")]
+    public async Task GetThumbnail_Returns400_IfUnsupportedQualityRequested(string quality)
+    {
+        // Arrange
+        var id = $"99/1/{nameof(GetThumbnail_Returns400_IfUnsupportedQualityRequested)}";
+
+        // Act
+        var response = await httpClient.GetAsync($"thumbs/{id}/full/max/0/{quality}.jpg");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        responseObject["message"].ToString().Should()
+            .Be($"Requested quality '{quality}' not supported, use 'default' or 'color'");
+        responseObject["statusCode"].ToString().Should().Be("400");
+    }
+    
+    [Theory]
+    [InlineData("!0")]
+    [InlineData("90")]
+    public async Task GetThumbnail_Returns400_IfUnsupportedRotationRequested(string rotation)
+    {
+        // Arrange
+        var id = $"99/1/{nameof(GetThumbnail_Returns400_IfUnsupportedRotationRequested)}";
+
+        // Act
+        var response = await httpClient.GetAsync($"thumbs/{id}/full/max/{rotation}/default.jpg");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+        responseObject["message"].ToString().Should()
+            .Be($"Requested rotation value not supported, use '0'");
+        responseObject["statusCode"].ToString().Should().Be("400");
+    }
+}

--- a/Thumbs/Startup.cs
+++ b/Thumbs/Startup.cs
@@ -73,7 +73,7 @@ namespace Thumbs
             {
                 app.UseDeveloperExceptionPage();
             }
-            
+
             app.UseRouting();
             // TODO: Consider better caching solutions
             app.UseResponseCaching();

--- a/Thumbs/ThumbsMiddleware.cs
+++ b/Thumbs/ThumbsMiddleware.cs
@@ -175,10 +175,6 @@ namespace Thumbs
         private string GetInfoJsonPath(ImageAssetDeliveryRequest imageAssetDeliveryRequest, Version requestedVersion)
         {
             var redirectPath = GetFullImagePath(imageAssetDeliveryRequest, requestedVersion);
-            /*if (!redirectPath.EndsWith('/'))
-            {
-                redirectPath += "/";
-            }*/
 
             var infoJson = redirectPath.ToConcatenated('/', "info.json");
             return infoJson;


### PR DESCRIPTION
Add extension method to check if iiif image request is candidate to be handled by thumbs, this checks:

* `Format` is `jpg`
* `Quality` is `color` or `default`
* `Rotation` is `/0/`

This check is used when returning image bytes from thumbs middleware - if request can't be handled a 400 is returned.

Check is also verified in reverse-proxy logic to validate that it could be handled by thumbs.

Also removed `?mode=dump` debug code from thumbs middleware.

Last change was to remove direct calls to Newtonsoft in thumbs and instead use system.text.json

For #283 