### PR TITLE
standardise naming in API controllers

### DIFF
--- a/src/protagonist/API/Features/Customer/ApiKeysController.cs
+++ b/src/protagonist/API/Features/Customer/ApiKeysController.cs
@@ -32,8 +32,13 @@ public class ApiKeysController : HydraController
         this.mediator = mediator;
     }
     
-    
-    // ################# GET /customers/id/keys #####################
+    /// <summary>
+    /// GET /customers/id/keys
+    ///
+    /// List of all the API Keys available for this customer
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <returns>HydraCollection of ApiKey objects</returns>
     [HttpGet]
     [Route("{customerId}/keys")]
     public async Task<IActionResult> GetApiKeys(int customerId)
@@ -44,7 +49,7 @@ public class ApiKeysController : HydraController
             return HydraNotFound();
         }
 
-        var urlRoots = getUrlRoots();
+        var urlRoots = GetUrlRoots();
         var collection = new HydraCollection<ApiKey>
         {
             WithContext = true,
@@ -59,30 +64,43 @@ public class ApiKeysController : HydraController
     }
         
         
-    // ################# POST /customers/id/keys #####################
+    /// <summary>
+    /// POST /customers/id/keys
+    ///
+    /// Client can obtain a new key by posting an empty payload
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <returns>newly created ApiKey</returns>
     [HttpPost]
     [Route("{customerId}/keys")]
-    public async Task<IActionResult> CreateNewApiKey(int customerId)
+    public async Task<IActionResult> CreateApiKey(int customerId)
     {
         var result = await mediator.Send(new CreateApiKey(customerId));
         if (result.Key.HasText() && result.Secret.HasText())
         {
-            return Ok(new ApiKey(getUrlRoots().BaseUrl, customerId, result.Key, result.Secret));
+            return Ok(new ApiKey(GetUrlRoots().BaseUrl, customerId, result.Key, result.Secret));
         }
 
-        return HydraProblem("Unable to create API key", null, 500, "API Key", null);
+        return HydraProblem("Unable to create API key", null, 500, "API Key");
     }
         
         
-    // ################# DELETE /customers/id/keys/key #####################
+    /// <summary>
+    /// DELETE /customers/id/keys/key
+    ///
+    /// Remove a key so that it can no longer be used.
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <param name="key"></param>
+    /// <returns>No content</returns>
     [HttpDelete]
     [Route("{customerId}/keys/{key}")]
-    public async Task<IActionResult> DeleteKey(int customerId, string key)
+    public async Task<IActionResult> DeleteApiKey(int customerId, string key)
     {
         var result = await mediator.Send(new DeleteApiKey(customerId, key));
         if (result.Error.HasText())
         {
-            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request", null);
+            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request");
         }
 
         return NoContent();

--- a/src/protagonist/API/Features/Customer/PortalUsersController.cs
+++ b/src/protagonist/API/Features/Customer/PortalUsersController.cs
@@ -35,16 +35,20 @@ public class PortalUsersController : HydraController
     }
     
     
-        
-    // ################# GET /customers/id/portalUsers #####################
+    /// <summary>
+    /// GET /customers/{customerId}/portalUsers
+    /// 
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <returns>HydraCollection of PortalUser</returns>
     [HttpGet]
     [Route("{customerId}/portalUsers")]
-    public async Task<HydraCollection<PortalUser>> GetUsers(int customerId)
+    public async Task<HydraCollection<PortalUser>> GetPortalUsers(int customerId)
     {
         var users = await mediator.Send(new GetPortalUsers { CustomerId = customerId });
             
-        var baseUrl = getUrlRoots().BaseUrl;
-        var collection = new HydraCollection<DLCS.HydraModel.PortalUser>
+        var baseUrl = GetUrlRoots().BaseUrl;
+        var collection = new HydraCollection<PortalUser>
         {
             WithContext = true,
             Members = users.Select(s => s.ToHydra(baseUrl)).ToArray(),
@@ -55,26 +59,39 @@ public class PortalUsersController : HydraController
         return collection;
     }
         
-    // ################# GET /customers/id/portalUsers/id #####################
+    
+    /// <summary>
+    /// GET /customers/{customerId}/portalUsers/{userId}
+    /// 
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <param name="userId"></param>
+    /// <returns></returns>
     [HttpGet]
     [Route("{customerId}/portalUsers/{userId}")]
-    public async Task<IActionResult> GetUser(int customerId, string userId)
+    public async Task<IActionResult> GetPortalUser(int customerId, string userId)
     {
         var users = await mediator.Send(new GetPortalUsers { CustomerId = customerId });
         var user = users.SingleOrDefault(u => u.Id == userId);
         if (user != null)
         {
-            return Ok(user.ToHydra(getUrlRoots().BaseUrl));
+            return Ok(user.ToHydra(GetUrlRoots().BaseUrl));
         }
 
         return HydraNotFound();
     }
         
         
-    // ################# POST /customers/id/portalUsers #####################
+    /// <summary>
+    /// POST /customers/{customerId}/portalUsers
+    /// 
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <param name="portalUser"></param>
+    /// <returns></returns>
     [HttpPost]
     [Route("{customerId}/portalUsers")]
-    public async Task<IActionResult> CreateUser(int customerId, [FromBody] PortalUser portalUser)
+    public async Task<IActionResult> CreatePortalUser(int customerId, [FromBody] PortalUser portalUser)
     {
         var request = new CreatePortalUser
         {
@@ -88,18 +105,29 @@ public class PortalUsersController : HydraController
         var result = await mediator.Send(request);
         if (result.Error.HasText() || result.PortalUser == null)
         {
-            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot create user", null);
+            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot create user");
         }
             
-        var hydraPortalUser = result.PortalUser.ToHydra(getUrlRoots().BaseUrl);
-        return Created(hydraPortalUser.Id, hydraPortalUser);
+        var hydraPortalUser = result.PortalUser.ToHydra(GetUrlRoots().BaseUrl);
+        if (hydraPortalUser.Id.HasText())
+        {
+            return Created(hydraPortalUser.Id, hydraPortalUser);
+        }
+        return HydraProblem("No id on returned portal user", null, 500, "Cannot create user");
     }
         
         
-    // ################# PATCH /customers/id/portalUsers/id #####################
+    /// <summary>
+    /// PATCH /customers/{customerId}/portalUsers/{userId}
+    /// 
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <param name="userId"></param>
+    /// <param name="portalUser"></param>
+    /// <returns></returns>
     [HttpPatch]
     [Route("{customerId}/portalUsers/{userId}")]
-    public async Task<IActionResult> PatchUser(int customerId, string userId, [FromBody] PortalUser portalUser)
+    public async Task<IActionResult> PatchPortalUser(int customerId, string userId, [FromBody] PortalUser portalUser)
     {
         // NB Deliverator doesn't support toggling Enabled here so we won't for now.
             
@@ -116,23 +144,29 @@ public class PortalUsersController : HydraController
         var result = await mediator.Send(request);
         if (result.Error.HasText() || result.PortalUser == null)
         {
-            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot Patch user", null);
+            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot PatchSpace user");
         }
             
-        var hydraPortalUser = result.PortalUser.ToHydra(getUrlRoots().BaseUrl);
+        var hydraPortalUser = result.PortalUser.ToHydra(GetUrlRoots().BaseUrl);
         return Ok(hydraPortalUser);
     }
         
         
-    // ################# DELETE /customers/id/portalUsers/id #####################
+    /// <summary>
+    /// DELETE /customers/{customerId}/portalUsers/{userId}
+    /// 
+    /// </summary>
+    /// <param name="customerId"></param>
+    /// <param name="userId"></param>
+    /// <returns></returns>
     [HttpDelete]
     [Route("{customerId}/portalUsers/{userId}")]
-    public async Task<IActionResult> DeleteUser(int customerId, string userId)
+    public async Task<IActionResult> DeletePortalUser(int customerId, string userId)
     {
         var result = await mediator.Send(new DeletePortalUser(customerId, userId));
         if (result.Error.HasText())
         {
-            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request", null);
+            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request");
         }
 
         return NoContent();

--- a/src/protagonist/API/Features/Customer/PortalUsersController.cs
+++ b/src/protagonist/API/Features/Customer/PortalUsersController.cs
@@ -144,7 +144,7 @@ public class PortalUsersController : HydraController
         var result = await mediator.Send(request);
         if (result.Error.HasText() || result.PortalUser == null)
         {
-            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot PatchSpace user");
+            return HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot Patch user");
         }
             
         var hydraPortalUser = result.PortalUser.ToHydra(GetUrlRoots().BaseUrl);

--- a/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
@@ -17,7 +17,7 @@ namespace API.Features.Customer.Requests;
 public class CreatePortalUser : IRequest<CreatePortalUserResult>
 {
     public User PortalUser { get; set; }
-    public string Password { get; set; }
+    public string? Password { get; set; }
     
 }
 

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -50,12 +50,12 @@ public class ImageController : HydraController
     /// <summary>
     /// GET /customers/{customerId}/spaces/{spaceId}/images/{imageId}
     /// 
-    /// A single Hydra GetImage.
+    /// A single Hydra Image.
     /// </summary>
     /// <param name="customerId">(from resource path)</param>
     /// <param name="spaceId">(from resource path)</param>
     /// <param name="imageId">(from resource path)</param>
-    /// <returns>A Hydra JSON-LD GetImage object representing the Asset.</returns>
+    /// <returns>A Hydra JSON-LD Image object representing the Asset.</returns>
     [HttpGet]
     [ProducesResponseType(200, Type = typeof(DLCS.HydraModel.Image))]
     [ProducesResponseType(404, Type = typeof(Error))]
@@ -83,7 +83,7 @@ public class ImageController : HydraController
     /// <param name="pageSize"></param>
     /// <param name="orderBy"></param>
     /// <param name="orderByDescending"></param>
-    /// <returns>A Hydra Collection of GetImage objects as JSON-LD</returns>
+    /// <returns>A Hydra Collection of Image objects as JSON-LD</returns>
     [HttpGet]
     [ProducesResponseType(200, Type = typeof(HydraCollection<DLCS.HydraModel.Image>))]
     [ProducesResponseType(404, Type = typeof(Error))]
@@ -127,8 +127,8 @@ public class ImageController : HydraController
     /// <param name="customerId">(from resource path)</param>
     /// <param name="spaceId">(from resource path)</param>
     /// <param name="imageId">(from resource path)</param>
-    /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (GetImage class)</param>
-    /// <returns>The created or updated Hydra GetImage object for the Asset</returns>
+    /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
+    /// <returns>The created or updated Hydra Image object for the Asset</returns>
     [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))] // for PatchSpace
     [ProducesResponseType((int)HttpStatusCode.Created, Type = typeof(DLCS.HydraModel.Image))] // for PUT when created
     [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(ProblemDetails))]
@@ -194,8 +194,8 @@ public class ImageController : HydraController
     /// </summary>
     /// <param name="customerId">(from resource path)</param>
     /// <param name="spaceId">(from resource path)</param>
-    /// <param name="images">The JSON-LD request body, a HydraCollection of Hydra GetImage objects.</param>
-    /// <returns>A HydraCollection of the updated Assets, as Hydra GetImage objects.</returns>
+    /// <param name="images">The JSON-LD request body, a HydraCollection of Hydra Image objects.</param>
+    /// <returns>A HydraCollection of the updated Assets, as Hydra Image objects.</returns>
     [HttpPatch]
     [ProducesResponseType(200, Type = typeof(HydraCollection<DLCS.HydraModel.Image>))]
     [ProducesResponseType(400, Type = typeof(Error))]
@@ -293,7 +293,7 @@ public class ImageController : HydraController
     ///
     ///     POST: /customers/1/spaces/1/images/my-image
     ///     {
-    ///         "@type":"GetImage",
+    ///         "@type":"Image",
     ///         "family": "I",
     ///         "file": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAM...."
     ///     }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -129,7 +129,7 @@ public class ImageController : HydraController
     /// <param name="imageId">(from resource path)</param>
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>
-    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))] // for PatchSpace
+    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))] // for PATCH
     [ProducesResponseType((int)HttpStatusCode.Created, Type = typeof(DLCS.HydraModel.Image))] // for PUT when created
     [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(ProblemDetails))]
     [ProducesResponseType((int)HttpStatusCode.MethodNotAllowed, Type = typeof(ProblemDetails))]

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -115,8 +115,66 @@ public class ImageController : HydraController
         PartialCollectionView.AddPaging(collection, page.Value, pageSize.Value, orderByField, descending);
         return Ok(collection);
     }
-    
-    
+
+
+    /// <summary>
+    /// PUT /customers/{customerId}/spaces/{spaceId}/images/{imageId}
+    /// 
+    /// PUT an asset to its ID location
+    /// </summary>
+    /// <param name="customerId">(from resource path)</param>
+    /// <param name="spaceId">(from resource path)</param>
+    /// <param name="imageId">(from resource path)</param>
+    /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
+    /// <returns>The created or updated Hydra Image object for the Asset</returns>
+    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))]
+    [ProducesResponseType((int)HttpStatusCode.Created, Type = typeof(DLCS.HydraModel.Image))]
+    [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.MethodNotAllowed, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.NotFound, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.InsufficientStorage, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.NotImplemented, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.InternalServerError, Type = typeof(ProblemDetails))]
+    [HttpPut]
+    [Route("{imageId}")]
+    public async Task<IActionResult> PutImage(
+        [FromRoute] int customerId,
+        [FromRoute] int spaceId,
+        [FromRoute] string imageId,
+        [FromBody] DLCS.HydraModel.Image hydraAsset)
+    {
+        return await PutOrPatchImage(customerId, spaceId, imageId, hydraAsset);
+    }
+
+    /// <summary>
+    /// PATCH /customers/{customerId}/spaces/{spaceId}/images/{imageId}
+    /// 
+    /// PATCH asset at that location.
+    /// </summary>
+    /// <param name="customerId">(from resource path)</param>
+    /// <param name="spaceId">(from resource path)</param>
+    /// <param name="imageId">(from resource path)</param>
+    /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
+    /// <returns>The created or updated Hydra Image object for the Asset</returns>
+    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))] // for PATCH
+    [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.MethodNotAllowed, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.NotFound, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.InsufficientStorage, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.NotImplemented, Type = typeof(ProblemDetails))]
+    [ProducesResponseType((int)HttpStatusCode.InternalServerError, Type = typeof(ProblemDetails))]
+    [HttpPatch]
+    [Route("{imageId}")]
+    public async Task<IActionResult> PatchImage(
+        [FromRoute] int customerId,
+        [FromRoute] int spaceId,
+        [FromRoute] string imageId,
+        [FromBody] DLCS.HydraModel.Image hydraAsset)
+    {
+        return await PutOrPatchImage(customerId, spaceId, imageId, hydraAsset);
+    }
+
+
     /// <summary>
     /// PUT   /customers/{customerId}/spaces/{spaceId}/images/{imageId}
     /// PATCH /customers/{customerId}/spaces/{spaceId}/images/{imageId}
@@ -129,18 +187,7 @@ public class ImageController : HydraController
     /// <param name="imageId">(from resource path)</param>
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>
-    [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))] // for PATCH
-    [ProducesResponseType((int)HttpStatusCode.Created, Type = typeof(DLCS.HydraModel.Image))] // for PUT when created
-    [ProducesResponseType((int)HttpStatusCode.BadRequest, Type = typeof(ProblemDetails))]
-    [ProducesResponseType((int)HttpStatusCode.MethodNotAllowed, Type = typeof(ProblemDetails))]
-    [ProducesResponseType((int)HttpStatusCode.NotFound, Type = typeof(ProblemDetails))]
-    [ProducesResponseType((int)HttpStatusCode.InsufficientStorage, Type = typeof(ProblemDetails))]
-    [ProducesResponseType((int)HttpStatusCode.NotImplemented, Type = typeof(ProblemDetails))]
-    [ProducesResponseType((int)HttpStatusCode.InternalServerError, Type = typeof(ProblemDetails))]
-    [HttpPut]
-    [HttpPatch]
-    [Route("{imageId}")]
-    public async Task<IActionResult> PutOrPatchImage(
+    private async Task<IActionResult> PutOrPatchImage(
         [FromRoute] int customerId,
         [FromRoute] int spaceId,
         [FromRoute] string imageId,

--- a/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
@@ -23,7 +23,7 @@ public class PatchSpace : IRequest<PatchSpaceResult>
 
 public class PatchSpaceResult
 {
-    public DLCS.Model.Spaces.Space Space;
+    public DLCS.Model.Spaces.Space? Space;
     public List<string> ErrorMessages = new List<string>();
     public bool Conflict { get; set; }
 }

--- a/src/protagonist/API/HydraController.cs
+++ b/src/protagonist/API/HydraController.cs
@@ -14,14 +14,22 @@ namespace API;
 /// </summary>
 public abstract class HydraController : Controller
 {
-    protected ApiSettings Settings;
+    /// <summary>
+    /// API Settings available to derived controller classes
+    /// </summary>
+    protected readonly ApiSettings Settings;
     
+    /// <inheritdoc />
     protected HydraController(ApiSettings settings)
     {
         Settings = settings;
     }
 
-    protected UrlRoots getUrlRoots()
+    /// <summary>
+    /// Used by derived controllers to construct correct fully qualified URLs in returned Hydra objects.
+    /// </summary>
+    /// <returns></returns>
+    protected UrlRoots GetUrlRoots()
     {
         return new UrlRoots
         {
@@ -66,7 +74,7 @@ public abstract class HydraController : Controller
     /// <param name="type">The value for <see cref="Error.Type" />.</param>
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
     [NonAction]
-    public virtual ObjectResult HydraProblem(
+    protected virtual ObjectResult HydraProblem(
         IEnumerable<string>? errorMessages = null,
         string? instance = null,
         int? statusCode = null,
@@ -93,7 +101,7 @@ public abstract class HydraController : Controller
     /// <param name="type">The value for <see cref="Error.Type" />.</param>
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
     [NonAction]
-    public virtual ObjectResult HydraProblem(
+    protected virtual ObjectResult HydraProblem(
         string? detail = null,
         string? instance = null,
         int? statusCode = null,
@@ -125,9 +133,9 @@ public abstract class HydraController : Controller
     /// <param name="otherException"></param>
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
     [NonAction]
-    public virtual ObjectResult HydraProblem(Exception otherException)
+    protected virtual ObjectResult HydraProblem(Exception otherException)
     {
-        return HydraProblem(otherException.Message, null, 500, null, null);
+        return HydraProblem(otherException.Message, null, 500);
     }
 
     /// <summary> 
@@ -136,7 +144,7 @@ public abstract class HydraController : Controller
     /// <returns>The created <see cref="ObjectResult"/> for the response.</returns>
     public virtual ObjectResult HydraNotFound(string? detail = null)
     {
-        return HydraProblem(detail, null, 404, "Not Found", null);
+        return HydraProblem(detail, null, 404, "Not Found");
     }
 }
 


### PR DESCRIPTION
Generally:

Standardising comments on Action methods, so they include the HTTP verb+path in the summary, e.g.,
GET /customers/{customerId}

Standardising action method names to _VerbEntity_ or _VerbEntities_
GetApiKey, PatchImages etc
One consequence of this is that the Action method name is then usually the same as the Mediatr Request class name. is that a problem?

Removing some null check warnings and unnecessary passing of nulls to the HydraProblem response.

