### PR TITLE
Fixes for deploying solution to AWS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,16 @@ docs/
 **/appsettings.Development.Example.json
 **/appsettings.Development.json
 Utils/
+**/Properties/launchSettings.json
+
+# build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/

--- a/src/protagonist/API.Tests/Infrastructure/Validation/ApiSettingsValidatorTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Validation/ApiSettingsValidatorTests.cs
@@ -1,0 +1,21 @@
+﻿using API.Settings;
+using API.Settings.Validation;
+using FluentValidation.TestHelper;
+
+namespace API.Tests.Infrastructure.Validation;
+
+public class ApiSettingsValidatorTests
+{
+    private readonly ApiSettingsValidator sut = new();
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Salt_Null(string salt)
+    {
+        var settings = new ApiSettings { Salt = salt };
+        var result = sut.TestValidate(settings);
+        result.ShouldHaveValidationErrorFor(a => a.Salt);
+    }
+}

--- a/src/protagonist/API.Tests/Integration/ApplicationTests.cs
+++ b/src/protagonist/API.Tests/Integration/ApplicationTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using API.Client;
+using API.Tests.Integration.Infrastructure;
+using DLCS.HydraModel;
+using DLCS.Repository;
+using Microsoft.EntityFrameworkCore;
+using Test.Helpers.Integration;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class ApplicationTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly HttpClient httpClient;
+    private readonly DlcsContext dlcsContext;
+
+    public ApplicationTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        dlcsContext = dbFixture.DbContext;
+        httpClient = factory.WithConnectionString(dbFixture.ConnectionString).CreateClient();
+        dbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task SetupApplication_Fail_Customer1AlreadyExists()
+    {
+        // Arrange
+        await dlcsContext.Customers.AddTestCustomer(1, "admin", "Admin");
+        await dlcsContext.SaveChangesAsync();
+        
+        // Act
+        var response = await httpClient.PostAsync("/setup", null!);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+    
+    [Fact]
+    public async Task SetupApplication_Success_CreatesCustomerAndCounter()
+    {
+        // Act
+        var response = await httpClient.PostAsync("/setup", null!);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var apiKeyResponse = await response.ReadAsHydraResponseAsync<ApiKey>();
+        
+        var customer = await dlcsContext.Customers.SingleAsync(c => c.Id == 1);
+        customer.Keys.Should().OnlyContain(s => s == apiKeyResponse.Key);
+        (await dlcsContext.EntityCounters
+                .AnyAsync(c => c.Scope == "1" && c.Customer == 1 && c.Type == "space"))
+            .Should().BeTrue();
+    }
+}

--- a/src/protagonist/API.Tests/Integration/CustomerTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerTests.cs
@@ -7,13 +7,11 @@ using API.Client;
 using API.Tests.Integration.Infrastructure;
 using DLCS.HydraModel;
 using DLCS.Repository;
-using FluentAssertions;
 using Hydra.Collections;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
-using Xunit;
 
 namespace API.Tests.Integration;
 

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.1" />
       <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />

--- a/src/protagonist/API/Auth/ApiKeyGenerator.cs
+++ b/src/protagonist/API/Auth/ApiKeyGenerator.cs
@@ -1,0 +1,31 @@
+﻿using API.Settings;
+using DLCS.Model.Customers;
+using DLCS.Web.Auth;
+using Microsoft.Extensions.Options;
+
+namespace API.Auth;
+
+public class ApiKeyGenerator
+{
+    private readonly ApiSettings settings;
+    private readonly DlcsApiAuth encryption;
+
+    public ApiKeyGenerator(DlcsApiAuth encryption, IOptions<ApiSettings> options)
+    {
+        this.encryption = encryption;
+        settings = options.Value;
+    }
+    
+    /// <summary>
+    /// Generate a new api key and secret for specified customer
+    /// </summary>
+    /// <param name="customer">Customer to create api key for</param>
+    /// <returns>ApiKey and Secret</returns>
+    public (string key, string secret) CreateApiKey(Customer customer)
+    {
+        var apiKey = Guid.NewGuid().ToString();
+        var apiSecret = encryption.GetApiSecret(customer, settings.Salt, apiKey);
+
+        return (apiKey, apiSecret);
+    }
+}

--- a/src/protagonist/API/Features/Application/ApplicationController.cs
+++ b/src/protagonist/API/Features/Application/ApplicationController.cs
@@ -1,0 +1,35 @@
+﻿using API.Features.Application.Requests;
+using API.Infrastructure;
+using API.Settings;
+using DLCS.HydraModel;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Application;
+
+/// <summary>
+/// API operations for application wide configuration
+/// </summary>
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("/")]
+[AllowAnonymous]
+public class ApplicationController : HydraController
+{
+    public ApplicationController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
+    {
+    }
+
+    [Route("/setup")]
+    [HttpPost]
+    public async Task<IActionResult> SetupApplication()
+    {
+        var request = new SetupApplication();
+        var result = await Mediator.Send(request);
+
+        return result.CreateSuccess
+            ? Ok(new ApiKey(GetUrlRoots().BaseUrl, 1, result.Key, result.Secret))
+            : this.HydraProblem("Unable to setup application", null, 500, "Setup");
+    }
+}

--- a/src/protagonist/API/Features/Application/Requests/SetupApplication.cs
+++ b/src/protagonist/API/Features/Application/Requests/SetupApplication.cs
@@ -1,0 +1,60 @@
+﻿using API.Auth;
+using API.Features.Customer.Requests;
+using DLCS.Model;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Application.Requests;
+
+/// <summary>
+/// First run setup of application - create admin Customer 
+/// </summary>
+public class SetupApplication : IRequest<CreateApiKeyResult>
+{
+}
+
+public class SetupApplicationHandler : IRequestHandler<SetupApplication, CreateApiKeyResult>
+{
+    private readonly DlcsContext dbContext;
+    private readonly ApiKeyGenerator apiKeyGenerator;
+    private readonly IEntityCounterRepository entityCounterRepository;
+
+    public SetupApplicationHandler(DlcsContext dbContext, ApiKeyGenerator apiKeyGenerator,
+        IEntityCounterRepository entityCounterRepository)
+    {
+        this.dbContext = dbContext;
+        this.apiKeyGenerator = apiKeyGenerator;
+        this.entityCounterRepository = entityCounterRepository;
+    }
+
+    public async Task<CreateApiKeyResult> Handle(SetupApplication request, CancellationToken cancellationToken)
+    {
+        var adminExists = await dbContext.Customers.AnyAsync(c => c.Id == 1, cancellationToken: cancellationToken);
+        if (adminExists)
+        {
+            return CreateApiKeyResult.Fail("Admin already exists");
+        }
+
+        var adminCustomer = new DLCS.Model.Customers.Customer
+        {
+            Administrator = true,
+            Id = 1,
+            Created = DateTime.UtcNow,
+            DisplayName = "Administrator",
+            Name = "admin",
+            AcceptedAgreement = true
+        };
+        var (apiKey, apiSecret) = apiKeyGenerator.CreateApiKey(adminCustomer);
+        adminCustomer.Keys = new[] { apiKey };
+        
+        await dbContext.Customers.AddAsync(adminCustomer, cancellationToken);
+        var updateCount = await dbContext.SaveChangesAsync(cancellationToken);
+
+        await entityCounterRepository.Create(adminCustomer.Id, "space", adminCustomer.Id.ToString());
+
+        return updateCount == 1
+            ? CreateApiKeyResult.Success(apiKey, apiSecret)
+            : CreateApiKeyResult.Fail("Error creating customer");
+    }
+}

--- a/src/protagonist/API/Features/Customer/ApiKeysController.cs
+++ b/src/protagonist/API/Features/Customer/ApiKeysController.cs
@@ -77,7 +77,7 @@ public class ApiKeysController : HydraController
     public async Task<IActionResult> CreateApiKey(int customerId)
     {
         var result = await Mediator.Send(new CreateApiKey(customerId));
-        if (result.Key.HasText() && result.Secret.HasText())
+        if (result.CreateSuccess)
         {
             return Ok(new ApiKey(GetUrlRoots().BaseUrl, customerId, result.Key, result.Secret));
         }

--- a/src/protagonist/API/Features/Customer/Requests/CreateApiKeyResult.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateApiKeyResult.cs
@@ -1,0 +1,13 @@
+namespace API.Features.Customer.Requests;
+
+public class CreateApiKeyResult
+{
+    public bool CreateSuccess { get; private init; }
+    public string? Key { get; private init; }
+    public string? Secret { get; private init; }
+    public string? Error { get; private init; }
+
+    public static CreateApiKeyResult Fail(string error) => new() { Error = error };
+    public static CreateApiKeyResult Success(string key, string secret) 
+        => new() { Key = key, Secret = secret, CreateSuccess = true };
+}

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -54,7 +54,6 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
         this.authServicesRepository = authServicesRepository;
     }
 
-    /// <inheritdoc />
     public async Task<CreateCustomerResult> Handle(CreateCustomer request, CancellationToken cancellationToken)
     {
         // Reproducing POST behaviour for customer in Deliverator

--- a/src/protagonist/API/Infrastructure/Validation/OptionsBuilderFluentValidationX.cs
+++ b/src/protagonist/API/Infrastructure/Validation/OptionsBuilderFluentValidationX.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace API.Infrastructure.Validation;
+
+/// <summary>
+/// Extension method to configure FluentValidation of IOptions
+/// </summary>
+/// <remarks>
+/// See https://andrewlock.net/adding-validation-to-strongly-typed-configuration-objects-using-flentvalidation/
+/// </remarks>
+public static class OptionsBuilderFluentValidationX
+{
+    public static OptionsBuilder<TOptions> ValidateFluentValidation<TOptions>(
+        this OptionsBuilder<TOptions> optionsBuilder) where TOptions : class
+    {
+        optionsBuilder.Services.AddSingleton<IValidateOptions<TOptions>>(
+            provider => new FluentValidationOptions<TOptions>(
+                optionsBuilder.Name, provider));
+        return optionsBuilder;
+    }
+}
+
+public class FluentValidationOptions<TOptions> 
+    : IValidateOptions<TOptions> where TOptions : class
+{
+    private readonly IServiceProvider serviceProvider;
+    private readonly string? name;
+    public FluentValidationOptions(string? name, IServiceProvider serviceProvider)
+    {
+        // we need the service provider to create a scope later
+        this.serviceProvider = serviceProvider; 
+        this.name = name; // Handle named options
+    }
+
+    public ValidateOptionsResult Validate(string? name, TOptions options)
+    {
+        // Null name is used to configure all named options.
+        if (this.name != null && this.name != name)
+        {
+            // Ignored if not validating this instance.
+            return ValidateOptionsResult.Skip;
+        }
+
+        // Ensure options are provided to validate against
+        ArgumentNullException.ThrowIfNull(options);
+        
+        // Validators are typically registered as scoped,
+        // so we need to create a scope to be safe, as this
+        // method is be called from the root scope
+        using IServiceScope scope = serviceProvider.CreateScope();
+
+        // retrieve an instance of the validator
+        var validator = scope.ServiceProvider.GetRequiredService<IValidator<TOptions>>();
+
+        // Run the validation
+        ValidationResult results = validator.Validate(options);
+        if (results.IsValid)
+        {
+            // All good!
+            return ValidateOptionsResult.Success;
+        }
+
+        // Validation failed, so build the error message
+        string typeName = options.GetType().Name;
+        var errors = new List<string>();
+        foreach (var result in results.Errors)
+        {
+            errors.Add(
+                $"Fluent validation failed for '{typeName}.{result.PropertyName}' with the error: '{result.ErrorMessage}'.");
+        }
+
+        return ValidateOptionsResult.Fail(errors);
+    }
+}

--- a/src/protagonist/API/Program.cs
+++ b/src/protagonist/API/Program.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using DLCS.AWS.SSM;
 using Serilog;
 
 namespace API;
@@ -35,14 +35,7 @@ public class Program
             )
             .ConfigureAppConfiguration((context, builder) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/protagonist/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-                }
+                builder.AddSystemsManager(context);
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/src/protagonist/API/Settings/Validation/ApiSettingsValidator.cs
+++ b/src/protagonist/API/Settings/Validation/ApiSettingsValidator.cs
@@ -1,0 +1,11 @@
+﻿using FluentValidation;
+
+namespace API.Settings.Validation;
+
+public class ApiSettingsValidator : AbstractValidator<ApiSettings>
+{
+    public ApiSettingsValidator()
+    {
+        RuleFor(a => a.Salt).NotEmpty();
+    }    
+}

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using API.Auth;
 using API.Features.Image.Ingest;
 using API.Infrastructure;
+using API.Infrastructure.Validation;
 using API.Settings;
 using DLCS.Core.Caching;
 using DLCS.Core.Encryption;
@@ -44,7 +45,11 @@ public class Startup
         var cachingSection = configuration.GetSection("Caching");
 
         services
-            .Configure<ApiSettings>(configuration)
+            .AddOptions<ApiSettings>().Bind(configuration)
+            .ValidateFluentValidation()
+            .ValidateOnStart();
+
+        services
             .Configure<NamedQueryTemplateSettings>(configuration)
             .Configure<DlcsSettings>(configuration.GetSection("DLCS"))
             .Configure<CacheSettings>(cachingSection);
@@ -54,6 +59,7 @@ public class Startup
         
         services
             .AddHttpContextAccessor()
+            .AddSingleton<ApiKeyGenerator>()
             .AddSingleton<IEncryption, SHA256>()
             .AddSingleton<DlcsApiAuth>()
             .AddTransient<ClaimsPrincipal>(s => s.GetRequiredService<IHttpContextAccessor>().HttpContext.User)

--- a/src/protagonist/DLCS.AWS/DLCS.AWS.csproj
+++ b/src/protagonist/DLCS.AWS/DLCS.AWS.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="4.0.0" />
       <PackageReference Include="AWSSDK.Core" Version="3.7.12.16" />
       <PackageReference Include="AWSSDK.ElasticTranscoder" Version="3.7.0.187" />
       <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.2" />

--- a/src/protagonist/DLCS.AWS/SSM/ConfigurationBuilderX.cs
+++ b/src/protagonist/DLCS.AWS/SSM/ConfigurationBuilderX.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace DLCS.AWS.SSM;
+
+public static class ConfigurationBuilderX
+{
+    /// <summary>
+    /// Add AWS SystemsManager (SSM) as a configuration source if Production hosting environment.
+    /// By default prefix is /protagonist/ but this can be overriden via SSM_PREFIX envvar 
+    /// </summary>
+    public static IConfigurationBuilder AddSystemsManager(this IConfigurationBuilder builder,
+        HostBuilderContext builderContext)
+    {
+        if (!builderContext.HostingEnvironment.IsProduction()) return builder;
+
+        var path = Environment.GetEnvironmentVariable("SSM_PREFIX") ?? "protagonist";
+        return builder.AddSystemsManager(configureSource =>
+        {
+            configureSource.Path = $"/{path}/";
+            configureSource.ReloadAfter = TimeSpan.FromMinutes(90);
+        });
+    }
+}

--- a/src/protagonist/DLCS.Core/Collections/StringArrays.cs
+++ b/src/protagonist/DLCS.Core/Collections/StringArrays.cs
@@ -2,8 +2,12 @@ using System.Linq;
 
 namespace DLCS.Core.Collections;
 
-public class StringArrays
+public static class StringArrays
 {
+    /// <summary>
+    /// Ensure that newString is contained within returned array.
+    /// If string already exists it is not added again.
+    /// </summary>
     public static string[] EnsureString(string[]? strings, string newString)
     {
         if (strings == null || strings.Length == 0)
@@ -16,9 +20,7 @@ public class StringArrays
             return strings;
         }
         
-        var list = strings.ToList();
-        list.Add(newString);
-        return list.ToArray();
+        return strings.Append(newString).ToArray();
     }
     
     

--- a/src/protagonist/DLCS.Model/Customers/ICustomerRepository.cs
+++ b/src/protagonist/DLCS.Model/Customers/ICustomerRepository.cs
@@ -18,7 +18,6 @@ public interface ICustomerRepository
     /// <returns><see cref="Customer"/> object if found, else null</returns>
     public Task<Customer?> GetCustomer(int customerId);
 
-    
     /// <summary>
     /// Get Customer with specified Name
     /// </summary>

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
         <PackageReference Include="iiif-net" Version="0.1.3" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/src/protagonist/Engine/Program.cs
+++ b/src/protagonist/Engine/Program.cs
@@ -1,3 +1,4 @@
+using DLCS.AWS.SSM;
 using Serilog;
 
 public class Program
@@ -38,14 +39,7 @@ public class Program
             )
             .ConfigureAppConfiguration((context, builder) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/protagonist/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-                }
+                builder.AddSystemsManager(context);
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/src/protagonist/Orchestrator/Orchestrator.csproj
+++ b/src/protagonist/Orchestrator/Orchestrator.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
         <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />

--- a/src/protagonist/Orchestrator/Program.cs
+++ b/src/protagonist/Orchestrator/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using DLCS.AWS.SSM;
 using Serilog;
 
 namespace Orchestrator;
@@ -37,20 +37,7 @@ public class Program
             )
             .ConfigureAppConfiguration((context, builder) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/thumbs/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/protagonist/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-                }
+                builder.AddSystemsManager(context);
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/src/protagonist/Portal/Portal.csproj
+++ b/src/protagonist/Portal/Portal.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
       <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />

--- a/src/protagonist/Portal/Program.cs
+++ b/src/protagonist/Portal/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using Destructurama;
+using DLCS.AWS.SSM;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -39,14 +39,7 @@ public class Program
             )
             .ConfigureAppConfiguration((context, builder) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/protagonist/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-                }
+                builder.AddSystemsManager(context);
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -69,6 +69,9 @@ public class DlcsDatabaseFixture : IAsyncLifetime
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"SessionUsers\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"AuthTokens\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"Batches\"");
+        DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'space' AND \"Customer\" != 99");
+        DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'space-images' AND \"Customer\" != 99");
+        DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'customer-images' AND \"Scope\" != '99'");
         DbContext.ChangeTracker.Clear();
     }
 

--- a/src/protagonist/Thumbs/Program.cs
+++ b/src/protagonist/Thumbs/Program.cs
@@ -1,6 +1,6 @@
 using System;
+using DLCS.AWS.SSM;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 
@@ -39,20 +39,7 @@ public class Program
             )
             .ConfigureAppConfiguration((context, builder) =>
             {
-                if (context.HostingEnvironment.IsProduction())
-                {
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/thumbs/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-
-                    builder.AddSystemsManager(configurationSource =>
-                    {
-                        configurationSource.Path = "/protagonist/";
-                        configurationSource.ReloadAfter = TimeSpan.FromMinutes(90);
-                    });
-                }
+                builder.AddSystemsManager(context);
             })
             .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
 }

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="2.1.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
     <PackageReference Include="iiif-net" Version="0.1.3" />


### PR DESCRIPTION
Add extension method to simplify adding SystemsManager config source - can override path via SSM_PREFIX envvar. Required as deploying to an AWS account that already has a working thumbs instance so could not reuse `/protagonist/` prefix.

Add `/setup` endpoint - differed from deliverator in that this takes a POST. Creates customer with Api key and an entity counter record.