### PR TITLE
Special Server handling

### DIFF
--- a/compose/.env.dist
+++ b/compose/.env.dist
@@ -34,6 +34,11 @@ Thumbs__UpscaleThreshold=40
 # ------------------------------------------------------------------------------
 KAKADU_APPS_LOCATION=s3://bucket/kakadu/kdu.tar.gz
 
+# Special Server
+# ------------------------------------------------------------------------------
+SS_AWS_ACCESS_KEY_ID=xxx
+SS_AWS_SECRET_ACCESS_KEY=xxx
+
 # Common
 # ------------------------------------------------------------------------------
 ASPNETCORE_ENVIRONMENT=Development

--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -6,13 +6,13 @@ volumes:
   dlcs_localstack_tmp: {}
 
 services:
-  iip:
-    image: ghcr.io/dlcs/iipsrv-openjpeg:2.4.0
-    ports:
-      - "5025:8080"
-    volumes:
-      - $HOME\Docker\scratch:/nas
-    entrypoint: /operations.sh
+  # iip:
+  #   image: ghcr.io/dlcs/iipsrv-openjpeg:2.4.0
+  #   ports:
+  #     - "5025:8080"
+  #   volumes:
+  #     - $HOME\Docker\scratch:/nas
+  #   entrypoint: /operations.sh
 
   cantaloupe:
     image: ghcr.io/dlcs/cantaloupe:5.0.5
@@ -25,6 +25,22 @@ services:
       - PROCESSOR_MANUALSELECTIONSTRATEGY_JP2=GrokProcessor
     volumes:
       - $HOME\Docker\scratch:/home/cantaloupe/images/
+
+  special-server:
+    image: ghcr.io/dlcs/cantaloupe:5.0.5
+    ports:
+      - "5126:8182"
+    environment:
+      - ENDPOINT_ADMIN_ENABLED=true
+      - ENDPOINT_ADMIN_SECRET=admin
+      - DELEGATE_SCRIPT_ENABLED=true
+      - SOURCE_STATIC=S3Source
+      - DELEGATE_SCRIPT_PATHNAME=/cantaloupe/delegates.rb
+      - S3SOURCE_LOOKUP_STRATEGY=ScriptLookupStrategy
+      - AWS_ACCESS_KEY_ID=${SS_AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${SS_AWS_SECRET_ACCESS_KEY}
+    env_file:
+      - .env
 
   fireball:
     image: fractos/fireball:1304a21459c2b6157abc46d3808512b578bd78b5

--- a/src/protagonist/Orchestrator.Tests/Features/Images/CustomHeaderProcessorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/CustomHeaderProcessorTests.cs
@@ -23,7 +23,7 @@ public class CustomHeaderProcessorTests
         List<CustomHeader> customerCustomHeaders = null;
         var orchestrationImage = new OrchestrationImage();
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -40,7 +40,7 @@ public class CustomHeaderProcessorTests
         List<CustomHeader> customerCustomHeaders = new();
         var orchestrationImage = new OrchestrationImage();
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -61,7 +61,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(true);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -83,7 +83,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(true);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -106,7 +106,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(true);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -130,7 +130,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(true);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -153,7 +153,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(false);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,
@@ -177,7 +177,7 @@ public class CustomHeaderProcessorTests
 
         var orchestrationImage = GetOrchestrationImage(false);
         var proxyImageServerResult =
-            new ProxyImageServerResult(orchestrationImage, false, ProxyDestination.Orchestrator);
+            new ProxyImageServerResult(orchestrationImage, false);
         
         // Act
         CustomHeaderProcessor.SetProxyImageHeaders(customerCustomHeaders, orchestrationImage,

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -151,9 +151,154 @@ public class ImageRequestHandlerTests
     }
 
     [Theory]
+    [InlineData("900,")]
+    [InlineData("900,900")]
+    [InlineData(",900")]
+    [InlineData("!900,900")]
+    [InlineData("pct:50")]
+    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequestSmallerThanMaxUnauthorised(
+        string sizeParameter)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = $"/iiif-img/2/2/test-image/full/{sizeParameter}/0/default.jpg";
+
+        var roles = new List<string> { "role" };
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
+                MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                S3Location = "s3://storage/2/2/test-image"
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+
+        // Assert
+        result.Target.Should().Be(ProxyDestination.SpecialServer);
+        result.HasPath.Should().BeTrue();
+        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequestSmallerThanMaxUnauthorised_MaxSize()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/2/2/test-image/full/max/0/default.jpg";
+
+        var roles = new List<string> { "role" };
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
+                MaxUnauthorised = 900, Width = 900, Height = 900, RequiresAuth = true,
+                S3Location = "s3://storage/2/2/test-image"
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+
+        // Assert
+        result.Target.Should().Be(ProxyDestination.SpecialServer);
+        result.HasPath.Should().BeTrue();
+        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
+    }
+
+    [Theory]
+    [InlineData("/full/901,901/", "Size too large")]
+    [InlineData("/full/max/", "Max size")]
+    [InlineData("/0,0,512,512/900,/", "Tiled region")]
+    [InlineData("/pct:0,0,512,512/!10,10/", "Percent region")]
+    [InlineData("/square/!90,90/", "Square region")]
+    public async Task HandleRequest_Returns401_IfAssetRequiresAuth_AndUserNotAuthorised_AndRequestNotForMaxUnauthorised(
+        string iiifRequest, string reason)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = $"/iiif-img/2/2/test-image{iiifRequest}0/default.jpg";
+
+        var roles = new List<string> { "role" };
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
+            .Returns(new OrchestrationImage
+            {
+                Roles = roles, MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                S3Location = "s3://storage/2/2/test-image"
+            });
+        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie))
+            .Returns(AssetAccessResult.Unauthorized);
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context);
+
+        // Assert
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized, reason);
+    }
+
+    [Fact]
+    public async Task HandleRequest_ProxiesToThumbs_IfRequiresAuth_AndFullRegionOfKnownSize_SmallerThanMaxUnauthorised()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
+
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } }, Height = 1000, Width = 1000,
+                RequiresAuth = true, Roles = new List<string> { "role" }, MaxUnauthorised = 200,
+                S3Location = "s3://storage/2/2/test-image"
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+            
+        // Assert
+        result.Target.Should().Be(ProxyDestination.Thumbs);
+        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
+    }
+
+    [Fact]
+    public async Task HandleRequest_ProxiesToThumbs_IfFullRegion_AndKnownSize()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
+
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
+                S3Location = "s3://storage/2/2/test-image"
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+            
+        // Assert
+        result.Target.Should().Be(ProxyDestination.Thumbs);
+        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
+    }
+    
+    [Theory]
     [InlineData(AssetAccessResult.Open)]
     [InlineData(AssetAccessResult.Authorized)]
-    public async Task HandleRequest_ProxiesToImageServer_IfAssetRequiresAuth_AndUserAuthorised(
+    public async Task HandleRequest_ProxiesToImageServer_IfFullRegion_AndNoKnownThumb_ButNoS3Location(
         AssetAccessResult accessResult)
     {
         // Arrange
@@ -181,154 +326,51 @@ public class ImageRequestHandlerTests
     }
     
     [Theory]
-    [InlineData("900,")]
-    [InlineData("900,900")]
-    [InlineData(",900")]
-    [InlineData("!900,900")]
-    [InlineData("pct:50")]
-    public async Task HandleRequest_ProxiesToImageServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequestSmallerThanMaxUnauthorised(
-        string sizeParameter)
+    [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg")] // full/<size>
+    [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg")] // /full/full
+    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg")] // /full/max
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png")] // png
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif")] // tif
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg")] // rotation
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg")] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg")] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg")] // gray
+    public async Task HandleRequest_ProxiesToSpecialServer_ForAllFull(string path)
     {
         // Arrange
         var context = new DefaultHttpContext();
-        context.Request.Path = $"/iiif-img/2/2/test-image/full/{sizeParameter}/0/default.jpg";
-
-        var roles = new List<string> { "role" };
-        var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage
-            {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true
-            });
-        var sut = GetImageRequestHandlerWithMockPathParser();
-
-        // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
-
-        // Assert
-        result.Target.Should().Be(ProxyDestination.ImageServer);
-        result.HasPath.Should().BeTrue();
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
-    }
-    
-    [Fact]
-    public async Task HandleRequest_ProxiesToImageServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequestSmallerThanMaxUnauthorised_MaxSize()
-    {
-        // Arrange
-        var context = new DefaultHttpContext();
-        context.Request.Path = $"/iiif-img/2/2/test-image/full/max/0/default.jpg";
-
-        var roles = new List<string> { "role" };
-        var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage
-            {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                MaxUnauthorised = 900, Width = 900, Height = 900, RequiresAuth = true
-            });
-        var sut = GetImageRequestHandlerWithMockPathParser();
-
-        // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
-
-        // Assert
-        result.Target.Should().Be(ProxyDestination.ImageServer);
-        result.HasPath.Should().BeTrue();
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
-    }
-
-    [Theory]
-    [InlineData("/full/901,901/", "Size too large")]
-    [InlineData("/full/max/", "Max size")]
-    [InlineData("/0,0,512,512/900,/", "Tiled region")]
-    [InlineData("/pct:0,0,512,512/!10,10/", "Percent region")]
-    [InlineData("/square/!90,90/", "Square region")]
-    public async Task HandleRequest_Returns401_IfAssetRequiresAuth_AndUserNotAuthorised_AndRequestNotForMaxUnauthorised(
-        string iiifRequest, string reason)
-    {
-        // Arrange
-        var context = new DefaultHttpContext();
-        context.Request.Path = $"/iiif-img/2/2/test-image{iiifRequest}0/default.jpg";
-
-        var roles = new List<string> { "role" };
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
-            .Returns(new OrchestrationImage
-            {
-                Roles = roles, MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true
-            });
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie))
-            .Returns(AssetAccessResult.Unauthorized);
-        var sut = GetImageRequestHandlerWithMockPathParser();
-
-        // Act
-        var result = await sut.HandleRequest(context);
-
-        // Assert
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized, reason);
-    }
-
-    [Fact]
-    public async Task HandleRequest_ProxiesToThumbs_IfRequiresAuth_AndFullRegionOfKnownSize_SmallerThanMaxUnauthorised()
-    {
-        // Arrange
-        var context = new DefaultHttpContext();
-        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
+        context.Request.Path = path;
 
         A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
+            
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
+
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
-            {
-                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } }, Height = 1000, Width = 1000,
-                RequiresAuth = true, Roles = new List<string> { "role" }, MaxUnauthorised = 200
-            });
-        var sut = GetImageRequestHandlerWithMockPathParser();
+                { AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image" });
 
         // Act
         var result = await sut.HandleRequest(context) as ProxyActionResult;
             
         // Assert
-        result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
-    }
-
-    [Fact]
-    public async Task HandleRequest_ProxiesToThumbs_IfFullOrMaxRegion_AndKnownSize()
-    {
-        // Arrange
-        var context = new DefaultHttpContext();
-        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
-
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage
-                { AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } } });
-        var sut = GetImageRequestHandlerWithMockPathParser();
-
-        // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
-            
-        // Assert
-        result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
+        result.Target.Should().Be(ProxyDestination.SpecialServer);
+        result.Path.Should().Be("cantaloupe-3s3:%2F%2Fstorage%2F2%2F2%2Ftest-image");
     }
         
     [Theory]
-    [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg", false)] // UV without ?t=
-    [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg", true)] // /full/full
-    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", true)] // /full/max
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png", false)] // png
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif", false)] // tif
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg", false)] // rotation
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg", false)] // rotation / mirrored
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", false)] // bitonal
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", false)] // bitonal
-    public async Task HandleRequest_ProxiesToImageServer_ForAllOtherCases(string path, bool knownThumb)
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/90,/0/default.jpg", false)] // UV without ?t=
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/full/0/default.jpg", true)] // /full/full
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/max/0/default.jpg", true)] // /full/max
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/gray.jpg", false)] // gray
+    public async Task HandleRequest_ProxiesToImageServer_ForAllTileRequests(string path, bool knownThumb)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -344,7 +386,8 @@ public class ImageRequestHandlerTests
             : new List<int[]>();
 
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage { AssetId = assetId, OpenThumbs = openSizes });
+            .Returns(new OrchestrationImage
+                { AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image" });
 
         // Act
         var result = await sut.HandleRequest(context) as ProxyImageServerResult;
@@ -355,11 +398,14 @@ public class ImageRequestHandlerTests
     }
 
     [Theory]
-    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v2/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-2")]
-    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-3")]
-    [InlineData(ImageServer.IIPImage, "/iiif-img/v2/2/2/test-image/full/90,/0/default.jpg", "iip")]
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v2/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-2", ProxyDestination.SpecialServer)]
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-3", ProxyDestination.SpecialServer)]
+    [InlineData(ImageServer.IIPImage, "/iiif-img/v2/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-2", ProxyDestination.SpecialServer)]
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v2/2/2/test-image/5,5,5,5/90,/0/default.jpg", "cantaloupe-2", ProxyDestination.ImageServer)]
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/5,5,5,5/90,/0/default.jpg", "cantaloupe-3", ProxyDestination.ImageServer)]
+    [InlineData(ImageServer.IIPImage, "/iiif-img/v2/2/2/test-image/5,5,5,5/90,/0/default.jpg", "iip", ProxyDestination.ImageServer)]
     public async Task HandleRequest_ProxiesToCorrectImageServerEndpoint_ForVersionedRequests(ImageServer imageServer,
-        string path, string startsWith)
+        string path, string startsWith, ProxyDestination proxyDestination)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -372,21 +418,22 @@ public class ImageRequestHandlerTests
         settings.ImageServer = imageServer;
         var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage { AssetId = assetId, OpenThumbs = new List<int[]>() });
+            .Returns(new OrchestrationImage
+                { AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image" });
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
 
         // Assert
-        result.Target.Should().Be(ProxyDestination.ImageServer);
+        result.Target.Should().Be(proxyDestination);
         result.HasPath.Should().BeTrue();
         result.Path.Should().StartWith(startsWith);
     }
 
     [Theory]
-    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v1/2/2/test-image/full/90,/0/default.jpg")] // Unknown version
-    [InlineData(ImageServer.IIPImage, "/iiif-img/v3/2/2/test-image/full/90,/0/default.jpg")] // Unsupported version
-    public async Task HandleRequest_Returns400_IfMatchingImageServerNotFound(ImageServer imageServer, string path)
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v1/2/2/test-image/0,0,512,512/90,/0/default.jpg")] // Unknown version
+    [InlineData(ImageServer.IIPImage, "/iiif-img/v3/2/2/test-image/0,0,512,512/90,/0/default.jpg")] // Unsupported version
+    public async Task HandleRequest_Returns400_IfMatchingImageServerNotFound_TileRequest(ImageServer imageServer, string path)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -399,7 +446,31 @@ public class ImageRequestHandlerTests
         settings.ImageServer = imageServer;
         var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage { AssetId = assetId, OpenThumbs = new List<int[]>() });
+            .Returns(new OrchestrationImage
+                { AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image" });
+
+        // Act
+        var result = await sut.HandleRequest(context) as StatusCodeResult;
+            
+        // Assert
+        result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task HandleRequest_Returns400_IfMatchingImageServerNotFound_Full()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/v10/2/2/test-image/full/90,/0/default.jpg";
+
+        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+
+        var settings = CreateOrchestratorSettings();
+        var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
+        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+            .Returns(new OrchestrationImage
+                { AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image" });
 
         // Act
         var result = await sut.HandleRequest(context) as StatusCodeResult;
@@ -408,12 +479,15 @@ public class ImageRequestHandlerTests
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    [Fact]
-    public async Task Handle_Request_ProxiesToImageServer_WithCustomHeaders()
+    [Theory]
+    [InlineData("/iiif-img/2/2/test-image/full/!150,150/0/default.jpg", ProxyDestination.Thumbs)]
+    [InlineData("/iiif-img/2/2/test-image/5,5,5,5/90,/0/default.jpg", ProxyDestination.ImageServer)]
+    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", ProxyDestination.SpecialServer)] 
+    public async Task HandleRequest_ProxiesAll_WithCustomHeaders(string path, ProxyDestination destination)
     {
         // Arrange
         var context = new DefaultHttpContext();
-        context.Request.Path = "/iiif-img/2/2/test-image/full/max/0/default.jpg";
+        context.Request.Path = path;
 
         A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => customHeaderRepository.GetForCustomer(2)).Returns(new List<CustomHeader>
@@ -429,13 +503,15 @@ public class ImageRequestHandlerTests
         List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
 
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
-            .Returns(new OrchestrationImage { AssetId = assetId, OpenThumbs = openSizes });
+            .Returns(new OrchestrationImage
+                { AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image" });
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
             
         // Assert
         result.Headers.Should().ContainKeys("x-test-header", "x-test-header-2");
+        result.Target.Should().Be(destination);
     }
 
     private ImageRequestHandler GetImageRequestHandlerWithMockPathParser(bool mockPathParser = false,

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -352,12 +352,14 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
                 { AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image" });
 
+        var expected = $"cantaloupe-3s3:%2F%2Fstorage%2F2%2F2%2Ftest-image/{string.Join("/", path.Split("/")[5..])}";
+
         // Act
         var result = await sut.HandleRequest(context) as ProxyActionResult;
             
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
-        result.Path.Should().Be("cantaloupe-3s3:%2F%2Fstorage%2F2%2F2%2Ftest-image");
+        result.Path.Should().Be(expected);
     }
         
     [Theory]
@@ -388,13 +390,15 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
                 { AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image" });
+        
+        var expected = $"cantaloupe-3/path/{string.Join("/", path.Split("/")[5..])}";
 
         // Act
         var result = await sut.HandleRequest(context) as ProxyImageServerResult;
             
         // Assert
         result.Target.Should().Be(ProxyDestination.ImageServer);
-        result.HasPath.Should().BeTrue();
+        result.Path.Should().Be(expected);
     }
 
     [Theory]

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -651,8 +651,9 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_Returns401_IfNoCookie(string path, string type)
     {
         // Arrange
-        await dbFixture.DbContext.Images.AddTestAsset($"99/1/test-auth-nocook{type}", roles: "basic",
-            maxUnauthorised: 100);
+        var id = $"99/1/test-auth-nocook{type}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -668,8 +669,9 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_Returns401_IfInvalidCookie(string path, string type)
     {
         // Arrange
-        await dbFixture.DbContext.Images.AddTestAsset($"99/1/test-auth-invalidcook{type}", roles: "basic",
-            maxUnauthorised: 100);
+        var id = $"99/1/test-auth-invalidcook{type}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -689,6 +691,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = $"99/1/test-auth-expcook{type}";
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -706,13 +709,14 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Theory]
-    [InlineData("iiif-img/99/1/test-auth-cookid/full/max/0/default.jpg", "id")]
-    [InlineData("iiif-img/test/1/test-auth-cookdisplay/full/max/0/default.jpg", "display")]
-    public async Task Get_ImageRequiresAuth_RedirectsToImageServer_AndSetsCookie_IfCookieProvided(string path, string type)
+    [InlineData("iiif-img/99/1/test-auth-cook-tileid/0,0,512,512/!512,512/0/default.jpg", "id")]
+    [InlineData("iiif-img/test/1/test-auth-cook-tiledisplay/0,0,512,512/!512,512/0/default.jpg", "display")]
+    public async Task Get_ImageRequiresAuth_RedirectsToImageServer_AndSetsCookie_IfCookieProvided_TileRequest(string path, string type)
     {
         // Arrange
-        var id = $"99/1/test-auth-cook{type}";
+        var id = $"99/1/test-auth-cook-tile{type}";
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -739,6 +743,41 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.Headers.Should().ContainKey("Set-Cookie");
     }
     
+    [Theory]
+    [InlineData("iiif-img/99/1/test-auth-cookid/full/max/0/default.jpg", "id")]
+    [InlineData("iiif-img/test/1/test-auth-cookdisplay/full/max/0/default.jpg", "display")]
+    public async Task Get_ImageRequiresAuth_RedirectsToImageServer_AndSetsCookie_IfCookieProvided_FullRequest(string path, string type)
+    {
+        // Arrange
+        var id = $"99/1/test-auth-cook{type}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
+        var userSession =
+            await dbFixture.DbContext.SessionUsers.AddTestSession(
+                DlcsDatabaseFixture.ClickThroughAuthService.AsList());
+        var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
+            sessionUserId: userSession.Entity.Id);
+        await dbFixture.DbContext.SaveChangesAsync();
+        
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": [[400,400], [200,200]]}",
+        });
+        
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Cookie", $"dlcs-token-99=id={authToken.Entity.CookieId};");
+        var response = await httpClient.SendAsync(request);
+        var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
+        
+        // Assert
+        proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("Set-Cookie");
+    }
+    
     [Fact]
     public async Task Get_ImageIsExactThumbMatch_RedirectsToThumbs()
     {
@@ -750,8 +789,9 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[200,200]]}",
         });
 
-        await dbFixture.DbContext.Images.AddTestAsset("99/1/known-thumb", origin: "/test/space", width: 1000,
-            height: 1000);
+        var id = "99/1/known-thumb";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri("http://thumbs/thumbs/99/1/known-thumb/full/!200,200/0/default.jpg");
         
@@ -776,6 +816,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[400,400], [200,200]]}",
         });
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!123,123/0/default.jpg");
         
@@ -788,10 +829,10 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToImageServer()
+    public async Task Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = $"99/1/{nameof(Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToImageServer)}";
+        var id = $"99/1/{nameof(Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToSpecialServer)}";
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -800,6 +841,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[400,400], [200,200]]}",
         });
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -807,14 +849,14 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
         
         // Assert
-        proxyResponse.Uri.ToString().Should().StartWith("http://image-server/iiif");
+        proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
     }
     
     [Fact]
-    public async Task Get_FullRegion_NoOpenThumbs_RedirectsToImageServer()
+    public async Task Get_FullRegion_NoOpenThumbs_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = $"99/1/{nameof(Get_FullRegion_NoOpenThumbs_RedirectsToImageServer)}";
+        var id = $"99/1/{nameof(Get_FullRegion_NoOpenThumbs_RedirectsToSpecialServer)}";
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -824,6 +866,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -831,14 +874,14 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
         
         // Assert
-        proxyResponse.Uri.ToString().Should().StartWith("http://image-server/iiif");
+        proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
     }
     
     [Fact]
-    public async Task Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToImageServer()
+    public async Task Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = $"99/1/upscale{nameof(Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToImageServer)}";
+        var id = $"99/1/upscale{nameof(Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToSpecialServer)}";
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -848,6 +891,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -855,7 +899,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
         
         // Assert
-        proxyResponse.Uri.ToString().Should().StartWith("http://image-server/iiif");
+        proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
     }
     
     [Fact]
@@ -872,6 +916,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!600,600/0/default.jpg");
         
@@ -900,9 +945,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Theory]
     [InlineData("iiif-img/99/1/resize/full/!200,200/0/default.jpg", "resize")]
     [InlineData("iiif-img/99/1/full/full/full/0/default.jpg", "full")]
-    [InlineData("iiif-img/99/1/tile/0,0,1000,1000/200,200/0/default.jpg", "tile")]
-    [InlineData("iiif-img/test/1/rewrite_id/0,0,1000,1000/200,200/0/default.jpg", "rewrite_id", "iiif-img/99/1/rewrite_id/0,0,1000,1000/200,200/0/default.jpg")]
-    public async Task Get_RedirectsImageServer_AsFallThrough(string path, string imageName, string rewrittenPath = null)
+    public async Task Get_RedirectsSpecialServer_AsFallThrough_ForFullRequests(string path, string imageName)
     {
         // Arrange
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -912,8 +955,40 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": []}",
         });
 
-        await dbFixture.DbContext.Images.AddTestAsset($"99/1/{imageName}", origin: "/test/space", width: 1000,
-            height: 1000);
+        var id = $"99/1/{imageName}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
+        await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
+        
+        // Assert
+        proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.SharedMaxAge.Should().Be(TimeSpan.FromDays(28));
+        response.Headers.CacheControl.MaxAge.Should().Be(TimeSpan.FromDays(28));
+        response.Headers.Should().ContainKey("x-test-key").WhoseValue.Should().BeEquivalentTo("foo bar");
+    }
+    
+    [Theory]
+    [InlineData("iiif-img/99/1/tile/0,0,1000,1000/200,200/0/default.jpg", "tile")]
+    [InlineData("iiif-img/test/1/rewrite_id/0,0,1000,1000/200,200/0/default.jpg", "rewrite_id")]
+    public async Task Get_RedirectsImageServer_AsFallThrough_ForTileRequests(string path, string imageName)
+    {
+        // Arrange
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"99/1/{imageName}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": []}",
+        });
+
+        var id = $"99/1/{imageName}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000);
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
         await dbFixture.DbContext.SaveChangesAsync();
 
@@ -991,6 +1066,5 @@ public class FakeImageServerClient : IImageServerClient
             Width = 100,
             Height = 100
         } as TImageService;
-
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Settings/OrchestratorSettingsTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Settings/OrchestratorSettingsTests.cs
@@ -86,4 +86,16 @@ public class OrchestratorSettingsTests
         // Assert
         actual.Should().BeNull();
     }
+    
+    [Theory]
+    [InlineData(Version.V3, "/iiif/3/s3:%2F%2Fbucket%2Fitem%2Fkey")]
+    [InlineData(Version.V2, "/iiif/2/s3:%2F%2Fbucket%2Fitem%2Fkey")]
+    public void GetSpecialServerPath_Versioned_Correct(Version version, string expected)
+    {
+        // Act
+        var actual = imageServerSettings.GetSpecialServerPath("s3://bucket/item/key", version);
+
+        // Assert
+        actual.Should().Be(expected);
+    }
 }

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -52,10 +52,10 @@
           }
         }
       },
-      "varnish_cache": {
+      "specialserver": {
         "Destinations": {
-          "varnish_cache/one": {
-            "Address": "http://varnish"
+          "specialserver/one": {
+            "Address": "http://special-server"
           }
         }
       },

--- a/src/protagonist/Orchestrator/Features/Images/CustomHeaderProcessor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/CustomHeaderProcessor.cs
@@ -8,14 +8,14 @@ using Orchestrator.Infrastructure.ReverseProxy;
 namespace Orchestrator.Features.Images;
 
 /// <summary>
-/// Processes <see cref="CustomHeader"/> and sets any headers in <see cref="ProxyImageServerResult"/>
+/// Processes <see cref="CustomHeader"/> and sets any headers in <see cref="IProxyActionResult"/>
 /// </summary>
 public static class CustomHeaderProcessor
 {
     public static void SetProxyImageHeaders(
         List<CustomHeader> customerCustomHeaders,
         OrchestrationImage orchestrationImage,
-        ProxyActionResult proxyImageServerResult)
+        IProxyActionResult proxyImageServerResult)
     {
         // order of precedence (low -> high), same header will be overwritten if present
         // no space or role

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -242,9 +242,10 @@ public class ImageRequestHandler
             return new StatusCodeResult(HttpStatusCode.BadRequest);
         }
         
+        var imageServerPath = $"{redirectPath}{requestModel.IIIFImageRequest.ImageRequestPath}";
         IProxyActionResult proxyActionResult = specialServer
-            ? new ProxyActionResult(ProxyDestination.SpecialServer, orchestrationImage.RequiresAuth, redirectPath)
-            : new ProxyImageServerResult(orchestrationImage, orchestrationImage.RequiresAuth, redirectPath);
+            ? new ProxyActionResult(ProxyDestination.SpecialServer, orchestrationImage.RequiresAuth, imageServerPath)
+            : new ProxyImageServerResult(orchestrationImage, orchestrationImage.RequiresAuth, imageServerPath);
         return proxyActionResult;
     }
 

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using API.Client;
+using DLCS.Core.Streams;
 using DLCS.Core.Threading;
 using DLCS.Core.Types;
 using DLCS.Repository.Strategy;
@@ -102,7 +103,7 @@ public class ImageOrchestrator : IImageOrchestrator
         await using (var originResponse = await s3OriginStrategy.LoadAssetFromOrigin(image.AssetId,
             image.S3Location, null, cancellationToken))
         {
-            if (originResponse == null || originResponse.Stream == Stream.Null)
+            if (originResponse == null || originResponse.Stream.IsNull())
             {
                 // TODO correct type of exception? Custom type?
                 logger.LogWarning("Unable to get asset {Asset} from {Origin}", image.AssetId,

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
@@ -122,6 +122,7 @@ public class DownstreamDestinationSelector
             ProxyDestination.Orchestrator => "deliverator",
             ProxyDestination.Thumbs => "thumbs",
             ProxyDestination.ResizeThumbs => "thumbresize",
+            ProxyDestination.SpecialServer => "specialserver",
             ProxyDestination.ImageServer => GetImageServerCluster(),
             _ => throw new ArgumentOutOfRangeException(nameof(destination), destination, null)
         };

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
@@ -53,7 +53,7 @@ public class PathRewriteTransformer : HttpTransformer
     private void EnsureCacheHeaders(HttpContext httpContext)
     {
         const string cacheControlHeader = "Cache-Control";
-        if (proxyAction.Target != ProxyDestination.ImageServer) return;
+        if (proxyAction.Target is not ProxyDestination.ImageServer and not ProxyDestination.SpecialServer) return;
         var cacheControl = proxyAction.RequiresAuth
             ? "private, max-age=600"
             : "public, s-maxage=2419200, max-age=2419200";

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
@@ -29,8 +29,7 @@ public class ProxyImageServerResult : ProxyActionResult
     public ProxyImageServerResult(
         OrchestrationImage orchestrationImage,
         bool requiresAuth,
-        ProxyDestination target,
-        string? path = null) : base(target, requiresAuth, path)
+        string? path = null) : base(ProxyDestination.ImageServer, requiresAuth, path)
     {
         OrchestrationImage = orchestrationImage;
     }

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyDestination.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyDestination.cs
@@ -26,9 +26,14 @@ public enum ProxyDestination
     ResizeThumbs,
     
     /// <summary>
-    /// Image-server, cluster targeted destination is determined by ImageServer value
+    /// Image-server, cluster target destination is determined by ImageServer value
     /// </summary>
     ImageServer,
+    
+    /// <summary>
+    /// Specially configured image-server to handle full + large image requests without the need to orchestrate
+    /// </summary>
+    SpecialServer,
     
     /// <summary>
     /// Proxy response from S3

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyDestination.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyDestination.cs
@@ -31,7 +31,7 @@ public enum ProxyDestination
     ImageServer,
     
     /// <summary>
-    /// Specially configured image-server to handle full + large image requests without the need to orchestrate
+    /// Specially configured image-server to handle /full/ image requests without the need to orchestrate
     /// </summary>
     SpecialServer,
     

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -118,6 +118,11 @@ public class ProxySettings
     /// A collection of resize config for serving resized thumbs rather than handling requests via image-server
     /// </summary>
     public Dictionary<string, ThumbUpscaleConfig> ThumbUpscaleConfig { get; set; } = new();
+
+    /// <summary>
+    /// If true details of proxied location are added as x-proxy-* headers. Intended for debug use only.
+    /// </summary>
+    public bool AddProxyDebugHeaders { get; set; } = false;
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
@@ -1,5 +1,6 @@
 ﻿using DLCS.Core.Types;
 using DLCS.Model.Templates;
+using Orchestrator.Assets;
 
 namespace Orchestrator.Settings;
 
@@ -34,6 +35,27 @@ public static class OrchestratorSettingsX
         => settings.ImageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate)
             ? GetImageServerFilePathInternal(assetId, settings.ImageServerConfig, pathTemplate)
             : null;
+
+    /// <summary>
+    /// Get the full redirect path for SpecialServer for specified ImageApi version. Includes parsed S3 location where
+    /// image-server can access asset file
+    /// </summary>
+    /// <returns>Path for image-server if image-server can handle requested version, else null</returns>
+    public static string? GetSpecialServerPath(this OrchestratorSettings settings, string s3Location,
+        IIIF.ImageApi.Version targetVersion)
+    {
+        if (!settings.ImageServerPathConfig.TryGetValue(ImageServer.Cantaloupe, out var imageServerConfig))
+        {
+            return null;
+        }
+
+        if (!imageServerConfig.VersionPathTemplates.TryGetValue(targetVersion, out var pathTemplate))
+        {
+            return null;
+        }
+
+        return $"{pathTemplate}{s3Location.Replace("/", imageServerConfig.Separator)}";
+    }
 
     private static string GetImageServerFilePathInternal(AssetId assetId, ImageServerConfig imageServerConfig,
         string versionTemplate)

--- a/src/protagonist/Orchestrator/readme.md
+++ b/src/protagonist/Orchestrator/readme.md
@@ -22,7 +22,10 @@ Handle image asset requests. Will:
 * Validate access for restricted assets.
 * Proxy `thumbs` for known thumbnail sizes.
 * Proxy `thumbsresize` for requests that can be served by resizing thumbs.
-* Ensure asset copied to fast disk and proxy to appropriate `image-server` for other sizes and tile requests. Image requests will have "CustomHeader" headers appended as required.
+* Proxy `specialserver` for `/full/` requests that cannot be handled by thumbs (e.g. due to size, quality, format, rotation).
+* Ensure asset copied to fast disk and proxy to appropriate `image-server` for other sizes and tile requests. 
+
+All image requests will have "CustomHeader" headers appended as required.
 
 Decision logic in `ImageRequestHandler` and routing logic in `ImageRouteHandler`. 
 
@@ -43,6 +46,7 @@ Decision logic in `TimeBasedRequestHandler` and routing logic in `TimeBasedRoute
 The following YARP Clusters are used:
 
 * cantaloupe - Cantaloupe image-server.
+* specialserver - Cantaloupe image-server configured to understand `s3://` URL from ImageLocation table and read directly from bucket, without needing to orchestrate.
 * iip - IIP image-server
 * thumbs - Protagonist thumbs service.
 * thumbsresize - Protagonist thumbs service, configured to resize thumbs on the fly.


### PR DESCRIPTION
For #286

Add a new value to `ProxyDestination` enum, `ProxyDestination.SpecialServer` to handle `/full/` requests. The path sent to SpecialServer will be the `ImageLocation.S3` value (either `s3://<region>/<bucket>/<key>` or `s3://<bucket>/<key>` depending on Engine config). 

Refactor `ImageRequestHandler` to redirect to SpecialServer if it's a `/full/` request that hasn't been proxied to thumbs. The exception to this is if `ImageLocation.S3` for requested image is empty - this is a rare occurrence that will require a reingest to handle. The call to reingest is already handled within the [`ImageOrchestrator`](https://github.com/dlcs/protagonist/blob/develop/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs#L77-L87), rather than complicate redirects to SpecialServer I opted to fallthrough to proxy to image-server if `S3` is empty - this will then be reingested and subsequent requests can be handled by SpecialServer.

Refactor of `ImageRequestHandler` included some safety checks and then the main orchestration logic has been moved to an internal method, this keeps the customer header setting happening in a single place. The overall flow is now:

```cs
public async Task<IProxyActionResult> HandleRequest(HttpContext httpContext)
{
    // omitted: parse request + get asset. May return 4xx or 5xx

    // New method: contains logic to decide if thumbs, special-server or image-server is appropriate
    var proxyActionResult = await HandleRequestInternal(httpContext, orchestrationImage, assetRequest);

    // No headers set if StatusCodeResult
    if (proxyActionResult is StatusCodeResult) return proxyActionResult;

    // set any custom headers + return
    await SetCustomHeaders(orchestrationImage, result);
    return proxyActionResult;
}
```

Added `"Proxy:AddProxyDebugHeaders"` config value, if `true` then `x-proxy-destination` header will be set to `ProxyDestination` enum value.

See https://github.com/dlcs/image-server-node-cantaloupe/pull/3 for update to cantaloupe image to allow "Special Server" config.