### PR TITLE
Do not add Services to info.json if no roles or auth-services

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -466,7 +466,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var responseStream = await response.Content.ReadAsStreamAsync();
         var infoJson = responseStream.FromJsonStream<ImageService3>();
 
-        infoJson.Id.Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_RestrictedImage_NoRole_Correct");
+        infoJson.Id.Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_RestrictedImage_NoRole_HasNoService");
         infoJson.Service.Should().BeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         response.Headers.CacheControl.Public.Should().BeFalse();

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core.Collections;
 using IIIF;
 using IIIF.ImageApi;
 using IIIF.ImageApi.V2;
@@ -57,11 +58,13 @@ public class InfoJsonConstructor
         // Placeholder, will be rewritten on way out
         imageService.Id = $"v2/{orchestrationImage.AssetId}";
 
-        if (orchestrationImage.RequiresAuth)
+        if (orchestrationImage.RequiresAuth && !orchestrationImage.Roles.IsNullOrEmpty())
         {
-            imageService.Service ??= new List<IService>(1);
             var authCookieServiceForAsset =
                 await iiifAuthBuilder.GetAuthCookieServiceForAsset(orchestrationImage, cancellationToken);
+            if (authCookieServiceForAsset == null) return;
+            
+            imageService.Service ??= new List<IService>(1);
             imageService.Service.Add(authCookieServiceForAsset);
         }
     }
@@ -74,11 +77,13 @@ public class InfoJsonConstructor
         // Placeholder, will be rewritten on way out
         imageService.Id = $"v3/{orchestrationImage.AssetId}";
 
-        if (orchestrationImage.RequiresAuth)
+        if (orchestrationImage.RequiresAuth && !orchestrationImage.Roles.IsNullOrEmpty())
         {
-            imageService.Service ??= new List<IService>(1);
             var authCookieServiceForAsset =
                 await iiifAuthBuilder.GetAuthCookieServiceForAsset(orchestrationImage, cancellationToken);
+            if (authCookieServiceForAsset == null) return;
+            
+            imageService.Service ??= new List<IService>(1);
             imageService.Service.Add(authCookieServiceForAsset);
         }
     }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
+using DLCS.Core.Streams;
 using DLCS.Model.Storage;
 using IIIF;
 using IIIF.ImageApi;
@@ -50,7 +51,7 @@ public class InfoJsonService
         var infoJsonKey = GetInfoJsonKey(orchestrationImage, version);
         await using var infoJson = await GetStoredInfoJson(infoJsonKey, cancellationToken);
 
-        if (infoJson != null && infoJson != Stream.Null)
+        if (!infoJson.IsNull())
         {
             // If info.json found in S3, return it
             JsonLdBase deserialisedInfoJson = version == Version.V2

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
@@ -53,7 +53,7 @@ public class YarpImageServerClient : IImageServerClient
             
         try
         {
-            // TODO - return something more descriptive here?
+            logger.LogDebug("Getting info.json for {AssetId} from image-server", orchestrationImage.AssetId);
             await using var infoJson = await httpClient.GetStreamAsync(imageServerPath, cancellationToken);
             return infoJson.FromJsonStream<TImageService>();
         }


### PR DESCRIPTION
Fix issue where a restricted image with no roles would result in a `null` service being added to the info.json. This would be served fine on initial request but would fail subsequent requests as it can't be deserialized from S3.

Example abberviated info.json as written to S3:

```
{
  "@context": "http://iiif.io/api/image/3/context.json",
  "id": "1/1/image",
  "type": "ImageService3",
  "profile": "level2",
  "protocol": "http://iiif.io/api/image",
  "width": 1724,
  "height": 1719,
  "sizes": [ ... ],
  "tiles": [ ... ],
  "extraQualities": [ ... ],
  "service": [ null ],
  "extraFormats": [ ... ],
  "extraFeatures": [ .. .]
}
```

Fix is to not add a `"service"` if there are no roles or if no authService found.

Bug spotted when testing #357, introduced as part of change in auth logic (#334) as not all images that require auth will have a role. 