### PR TITLE
Handle caret character in iiif image request

### DIFF
--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -23,6 +23,7 @@ services:
       - ENDPOINT_ADMIN_SECRET=admin
       - PROCESSOR_SELECTION_STRATEGY=ManualSelectionStrategy
       - PROCESSOR_MANUALSELECTIONSTRATEGY_JP2=GrokProcessor
+      - MAX_SCALE=0
     volumes:
       - $HOME\Docker\scratch:/home/cantaloupe/images/
 
@@ -39,6 +40,7 @@ services:
       - S3SOURCE_LOOKUP_STRATEGY=ScriptLookupStrategy
       - AWS_ACCESS_KEY_ID=${SS_AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${SS_AWS_SECRET_ACCESS_KEY}
+      - MAX_SCALE=0
     env_file:
       - .env
 

--- a/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
@@ -91,6 +91,31 @@ public class AssetDeliveryPathParserTests
         imageRequest.AssetId.Should().Be("the-astronaut");
         imageRequest.IIIFImageRequest.ImageRequestPath.Should().Be("/full/!800,400/0/default.jpg");
     }
+
+    [Fact]
+    public async Task Parse_ImageRequest_HandlesEscapedUrl()
+    {
+        // Arrange
+        const string path = "/iiif-img/test-customer/1/the-astronaut/full/%5E!800,400/0/default.jpg";
+        var customer = new CustomerPathElement(99, "test-customer");
+        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+            .Returns(customer);
+
+        // Act
+        var imageRequest = await sut.Parse<ImageAssetDeliveryRequest>(path);
+
+        // Assert
+        imageRequest.RoutePrefix.Should().Be("iiif-img");
+        imageRequest.VersionedRoutePrefix.Should().Be("iiif-img");
+        imageRequest.VersionPathValue.Should().BeNull();
+        imageRequest.CustomerPathValue.Should().Be("test-customer");
+        imageRequest.Customer.Should().Be(customer);
+        imageRequest.BasePath.Should().Be("/iiif-img/test-customer/1/");
+        imageRequest.Space.Should().Be(1);
+        imageRequest.AssetPath.Should().Be("the-astronaut/full/^!800,400/0/default.jpg");
+        imageRequest.AssetId.Should().Be("the-astronaut");
+        imageRequest.IIIFImageRequest.ImageRequestPath.Should().Be("/full/^!800,400/0/default.jpg");
+    }
     
     [Fact]
     public async Task Parse_ImageRequest_WithCustomerNameStartingV_IsNotParsedAsVersioned()

--- a/src/protagonist/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
+++ b/src/protagonist/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -38,11 +39,12 @@ public class AssetDeliveryPathParser : IAssetDeliveryPathParser
         where T : BaseAssetRequest, new()
     {
         var assetRequest = new T();
-        await ParseBaseAssetRequest(path, assetRequest);
+        var escapedPath = WebUtility.UrlDecode(path);
+        await ParseBaseAssetRequest(escapedPath, assetRequest);
 
         if (assetRequest is ImageAssetDeliveryRequest imageAssetRequest)
         {
-            imageAssetRequest.IIIFImageRequest = ImageRequest.Parse(path, assetRequest.BasePath);
+            imageAssetRequest.IIIFImageRequest = ImageRequest.Parse(escapedPath, assetRequest.BasePath);
         }
         else if (assetRequest is TimeBasedAssetDeliveryRequest timebasedAssetRequest)
         {
@@ -57,7 +59,7 @@ public class AssetDeliveryPathParser : IAssetDeliveryPathParser
         const int routeIndex = 0;
         const int defaultCustomerIndex = 1;
         const int defaultSpacesIndex = 2;
-        
+
         string[] parts = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
         
         // The first slug after prefix is generally customer but it might be version number


### PR DESCRIPTION
Caret is escaped to %5E, which was causing SizeParameter parsing to fail.

Also set `max_scale=0` for cantaloupe images in docker-compose to allow upscaling.