### PR TITLE
Customer image API endpoints

### DIFF
--- a/src/protagonist/API.Tests/Features/Customer/Validation/AllImagesValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/AllImagesValidatorTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using API.Features.Customer.Validation;
+using API.Settings;
+using DLCS.Model;
+using FluentValidation.TestHelper;
+using Hydra.Collections;
+using Microsoft.Extensions.Options;
+
+namespace API.Tests.Features.Customer.Validation;
+
+public class AllImagesValidatorTests
+{
+    private readonly AllImagesValidator sut;
+
+    public AllImagesValidatorTests()
+    {
+        var apiSettings = new ApiSettings { MaxImageListSize = 4 };
+        sut = new AllImagesValidator(Options.Create(apiSettings));
+    }
+
+    [Fact]
+    public void Members_Null()
+    {
+        var model = new HydraCollection<IdentifierOnly>();
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members);
+    }
+    
+    [Fact]
+    public void Members_Empty()
+    {
+        var model = new HydraCollection<IdentifierOnly> { Members = Array.Empty<IdentifierOnly>() };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members);
+    }
+
+    [Fact]
+    public void Members_GreaterThanMaxBatchSize()
+    {
+        var model = new HydraCollection<IdentifierOnly>
+        {
+            Members = new[]
+            {
+                new IdentifierOnly(), new IdentifierOnly(), new IdentifierOnly(), new IdentifierOnly(),
+                new IdentifierOnly()
+            }
+        };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members);
+    }
+
+    [Fact]
+    public void Members_ContainsDuplicateIds()
+    {
+        var model = new HydraCollection<IdentifierOnly>
+        {
+            Members = new[]
+            {
+                new IdentifierOnly { Id = "1/2/foo" },
+                new IdentifierOnly { Id = "1/2/bar" },
+                new IdentifierOnly { Id = "1/2/foo" },
+            }
+        };
+        var result = sut.TestValidate(model);
+        result
+            .ShouldHaveValidationErrorFor(r => r.Members)
+            .WithErrorMessage("Members contains 1 duplicate Id(s): 1/2/foo");
+    }
+}

--- a/src/protagonist/API.Tests/Features/Customer/Validation/ImageIdListValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/ImageIdListValidatorTests.cs
@@ -8,14 +8,14 @@ using Microsoft.Extensions.Options;
 
 namespace API.Tests.Features.Customer.Validation;
 
-public class AllImagesValidatorTests
+public class ImageIdListValidatorTests
 {
-    private readonly AllImagesValidator sut;
+    private readonly ImageIdListValidator sut;
 
-    public AllImagesValidatorTests()
+    public ImageIdListValidatorTests()
     {
         var apiSettings = new ApiSettings { MaxImageListSize = 4 };
-        sut = new AllImagesValidator(Options.Create(apiSettings));
+        sut = new ImageIdListValidator(Options.Create(apiSettings));
     }
 
     [Fact]

--- a/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
@@ -113,4 +113,82 @@ public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         collection.PageSize.Should().Be(3);
         collection.TotalItems.Should().Be(3);
     }
+    
+    [Fact]
+    public async Task Post_DeleteImages_400_IfInvalidFormatId()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [
+    { ""id"": ""1/not-an-id"" },
+    ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/deleteImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Post_DeleteImages_400_IfRequestDifferentCustomer()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ { ""id"": ""1/1/diff-customer"" } ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/deleteImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Post_DeleteImages_400_IfNoMatches()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ { ""id"": ""99/1/not-found"" }, { ""id"": ""99/1/not-found-2"" } ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/deleteImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Post_DeleteImages_200_WithMatches()
+    {
+        // Arrange
+        await dbContext.Images.AddTestAsset("99/1/deleteImages_1");
+        await dbContext.Images.AddTestAsset("99/1/deleteImages_2");
+        await dbContext.Images.AddTestAsset("99/2/deleteImages_3", space: 2);
+        await dbContext.SaveChangesAsync();
+        
+        const string newCustomerJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ 
+    { ""id"": ""99/1/deleteImages_1"" }, { ""id"": ""99/1/deleteImages_2"" },
+    { ""id"": ""99/2/deleteImages_3"" }, { ""id"": ""99/1/not-found"" }
+ ]
+}";
+        var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/deleteImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using API.Client;
+using API.Tests.Integration.Infrastructure;
+using DLCS.HydraModel;
+using DLCS.Repository;
+using Hydra.Collections;
+using Test.Helpers.Integration;
+using Test.Helpers.Integration.Infrastructure;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsContext dbContext;
+    private readonly HttpClient httpClient;
+
+    public CustomerImageTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        dbContext = dbFixture.DbContext;
+        httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
+        dbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task Post_AllImages_400_IfInvalidFormatId()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [
+    { ""id"": ""1/not-an-id"" },
+    ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Post_AllImages_400_IfRequestDifferentCustomer()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ { ""id"": ""1/1/diff-customer"" } ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Post_AllImages_200_IfNoMatches()
+    {
+        // Arrange
+        const string allImagesJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ { ""id"": ""99/1/not-found"" }, { ""id"": ""99/1/not-found-2"" } ]
+}";
+        var content = new StringContent(allImagesJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        collection.Members.Should().BeEmpty();
+        collection.PageSize.Should().Be(0);
+        collection.TotalItems.Should().Be(0);
+    }
+    
+    [Fact]
+    public async Task Post_AllImages_200_WithMatches()
+    {
+        // Arrange
+        await dbContext.Images.AddTestAsset("99/1/allImages_1");
+        await dbContext.Images.AddTestAsset("99/1/allImages_2");
+        await dbContext.Images.AddTestAsset("99/2/allImages_3", space: 2);
+        await dbContext.SaveChangesAsync();
+        
+        const string newCustomerJson = @"{
+  ""@type"": ""Collection"",
+  ""member"": [ 
+    { ""id"": ""99/1/allImages_1"" }, { ""id"": ""99/1/allImages_2"" },
+    { ""id"": ""99/2/allImages_3"" }, { ""id"": ""99/1/not-found"" }
+ ]
+}";
+        var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        collection.Members.Should().HaveCount(3);
+        collection.PageSize.Should().Be(3);
+        collection.TotalItems.Should().Be(3);
+    }
+}

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -24,6 +24,7 @@
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+      <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.15.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/API/Features/Customer/ApiKeysController.cs
+++ b/src/protagonist/API/Features/Customer/ApiKeysController.cs
@@ -41,7 +41,7 @@ public class ApiKeysController : HydraController
     [Route("{customerId}/keys")]
     public async Task<IActionResult> GetApiKeys(int customerId)
     {
-        var dbCustomer = await mediator.Send(new GetCustomer(customerId));
+        var dbCustomer = await Mediator.Send(new GetCustomer(customerId));
         if (dbCustomer == null)
         {
             return this.HydraNotFound();
@@ -73,7 +73,7 @@ public class ApiKeysController : HydraController
     [Route("{customerId}/keys")]
     public async Task<IActionResult> CreateApiKey(int customerId)
     {
-        var result = await mediator.Send(new CreateApiKey(customerId));
+        var result = await Mediator.Send(new CreateApiKey(customerId));
         if (result.Key.HasText() && result.Secret.HasText())
         {
             return Ok(new ApiKey(GetUrlRoots().BaseUrl, customerId, result.Key, result.Secret));
@@ -95,7 +95,7 @@ public class ApiKeysController : HydraController
     [Route("{customerId}/keys/{key}")]
     public async Task<IActionResult> DeleteApiKey(int customerId, string key)
     {
-        var result = await mediator.Send(new DeleteApiKey(customerId, key));
+        var result = await Mediator.Send(new DeleteApiKey(customerId, key));
         if (result.Error.HasText())
         {
             return this.HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request");

--- a/src/protagonist/API/Features/Customer/CustomerController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerController.cs
@@ -52,7 +52,7 @@ public class CustomerController : HydraController
     public async Task<HydraCollection<JObject>> GetCustomers()
     {
         var baseUrl = GetUrlRoots().BaseUrl;
-        var dbCustomers = await mediator.Send(new GetAllCustomers());
+        var dbCustomers = await Mediator.Send(new GetAllCustomers());
             
         return new HydraCollection<JObject>
         {
@@ -90,7 +90,7 @@ public class CustomerController : HydraController
 
         try
         {
-            var result = await mediator.Send(command);
+            var result = await Mediator.Send(command);
             if (result.Customer == null || result.ErrorMessages.Any())
             {
                 int statusCode = result.Conflict ? 409 : 500;
@@ -121,7 +121,7 @@ public class CustomerController : HydraController
     [Route("{customerId}")]
     public async Task<IActionResult> GetCustomer(int customerId)
     {
-        var dbCustomer = await mediator.Send(new GetCustomer(customerId));
+        var dbCustomer = await Mediator.Send(new GetCustomer(customerId));
         if (dbCustomer == null)
         {
             return this.HydraNotFound();

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using System.Threading;
+using API.Converters;
+using API.Features.Customer.Requests;
+using API.Features.Customer.Validation;
+using API.Infrastructure;
+using API.Settings;
+using DLCS.Model;
+using DLCS.Model.Assets;
+using Hydra.Collections;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Customer;
+
+/// <summary>
+/// Controller for handling bulk requests for images associated with a customer 
+/// </summary>
+[Route("/customers/{customerId}")]
+[ApiController]
+public class CustomerImagesController : HydraController
+{
+    /// <inheritdoc />
+    public CustomerImagesController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
+    {
+    }
+
+    /// <summary>
+    /// POST /customers/{customerId}/allImages
+    /// 
+    /// Accepts a list of image identifiers, will return a list of matching images
+    /// </summary>
+    /// <remarks>
+    /// Sample request:
+    /// 
+    ///     POST: /customers/1/allImages
+    ///     {
+    ///         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+    ///         "@type":"Collection",
+    ///         "member": [
+    ///             { "id": "1/1/foo" },
+    ///             { "id": "1/99/bar" }
+    ///         ]
+    ///     }
+    /// </remarks>
+    [HttpPost]
+    [Route("allImages")]
+    public async Task<IActionResult> GetAllImages(
+        [FromRoute] int customerId,
+        [FromBody] HydraCollection<IdentifierOnly> imageIdentifiers,
+        [FromServices] AllImagesValidator validator,
+        CancellationToken cancellationToken = default)
+    {
+        var validationResult = await validator.ValidateAsync(imageIdentifiers, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            return this.ValidationFailed(validationResult);
+        }
+
+        var request = new GetMultipleImagesById(imageIdentifiers.Members!.Select(m => m.Id).ToList(), customerId);
+
+        return await HandleListFetch<Asset, GetMultipleImagesById, DLCS.HydraModel.Image>(
+            request,
+            a => a.ToHydra(GetUrlRoots()),
+            "Get customer images failed",
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/protagonist/API/Features/Customer/PortalUsersController.cs
+++ b/src/protagonist/API/Features/Customer/PortalUsersController.cs
@@ -42,7 +42,7 @@ public class PortalUsersController : HydraController
     [Route("{customerId}/portalUsers")]
     public async Task<HydraCollection<PortalUser>> GetPortalUsers(int customerId)
     {
-        var users = await mediator.Send(new GetPortalUsers { CustomerId = customerId });
+        var users = await Mediator.Send(new GetPortalUsers { CustomerId = customerId });
             
         var baseUrl = GetUrlRoots().BaseUrl;
         var collection = new HydraCollection<PortalUser>
@@ -68,7 +68,7 @@ public class PortalUsersController : HydraController
     [Route("{customerId}/portalUsers/{userId}")]
     public async Task<IActionResult> GetPortalUser(int customerId, string userId)
     {
-        var users = await mediator.Send(new GetPortalUsers { CustomerId = customerId });
+        var users = await Mediator.Send(new GetPortalUsers { CustomerId = customerId });
         var user = users.SingleOrDefault(u => u.Id == userId);
         if (user != null)
         {
@@ -99,7 +99,7 @@ public class PortalUsersController : HydraController
                 Email = portalUser.Email
             }
         };
-        var result = await mediator.Send(request);
+        var result = await Mediator.Send(request);
         if (result.Error.HasText() || result.PortalUser == null)
         {
             return this.HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot create user");
@@ -138,7 +138,7 @@ public class PortalUsersController : HydraController
                 Email = portalUser.Email
             }
         };
-        var result = await mediator.Send(request);
+        var result = await Mediator.Send(request);
         if (result.Error.HasText() || result.PortalUser == null)
         {
             return this.HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Cannot Patch user");
@@ -160,7 +160,7 @@ public class PortalUsersController : HydraController
     [Route("{customerId}/portalUsers/{userId}")]
     public async Task<IActionResult> DeletePortalUser(int customerId, string userId)
     {
-        var result = await mediator.Send(new DeletePortalUser(customerId, userId));
+        var result = await Mediator.Send(new DeletePortalUser(customerId, userId));
         if (result.Error.HasText())
         {
             return this.HydraProblem(result.Error, null, (int)HttpStatusCode.BadRequest, "Bad Request");

--- a/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using API.Features.Customer.Validation;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace API.Features.Customer.Requests;
+
+/// <summary>
+/// Get a list of all images whose id is in ImageIds list
+/// </summary>
+public class DeleteMultipleImagesById : IRequest<int>
+{
+    public IReadOnlyCollection<string> AssetIds { get; }
+    public int CustomerId { get; }
+
+    public DeleteMultipleImagesById(IReadOnlyCollection<string> assetIds, int customerId)
+    {
+        AssetIds = assetIds;
+        CustomerId = customerId;
+    }
+}
+
+public class DeleteMultipleImagesByIdHandler : IRequestHandler<DeleteMultipleImagesById, int>
+{
+    private readonly DlcsContext dlcsContext;
+    private readonly IAssetNotificationSender assetNotificationSender;
+    private readonly ILogger<DeleteMultipleImagesByIdHandler> logger;
+
+    public DeleteMultipleImagesByIdHandler(
+        DlcsContext dlcsContext,
+        IAssetNotificationSender assetNotificationSender,
+        ILogger<DeleteMultipleImagesByIdHandler> logger)
+    {
+        this.dlcsContext = dlcsContext;
+        this.assetNotificationSender = assetNotificationSender;
+        this.logger = logger;
+    }
+
+    public async Task<int> Handle(DeleteMultipleImagesById request, CancellationToken cancellationToken)
+    {
+        ImageIdListValidation.ValidateRequest(request.AssetIds, request.CustomerId);
+
+        var deletedRows = await dlcsContext.Images.AsNoTracking()
+            .Where(i => i.Customer == request.CustomerId && request.AssetIds.Contains(i.Id))
+            .DeleteFromQueryAsync(cancellationToken);
+
+        logger.LogInformation("Deleted {DeletedRows} assets from a requested {RequestedRows}", deletedRows,
+            request.AssetIds.Count);
+
+        if (deletedRows == 0) return 0;
+
+        await RaiseModifiedNotifications(request);
+
+        return deletedRows;
+    }
+
+    private async Task RaiseModifiedNotifications(DeleteMultipleImagesById request)
+    {
+        // NOTE(DG) there is the possibility to raise a notification for an object that doesn't exist here,
+        // we just issue a DELETE request to DB without checking which items exist 
+        foreach (var asset in request.AssetIds.Select(i => new Asset { Id = i }))
+        {
+            await assetNotificationSender.SendAssetModifiedNotification(ChangeType.Delete, asset, null);
+        }
+    }
+}

--- a/src/protagonist/API/Features/Customer/Requests/GetAllCustomers.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetAllCustomers.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using DLCS.Repository;
 using MediatR;
 using Microsoft.EntityFrameworkCore;

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using API.Infrastructure.Requests;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Customer.Requests;
+
+/// <summary>
+/// Get a list of all images whose id is in ImageIds list
+/// </summary>
+public class GetMultipleImagesById : IRequest<FetchEntityResult<IReadOnlyCollection<Asset>>>
+{
+    public IReadOnlyCollection<string> ImageIds { get; }
+    public int CustomerId { get; }
+
+    public GetMultipleImagesById(IReadOnlyCollection<string> imageIds, int customerId)
+    {
+        ImageIds = imageIds;
+        CustomerId = customerId;
+    }
+}
+
+public class GetMultipleImagesByIdHandler 
+    : IRequestHandler<GetMultipleImagesById, FetchEntityResult<IReadOnlyCollection<Asset>>>
+{
+    private readonly DlcsContext dlcsContext;
+
+    public GetMultipleImagesByIdHandler(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    public async Task<FetchEntityResult<IReadOnlyCollection<Asset>>> Handle(GetMultipleImagesById request,
+        CancellationToken cancellationToken)
+    {
+        ValidateRequest(request);
+
+        var results = await dlcsContext.Images.AsNoTracking()
+            .Where(i => i.Customer == request.CustomerId && request.ImageIds.Contains(i.Id))
+            .ToListAsync(cancellationToken);
+
+        return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);
+    }
+
+    private static void ValidateRequest(GetMultipleImagesById request)
+    {
+        IEnumerable<AssetId> assetIds;
+        try
+        {
+            assetIds = request.ImageIds.Select(i => AssetId.FromString(i));
+        }
+        catch (FormatException formatException)
+        {
+            throw new BadRequestException(formatException.Message, formatException);
+        }
+
+        if (assetIds.Any(a => a.Customer != request.CustomerId))
+        {
+            throw new BadRequestException("Cannot request images for different customer");
+        }
+    }
+}

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -50,19 +50,18 @@ public class GetMultipleImagesByIdHandler
 
     private static void ValidateRequest(GetMultipleImagesById request)
     {
-        IEnumerable<AssetId> assetIds;
         try
         {
-            assetIds = request.ImageIds.Select(i => AssetId.FromString(i));
+            var assetIds = request.ImageIds.Select(i => AssetId.FromString(i)).ToList();
+            
+            if (assetIds.Any(a => a.Customer != request.CustomerId))
+            {
+                throw new BadRequestException("Cannot request images for different customer");
+            }
         }
         catch (FormatException formatException)
         {
             throw new BadRequestException(formatException.Message, formatException);
-        }
-
-        if (assetIds.Any(a => a.Customer != request.CustomerId))
-        {
-            throw new BadRequestException("Cannot request images for different customer");
         }
     }
 }

--- a/src/protagonist/API/Features/Customer/Validation/AllImagesValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/AllImagesValidator.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using API.Settings;
+using DLCS.Core.Collections;
+using DLCS.Model;
+using FluentValidation;
+using Hydra.Collections;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Customer.Validation;
+
+/// <summary>
+/// Validator for body sent to POST /customer/{id}/allImages
+/// </summary>
+public class AllImagesValidator : AbstractValidator<HydraCollection<IdentifierOnly>>
+{
+    public AllImagesValidator(IOptions<ApiSettings> apiSettings)
+    {
+        RuleFor(c => c.Members)
+            .NotEmpty().WithMessage("Members cannot be empty");
+        
+        RuleFor(c => c.Members)
+            .Must(m => m.IsNullOrEmpty() || m!.Select(a => a.Id).Distinct().Count() == m!.Length)
+            .WithMessage((_, mem) =>
+            {
+                var dupes = mem!.Select(a => a.Id).GetDuplicates().ToList();
+                return $"Members contains {dupes.Count} duplicate Id(s): {string.Join(",", dupes)}";
+            });
+        
+        var maxBatch = apiSettings.Value.MaxImageListSize;
+        RuleFor(c => c.Members)
+            .Must(m => (m?.Length ?? 0) < maxBatch)
+            .WithMessage($"Maximum assets in single batch is {maxBatch}");
+    }
+}

--- a/src/protagonist/API/Features/Customer/Validation/ImageIdListValidation.cs
+++ b/src/protagonist/API/Features/Customer/Validation/ImageIdListValidation.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DLCS.Core.Types;
+
+namespace API.Features.Customer.Validation;
+
+internal static class ImageIdListValidation
+{
+    /// <summary>
+    /// Validate that imageIds are all in a valid format and are all for the same customer
+    /// </summary>
+    public static void ValidateRequest(IReadOnlyCollection<string> assetIdentifiers, int customerId)
+    {
+        try
+        {
+            var assetIds = assetIdentifiers.Select(i => AssetId.FromString(i)).ToList();
+            
+            if (assetIds.Any(a => a.Customer != customerId))
+            {
+                throw new BadRequestException("Cannot request images for different customer");
+            }
+        }
+        catch (FormatException formatException)
+        {
+            throw new BadRequestException(formatException.Message, formatException);
+        }
+    }
+}

--- a/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
@@ -11,9 +11,9 @@ namespace API.Features.Customer.Validation;
 /// <summary>
 /// Validator for body sent to POST /customer/{id}/allImages
 /// </summary>
-public class AllImagesValidator : AbstractValidator<HydraCollection<IdentifierOnly>>
+public class ImageIdListValidator : AbstractValidator<HydraCollection<IdentifierOnly>>
 {
-    public AllImagesValidator(IOptions<ApiSettings> apiSettings)
+    public ImageIdListValidator(IOptions<ApiSettings> apiSettings)
     {
         RuleFor(c => c.Members)
             .NotEmpty().WithMessage("Members cannot be empty");

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net;
 using System.Threading;
-using System.Threading.Tasks;
 using API.Converters;
 using API.Features.Image.Requests;
 using API.Infrastructure;

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -44,7 +44,7 @@ public class ImageController : HydraController
     public async Task<IActionResult> GetImage(int customerId, int spaceId, string imageId)
     {
         var assetId = new AssetId(customerId, spaceId, imageId);
-        var dbImage = await mediator.Send(new GetImage(assetId));
+        var dbImage = await Mediator.Send(new GetImage(assetId));
         if (dbImage == null)
         {
             return this.HydraNotFound();
@@ -125,7 +125,7 @@ public class ImageController : HydraController
         [FromRoute] string imageId, CancellationToken cancellationToken)
     {
         var deleteRequest = new DeleteAsset(customerId, spaceId, imageId);
-        var result = await mediator.Send(deleteRequest, cancellationToken);
+        var result = await Mediator.Send(deleteRequest, cancellationToken);
 
         return result switch
         {
@@ -202,7 +202,7 @@ public class ImageController : HydraController
             MediaType = asset.MediaType
         };
 
-        var result = await mediator.Send(saveRequest);
+        var result = await Mediator.Send(saveRequest);
         if (string.IsNullOrEmpty(result.Origin))
         {
             return this.HydraProblem("Could not save uploaded file", assetId.ToString(), 500, errorTitle);

--- a/src/protagonist/API/Features/Image/ImagesController.cs
+++ b/src/protagonist/API/Features/Image/ImagesController.cs
@@ -115,7 +115,7 @@ public class ImagesController : HydraController
                 {
                     var asset = hydraImage.ToDlcsModel(customerId, spaceId);
                     var request = new CreateOrUpdateImage(asset, "PATCH");
-                    var result = await mediator.Send(request);
+                    var result = await Mediator.Send(request);
                     if (result.Entity != null)
                     {
                         patchedAssets.Add(result.Entity);

--- a/src/protagonist/API/Features/Image/ImagesController.cs
+++ b/src/protagonist/API/Features/Image/ImagesController.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using API.Converters;
 using API.Exceptions;
 using API.Features.Image.Requests;
@@ -10,7 +9,6 @@ using API.Features.Space.Requests;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Strings;
-using DLCS.HydraModel;
 using DLCS.Model.Assets;
 using DLCS.Web.Requests;
 using Hydra.Collections;

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -28,7 +28,7 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
 
         var maxBatch = apiSettings.Value.MaxBatchSize;
         RuleFor(c => c.Members)
-            .Must(m => (m?.Length ?? 0) < apiSettings.Value.MaxBatchSize)
+            .Must(m => (m?.Length ?? 0) < maxBatch)
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
 
         RuleForEach(c => c.Members).SetValidator(new QueuePostImageValidator());

--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -54,7 +54,7 @@ public class SpaceController : HydraController
         if (page is null or < 0) page = 1;
         var orderByField = this.GetOrderBy(orderBy, orderByDescending, out var descending);
         var baseUrl = GetUrlRoots().BaseUrl;
-        var pageOfSpaces = await mediator.Send(new GetPageOfSpaces(
+        var pageOfSpaces = await Mediator.Send(new GetPageOfSpaces(
             page.Value, pageSize.Value, customerId, orderByField, descending));
         
         var collection = new HydraCollection<DLCS.HydraModel.Space>
@@ -103,7 +103,7 @@ public class SpaceController : HydraController
 
         try
         {
-            var newDbSpace = await mediator.Send(command);
+            var newDbSpace = await Mediator.Send(command);
             var newApiSpace = newDbSpace.ToHydra(GetUrlRoots().BaseUrl);
             if (newApiSpace.Id.HasText())
             {
@@ -133,7 +133,7 @@ public class SpaceController : HydraController
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetSpace(int customerId, int spaceId)
     {
-        var dbSpace = await mediator.Send(new GetSpace(customerId, spaceId));
+        var dbSpace = await Mediator.Send(new GetSpace(customerId, spaceId));
         if (dbSpace != null)
         {
             return Ok(dbSpace.ToHydra(GetUrlRoots().BaseUrl));
@@ -166,7 +166,7 @@ public class SpaceController : HydraController
             Roles = space.DefaultRoles
         };
         
-        var result = await mediator.Send(patchSpace);
+        var result = await Mediator.Send(patchSpace);
         if (!result.ErrorMessages.Any() && result.Space != null)
         {
             return Ok(result.Space.ToHydra(GetUrlRoots().BaseUrl));

--- a/src/protagonist/API/Infrastructure/ControllerBaseX.cs
+++ b/src/protagonist/API/Infrastructure/ControllerBaseX.cs
@@ -97,8 +97,7 @@ public static class ControllerBaseX
             StatusCode = hydraError.Status
         };
     }
-    
-    
+
     /// <summary>
     /// Creates an <see cref="ObjectResult"/> that produces a <see cref="Error"/> response.
     /// This overload can wrap otherwise uncaught exceptions.

--- a/src/protagonist/API/Infrastructure/HydraController.cs
+++ b/src/protagonist/API/Infrastructure/HydraController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -185,6 +186,65 @@ public abstract class HydraController : Controller
                     };
                     PartialCollectionView.AddPaging(collection, pageOf.Page, pageOf.PageSize);
                     return collection;
+                },
+                instance,
+                errorTitle);
+        }
+        catch (APIException apiEx)
+        {
+            return this.HydraProblem(apiEx.Message, null, apiEx.StatusCode ?? 500, apiEx.Label);
+        }
+        catch (Exception ex)
+        {
+            return this.HydraProblem(ex.Message, null, 500, errorTitle);
+        }
+    }
+    
+    /// <summary>
+    /// Handle a request that returns a non-paged list of assets.
+    /// This takes a IRequest which returns a FetchEntityResult{IReadOnlyCollection{T}}
+    /// The request is sent and result is transformed to HydraCollection.
+    /// </summary>
+    /// <param name="request">IRequest to fetch data</param>
+    /// <param name="hydraBuilder">Delegate to transform each returned entity to a Hydra representation</param>
+    /// <param name="instance">The value for <see cref="Error.Instance" />.</param>
+    /// <param name="errorTitle">
+    /// The value for <see cref="Error.Title" />. In some instances this will be prepended to the actual error name.
+    /// e.g. errorTitle + ": Conflict"
+    /// </param>
+    /// <param name="cancellationToken">Current cancellation token</param>
+    /// <typeparam name="TEntity">Type of db entity being fetched</typeparam>
+    /// <typeparam name="TRequest">Type of mediatr request being page</typeparam>
+    /// <typeparam name="THydra">Hydra type for each member</typeparam>
+    /// <returns>
+    /// ActionResult generated from FetchEntityResult. This will be the HydraCollection + 200 on success. Or a Hydra
+    /// error and appropriate status code if failed.
+    /// </returns>
+    protected async Task<IActionResult> HandleListFetch<TEntity, TRequest, THydra>(
+        TRequest request,
+        Func<TEntity, THydra> hydraBuilder,
+        string? instance = null,
+        string? errorTitle = "Fetch failed",
+        CancellationToken cancellationToken = default)
+        where TRequest : IRequest<FetchEntityResult<IReadOnlyCollection<TEntity>>>
+        where THydra : DlcsResource
+    {
+        try
+        {
+            var result = await mediator.Send(request, cancellationToken);
+
+            return this.FetchResultToHttpResult(
+                result,
+                results =>
+                {
+                    return new HydraCollection<THydra>
+                    {
+                        WithContext = true,
+                        Members = results.Select(b => hydraBuilder(b)).ToArray(),
+                        TotalItems = results.Count,
+                        PageSize = results.Count,
+                        Id = Request.GetJsonLdId()
+                    };
                 },
                 instance,
                 errorTitle);

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -29,4 +29,9 @@ public class ApiSettings
     /// The maximum number of images that can be POSTed in a single batch
     /// </summary>
     public int MaxBatchSize { get; set; } = 250;
+    
+    /// <summary>
+    /// The maximum number of images that can be POSTed in a single batch
+    /// </summary>
+    public int MaxImageListSize { get; set; } = 500;
 }

--- a/src/protagonist/API/Usings.cs
+++ b/src/protagonist/API/Usings.cs
@@ -1,0 +1,1 @@
+global using System.Threading.Tasks;

--- a/src/protagonist/DLCS.Core.Tests/Types/AssetImageIdTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/Types/AssetImageIdTests.cs
@@ -31,9 +31,13 @@ public class AssetImageIdTests
     [Theory]
     [InlineData("image")]
     [InlineData("1/2/image/easrwt")]
+    [InlineData("1/str/image")]
+    [InlineData("str/2/image")]
     public void FromString_Throws_IfInvalidFormat(string assetId)
     {
         Action action = () => AssetId.FromString(assetId);
-        action.Should().Throw<FormatException>();
+        action.Should()
+            .Throw<FormatException>()
+            .WithMessage($"AssetId '{assetId}' is invalid. Must be in format customer/space/asset");
     }
 }

--- a/src/protagonist/DLCS.Core/Types/AssetId.cs
+++ b/src/protagonist/DLCS.Core/Types/AssetId.cs
@@ -54,9 +54,16 @@ public record AssetId(int Customer, int Space, string Asset)
         var parts = assetImageId.Split("/", StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 3)
         {
-            throw new FormatException("AssetId string must be in format customer/space/asset");
+            throw new FormatException($"AssetId '{assetImageId}' is invalid. Must be in format customer/space/asset");
         }
 
-        return new AssetId(int.Parse(parts[0]), int.Parse(parts[1]), parts[2]);
+        try
+        {
+            return new AssetId(int.Parse(parts[0]), int.Parse(parts[1]), parts[2]);
+        }
+        catch (FormatException)
+        {
+            throw new FormatException($"AssetId '{assetImageId}' is invalid. Must be in format customer/space/asset");
+        }
     }
 }

--- a/src/protagonist/DLCS.Model/IdentifierOnly.cs
+++ b/src/protagonist/DLCS.Model/IdentifierOnly.cs
@@ -1,0 +1,9 @@
+﻿namespace DLCS.Model;
+
+/// <summary>
+/// An object that contains a single Identifier property
+/// </summary>
+public class IdentifierOnly
+{
+    public string Id { get; set; }
+}

--- a/src/protagonist/DLCS.Repository/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/AssetNotificationSender.cs
@@ -81,6 +81,10 @@ public class AssetNotificationSender : IAssetNotificationSender
 
     public Task SendAssetModifiedNotification(ChangeType changeType, Asset? before, Asset? after)
     {
+        /*
+         * TODO - this should probably have a bulk implementation, assuming it handles bulk enqueuing of messages
+         * it's more efficient to do in batches rather than 1 at a time (like engine client)
+         */
         switch (changeType)
         {
             case ChangeType.Create when before != null:

--- a/src/protagonist/Hydra/JsonLdBase.cs
+++ b/src/protagonist/Hydra/JsonLdBase.cs
@@ -16,7 +16,6 @@ public abstract class JsonLdBase
     [JsonIgnore]
     protected string? InternalContext;
 
-    
     [JsonProperty(Order = 2, PropertyName = "@id")]
     public string? Id { get; set; }
 

--- a/src/protagonist/Hydra/Link.cs
+++ b/src/protagonist/Hydra/Link.cs
@@ -5,8 +5,5 @@ namespace Hydra;
 /// </summary>
 public class Link : JsonLdBase
 {
-    public override string Type
-    {
-        get { return "@id"; }
-    }
+    public override string Type => "@id";
 }


### PR DESCRIPTION
Implemented `/customer/{customer}/allImages` and `/customer/{customer}/deleteImages`.

Added new `CustomerImagesController` within `Customer` feature for these endpoints. 

Both of these take a `HydraCollection<IdentifierOnly>`. Identifier only is the minimum class to just have `{"id": "_value_" }`

Followed same approach as current Deliverator, `/deleteImages` returns `200: {"message": "images deleted"}` on success - this should be something better. Also maintained use of `POST` but should arguably be `DELETE`. A slight change in behaviour is that a 400 is returned if nothing was deleted, deliverator returns 200.

`DeleteImage` handler uses `DeleteFromQueryAsync()` from new EntityFramework+ nuget package. This runs a sql DELETE without needing to load assets first. The downside of this is that the handler raises asset modified notification for _all_ asset ids sent to handler but there's a chance 1 or more of these didn't delete anything.

Handlers for both endpoints share similar validation - namely checking that requested Ids are valid asset Ids and they are all for same customer. This was pulled out to `ImageIdListValidation` which is run within controller in addition to FluentValidator validation of actual request.

Added a new `HandleHydraRequest` handler to `HydraController` this avoids needing to have the following error handling in multiple places:

```cs
try
{
    // run code
}
catch (APIException apiEx)
{
    return this.HydraProblem(apiEx.Message, null, apiEx.StatusCode ?? 500, apiEx.Label);
}
catch (Exception ex)
{
    return this.HydraProblem(ex.Message, null, 500, errorTitle);
}
```

Modified `AssetId.FromString` to return a `FormatException` with consistent message as it makes handling it easier. The default message if customer or space was non-numeric is `"Input string was not in a correct format."`