### PR TITLE
Implement basic GET requests for policies + strategy

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -26,6 +26,7 @@ using Newtonsoft.Json.Linq;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
 using AssetFamily = DLCS.Model.Assets.AssetFamily;
+using ImageOptimisationPolicy = DLCS.Model.Policies.ImageOptimisationPolicy;
 
 namespace API.Tests.Integration;
 
@@ -496,7 +497,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         await dbContext.Images.AddTestAsset(assetId.ToString(), ref1: "I am string 1",
             origin: "https://images.org/image1.tiff");
-        var testPolicy = new DLCS.Model.Assets.ImageOptimisationPolicy
+        var testPolicy = new ImageOptimisationPolicy
         {
             Id = "test-policy",
             Name = "Test Policy",

--- a/src/protagonist/API.Tests/Integration/PolicyTests.cs
+++ b/src/protagonist/API.Tests/Integration/PolicyTests.cs
@@ -1,0 +1,250 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using API.Client;
+using API.Tests.Integration.Infrastructure;
+using DLCS.HydraModel;
+using DLCS.Repository;
+using Hydra.Collections;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class PolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsContext dbContext;
+    private readonly HttpClient httpClient;
+
+    public PolicyTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        dbContext = dbFixture.DbContext;
+        httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicies_200()
+    {
+        // Arrange
+        var path = "imageOptimisationPolicies";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<ImageOptimisationPolicy>>();
+        model.Members.Should().HaveCount(3);
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicies_SupportsPaging()
+    {
+        // Arrange
+        var path = "imageOptimisationPolicies?pageSize=2";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<ImageOptimisationPolicy>>();
+        model.Members.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_200()
+    {
+        // Arrange
+        var path = "imageOptimisationPolicies/video-max";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<ImageOptimisationPolicy>();
+        model.TechnicalDetails.Should().BeEquivalentTo("System preset: Webm 720p(webm)");
+    }
+
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_400_IfNotFound()
+    {
+        // Arrange
+        var path = "imageOptimisationPolicies/foofoo";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_StoragePolicies_200()
+    {
+        // Arrange
+        var path = "storagePolicies";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<StoragePolicy>>();
+        model.Members.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_StoragePolicies_SupportsPaging()
+    {
+        // Arrange
+        var path = "storagePolicies?pageSize=1";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<StoragePolicy>>();
+        model.Members.Should().HaveCount(1);
+    }
+    
+    [Fact]
+    public async Task Get_StoragePolicy_200()
+    {
+        // Arrange
+        var path = "storagePolicies/small";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<StoragePolicy>();
+        model.MaximumNumberOfStoredImages.Should().Be(10);
+        model.MaximumTotalSizeOfStoredImages.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Get_StoragePolicy_400_IfNotFound()
+    {
+        // Arrange
+        var path = "storagePolicies/foofoo";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Get_ThumbnailPolicies_200()
+    {
+        // Arrange
+        var path = "thumbnailPolicies";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<ThumbnailPolicy>>();
+        model.Members.Should().HaveCount(1);
+    }
+    
+    [Fact]
+    public async Task Get_ThumbnailPolicy_200()
+    {
+        // Arrange
+        var path = "thumbnailPolicies/default";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<ThumbnailPolicy>();
+        model.Sizes.Should().BeEquivalentTo(new[] { 200, 400, 800 });
+    }
+
+    [Fact]
+    public async Task Get_ThumbnailPolicy_400_IfNotFound()
+    {
+        // Arrange
+        var path = "thumbnailPolicies/foofoo";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_OriginStrategies_200()
+    {
+        // Arrange
+        await dbContext.OriginStrategies.AddRangeAsync(
+            new DLCS.Model.Policies.OriginStrategy { Id = "foo" },
+            new DLCS.Model.Policies.OriginStrategy { Id = "bar" }
+        );
+        await dbContext.SaveChangesAsync();
+        
+        var path = "originStrategies";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<OriginStrategy>>();
+        model.Members.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_OriginStrategy_200()
+    {
+        // Arrange
+        await dbContext.OriginStrategies.AddRangeAsync(
+            new DLCS.Model.Policies.OriginStrategy { Id = "con" },
+            new DLCS.Model.Policies.OriginStrategy { Id = "cept", RequiresCredentials = true}
+        );
+        await dbContext.SaveChangesAsync();
+        var path = "originStrategies/cept";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<OriginStrategy>();
+        model.RequiresCredentials.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Get_OriginStrategy_400_IfNotFound()
+    {
+        // Arrange
+        var path = "originStrategies/foofoo";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Converters/PolicyConverters.cs
+++ b/src/protagonist/API/Features/Policies/Converters/PolicyConverters.cs
@@ -1,0 +1,63 @@
+﻿namespace API.Features.Policies.Converters;
+
+using HydraOptimisationPolicy = DLCS.HydraModel.ImageOptimisationPolicy;
+using EntityOptimisationPolicy = DLCS.Model.Policies.ImageOptimisationPolicy;
+
+using HydraStoragePolicy = DLCS.HydraModel.StoragePolicy;
+using EntityStoragePolicy = DLCS.Model.Storage.StoragePolicy;
+
+using HydraThumbPolicy = DLCS.HydraModel.ThumbnailPolicy;
+using EntityThumbPolicy = DLCS.Model.Policies.ThumbnailPolicy;
+
+using HydraOriginStrategy = DLCS.HydraModel.OriginStrategy;
+using EntityOriginStrategy = DLCS.Model.Policies.OriginStrategy;
+
+public static class PolicyConverters
+{
+    /// <summary>
+    /// Convert ImageOptimisationPolicy entity to API resource
+    /// </summary>
+    public static HydraOptimisationPolicy ToHydra(this EntityOptimisationPolicy policy, string baseUrl)
+    {
+        var hydra = new HydraOptimisationPolicy(baseUrl, policy.Id, policy.Name, string.Join(",", policy.TechnicalDetails));
+        return hydra;
+    }
+    
+    /// <summary>
+    /// Convert StoragePolicy entity to API resource
+    /// </summary>
+    public static HydraStoragePolicy ToHydra(this EntityStoragePolicy policy, string baseUrl)
+    {
+        var hydra = new HydraStoragePolicy(baseUrl, policy.Id)
+        {
+            MaximumNumberOfStoredImages = policy.MaximumNumberOfStoredImages,
+            MaximumTotalSizeOfStoredImages = policy.MaximumTotalSizeOfStoredImages
+        };
+        return hydra;
+    }
+    
+    /// <summary>
+    /// Convert ThumbnailPolicy entity to API resource
+    /// </summary>
+    public static HydraThumbPolicy ToHydra(this EntityThumbPolicy policy, string baseUrl)
+    {
+        var hydra = new HydraThumbPolicy(baseUrl, policy.Id)
+        {
+            Name = policy.Name,
+            Sizes = policy.SizeList.ToArray()
+        };
+        return hydra;
+    }
+    
+    /// <summary>
+    /// Convert OriginStrategy entity to API resource
+    /// </summary>
+    public static HydraOriginStrategy ToHydra(this EntityOriginStrategy policy, string baseUrl)
+    {
+        var hydra = new HydraOriginStrategy(baseUrl, policy.Id)
+        {
+            RequiresCredentials = policy.RequiresCredentials
+        };
+        return hydra;
+    }
+}

--- a/src/protagonist/API/Features/Policies/PolicyController.cs
+++ b/src/protagonist/API/Features/Policies/PolicyController.cs
@@ -1,0 +1,207 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.Features.Policies.Converters;
+using API.Features.Policies.Requests;
+using API.Infrastructure;
+using API.Settings;
+using DLCS.HydraModel;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Policies;
+
+/// <summary>
+/// Controller for handling requests for imageOptimisationPolicies, storagePolicies and thumbnailPolicies
+/// </summary>
+public class PolicyController : HydraController
+{
+    /// <inheritdoc />
+    public PolicyController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
+    {
+    }
+    
+    /// <summary>
+    /// GET /imageOptimisationPolicies
+    ///
+    /// Get paged list of all image optimisation policies
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Collection of Hydra JSON-LD image optimisation policy object</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/imageOptimisationPolicies")]
+    public async Task<IActionResult> GetImageOptimisationPolicies(CancellationToken cancellationToken)
+    {
+        var getImageOptimisationPolicies = new GetImageOptimisationPolicies();
+
+        return await HandlePagedFetch<DLCS.Model.Policies.ImageOptimisationPolicy, GetImageOptimisationPolicies,
+            ImageOptimisationPolicy>(
+            getImageOptimisationPolicies,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get image optimisation policies failed",
+            cancellationToken: cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// GET /imageOptimisationPolicies/{imageOptimisationPolicyId}
+    /// 
+    /// Get details of specified image optimisation policies
+    /// </summary>
+    /// <param name="imageOptimisationPolicyId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Hydra JSON-LD image optimisation policy object</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/imageOptimisationPolicies/{imageOptimisationPolicyId}")]
+    public async Task<IActionResult> GetImageOptimisationPolicy([FromRoute] string imageOptimisationPolicyId, CancellationToken cancellationToken)
+    {
+        var getImageOptimisationPolicy = new GetImageOptimisationPolicy(imageOptimisationPolicyId);
+
+        return await HandleFetch(
+            getImageOptimisationPolicy,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get image optimisation policy failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /storagePolices
+    ///
+    /// Get paged list of all storage policies
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Collection of Hydra JSON-LD storage policy objects</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/storagePolicies")]
+    public async Task<IActionResult> GetStoragePolicies(CancellationToken cancellationToken)
+    {
+        var getStoragePolicies = new GetStoragePolicies();
+
+        return await HandlePagedFetch<DLCS.Model.Storage.StoragePolicy, GetStoragePolicies,
+            StoragePolicy>(
+            getStoragePolicies,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get storage policies failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /storagePolicies/{storagePolicyId}
+    /// 
+    /// Get details of specified storage policy
+    /// </summary>
+    /// <param name="storagePolicyId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Hydra JSON-LD storage policy object</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/storagePolicies/{storagePolicyId}")]
+    public async Task<IActionResult> GetStoragePolicy([FromRoute] string storagePolicyId, CancellationToken cancellationToken)
+    {
+        var getStoragePolicy = new GetStoragePolicy(storagePolicyId);
+
+        return await HandleFetch(
+            getStoragePolicy,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get storage policy failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /thumbnailPolicies
+    ///
+    /// Get paged list of all thumbnail policies
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Collection of Hydra JSON-LD image optimisation policy objects</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/thumbnailPolicies")]
+    public async Task<IActionResult> GetThumbnailPolicies(CancellationToken cancellationToken)
+    {
+        var getThumbnailPolicies = new GetThumbnailPolicies();
+
+        return await HandlePagedFetch<DLCS.Model.Policies.ThumbnailPolicy, GetThumbnailPolicies, ThumbnailPolicy>(
+            getThumbnailPolicies,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get thumbnail policies failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /thumbnailPolicies/{thumbnailPolicyId}
+    /// 
+    /// Get details of specified thumbnail policy
+    /// </summary>
+    /// <param name="originStrategyId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Hydra JSON-LD storage policy object</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/thumbnailPolicies/{originStrategyId}")]
+    public async Task<IActionResult> GetThumbnailPolicy([FromRoute] string originStrategyId, 
+        CancellationToken cancellationToken)
+    {
+        var getThumbnailPolicy = new GetThumbnailPolicy(originStrategyId);
+
+        return await HandleFetch(
+            getThumbnailPolicy,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get thumbnail policy failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /originStrategies
+    ///
+    /// Get paged list of all origin strategies
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Collection of Hydra JSON-LD origin strategy objects</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/originStrategies")]
+    public async Task<IActionResult> GetOriginStrategies(CancellationToken cancellationToken)
+    {
+        var getOriginStrategies = new GetOriginStrategies();
+
+        return await HandlePagedFetch<DLCS.Model.Policies.OriginStrategy, GetOriginStrategies, OriginStrategy>(
+            getOriginStrategies,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get thumbnail policies failed",
+            cancellationToken: cancellationToken
+        );
+    }
+    
+    /// <summary>
+    /// GET /originStrategies/{originStrategyId}
+    /// 
+    /// Get details of specified origin strategy
+    /// </summary>
+    /// <param name="originStrategyId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>Hydra JSON-LD origin strategy object</returns>
+    [HttpGet]
+    [AllowAnonymous]
+    [Route("/originStrategies/{originStrategyId}")]
+    public async Task<IActionResult> GetOriginStrategy([FromRoute] string originStrategyId, CancellationToken cancellationToken)
+    {
+        var getStrategy = new GetOriginStrategy(originStrategyId);
+
+        return await HandleFetch(
+            getStrategy,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get thumbnail policy failed",
+            cancellationToken: cancellationToken
+        );
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicies.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicies.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Page;
+using DLCS.Model.Policies;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get a paged list of all image optimisation policies
+/// </summary>
+public class GetImageOptimisationPolicies : IRequest<FetchEntityResult<PageOf<ImageOptimisationPolicy>>>, IPagedRequest
+{
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
+public class GetImageOptimisationPoliciesHandler : IRequestHandler<GetImageOptimisationPolicies,
+    FetchEntityResult<PageOf<ImageOptimisationPolicy>>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetImageOptimisationPoliciesHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<PageOf<ImageOptimisationPolicy>>> Handle(GetImageOptimisationPolicies request,
+        CancellationToken cancellationToken)
+    {
+        var result = await dlcsContext.ImageOptimisationPolicies.AsNoTracking().CreatePagedResult(request,
+            q => q,
+            q => q.OrderBy(i => i.Id),
+            cancellationToken: cancellationToken);
+
+        return FetchEntityResult<PageOf<ImageOptimisationPolicy>>.Success(result);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Policies;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get details of specified image optimisation policy
+/// </summary>
+public class GetImageOptimisationPolicy : IRequest<FetchEntityResult<ImageOptimisationPolicy>>
+{
+    public string ImageOptimisationPolicyId { get; }
+
+    public GetImageOptimisationPolicy(string imageOptimisationPolicyId)
+    {
+        ImageOptimisationPolicyId = imageOptimisationPolicyId;
+    }
+}
+
+public class GetImageOptimisationPolicyHandler : IRequestHandler<GetImageOptimisationPolicy,
+    FetchEntityResult<ImageOptimisationPolicy>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetImageOptimisationPolicyHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<ImageOptimisationPolicy>> Handle(GetImageOptimisationPolicy request,
+        CancellationToken cancellationToken)
+    {
+        var policy = await dlcsContext.ImageOptimisationPolicies.AsNoTracking()
+            .SingleOrDefaultAsync(b => b.Id == request.ImageOptimisationPolicyId,
+                cancellationToken);
+        return policy == null
+            ? FetchEntityResult<ImageOptimisationPolicy>.NotFound()
+            : FetchEntityResult<ImageOptimisationPolicy>.Success(policy);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetOriginStrategies.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetOriginStrategies.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Page;
+using DLCS.Model.Policies;
+using DLCS.Repository;
+using DLCS.Repository.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get a paged list of all origin strategies
+/// </summary>
+public class GetOriginStrategies : IRequest<FetchEntityResult<PageOf<OriginStrategy>>>, IPagedRequest
+{
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
+public class GetOriginStrategiesHandler : IRequestHandler<GetOriginStrategies,
+    FetchEntityResult<PageOf<OriginStrategy>>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetOriginStrategiesHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<PageOf<OriginStrategy>>> Handle(GetOriginStrategies request,
+        CancellationToken cancellationToken)
+    {
+        var result = await dlcsContext.OriginStrategies.AsNoTracking().CreatePagedResult(request,
+            q => q,
+            q => q.OrderBy(i => i.Id),
+            cancellationToken: cancellationToken);
+
+        return FetchEntityResult<PageOf<OriginStrategy>>.Success(result);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetOriginStrategy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetOriginStrategy.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Policies;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get details of specified origin strategy
+/// </summary>
+public class GetOriginStrategy : IRequest<FetchEntityResult<OriginStrategy>>
+{
+    public string OriginStrategyId { get; }
+
+    public GetOriginStrategy(string originStrategyId)
+    {
+        OriginStrategyId = originStrategyId;
+    }
+}
+
+public class GetOriginStrategyHandler : IRequestHandler<GetOriginStrategy,
+    FetchEntityResult<OriginStrategy>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetOriginStrategyHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<OriginStrategy>> Handle(GetOriginStrategy request,
+        CancellationToken cancellationToken)
+    {
+        var strategy = await dlcsContext.OriginStrategies.AsNoTracking()
+            .SingleOrDefaultAsync(b => b.Id == request.OriginStrategyId,
+                cancellationToken);
+        return strategy == null
+            ? FetchEntityResult<OriginStrategy>.NotFound()
+            : FetchEntityResult<OriginStrategy>.Success(strategy);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetStoragePolicies.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetStoragePolicies.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Page;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get a paged list of all storage policies
+/// </summary>
+public class GetStoragePolicies : IRequest<FetchEntityResult<PageOf<StoragePolicy>>>, IPagedRequest
+{
+public int Page { get; set; }
+public int PageSize { get; set; }
+}
+
+public class GetStoragePoliciesHandler : IRequestHandler<GetStoragePolicies, FetchEntityResult<PageOf<StoragePolicy>>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetStoragePoliciesHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<PageOf<StoragePolicy>>> Handle(GetStoragePolicies request,
+        CancellationToken cancellationToken)
+    {
+        var result = await dlcsContext.StoragePolicies.AsNoTracking().CreatePagedResult(request,
+            q => q,
+            q => q.OrderBy(i => i.Id),
+            cancellationToken: cancellationToken);
+
+        return FetchEntityResult<PageOf<StoragePolicy>>.Success(result);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetStoragePolicy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetStoragePolicy.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get details of specified storage policy
+/// </summary>
+public class GetStoragePolicy : IRequest<FetchEntityResult<StoragePolicy>>
+{
+    public string StoragePolicyId { get; }
+
+    public GetStoragePolicy(string storagePolicyId)
+    {
+        StoragePolicyId = storagePolicyId;
+    }
+}
+
+public class GetStoragePolicyHandler : IRequestHandler<GetStoragePolicy,
+    FetchEntityResult<StoragePolicy>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetStoragePolicyHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<StoragePolicy>> Handle(GetStoragePolicy request,
+        CancellationToken cancellationToken)
+    {
+        var policy = await dlcsContext.StoragePolicies.AsNoTracking()
+            .SingleOrDefaultAsync(b => b.Id == request.StoragePolicyId,
+                cancellationToken);
+        return policy == null
+            ? FetchEntityResult<StoragePolicy>.NotFound()
+            : FetchEntityResult<StoragePolicy>.Success(policy);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetThumbnailPolicies.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetThumbnailPolicies.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Page;
+using DLCS.Model.Policies;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get a paged list of all thumbnail policies
+/// </summary>
+public class GetThumbnailPolicies : IRequest<FetchEntityResult<PageOf<ThumbnailPolicy>>>, IPagedRequest
+{
+public int Page { get; set; }
+public int PageSize { get; set; }
+}
+
+public class GetThumbnailPoliciesHandler 
+    : IRequestHandler<GetThumbnailPolicies, FetchEntityResult<PageOf<ThumbnailPolicy>>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetThumbnailPoliciesHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<PageOf<ThumbnailPolicy>>> Handle(GetThumbnailPolicies request,
+        CancellationToken cancellationToken)
+    {
+        var result = await dlcsContext.ThumbnailPolicies.AsNoTracking().CreatePagedResult(request,
+            q => q,
+            q => q.OrderBy(i => i.Id),
+            cancellationToken: cancellationToken);
+
+        return FetchEntityResult<PageOf<ThumbnailPolicy>>.Success(result);
+    }
+}

--- a/src/protagonist/API/Features/Policies/Requests/GetThumbnailPolicy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetThumbnailPolicy.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Requests;
+using DLCS.Model.Policies;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Policies.Requests;
+
+/// <summary>
+/// Get details of specified image optimisation policy
+/// </summary>
+public class GetThumbnailPolicy : IRequest<FetchEntityResult<ThumbnailPolicy>>
+{
+    public string ThumbnailPolicyId { get; }
+
+    public GetThumbnailPolicy(string thumbnailPolicyId)
+    {
+        ThumbnailPolicyId = thumbnailPolicyId;
+    }
+}
+
+public class GetThumbnailPolicyHandler : IRequestHandler<GetThumbnailPolicy,
+    FetchEntityResult<ThumbnailPolicy>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetThumbnailPolicyHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<ThumbnailPolicy>> Handle(GetThumbnailPolicy request,
+        CancellationToken cancellationToken)
+    {
+        var policy = await dlcsContext.ThumbnailPolicies.AsNoTracking()
+            .SingleOrDefaultAsync(b => b.Id == request.ThumbnailPolicyId,
+                cancellationToken);
+        return policy == null
+            ? FetchEntityResult<ThumbnailPolicy>.NotFound()
+            : FetchEntityResult<ThumbnailPolicy>.Success(policy);
+    }
+}

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using DLCS.Model.Policies;
 using FluentAssertions;
 using IIIF;
 using Xunit;

--- a/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailPolicyTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailPolicyTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using DLCS.Model.Assets;
+using DLCS.Model.Policies;
 using FluentAssertions;
 using Xunit;
 

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using DLCS.Core.Collections;
 using DLCS.Core.Guard;
+using DLCS.Model.Policies;
 
 namespace DLCS.Model.Assets;
 

--- a/src/protagonist/DLCS.Model/Assets/AssetX.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetX.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using DLCS.Core.Guard;
 using DLCS.Core.Types;
+using DLCS.Model.Policies;
 using IIIF;
 
 namespace DLCS.Model.Assets;

--- a/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
@@ -1,11 +1,9 @@
-﻿#nullable disable
+﻿using System.Diagnostics;
 
-using System.Diagnostics;
-
-namespace DLCS.Model.Assets;
+namespace DLCS.Model.Policies;
 
 [DebuggerDisplay("{Name}")]
-public partial class ImageOptimisationPolicy
+public class ImageOptimisationPolicy
 {
     public string Id { get; set; }
     public string Name { get; set; }

--- a/src/protagonist/DLCS.Model/Policies/OriginStrategy.cs
+++ b/src/protagonist/DLCS.Model/Policies/OriginStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace DLCS.Model.Policies;
+
+public class OriginStrategy
+{
+    public string Id { get; set; }
+    public bool RequiresCredentials { get; set; }
+}

--- a/src/protagonist/DLCS.Model/Policies/ThumbnailPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ThumbnailPolicy.cs
@@ -2,10 +2,8 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using IIIF.ImageApi;
 
-namespace DLCS.Model.Assets;
+namespace DLCS.Model.Policies;
 
 [DebuggerDisplay("{Name}: {Sizes}")]
 public class ThumbnailPolicy

--- a/src/protagonist/DLCS.Repository/Assets/Thumbs/ThumbsManager.cs
+++ b/src/protagonist/DLCS.Repository/Assets/Thumbs/ThumbsManager.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using DLCS.Model.Policies;
 using IIIF;
 using Newtonsoft.Json;
 

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -11,6 +11,7 @@ using DLCS.Model.Assets.CustomHeaders;
 using DLCS.Model.Assets.NamedQueries;
 using DLCS.Model.Auth.Entities;
 using DLCS.Model.Customers;
+using DLCS.Model.Policies;
 using DLCS.Model.Processing;
 using DLCS.Model.Spaces;
 using DLCS.Model.Storage;
@@ -21,7 +22,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using OriginStrategy = DLCS.Repository.Entities.OriginStrategy;
+using OriginStrategy = DLCS.Model.Policies.OriginStrategy;
 namespace DLCS.Repository;
 
 public partial class DlcsContext : DbContext

--- a/src/protagonist/DLCS.Repository/Entities/OriginStrategy.cs
+++ b/src/protagonist/DLCS.Repository/Entities/OriginStrategy.cs
@@ -1,9 +1,0 @@
-﻿#nullable disable
-
-namespace DLCS.Repository.Entities;
-
-public partial class OriginStrategy
-{
-    public string Id { get; set; }
-    public bool RequiresCredentials { get; set; }
-}

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
@@ -6,6 +6,7 @@ using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
+using DLCS.Model.Policies;
 using Engine.Ingest;
 using Engine.Ingest.Image;
 using Engine.Ingest.Image.Appetiser;

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
@@ -5,6 +5,7 @@ using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using DLCS.Model.Policies;
 using Engine.Ingest;
 using Engine.Ingest.Persistence;
 using Engine.Ingest.Timebased.Transcode;

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using DLCS.Model.Assets;
 using DLCS.Model.Auth.Entities;
 using DLCS.Model.Customers;
+using DLCS.Model.Policies;
 using DLCS.Model.Spaces;
 using DLCS.Model.Storage;
 using DLCS.Repository;
@@ -84,18 +85,18 @@ public class DlcsDatabaseFixture : IAsyncLifetime
             Name = "test",
             Keys = Array.Empty<string>()
         });
-        await DbContext.StoragePolicies.AddAsync(new StoragePolicy
-        {
-            Id = "default",
-            MaximumNumberOfStoredImages = 1000000,
-            MaximumTotalSizeOfStoredImages = 1000000000
-        });
-        await DbContext.StoragePolicies.AddAsync(new StoragePolicy
-        {
-            Id = "small",
-            MaximumNumberOfStoredImages = 10,
-            MaximumTotalSizeOfStoredImages = 100
-        });
+        await DbContext.StoragePolicies.AddRangeAsync(new StoragePolicy
+            {
+                Id = "default",
+                MaximumNumberOfStoredImages = 1000000,
+                MaximumTotalSizeOfStoredImages = 1000000000
+            },
+            new StoragePolicy
+            {
+                Id = "small",
+                MaximumNumberOfStoredImages = 10,
+                MaximumTotalSizeOfStoredImages = 100
+            });
         await DbContext.EntityCounters.AddRangeAsync(new EntityCounter
         {
             Type = "space",


### PR DESCRIPTION
Implemented the following endpoints:

GET `/imageOptimisationPolicies`
GET `/imageOptimisationPolicies/{imageOptimisationPolicy}`
GET `/originStrategies`
GET `/originStrategies/{originStrategy}`
GET `/storagePolicies`
GET `/storagePolicies/{storagePolicy}`
GET `/thumbnailPolicies`
GET `/thumbnailPolicies/{thumbnailPolicy}`

Mostly boiler plate request implementation, left it as is rather than trying to make a reusable basic `GetPolicy<T>` request to allow for queries to be changed easier moving forward.

Important implementation is in `PoliciesController`, some other changes due to moving some entities to new namespace.