### PR TITLE
Customer Patch

### DIFF
--- a/src/protagonist/API.Tests/Features/Customer/Validation/CustomerPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/CustomerPatchValidatorTests.cs
@@ -64,4 +64,15 @@ public class CustomerPatchValidatorTests
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(c => c.AcceptedAgreement);
     }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Error_DisplayName_NotProvided(string displayName)
+    {
+        var model = new DLCS.HydraModel.Customer { DisplayName = displayName };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.DisplayName);
+    }
 }

--- a/src/protagonist/API.Tests/Features/Customer/Validation/CustomerPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/CustomerPatchValidatorTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using API.Features.Customer.Validation;
+using FluentValidation.TestHelper;
+
+namespace API.Tests.Features.Customer.Validation;
+
+public class CustomerPatchValidatorTests
+{
+    private readonly CustomerPatchValidator sut;
+
+    public CustomerPatchValidatorTests()
+    {
+        sut = new CustomerPatchValidator();
+    }
+
+    [Fact]
+    public void Error_Id_Provided()
+    {
+        var model = new DLCS.HydraModel.Customer { Id = "foo" };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Id);
+    }
+    
+    [Fact]
+    public void Error_Name_Provided()
+    {
+        var model = new DLCS.HydraModel.Customer { Name = "foo" };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Name);
+    }
+    
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Error_Admin_Provided(bool admin)
+    {
+        var model = new DLCS.HydraModel.Customer { Administrator = admin };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Administrator);
+    }
+    
+    [Fact]
+    public void Error_Created_Provided()
+    {
+        var model = new DLCS.HydraModel.Customer { Created = DateTime.Now };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Created);
+    }
+
+    [Fact]
+    public void Error_Keys_Provided()
+    {
+        var model = new DLCS.HydraModel.Customer { Keys = "foo" };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.Keys);
+    }
+    
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Error_AcceptedAgreement_Provided(bool acceptedAgreement)
+    {
+        var model = new DLCS.HydraModel.Customer { AcceptedAgreement = acceptedAgreement };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(c => c.AcceptedAgreement);
+    }
+}

--- a/src/protagonist/API.Tests/Integration/CustomerTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerTests.cs
@@ -23,21 +23,19 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
 {
     private readonly DlcsContext dbContext;
     private readonly HttpClient httpClient;
-    
+
     public CustomerTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
     {
         dbContext = dbFixture.DbContext;
         httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
         dbFixture.CleanUp();
     }
-    
-    
-    
+
     [Fact]
     public async Task GetCustomers_Returns_HydraCollection()
     {
         var response = await httpClient.AsCustomer().GetAsync("/customers");
-        
+
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var coll = await response.ReadAsHydraResponseAsync<HydraCollection<JObject>>();
         coll.Should().NotBeNull();
@@ -45,26 +43,23 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         coll.Members.Should().NotBeEmpty();
         coll.Members.Should().Contain(jo => jo["@id"].Value<string>().EndsWith("customers/99"));
     }
-    
-    
+
     [Fact]
     public async Task GetCustomer_Returns_Customer()
     {
         var response = await httpClient.AsCustomer().GetAsync("/customers/99");
-        
+
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var cust = await response.ReadAsHydraResponseAsync<Customer>();
         cust.Type.Should().Be("vocab:Customer");
         cust.Id.Should().EndWith("/customers/99");
     }
-    
-    
-    
+
     [Fact]
     public async Task GetOtherCustomer_Returns_NotFound()
     {
         var response = await httpClient.AsAdmin().GetAsync("/customers/100");
-        
+
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
@@ -73,15 +68,14 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // arrange
         // Need to create an entity counter global for customers
-        int expectedNewCustomerId = 1;
-        
-        var customerCounter = await dbContext.EntityCounters.SingleOrDefaultAsync(ec 
+        var expectedNewCustomerId = 1;
+
+        var customerCounter = await dbContext.EntityCounters.SingleOrDefaultAsync(ec
             => ec.Customer == 0 && ec.Scope == "0" && ec.Type == "customer");
         customerCounter.Should().BeNull();
         // this is true atm but Seed data might change this.
         // The counter should be created on first use, see below
-        
-        
+
         const string newCustomerJson = @"{
   ""@type"": ""Customer"",
   ""name"": ""my-new-customer"",
@@ -90,14 +84,13 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
         // act
         var response = await httpClient.AsAdmin().PostAsync("/customers", content);
-        
+
         // assert
         // Need to demonstrate that
         // - this does what we think it should do
         // - it does what Deliverator does.
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var newCustomer = await response.ReadAsHydraResponseAsync<Customer>();
-        
         
         // The entity counter should allocate the next available ID.
         // The DB has 1 customer 99 initially... is that going to change things?
@@ -111,17 +104,18 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         newDbCustomer.Administrator.Should().BeFalse();
         // what else to check?
         // Customer Does NOT have keys
-        
+
         // The global customer entity counter should be incremented
-        customerCounter = await dbContext.EntityCounters.SingleAsync(ec 
+        customerCounter = await dbContext.EntityCounters.SingleAsync(ec
             => ec.Customer == 0 && ec.Scope == "0" && ec.Type == "customer");
-        
+
         customerCounter.Should().NotBeNull(); // it would have been created on demand
         customerCounter.Next.Should().Be(expectedNewCustomerId + 1);
-        
+
         // There should be a space entity counter for the new customer
-        var spaceCounter = await dbContext.EntityCounters.SingleOrDefaultAsync(ec 
-            => ec.Customer == expectedNewCustomerId && ec.Scope == expectedNewCustomerId.ToString() && ec.Type == "space");
+        var spaceCounter = await dbContext.EntityCounters.SingleOrDefaultAsync(ec
+            => ec.Customer == expectedNewCustomerId && ec.Scope == expectedNewCustomerId.ToString() &&
+               ec.Type == "space");
         spaceCounter.Should().NotBeNull();
         spaceCounter.Next.Should().Be(1);
 
@@ -130,7 +124,7 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // | 79b20327-5d55-4a7f-b95d-02cb94737bcd | 21 | clickthrough |  |  |  |  |  |  | 600 | NULL | d87d1619-e357-49c5-a45e-757407af7638 |
         // | d87d1619-e357-49c5-a45e-757407af7638 | 21 | logout | http://iiif.io/api/auth/0/logout |  |  |  |  |  | 600 | NULL | NULL |
 
-        var customerAuthServices = await dbContext.AuthServices.Where(svc 
+        var customerAuthServices = await dbContext.AuthServices.Where(svc
             => svc.Customer == expectedNewCustomerId).ToListAsync();
         customerAuthServices.Should().HaveCount(2); // two new services
 
@@ -144,31 +138,30 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         logoutService.Profile.Should().Be("http://iiif.io/api/auth/1/logout");
         clickthroughService.Ttl.Should().Be(600);
         logoutService.Ttl.Should().Be(600);
-        
+
         // Role: Should be a clickthrough Role for AuthService
-        var roles = await dbContext.Roles.Where(role 
+        var roles = await dbContext.Roles.Where(role
             => role.Customer == expectedNewCustomerId).ToListAsync();
         roles.Should().HaveCount(1); // one new role
         var clickthroughRole = roles.SingleOrDefault(role => role.Name == "clickthrough");
         clickthroughRole.Should().NotBeNull();
         clickthroughRole.AuthService.Should().Be(clickthroughService.Id);
-        
+
         // What should this URL be? api.dlcs.io is... not right?
         var roleId = $"https://api.dlcs.io/customers/{expectedNewCustomerId}/roles/clickthrough";
         clickthroughRole.Id.Should().Be(roleId);
-        
+
         // Deliverator does not create a row in CustomerStorage at this point
-        
+
         // Should be a row in Queues
         var queue = await dbContext.Queues.SingleOrDefaultAsync(q => q.Customer == expectedNewCustomerId);
         queue.Should().NotBeNull();
         queue.Name.Should().Be("default");
         queue.Size.Should().Be(0);
-
     }
-    
+
     [Fact]
-    public async void CreateNewCustomer_Throws_IfNameConflicts()
+    public async Task CreateNewCustomer_Throws_IfNameConflicts()
     {
         // Tests CreateCustomer::EnsureCustomerNamesNotTaken
         // These display names have already been taken by the seed data
@@ -177,31 +170,48 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
   ""name"": ""test"",
   ""displayName"": ""TestUser""
 }";
-        
+
         // act
         var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
         var response = await httpClient.AsAdmin().PostAsync("/customers", content);
-        
+
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [Fact]
-    public async void Non_Admin_Cant_Create_Customer()
+    public async Task Non_Admin_Cant_Create_Customer()
     {
         const string newCustomerJson = @"{
   ""@type"": ""Customer"",
   ""name"": ""test"",
   ""displayName"": ""TestUser""
 }";
-        
+
         // act
         var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
         var response = await httpClient.AsCustomer(99).PostAsync("/customers", content);
-        
+
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-        
     }
 
+    [Fact]
+    public async Task Patch_Returns400_IfValidationFails()
+    {
+        // This doesn't validate all possible invalid requests, see Validator tests
+        // Arrange
+        const string patchJson = @"{
+  ""@type"": ""Customer"",
+  ""Name"": ""A new name""
+}";
+        
+        var content = new StringContent(patchJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PatchAsync("/customers/2", content);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/src/protagonist/API.Tests/Usings.cs
+++ b/src/protagonist/API.Tests/Usings.cs
@@ -1,0 +1,2 @@
+﻿global using FluentAssertions;
+global using Xunit;

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
+      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.1" />
       <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
       <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />

--- a/src/protagonist/API/Features/Customer/ApiKeysController.cs
+++ b/src/protagonist/API/Features/Customer/ApiKeysController.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using API.Features.Customer.Requests;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Strings;
 using DLCS.HydraModel;

--- a/src/protagonist/API/Features/Customer/CustomerController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerController.cs
@@ -6,6 +6,7 @@ using API.Features.Customer.Requests;
 using API.Features.Customer.Validation;
 using API.Infrastructure;
 using API.Settings;
+using DLCS.Core;
 using DLCS.Core.Strings;
 using DLCS.Web.Auth;
 using DLCS.Web.Requests;
@@ -154,6 +155,19 @@ public class CustomerController : HydraController
             return ValidationFailed(validationResult);
         }
 
-        throw new NotImplementedException();
+        var request = new PatchCustomer(customerId, hydraCustomer.DisplayName!);
+        var result = await mediator.Send(request);
+
+        switch (result.UpdateResult)
+        {
+            case UpdateResult.Updated:
+                return Ok(result.Customer!.ToHydra(GetUrlRoots().BaseUrl));
+            case UpdateResult.NotFound:
+                return HydraNotFound();
+            case UpdateResult.Error:
+                return HydraProblem(result.Error, null, 500, "Error patching customer");
+        }
+
+        return HydraProblem("Unknown result", null, 500, "Unknown result");
     }
 }

--- a/src/protagonist/API/Features/Customer/CustomerController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerController.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Converters;
 using API.Features.Customer.Requests;
+using API.Features.Customer.Validation;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Strings;
 using DLCS.Web.Auth;
@@ -18,9 +20,11 @@ namespace API.Features.Customer;
 
 /// <summary>
 /// DLCS REST API Operations for customers.
+/// </summary>
+/// <remarks>
 /// This controller does not do any data access; it creates Mediatr requests and passes them on.
 /// It converts to and from the Hydra form of the DLCS API.
-/// </summary>
+/// </remarks>
 [Route("/customers/")]
 [ApiController]
 public class CustomerController : HydraController
@@ -34,16 +38,17 @@ public class CustomerController : HydraController
     {
         this.mediator = mediator;
     }
-        
-    
+
     /// <summary>
     /// GET /customers
     /// 
     /// Get all the customers.
-    /// Although it returns a paged collection, the page size is always the total number of customers:
-    /// clients don't need to page this collection, it contains all customers.
     /// </summary>
     /// <returns>HydraCollection of JObject (simplified customer)</returns>
+    /// <remarks>
+    /// Although it returns a paged collection, the page size is always the total number of customers:
+    /// clients don't need to page this collection, it contains all customers.
+    /// </remarks>
     [AllowAnonymous]
     [HttpGet]
     public async Task<HydraCollection<JObject>> GetCustomers()
@@ -109,7 +114,7 @@ public class CustomerController : HydraController
         
         
     /// <summary>
-    /// GET /customers/id
+    /// GET /customers/{id}
     /// 
     /// Get a Customer
     /// </summary>
@@ -125,5 +130,30 @@ public class CustomerController : HydraController
             return HydraNotFound();
         }
         return Ok(dbCustomer.ToHydra(GetUrlRoots().BaseUrl));
+    }
+
+    /// <summary>
+    /// PATCH /customers/{id}
+    /// 
+    /// Make a partial update to customer.
+    /// </summary>
+    /// <param name="customerId">Id of customer to Patch</param>
+    /// <param name="hydraCustomer"></param>
+    /// <param name="validator">Model validator</param>
+    /// <returns>The updated Customer entity</returns>
+    [HttpPatch]
+    [Route("{customerId}")]
+    public async Task<IActionResult> PatchCustomer(
+        [FromRoute] int customerId,
+        [FromBody] DLCS.HydraModel.Customer hydraCustomer,
+        [FromServices] CustomerPatchValidator validator)
+    {
+        var validationResult = await validator.ValidateAsync(hydraCustomer);
+        if (!validationResult.IsValid)
+        {
+            return ValidationFailed(validationResult);
+        }
+
+        throw new NotImplementedException();
     }
 }

--- a/src/protagonist/API/Features/Customer/CustomerController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerController.cs
@@ -139,7 +139,7 @@ public class CustomerController : HydraController
     /// Make a partial update to customer.
     /// </summary>
     /// <param name="customerId">Id of customer to Patch</param>
-    /// <param name="hydraCustomer"></param>
+    /// <param name="hydraCustomer">Hydra model containing changes to make (only DisplayName is supported)</param>
     /// <param name="validator">Model validator</param>
     /// <returns>The updated Customer entity</returns>
     [HttpPatch]

--- a/src/protagonist/API/Features/Customer/PortalUsersController.cs
+++ b/src/protagonist/API/Features/Customer/PortalUsersController.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading.Tasks;
 using API.Converters;
 using API.Features.Customer.Requests;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Strings;
 using DLCS.HydraModel;

--- a/src/protagonist/API/Features/Customer/Requests/PatchCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/PatchCustomer.cs
@@ -1,0 +1,69 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core;
+using DLCS.Repository;
+using MediatR;
+using DlcsCustomer = DLCS.Model.Customers.Customer;
+
+namespace API.Features.Customer.Requests;
+
+/// <summary>
+/// Make a partial update to a customer.
+/// </summary>
+/// <remarks>This only takes a single field as it's the only one that can be updated</remarks>
+public class PatchCustomer : IRequest<PatchCustomerResult>
+{
+    public int CustomerId { get; }
+    
+    public string DisplayName { get; }
+
+    public PatchCustomer(int customerId, string displayName)
+    {
+        CustomerId = customerId;
+        DisplayName = displayName;
+    }
+}
+
+public class PatchCustomerResult
+{
+    public UpdateResult UpdateResult { get; private init;}
+    public DlcsCustomer? Customer { get; private init;}
+    public string? Error { get; private init; }
+
+    public static PatchCustomerResult Failure(string error, UpdateResult result = UpdateResult.Unknown)
+        => new() { Error = error, UpdateResult = result };
+    
+    public static PatchCustomerResult Success(DlcsCustomer customer, UpdateResult result = UpdateResult.Updated)
+        => new() { Customer = customer, UpdateResult = result };
+}
+
+public class PatchCustomerHandler : IRequestHandler<PatchCustomer, PatchCustomerResult>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public PatchCustomerHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+    
+    public async Task<PatchCustomerResult> Handle(PatchCustomer request, CancellationToken cancellationToken)
+    {
+        var customer = await dlcsContext.Customers.FindAsync(new object?[] { request.CustomerId }, cancellationToken);
+        if (customer == null)
+        {
+            return PatchCustomerResult.Failure("Customer not found", UpdateResult.NotFound);
+        }
+
+        // This is the only field that can be updated for an existing customer
+        customer.DisplayName = request.DisplayName;
+
+        var rowCount = await dlcsContext.SaveChangesAsync(cancellationToken);
+        if (rowCount == 0)
+        {
+            return PatchCustomerResult.Failure("Unable to Patch Customer", UpdateResult.Error);
+        }
+
+        await dlcsContext.Entry(customer).ReloadAsync(cancellationToken);
+        return PatchCustomerResult.Success(customer);
+    }
+}

--- a/src/protagonist/API/Features/Customer/Requests/PatchPortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/PatchPortalUser.cs
@@ -47,7 +47,6 @@ public class PatchPortalUserHandler : IRequestHandler<PatchPortalUser, PatchPort
         settings = options.Value;
     }
 
-
     public async Task<PatchPortalUserResult> Handle(PatchPortalUser request, CancellationToken cancellationToken)
     {
         var dbUser = await dbContext.Users.FindAsync(new object?[]{request.PortalUser.Id}, cancellationToken);

--- a/src/protagonist/API/Features/Customer/Validation/CustomerPatchValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/CustomerPatchValidator.cs
@@ -16,5 +16,7 @@ public class CustomerPatchValidator : AbstractValidator<DLCS.HydraModel.Customer
         RuleFor(c => c.Created).Empty().WithMessage("Should not include created field");
         RuleFor(c => c.Keys).Empty().WithMessage("Should not include keys");
         RuleFor(c => c.AcceptedAgreement).Empty().WithMessage("Should not include acceptedAgreement field");
+        
+        RuleFor(c => c.DisplayName).NotEmpty().WithMessage("DisplayName cannot be empty");
     }
 }

--- a/src/protagonist/API/Features/Customer/Validation/CustomerPatchValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/CustomerPatchValidator.cs
@@ -1,0 +1,20 @@
+﻿using FluentValidation;
+
+namespace API.Features.Customer.Validation;
+
+/// <summary>
+/// Validator for model sent to PATCH /customer/{id}
+/// </summary>
+public class CustomerPatchValidator : AbstractValidator<DLCS.HydraModel.Customer>
+{
+    public CustomerPatchValidator()
+    {
+        // Note - this seems a bit excessive but it maps what is in Deliverator
+        RuleFor(c => c.Id).Empty().WithMessage("Should not include customer id");
+        RuleFor(c => c.Name).Empty().WithMessage("Should not include name");
+        RuleFor(c => c.Administrator).Empty().WithMessage("Should not include administrator field");
+        RuleFor(c => c.Created).Empty().WithMessage("Should not include created field");
+        RuleFor(c => c.Keys).Empty().WithMessage("Should not include keys");
+        RuleFor(c => c.AcceptedAgreement).Empty().WithMessage("Should not include acceptedAgreement field");
+    }
+}

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using API.Converters;
 using API.Features.Image.Requests;
 using API.Features.Space.Requests;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Core;
 using DLCS.Core.Collections;

--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -179,6 +179,4 @@ public class SpaceController : HydraController
         }
         return HydraProblem(result.ErrorMessages, null, 500, "Cannot patch space");
     }
-    
-    
 }

--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using API.Converters;
 using API.Features.Space.Requests;
+using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Strings;
 using DLCS.Web.Requests;

--- a/src/protagonist/API/Infrastructure/HydraController.cs
+++ b/src/protagonist/API/Infrastructure/HydraController.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using API.Converters;
 using API.Settings;
 using DLCS.Core.Strings;
 using DLCS.Web.Requests;
+using FluentValidation.Results;
 using Hydra.Model;
 using Microsoft.AspNetCore.Mvc;
 
-namespace API;
+namespace API.Infrastructure;
 
 /// <summary>
 /// Base class for DLCS API Controllers that return Hydra responses
@@ -146,6 +148,17 @@ public abstract class HydraController : Controller
     public virtual ObjectResult HydraNotFound(string? detail = null)
     {
         return HydraProblem(detail, null, 404, "Not Found");
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ObjectResult"/> that produces a <see cref="Error"/> response with 404 status code.
+    /// </summary>
+    /// <param name="validationResult"></param>
+    /// <returns></returns>
+    protected ObjectResult ValidationFailed(ValidationResult validationResult)
+    {
+        var message = string.Join(". ", validationResult.Errors.Select(s => s.ErrorMessage));
+        return HydraProblem(message, null, 400, "Bad request");
     }
 }
 

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -29,6 +29,7 @@ using DLCS.Repository.Spaces;
 using DLCS.Repository.Storage;
 using DLCS.Web.Auth;
 using DLCS.Web.Configuration;
+using FluentValidation;
 using Hydra;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -90,6 +91,7 @@ public class Startup
             .AddSingleton<IAuthServicesRepository, DapperAuthServicesRepository>()
             .AddScoped<IPolicyRepository, PolicyRepository>()
             .AddScoped<IAssetNotificationSender, AssetNotificationSender>()
+            .AddValidatorsFromAssemblyContaining<Startup>()
             .ConfigureMediatR()
             .ConfigureSwagger();
 

--- a/src/protagonist/DLCS.Core/UpdateResult.cs
+++ b/src/protagonist/DLCS.Core/UpdateResult.cs
@@ -1,0 +1,37 @@
+namespace DLCS.Core;
+
+/// <summary>
+/// Represents the result of an Update operation
+/// </summary>
+public enum UpdateResult
+{
+    /// <summary>
+    /// Default state - likely operation has yet to be run.
+    /// </summary>
+    Unknown,
+    
+    /// <summary>
+    /// Source item not found
+    /// </summary>
+    NotFound,
+    
+    /// <summary>
+    /// An error occurred handling update
+    /// </summary>
+    Error,
+    
+    /// <summary>
+    /// The update values would have resulted in a conflict with an existing resource
+    /// </summary>
+    Conflict,
+    
+    /// <summary>
+    /// Request failed validation
+    /// </summary>
+    FailedValidation,
+    
+    /// <summary>
+    /// Entity was successfully updated
+    /// </summary>
+    Updated
+}

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
@@ -78,7 +78,7 @@ public abstract class AssetRepositoryCachingBase : IAssetRepository
             }
 
             return dbAsset;
-        }, CacheSettings.GetMemoryCacheOptions(CacheDuration.Short));
+        }, CacheSettings.GetMemoryCacheOptions());
         
         return asset.Id == NullAsset.Id ? null : asset;
     }


### PR DESCRIPTION
Followed validation rules from Deliverator - only DisplayName can be updated.

Added FluentValidation to contain validation rules for the hydra model, this is injected into action method via `[FromServices]`.

Added `UpdateResult` enum that contains possible results of save operation with a view to using this more widely in other operations. It's just could allow us to make a reusable method of converting `UpdateResult` to a HydraResult, even if it's just setting the status code.