### PR TITLE
Add Images.NotForDelivery column

### DIFF
--- a/DLCS.Model/Assets/Asset.cs
+++ b/DLCS.Model/Assets/Asset.cs
@@ -40,6 +40,11 @@ namespace DLCS.Model.Assets
         public AssetFamily Family { get; set; }
         public string MediaType { get; set; }
         public long Duration { get; set; }
+        
+        /// <summary>
+        /// Flags the asset as not to be delivered for viewing under any circumstances
+        /// </summary>
+        public bool NotForDelivery { get; set; }
 
         private IEnumerable<string>? rolesList;
         

--- a/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -104,7 +104,8 @@ namespace DLCS.Repository.Assets
                     NumberReference3 = rawAsset.NumberReference3,
                     PreservedUri = rawAsset.PreservedUri,
                     ThumbnailPolicy = rawAsset.ThumbnailPolicy,
-                    ImageOptimisationPolicy = rawAsset.ImageOptimisationPolicy
+                    ImageOptimisationPolicy = rawAsset.ImageOptimisationPolicy,
+                    NotForDelivery = rawAsset.NotForDelivery
                 };
             }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Short));
         }
@@ -114,7 +115,7 @@ SELECT ""Id"", ""Customer"", ""Space"", ""Created"", ""Origin"", ""Tags"", ""Rol
 ""PreservedUri"", ""Reference1"", ""Reference2"", ""Reference3"", ""MaxUnauthorised"", 
 ""NumberReference1"", ""NumberReference2"", ""NumberReference3"", ""Width"", 
 ""Height"", ""Error"", ""Batch"", ""Finished"", ""Ingesting"", ""ImageOptimisationPolicy"", 
-""ThumbnailPolicy"", ""Family"", ""MediaType"", ""Duration""
+""ThumbnailPolicy"", ""Family"", ""MediaType"", ""Duration"", ""NotForDelivery""
   FROM public.""Images""
   WHERE ""Id""=@Id;";
 

--- a/DLCS.Repository/Assets/NamedQueryRepository.cs
+++ b/DLCS.Repository/Assets/NamedQueryRepository.cs
@@ -53,7 +53,7 @@ namespace DLCS.Repository.Assets
 
         public IQueryable<Asset> GetNamedQueryResults(ParsedNamedQuery query)
         {
-            var imageFilter = dlcsContext.Images.Where(i => i.Customer == query.Customer);
+            var imageFilter = dlcsContext.Images.Where(i => i.Customer == query.Customer && !i.NotForDelivery);
 
             if (query.String1.HasText())
             {

--- a/DLCS.Repository/DlcsContext.cs
+++ b/DLCS.Repository/DlcsContext.cs
@@ -9,7 +9,6 @@ using DLCS.Core.Enum;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.CustomHeaders;
 using DLCS.Model.Assets.NamedQueries;
-using DLCS.Model.Auth;
 using DLCS.Model.Auth.Entities;
 using DLCS.Model.Customers;
 using DLCS.Model.Spaces;

--- a/DLCS.Repository/Migrations/20220701092842_Asset gains notForDelivery.Designer.cs
+++ b/DLCS.Repository/Migrations/20220701092842_Asset gains notForDelivery.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20220701092842_Asset gains notForDelivery")]
+    partial class AssetgainsnotForDelivery
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DLCS.Repository/Migrations/20220701092842_Asset gains notForDelivery.cs
+++ b/DLCS.Repository/Migrations/20220701092842_Asset gains notForDelivery.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class AssetgainsnotForDelivery : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Expires",
+                table: "SignupLinks",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "SignupLinks",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "NotForDelivery",
+                table: "Images",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NotForDelivery",
+                table: "Images");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Expires",
+                table: "SignupLinks",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "SignupLinks",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+    }
+}

--- a/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -65,6 +65,24 @@ namespace Orchestrator.Tests.Assets
             result.Should().BeOfType(expectedType);
         }
         
+        [Theory]
+        [InlineData(AssetFamily.Image)]
+        [InlineData(AssetFamily.Timebased)]
+        [InlineData(AssetFamily.File)]
+        public async Task GetOrchestrationAsset_Null_IfAssetFoundButNotForDelivery(AssetFamily family)
+        {
+            // Arrange
+            var assetId = new AssetId(1, 1, "go!");
+            A.CallTo(() => assetRepository.GetAsset(assetId))
+                .Returns(new Asset { Family = family, NotForDelivery = true });
+            
+            // Act
+            var result = await sut.GetOrchestrationAsset(assetId);
+            
+            // Assert
+            result.Should().BeNull();
+        }
+        
         [Fact]
         public async Task GetOrchestrationAssetT_Null_IfOrchestrationAssetNotFound()
         {
@@ -85,6 +103,20 @@ namespace Orchestrator.Tests.Assets
             // Arrange
             var assetId = new AssetId(1, 1, "go!");
             A.CallTo(() => assetRepository.GetAsset(assetId)).Returns<Asset>(null);
+            
+            // Act
+            var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+            
+            // Assert
+            result.Should().BeNull();
+        }
+        
+        [Fact]
+        public async Task GetOrchestrationAssetT_Null_IfAssetFoundButNotForDelivery()
+        {
+            // Arrange
+            var assetId = new AssetId(1, 1, "go!");
+            A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset { NotForDelivery = true });
             
             // Act
             var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);

--- a/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -87,16 +87,31 @@ namespace Orchestrator.Tests.Integration
         }
         
         [Fact]
-        public async Task Get_NotFoundHttOrigin_Returns404()
+        public async Task Get_NotFoundHttpOrigin_Returns404()
         {
             // Arrange
-            var id = "99/1/Get_NotFoundHttOrigin_Returns404";
+            var id = $"99/1/{nameof(Get_NotFoundHttpOrigin_Returns404)}";
             await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
                 origin: $"{stubAddress}/not-found");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
-            var response = await httpClient.GetAsync("file/99/1/Get_DefaultOrigin_ReturnsFile");
+            var response = await httpClient.GetAsync($"file/{id}");
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+        
+        [Fact]
+        public async Task Get_Returns404_IfNotForDelivery()
+        {
+            // Arrange
+            var id = $"99/1/{nameof(Get_Returns404_IfNotForDelivery)}";
+            await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true);
+            await dbFixture.DbContext.SaveChangesAsync();
+
+            // Act
+            var response = await httpClient.GetAsync($"file/{id}");
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -106,13 +121,13 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_HttpOrigin_ReturnsFile()
         {
             // Arrange
-            var id = "99/1/Get_HttpOrigin_ReturnsFile";
+            var id = $"99/1/{nameof(Get_HttpOrigin_ReturnsFile)}";
             await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
                 origin: $"{stubAddress}/testfile");
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
-            var response = await httpClient.GetAsync("file/99/1/Get_HttpOrigin_ReturnsFile");
+            var response = await httpClient.GetAsync($"file/{id}");
             
             // Assert
             response.Content.Headers.ContentType.MediaType.Should().Be("application/pdf");
@@ -123,7 +138,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_BasicAuthHttpOrigin_ReturnsFile()
         {
             // Arrange
-            var id = "99/1/Get_BasicAuthHttpOrigin_ReturnsFile";
+            var id = $"99/1/{nameof(Get_BasicAuthHttpOrigin_ReturnsFile)}";
             await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
                 origin: $"{stubAddress}/authfile");
             await dbFixture.DbContext.CustomerOriginStrategies.AddAsync(new CustomerOriginStrategy
@@ -134,7 +149,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
-            var response = await httpClient.GetAsync("file/99/1/Get_BasicAuthHttpOrigin_ReturnsFile");
+            var response = await httpClient.GetAsync($"file/{id}");
             
             // Assert
             response.Content.Headers.ContentType.MediaType.Should().Be("application/pdf");
@@ -145,7 +160,7 @@ namespace Orchestrator.Tests.Integration
         public async Task Get_BasicAuthHttpOrigin_BadCredentials_Returns404()
         {
             // Arrange
-            var id = "99/1/Get_BasicAuthHttpOrigin_BadCredentials_Returns404";
+            var id = $"99/1/{nameof(Get_BasicAuthHttpOrigin_BadCredentials_Returns404)}";
             await dbFixture.DbContext.Images.AddTestAsset(id, family: AssetFamily.File, mediaType: "application/pdf",
                 origin: $"{stubAddress}/forbiddenfile");
             await dbFixture.DbContext.CustomerOriginStrategies.AddAsync(new CustomerOriginStrategy
@@ -156,7 +171,7 @@ namespace Orchestrator.Tests.Integration
             await dbFixture.DbContext.SaveChangesAsync();
 
             // Act
-            var response = await httpClient.GetAsync("file/99/1/Get_BasicAuthHttpOrigin_BadCredentials_Returns404");
+            var response = await httpClient.GetAsync($"file/{id}");
             
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -39,6 +39,8 @@ namespace Orchestrator.Tests.Integration
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-2", num1: 1, ref1: "my-ref");
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-nothumbs", num1: 3, ref1: "my-ref",
                 maxUnauthorised: 10, roles: "default");
+            dbFixture.DbContext.Images.AddTestAsset("99/1/not-for-delivery", num1: 4, ref1: "my-ref",
+                notForDelivery: true);
             dbFixture.DbContext.SaveChanges();
         }
 

--- a/Orchestrator.Tests/Integration/PdfTests.cs
+++ b/Orchestrator.Tests/Integration/PdfTests.cs
@@ -59,6 +59,8 @@ namespace Orchestrator.Tests.Integration
                 maxUnauthorised: 10, roles: "default");
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-pdf-4", num1: 4, ref1: "my-ref");
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-pdf-5", num1: 5, ref1: "my-ref");
+            dbFixture.DbContext.Images.AddTestAsset("99/1/not-for-delivery", num1: 6, ref1: "my-ref",
+                notForDelivery: true);
             dbFixture.DbContext.SaveChanges();
         }
         

--- a/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -80,6 +80,21 @@ namespace Orchestrator.Tests.Integration
             // Assert
             response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+        
+        [Fact]
+        public async Task Get_Returns404_IfNotForDelivery()
+        {
+            // Arrange
+            var id = $"99/1/{nameof(Get_Returns404_IfNotForDelivery)}";
+            await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true);
+            await dbFixture.DbContext.SaveChangesAsync();
+
+            // Act
+            var response = await httpClient.GetAsync($"iiif-av/{id}/full/full/max/max/0/default.mp4");
+            
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
 
         [Fact]
         public async Task Get_AssetDoesNotRequireAuth_Returns302ToS3Location()

--- a/Orchestrator.Tests/Integration/ZipTests.cs
+++ b/Orchestrator.Tests/Integration/ZipTests.cs
@@ -58,6 +58,8 @@ namespace Orchestrator.Tests.Integration
                 maxUnauthorised: 10, roles: "default");
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-zip-4", num1: 4, ref1: "my-ref");
             dbFixture.DbContext.Images.AddTestAsset("99/1/matching-zip-5", num1: 5, ref1: "my-ref");
+            dbFixture.DbContext.Images.AddTestAsset("99/1/not-for-delivery", num1: 6, ref1: "my-ref",
+                notForDelivery: true);
             dbFixture.DbContext.SaveChanges();
         }
         

--- a/README.md
+++ b/README.md
@@ -120,3 +120,8 @@ dotnet run ./Utils/TestData/TestData.csproj
 ```
 
 > Note that the seed data added by `TestData` is insufficient to fully run DLCS and will need expanded as Engine and API are ported.
+
+Migrations are added using:
+```bash
+dotnet ef migrations add "Table gains column" -p DLCS.Repository -s API
+```

--- a/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -29,14 +29,15 @@ namespace Test.Helpers.Integration
             string ref3 = "",
             int num1 = 0,
             int num2 = 0,
-            int num3 = 0)
+            int num3 = 0,
+            bool notForDelivery = false)
             => assets.AddAsync(new Asset
             {
                 Created = DateTime.UtcNow, Customer = customer, Space = space, Id = id, Origin = origin,
                 Width = width, Height = height, Roles = roles, Family = family, MediaType = mediaType,
                 ThumbnailPolicy = "default", MaxUnauthorised = maxUnauthorised, Reference1 = ref1,
                 Reference2 = ref2, Reference3 = ref3, NumberReference1 = num1, NumberReference2 = num2,
-                NumberReference3 = num3
+                NumberReference3 = num3, NotForDelivery = notForDelivery
             });
 
         public static ValueTask<EntityEntry<AuthToken>> AddTestToken(this DbSet<AuthToken> authTokens,

--- a/Thumbs.Tests/ThumbReorganiserTests.cs
+++ b/Thumbs.Tests/ThumbReorganiserTests.cs
@@ -50,7 +50,7 @@ namespace Thumbs.Tests
             
             // Assert
             response.Should().Be(ReorganiseResult.HasExpectedLayout);
-            A.CallTo(() => assetRepository.GetAsset(A<string>._))
+            A.CallTo(() => assetRepository.GetAsset(A<AssetId>._))
                 .MustNotHaveHappened();
         }
 


### PR DESCRIPTION
If `true` then Orchestrator will not return assets - added filtering to `MemoryAssetTracker` so that normal orchestration logic is not aware of it and also to `NamedQueryRepository` to exclude from all datasets to projections.