### PR TITLE
Resolve issue with thumbs erroring

### DIFF
--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
       <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.15.1" />

--- a/src/protagonist/DLCS.Model/Policies/IPolicyRepository.cs
+++ b/src/protagonist/DLCS.Model/Policies/IPolicyRepository.cs
@@ -1,17 +1,11 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Model.Assets;
 using DLCS.Model.Storage;
 
 namespace DLCS.Model.Policies;
 
-public interface IPolicyRepository
+public interface IPolicyRepository : IThumbnailPolicyRepository
 {
-    /// <summary>
-    /// Get ThumbnailPolicy with specified Id.
-    /// </summary>
-    Task<ThumbnailPolicy?> GetThumbnailPolicy(string thumbnailPolicyId, CancellationToken cancellationToken = default);
-
     /// <summary>
     /// Get ImageOptimisationPolicy with specified Id.
     /// </summary>

--- a/src/protagonist/DLCS.Model/Policies/IThumbnailPolicyRepository.cs
+++ b/src/protagonist/DLCS.Model/Policies/IThumbnailPolicyRepository.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace DLCS.Model.Policies;
+
+public interface IThumbnailPolicyRepository
+{
+    /// <summary>
+    /// Get ThumbnailPolicy with specified Id.
+    /// </summary>
+    Task<ThumbnailPolicy?> GetThumbnailPolicy(string thumbnailPolicyId, CancellationToken cancellationToken = default);
+}

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="6.0.5" />
-    <PackageReference Include="Npgsql" Version="6.0.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+    <PackageReference Include="Npgsql" Version="6.0.5" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/protagonist/DLCS.Repository/Policies/DapperThumbnailPolicy.cs
+++ b/src/protagonist/DLCS.Repository/Policies/DapperThumbnailPolicy.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core.Caching;
+using DLCS.Model.Policies;
+using LazyCache;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DLCS.Repository.Policies;
+
+public class DapperThumbnailPolicy : IDapperConfigRepository, IThumbnailPolicyRepository
+{
+    public IConfiguration Configuration { get; }
+    private readonly IAppCache appCache;
+    private readonly CacheSettings cacheSettings;
+    private readonly ILogger<DapperThumbnailPolicy> logger;
+        
+    public DapperThumbnailPolicy(
+        IAppCache appCache,
+        IConfiguration configuration,
+        IOptions<CacheSettings> cacheOptions,
+        ILogger<DapperThumbnailPolicy> logger)
+    {
+        this.appCache = appCache;
+        this.logger = logger;
+        cacheSettings = cacheOptions.Value;
+        Configuration = configuration;
+    }
+
+    public async Task<ThumbnailPolicy?> GetThumbnailPolicy(string thumbnailPolicyId,
+        CancellationToken cancellationToken = default)
+    {
+        var thumbnailPolicies = await GetThumbnailPolicies();
+        return thumbnailPolicies.SingleOrDefault(p => p.Id == thumbnailPolicyId);
+    }
+
+    private Task<List<ThumbnailPolicy>> GetThumbnailPolicies()
+    {
+        const string key = "ThumbnailPolicies";
+        return appCache.GetOrAddAsync(key, async () =>
+        {
+            logger.LogDebug("Refreshing ThumbnailPolicies from database");
+            var thumbnailPolicies = await this.QueryAsync<ThumbnailPolicy>(
+                "SELECT \"Id\", \"Name\", \"Sizes\" FROM \"ThumbnailPolicies\"");
+            return thumbnailPolicies.ToList();
+        }, cacheSettings.GetMemoryCacheOptions());
+    }
+}

--- a/src/protagonist/Orchestrator/Orchestrator.csproj
+++ b/src/protagonist/Orchestrator/Orchestrator.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="Yarp.ReverseProxy" Version="1.1.0" />
     </ItemGroup>

--- a/src/protagonist/Portal.Tests/Portal.Tests.csproj
+++ b/src/protagonist/Portal.Tests/Portal.Tests.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="FluentAssertions" Version="6.6.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/protagonist/Portal/Portal.csproj
+++ b/src/protagonist/Portal/Portal.csproj
@@ -18,7 +18,7 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.18" />
     </ItemGroup>

--- a/src/protagonist/Thumbs/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Thumbs/Infrastructure/ServiceCollectionX.cs
@@ -4,6 +4,7 @@ using DLCS.AWS.S3;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.Thumbs;
 using DLCS.Model.Policies;
+using DLCS.Repository;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Assets.Thumbs;
 using DLCS.Repository.Policies;
@@ -26,8 +27,7 @@ public static class ServiceCollectionX
     public static IServiceCollection AddThumbnailHandling(this IServiceCollection services, ThumbsSettings settings)
     {
         services
-            .AddSingleton<ThumbnailHandler>()
-            .AddSingleton<IPolicyRepository, PolicyRepository>();
+            .AddSingleton<ThumbnailHandler>();
 
         if (settings.EnsureNewThumbnailLayout)
         {
@@ -35,6 +35,7 @@ public static class ServiceCollectionX
             // decorator for default IThumbRespositry
             Log.Information("Thumbs supports reorganising thumbs");
             services
+                .AddSingleton<IThumbnailPolicyRepository, DapperThumbnailPolicy>()
                 .AddSingleton<ThumbRepository>()
                 .AddSingleton<IThumbRepository>(provider =>
                     ActivatorUtilities.CreateInstance<ReorganisingThumbRepository>(

--- a/src/protagonist/Thumbs/Reorganising/ThumbReorganiser.cs
+++ b/src/protagonist/Thumbs/Reorganising/ThumbReorganiser.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
-using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Core.Threading;
 using DLCS.Core.Types;
@@ -26,7 +25,7 @@ public class ThumbReorganiser : ThumbsManager, IThumbReorganiser
     private readonly IBucketReader bucketReader;
     private readonly ILogger<ThumbReorganiser> logger;
     private readonly IAssetRepository assetRepository;
-    private readonly IPolicyRepository policyRepository;
+    private readonly IThumbnailPolicyRepository policyRepository;
     private readonly AsyncKeyedLock asyncLocker = new();
     private static readonly Regex BoundedThumbRegex = new("^[0-9]+.jpg$");
 
@@ -35,7 +34,7 @@ public class ThumbReorganiser : ThumbsManager, IThumbReorganiser
         IBucketWriter bucketWriter,
         ILogger<ThumbReorganiser> logger,
         IAssetRepository assetRepository,
-        IPolicyRepository policyRepository,
+        IThumbnailPolicyRepository policyRepository,
         IStorageKeyGenerator storageKeyGenerator) : base(bucketWriter, storageKeyGenerator)
     {
         this.bucketReader = bucketReader;


### PR DESCRIPTION
Align versions of npgsql nuget packages with referenced EF packages. Something in this was causing the `The located assembly's manifest definition does not match the assembly reference` error seen in Cloudwatch logs as `Microsoft.EntityFrameworkCore` 6.0.5 and 6.0.4 were referenced.

Also introduced `IThumbnailPolicyRepository` and a dapper implementation. This was originally implemented but removed as part of Engine refactoring to consolidate with the other policy repositories and use `DlcsContext` rather than dapper. However, introducing `DlcsContext` means that we need scoped dependencies, which would need to introduce as cope to the middleware as it's a singleton so simpler route is to use Dapper.