### PR TITLE
Update example configs for s3 settings

### DIFF
--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -12,7 +12,7 @@
   "DLCS": {
     "ApiRoot": "https://api.dlcs.digirati.io",
     "ResourceRoot": "https://dlcs.digirati.io",
-    "EngineDirectIngestUri": "http://engine.dlcs.digirati.io/image-ingest.aspx",
+    "EngineDirectIngestUri": "http://engine.dlcs.digirati.io/image-ingest",
     "IngestDefaults": {
       "StoragePolicy": "default",
       "ImageOptimisationPolicies": {

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -12,7 +12,7 @@
   "DLCS": {
     "ApiRoot": "https://api.dlcs.digirati.io",
     "ResourceRoot": "https://dlcs.digirati.io",
-    "EngineDirectIngestUri": "http://engine.dlcs.digirati.io/image-ingest.aspx",
+    "EngineDirectIngestUri": "http://engine.dlcs.digirati.io/image-ingest",
     "IngestDefaults": {
       "StoragePolicy": "default",
       "ImageOptimisationPolicies": {

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -1,0 +1,32 @@
+{
+  "ConnectionStrings": {
+    "PostgreSQLConnection": "<conn-str>"
+  },
+  "AWS": {
+    "Profile": "dlcsspinup",
+    "Region": "eu-west-1",
+    "S3": {
+      "OriginBucket": "<storage-origin-bucket>"
+    }
+  },
+  "DLCS": {
+    "ApiRoot": "https://api.dlcs.digirati.io",
+    "ResourceRoot": "https://dlcs.digirati.io",
+    "EngineDirectIngestUri": "http://engine.dlcs.digirati.io/image-ingest.aspx",
+    "IngestDefaults": {
+      "StoragePolicy": "default",
+      "ImageOptimisationPolicies": {
+        "Audio": "audio-max",
+        "Video": "video-max",
+        "Graphics": "fast-higher"
+      },
+      "ThumbnailPolicies": {
+        "Video": "video-default",
+        "Graphics": "default"
+      }
+    }
+  },
+  "PathBase": "",
+  "Salt": "xxx",
+  "PageSize": 100
+}

--- a/src/protagonist/Portal.Tests/appsettings.Testing.json
+++ b/src/protagonist/Portal.Tests/appsettings.Testing.json
@@ -3,6 +3,9 @@
     "LoginSalt": "7tEcSrYsM4DN6ACfAhxa",
     "ApiSalt": "bEepssrMa3wzvtwSWk6C"
   },
+  "DLCS": {
+    "ApiRoot": "https://api.dlcs.digirati.io"
+  },
   "AWS": {
     "Profile": "test-profile",
     "Region": "eu-west-1",

--- a/src/protagonist/Portal.Tests/appsettings.Testing.json
+++ b/src/protagonist/Portal.Tests/appsettings.Testing.json
@@ -5,9 +5,9 @@
   },
   "AWS": {
     "Profile": "test-profile",
-    "Region": "eu-west-1"
-  },
-  "DLCS": {
-    "OriginBucket": "protagonist-test-origin"
+    "Region": "eu-west-1",
+    "S3": {
+      "OriginBucket": "protagonist-test-origin"
+    }
   }
 }

--- a/src/protagonist/Portal/Features/Spaces/DropzoneController.cs
+++ b/src/protagonist/Portal/Features/Spaces/DropzoneController.cs
@@ -118,7 +118,8 @@ public class DropzoneController : Controller
         {
             return Json(new { message = "completed: " + fileNameForSaving });
         }
-        return Json(new { error = errorMessage, message = "error: " + fileNameForSaving + ", " + errorMessage });
+
+        return Problem(errorMessage, null, 500, "Unable to upload image");
     }
 
     private static string GetTargetFilePath(int customer, int space, string fileNameForSaving)

--- a/src/protagonist/Portal/appSettings-Development-Example.json
+++ b/src/protagonist/Portal/appSettings-Development-Example.json
@@ -24,7 +24,10 @@
   },
   "AWS": {
     "Profile": "default",
-    "Region": "eu-west-1"
+    "Region": "eu-west-1",
+    "S3": {
+      "OriginBucket": "<storage-origin-bucket>"
+    }
   },
   "Portal": {
     "loginSalt": "a-salt-value"
@@ -33,7 +36,6 @@
     "PageSize": 100
   },
   "DLCS": {
-    "ApiRoot": "https://api.dlcs",
-    "OriginBucket": "-bucket-name-"
+    "ApiRoot": "https://api.dlcs"
   }
 }


### PR DESCRIPTION
Noticed a problem on spinup portal where adding new images didn't do anything.

When running locally noticed first issue was that config did not have correct S3 origin bucket, so fixed that and updated the example dev config to reflect the new layout.
