### PR TITLE
Support `q` and `string1`, `number1` etc params on paged Asset API calls

### DIFF
--- a/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
+++ b/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
@@ -39,7 +39,7 @@ public class ApiAssetRepository : DapperRepository, IApiAssetRepository
     public Task<ImageLocation> GetImageLocation(AssetId assetId) => assetRepository.GetImageLocation(assetId);
 
     public async Task<PageOfAssets?> GetPageOfAssets(int customerId, int spaceId, int page, int pageSize,
-        string orderBy, bool descending, CancellationToken cancellationToken)
+        string orderBy, bool descending, AssetFilter? assetFilter, CancellationToken cancellationToken)
     {
         var space = await dlcsContext.Spaces.SingleOrDefaultAsync(
             s => s.Customer == customerId && s.Id == spaceId, cancellationToken: cancellationToken);
@@ -55,6 +55,7 @@ public class ApiAssetRepository : DapperRepository, IApiAssetRepository
                 a => a.Customer == customerId && a.Space == spaceId, cancellationToken: cancellationToken),
             Assets = await dlcsContext.Images.AsNoTracking()
                 .Where(a => a.Customer == customerId && a.Space == spaceId)
+                .ApplyAssetFilter(assetFilter, false)
                 .AsOrderedAssetQuery(orderBy, descending)
                 .Skip((page - 1) * pageSize)
                 .Take(pageSize)

--- a/src/protagonist/API/Features/Assets/IApiAssetRepository.cs
+++ b/src/protagonist/API/Features/Assets/IApiAssetRepository.cs
@@ -9,8 +9,8 @@ namespace API.Features.Assets;
 /// </summary>
 public interface IApiAssetRepository : IAssetRepository
 {
-    public Task<PageOfAssets?> GetPageOfAssets(int customerId, int spaceId, int page, int pageSize, string orderBy,
-        bool descending, CancellationToken cancellationToken);
+    public Task<PageOfAssets?> GetPageOfAssets(int customerId, int spaceId, int page, int pageSize, string? orderBy,
+        bool descending, AssetFilter? assetFilter, CancellationToken cancellationToken);
 
     public Task Save(Asset asset, CancellationToken cancellationToken);
 }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -96,17 +96,12 @@ public class ImageController : HydraController
     {
         if (pageSize is null or < 0) pageSize = Settings.PageSize;
         if (page is null or < 0) page = 1;
-        AssetFilter? assetFilter = null;
-        if (q.HasText())
-        {
-            assetFilter = Request.GetAssetFilterFromQParam(q);
-            if (assetFilter == null)
-            {
-                return HydraProblem("Could not parse query", null, 400);
-            }
-        }
-        // Now augment this assetFilter, or create one if we don't have one yet
+        var assetFilter = Request.GetAssetFilterFromQParam(q);
         assetFilter = Request.UpdateAssetFilterFromQueryStringParams(assetFilter);
+        if (q.HasText() && assetFilter == null)
+        {
+            return HydraProblem("Could not parse query", null, 400);
+        }
         var orderByField = GetOrderBy(orderBy, orderByDescending, out var descending);
         var imagesRequest = new GetSpaceImages(descending, page.Value, pageSize.Value, 
             spaceId, customerId, orderByField, assetFilter);

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -13,7 +13,8 @@ namespace API.Features.Space.Requests;
 
 public class GetSpaceImages : IRequest<GetSpaceImagesResult>
 {
-    public GetSpaceImages(bool descending, int page, int pageSize, int spaceId, int? customerId = null, string? orderBy = null)
+    public GetSpaceImages(bool descending, int page, int pageSize, int spaceId, int? customerId = null,
+        string? orderBy = null, AssetFilter? assetFilter = null)
     {
         Page = page;
         PageSize = pageSize;
@@ -21,14 +22,17 @@ public class GetSpaceImages : IRequest<GetSpaceImagesResult>
         SpaceId = spaceId;
         OrderBy = orderBy;
         Descending = descending;
+        AssetFilter = assetFilter;
     }
     
     public int SpaceId { get; set; }
     public int? CustomerId { get; }
     public int Page { get; }
     public int PageSize { get; }
-    public string OrderBy { get; }
+    public string? OrderBy { get; }
     public bool Descending { get; }
+    
+    public AssetFilter? AssetFilter { get; }
 }
 
 public class GetSpaceImagesResult
@@ -66,6 +70,7 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, GetSpaceIma
             customerId.Value, request.SpaceId,
             request.Page, request.PageSize,
             request.OrderBy, request.Descending,
+            request.AssetFilter,
             cancellationToken);
 
         if (pageOfAssets == null)

--- a/src/protagonist/DLCS.HydraModel/ImageQuery.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageQuery.cs
@@ -1,0 +1,40 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace DLCS.HydraModel;
+
+public class ImageQuery
+{
+    private static readonly JsonSerializerSettings JsonSerializerSettings;
+
+    static ImageQuery()
+    {
+        JsonSerializerSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        };
+    }
+    
+    public int? Space { get; set; }
+
+    public string? String1 { get; set; }
+    public string? String2 { get; set; }
+    public string? String3 { get; set; }
+
+    public int? Number1 { get; set; }
+    public int? Number2 { get; set; }
+    public int? Number3 { get; set; }
+
+    public static ImageQuery? Parse(string s)
+    {
+        try
+        {
+            return JsonConvert.DeserializeObject<ImageQuery>(s, JsonSerializerSettings);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
@@ -1,0 +1,95 @@
+using API.Converters;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace DLCS.Model.Tests.Assets;
+
+public class AssetFilterTests
+{
+    [Fact]
+    public void Obtain_AssetFilter_From_Q_Param_Directly()
+    {
+        // arrange
+        var q = @"{""string1"":""s1"",""string2"":""s2"",""number3"":3,""space"":99}";
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?q=" + q);
+        
+        // act
+        var filter = httpRequest.GetAssetFilterFromQParam(q);
+        
+        // assert
+        filter.Should().NotBeNull();
+        filter.Reference1.Should().Be("s1");
+        filter.Reference2.Should().Be("s2");
+        filter.Reference3.Should().BeNull();
+        filter.NumberReference1.Should().BeNull();
+        filter.NumberReference3.Should().Be(3);
+        filter.Space.Should().Be(99);
+
+    }
+    
+    [Fact]
+    public void Parse_AssetFilter_From_Request()
+    {
+        // arrange
+        var q = @"{""string3"":""s3"",""number1"":1}";
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?q=" + q);
+        
+        // act
+        var filter = httpRequest.GetAssetFilterFromQParam();
+        
+        // assert
+        filter.Should().NotBeNull();
+        filter.Reference1.Should().Be(null);
+        filter.Reference3.Should().Be("s3");
+        filter.NumberReference1.Should().Be(1);
+        filter.NumberReference3.Should().BeNull();
+        filter.Space.Should().BeNull();
+    }
+
+    [Fact]
+    public void Construct_AssetFilter_From_Specific_Params()
+    {
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?string1=s1&string2=s2&string3=s3&number1=1&number2=2&number3=3");
+        
+        // act
+        var filter = httpRequest.UpdateAssetFilterFromQueryStringParams(null);
+        
+        // assert
+        filter.Should().NotBeNull();
+        filter.Reference1.Should().Be("s1");
+        filter.Reference2.Should().Be("s2");
+        filter.Reference3.Should().Be("s3");
+        filter.NumberReference1.Should().Be(1);
+        filter.NumberReference2.Should().Be(2);
+        filter.NumberReference3.Should().Be(3);
+        filter.Space.Should().BeNull();
+    }
+    
+    
+    [Fact]
+    public void Update_AssetFilter_From_Specific_Params()
+    {
+        var q = @"{""string3"":""s3"",""number1"":1}";
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?q=" + q + "&string1=s1&string3=s3updated&number3=3");
+        
+        // act
+        var filter = httpRequest.GetAssetFilterFromQParam();
+        filter = httpRequest.UpdateAssetFilterFromQueryStringParams(filter);
+        
+        // assert
+        filter.Should().NotBeNull();
+        filter.Reference1.Should().Be("s1");
+        filter.Reference2.Should().BeNull();
+        filter.Reference3.Should().Be("s3updated");
+        filter.NumberReference1.Should().Be(1);
+        filter.NumberReference2.Should().BeNull();
+        filter.NumberReference3.Should().Be(3);
+        filter.Space.Should().BeNull();
+    }
+    
+}

--- a/src/protagonist/DLCS.Model.Tests/Assets/ImageQueryTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ImageQueryTests.cs
@@ -1,0 +1,28 @@
+using DLCS.HydraModel;
+using FluentAssertions;
+using Xunit;
+
+namespace DLCS.Model.Tests.Assets;
+
+public class ImageQueryTests
+{
+    [Fact]
+    public void ImageQuery_Can_Parse_From_String()
+    {
+        // arrange
+        var s =
+            @"{""string1"":""s1"",""string2"":""s2"",""string3"":""s3"",""number1"":1,""number2"":2,""number3"":3,""space"":99}";
+        
+        // act
+        var iq = ImageQuery.Parse(s);
+        
+        // assert
+        iq.Should().NotBeNull();
+        iq.String1.Should().Be("s1");
+        iq.String2.Should().Be("s2");
+        iq.String3.Should().Be("s3");
+        iq.Number1.Should().Be(1);
+        iq.Number2.Should().Be(2);
+        iq.Number3.Should().Be(3);
+    }
+}

--- a/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
@@ -1,0 +1,13 @@
+namespace DLCS.Model.Assets;
+
+public class AssetFilter
+{
+    public int? Space { get; set; }
+    public string? Reference1 { get; set; }
+    public string? Reference2 { get; set; }
+    public string? Reference3 { get; set; }
+    public int? NumberReference1 { get; set; }
+    public int? NumberReference2 { get; set; }
+    public int? NumberReference3 { get; set; }
+    public string[]? Tags { get; set; }
+}

--- a/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 
 namespace DLCS.Repository.Assets;
@@ -63,4 +64,48 @@ public static class AssetQueryX
 
         return Expression.Lambda(body, param);
     }
+
+    public static IQueryable<Asset> ApplyAssetFilter(this IQueryable<Asset> queryable, 
+        AssetFilter? assetFilter, bool filterOnSpace = false)
+    {
+        if (assetFilter == null)
+        {
+            return queryable;
+        }
+
+        var filtered = queryable;
+        // is HasText right here? Would we want to select string1 = ""?
+        if (assetFilter.Reference1.HasText())
+        {
+            filtered = filtered.Where(a => a.Reference1 == assetFilter.Reference1);
+        }
+        if (assetFilter.Reference2.HasText())
+        {
+            filtered = filtered.Where(a => a.Reference2 == assetFilter.Reference2);
+        }
+        if (assetFilter.Reference3.HasText())
+        {
+            filtered = filtered.Where(a => a.Reference3 == assetFilter.Reference3);
+        }
+        if (assetFilter.NumberReference1 != null)
+        {
+            filtered = filtered.Where(a => a.NumberReference1 == assetFilter.NumberReference1);
+        }
+        if (assetFilter.NumberReference2 != null)
+        {
+            filtered = filtered.Where(a => a.NumberReference2 == assetFilter.NumberReference2);
+        }
+        if (assetFilter.NumberReference3 != null)
+        {
+            filtered = filtered.Where(a => a.NumberReference3 == assetFilter.NumberReference3);
+        }
+
+        if (filterOnSpace && assetFilter.Space is > 0)
+        {
+            filtered = filtered.Where(a => a.Space == assetFilter.Space.Value);
+        }
+
+        return filtered;
+    }
+    
 }

--- a/src/protagonist/DLCS.Web.Tests/Requests/HttpRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/HttpRequestXTests.cs
@@ -1,0 +1,53 @@
+using DLCS.Web.Requests;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace DLCS.Web.Tests.Requests;
+
+public class HttpRequestXTests
+{
+    [Fact]
+    public void GetFirstQueryParamValue_Finds_Single_Value()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?test=aaa&test2=bbb");
+        
+        // act
+        var test = httpRequest.GetFirstQueryParamValue("test");
+        
+        // assert
+        test.Should().Be("aaa");
+    }
+    
+    
+    [Fact]
+    public void GetFirstQueryParamValue_Ignores_Further_Values()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?test=aaa&test=bbb&test2=ccc");
+        
+        // act
+        var test = httpRequest.GetFirstQueryParamValue("test");
+        
+        // assert
+        test.Should().Be("aaa");
+    }
+    
+    
+    [Fact]
+    public void GetFirstQueryParamValueAsInt_Finds_Int()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.QueryString = new QueryString("?test=12");
+        
+        // act
+        var test = httpRequest.GetFirstQueryParamValueAsInt("test");
+        
+        // assert
+        test.Should().Be(12);
+    }
+}

--- a/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
+++ b/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using DLCS.Core.Collections;
 using Microsoft.AspNetCore.Http;
 
 namespace DLCS.Web.Requests;
@@ -69,5 +70,28 @@ public static class HttpRequestX
     public static string GetJsonLdId(this HttpRequest request)
     {
         return GetDisplayUrl(request, request.Path);
+    }
+    
+    public static string? GetFirstQueryParamValue(this HttpRequest request, string paramName)
+    {
+        if (request.Query.ContainsKey(paramName))
+        {
+            var values = request.Query[paramName].ToArray();
+            if (values.Length > 0) return values[0];
+        }
+
+        return null;
+    }
+
+    public static int? GetFirstQueryParamValueAsInt(this HttpRequest request, string paramName)
+    {
+        var value = GetFirstQueryParamValue(request, paramName);
+        if (value.IsNullOrEmpty()) return null;
+        if (int.TryParse(value, out var num))
+        {
+            return num;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
The Hydra classes gain an `ImageQuery` object which as serialised JSON can be used as the `q` parameter to an asset query.

`/customers/99/spaces/377/images?pageSize=50&q={"number3": 2}`

(NB there is a class like this in DDS which can ultimately be replaced with a ref to this one).

This is called ImageQuery rather than AssetQuery to reflect the rest of the current Hydra API.

However it is parsed to an `AssetFilter` object in the controller. While this looks similar it means that we don't pass the hydra-related on any deeper than the controller.

This AssetFilter can also be obtained directly by parsing out string1=xxx etc from the query string. I did not add these to the action method signature as I felt it would get very messy; there are helpers to examine the request querystring.

If an ImageQuery object is present AND direct params are present, the ImageQuery is parsed first then any direct params added to the AssetFilter - or override the same field on the AssetFilter if already present.

Multiple fields are ANDs, so `/customers/99/spaces/377/images?pageSize=50&q={"number3": 2, "string2": "1-10"}` requires both to match.

