### PR TITLE
Do not check if roles are empty when validating request

### DIFF
--- a/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
@@ -92,8 +92,6 @@ public class AssetAccessValidator : IAssetAccessValidator
         Func<Task<AuthToken?>> getAuthToken, bool setCookieInResponse)
     {
         var assetRoles = roles.ToList();
-        if (assetRoles.IsNullOrEmpty()) return AssetAccessResult.Open;
-
         var authToken = await getAuthToken();
         
         if (authToken?.SessionUser == null)


### PR DESCRIPTION
This is done higher up before calling this method. Calling code will know whether to take maxUnauthorised etc into account before calling.

This allows images to have `maxUnauthorised` and never be viewable as they have no roles.