### PR TITLE
Add 'global' and 'customer' to ImageOptimisationPolicy

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerPolicyTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerPolicyTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using API.Client;
+using API.Tests.Integration.Infrastructure;
+using DLCS.HydraModel;
+using DLCS.Repository;
+using Hydra.Collections;
+using Test.Helpers.Integration;
+using Test.Helpers.Integration.Infrastructure;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class CustomerPolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly HttpClient httpClient;
+
+    public CustomerPolicyTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicies_200()
+    {
+        // Arrange
+        var path = "customers/99/imageOptimisationPolicies";
+
+        // Act
+        var response = await httpClient.AsCustomer(99).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<ImageOptimisationPolicy>>();
+        model.Members.Should().HaveCount(4);
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicies_SupportsPaging()
+    {
+        // Arrange
+        var path = "customers/99/imageOptimisationPolicies?pageSize=2";
+
+        // Act
+        var response = await httpClient.AsCustomer(99).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<HydraCollection<ImageOptimisationPolicy>>();
+        model.Members.Should().HaveCount(2);
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_200_Global()
+    {
+        // Arrange
+        var path = "customers/99/imageOptimisationPolicies/video-max";
+
+        // Act
+        var response = await httpClient.AsCustomer(99).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var model = await response.ReadAsHydraResponseAsync<ImageOptimisationPolicy>();
+        model.TechnicalDetails.Should().BeEquivalentTo("System preset: Webm 720p(webm)");
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_200_CustomerSpecific()
+    {
+        // Arrange
+        var path = "customers/99/imageOptimisationPolicies/cust-default";
+
+        // Act
+        var response = await httpClient.AsCustomer(99).GetAsync(path);
+
+        // Assert
+        var model = await response.ReadAsHydraResponseAsync<ImageOptimisationPolicy>();
+        model.TechnicalDetails.Should().BeEquivalentTo("default");
+    }
+
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_404_IfNotFound()
+    {
+        // Arrange
+        var path = "customers/99/imageOptimisationPolicies/foofoo";
+
+        // Act
+        var response = await httpClient.AsCustomer(99).GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/src/protagonist/API.Tests/Integration/CustomerPolicyTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerPolicyTests.cs
@@ -56,7 +56,7 @@ public class CustomerPolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task Get_ImageOptimisationPolicy_200_Global()
+    public async Task Get_ImageOptimisationPolicy_404_Global()
     {
         // Arrange
         var path = "customers/99/imageOptimisationPolicies/video-max";
@@ -65,10 +65,7 @@ public class CustomerPolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var response = await httpClient.AsCustomer(99).GetAsync(path);
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        
-        var model = await response.ReadAsHydraResponseAsync<ImageOptimisationPolicy>();
-        model.TechnicalDetails.Should().BeEquivalentTo("System preset: Webm 720p(webm)");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/PolicyTests.cs
+++ b/src/protagonist/API.Tests/Integration/PolicyTests.cs
@@ -73,10 +73,23 @@ public class PolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
 
     [Fact]
-    public async Task Get_ImageOptimisationPolicy_400_IfNotFound()
+    public async Task Get_ImageOptimisationPolicy_404_IfNotFound()
     {
         // Arrange
         var path = "imageOptimisationPolicies/foofoo";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_ImageOptimisationPolicy_404_IfCustomerSpecific()
+    {
+        // Arrange
+        var path = "imageOptimisationPolicies/cust-default";
 
         // Act
         var response = await httpClient.GetAsync(path);

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -265,11 +265,19 @@ public static class AssetConverter
         {
             asset.ThumbnailPolicy = thumbnailPolicy;
         }
+        else if (hydraImage.ThumbnailPolicy.HasText())
+        {
+            asset.ThumbnailPolicy = hydraImage.ThumbnailPolicy;
+        }
         
         var imageOptimisationPolicy = hydraImage.ImageOptimisationPolicy.GetLastPathElement("imageOptimisationPolicies/");
         if (imageOptimisationPolicy != null)
         {
             asset.ImageOptimisationPolicy = imageOptimisationPolicy;
+        }
+        else if (hydraImage.ImageOptimisationPolicy.HasText())
+        {
+            asset.ImageOptimisationPolicy = hydraImage.ImageOptimisationPolicy;
         }
         
         // This can only arrive on a new Asset

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -205,7 +205,7 @@ public class AssetProcessor
         ImageOptimisationPolicy? policy = null;
         if (incomingPolicy.HasText())
         {
-            policy = await policyRepository.GetImageOptimisationPolicy(incomingPolicy);
+            policy = await policyRepository.GetImageOptimisationPolicy(incomingPolicy, asset.Customer);
         }
 
         if (policy == null)
@@ -213,7 +213,7 @@ public class AssetProcessor
             // The asset doesn't have a valid ImageOptimisationPolicy
             // This is adapted from Deliverator, but there wasn't a way of 
             // taking the policy from the incoming PUT. There now is.
-            var imagePolicy = await policyRepository.GetImageOptimisationPolicy(key);
+            var imagePolicy = await policyRepository.GetImageOptimisationPolicy(key, asset.Customer);
             if (imagePolicy != null)
             {
                 asset.ImageOptimisationPolicy = imagePolicy.Id;

--- a/src/protagonist/API/Features/Policies/Converters/PolicyConverters.cs
+++ b/src/protagonist/API/Features/Policies/Converters/PolicyConverters.cs
@@ -19,7 +19,8 @@ public static class PolicyConverters
     /// </summary>
     public static HydraOptimisationPolicy ToHydra(this EntityOptimisationPolicy policy, string baseUrl)
     {
-        var hydra = new HydraOptimisationPolicy(baseUrl, policy.Id, policy.Name, string.Join(",", policy.TechnicalDetails));
+        var hydra = new HydraOptimisationPolicy(baseUrl, policy.Id, policy.Name,
+            string.Join(",", policy.TechnicalDetails), policy.Global, policy.Customer);
         return hydra;
     }
     

--- a/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
+++ b/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
@@ -24,17 +24,11 @@ public class CustomerPolicyController : HydraController
     }
 
     /// <summary>
-    /// Get paged list of all customer accessible image optimisation policies (customer specific + global).
+    /// Get paged list of all customer accessible image optimisation policies (customer specific + global)
     ///
     /// Supports ?page= and ?pageSize= query parameters
     /// </summary>
     /// <returns>Collection of Hydra JSON-LD image optimisation policy object</returns>
-    /// <remarks>
-    /// Sample request:
-    ///
-    ///     GET: /customer/99/imageOptimisationPolicies/123
-    ///     GET: /customer/99//imageOptimisationPolicies/123?page=2&pagesize=10
-    /// </remarks>
     [HttpGet]
     [Route("imageOptimisationPolicies")]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
+++ b/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
@@ -32,8 +32,8 @@ public class CustomerPolicyController : HydraController
     /// <remarks>
     /// Sample request:
     ///
-    ///     GET: /imageOptimisationPolicies/123
-    ///     GET: /imageOptimisationPolicies/123?page=2&pagesize=10
+    ///     GET: /customer/99/imageOptimisationPolicies/123
+    ///     GET: /customer/99//imageOptimisationPolicies/123?page=2&pagesize=10
     /// </remarks>
     [HttpGet]
     [Route("imageOptimisationPolicies")]

--- a/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
+++ b/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
@@ -1,0 +1,75 @@
+﻿using API.Features.Policies.Converters;
+using API.Features.Policies.Requests;
+using API.Infrastructure;
+using API.Settings;
+using DLCS.HydraModel;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Policies;
+
+/// <summary>
+/// Controller for handling requests for imageOptimisationPolicies, storagePolicies and thumbnailPolicies for customers
+/// </summary>
+[Route("/customers/{customerId}")]
+[ApiController]
+public class CustomerPolicyController : HydraController
+{
+    /// <inheritdoc />
+    public CustomerPolicyController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
+    {
+    }
+
+    /// <summary>
+    /// Get paged list of all customer accessible image optimisation policies (customer specific + global).
+    ///
+    /// Supports ?page= and ?pageSize= query parameters
+    /// </summary>
+    /// <returns>Collection of Hydra JSON-LD image optimisation policy object</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET: /imageOptimisationPolicies/123
+    ///     GET: /imageOptimisationPolicies/123?page=2&pagesize=10
+    /// </remarks>
+    [HttpGet]
+    [Route("imageOptimisationPolicies")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetImageOptimisationPolicies([FromRoute] int customerId,
+        CancellationToken cancellationToken)
+    {
+        var getImageOptimisationPolicies = new GetImageOptimisationPolicies(customerId);
+
+        return await HandlePagedFetch<DLCS.Model.Policies.ImageOptimisationPolicy, GetImageOptimisationPolicies,
+            ImageOptimisationPolicy>(
+            getImageOptimisationPolicies,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get image optimisation policies failed",
+            cancellationToken: cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Get details of specified image optimisation policy
+    /// </summary>
+    /// <returns>Hydra JSON-LD image optimisation policy object</returns>
+    [HttpGet]
+    [Route("imageOptimisationPolicies/{imageOptimisationPolicyId}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetImageOptimisationPolicy([FromRoute] int customerId,
+        [FromRoute] string imageOptimisationPolicyId, CancellationToken cancellationToken)
+    {
+        var getImageOptimisationPolicy = new GetImageOptimisationPolicy(imageOptimisationPolicyId, customerId);
+
+        return await HandleFetch(
+            getImageOptimisationPolicy,
+            policy => policy.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Get image optimisation policy failed",
+            cancellationToken: cancellationToken
+        );
+    }
+}

--- a/src/protagonist/API/Features/Policies/PolicyController.cs
+++ b/src/protagonist/API/Features/Policies/PolicyController.cs
@@ -27,12 +27,6 @@ public class PolicyController : HydraController
     /// Supports ?page= and ?pageSize= query parameters
     /// </summary>
     /// <returns>Collection of Hydra JSON-LD image optimisation policy object</returns>
-    /// <remarks>
-    /// Sample request:
-    ///
-    ///     GET: /imageOptimisationPolicies
-    ///     GET: /imageOptimisationPolicies?page=2&pagesize=10
-    /// </remarks>
     [HttpGet]
     [AllowAnonymous]
     [Route("/imageOptimisationPolicies")]

--- a/src/protagonist/API/Features/Policies/PolicyController.cs
+++ b/src/protagonist/API/Features/Policies/PolicyController.cs
@@ -22,7 +22,7 @@ public class PolicyController : HydraController
     }
     
     /// <summary>
-    /// Get paged list of all image optimisation policies.
+    /// Get paged list of all global image optimisation policies.
     ///
     /// Supports ?page= and ?pageSize= query parameters
     /// </summary>

--- a/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicies.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicies.cs
@@ -8,12 +8,19 @@ using Microsoft.EntityFrameworkCore;
 namespace API.Features.Policies.Requests;
 
 /// <summary>
-/// Get a paged list of all image optimisation policies
+/// Get a paged list of all image optimisation policies.
+/// If Customer specified, get customer specific entities AND global. Else get global only
 /// </summary>
 public class GetImageOptimisationPolicies : IRequest<FetchEntityResult<PageOf<ImageOptimisationPolicy>>>, IPagedRequest
 {
     public int Page { get; set; }
     public int PageSize { get; set; }
+    public int? Customer { get; }
+    
+    public GetImageOptimisationPolicies(int? customer = null)
+    {
+        Customer = customer;
+    }
 }
 
 public class GetImageOptimisationPoliciesHandler : IRequestHandler<GetImageOptimisationPolicies,
@@ -29,11 +36,22 @@ public class GetImageOptimisationPoliciesHandler : IRequestHandler<GetImageOptim
     public async Task<FetchEntityResult<PageOf<ImageOptimisationPolicy>>> Handle(GetImageOptimisationPolicies request,
         CancellationToken cancellationToken)
     {
+        var filter = GetFilterForRequest(request);
+
         var result = await dlcsContext.ImageOptimisationPolicies.AsNoTracking().CreatePagedResult(request,
-            q => q,
+            filter,
             q => q.OrderBy(i => i.Id),
             cancellationToken: cancellationToken);
 
         return FetchEntityResult<PageOf<ImageOptimisationPolicy>>.Success(result);
+    }
+
+    private static Func<IQueryable<ImageOptimisationPolicy>, IQueryable<ImageOptimisationPolicy>> GetFilterForRequest(GetImageOptimisationPolicies request)
+    {
+        Func<IQueryable<ImageOptimisationPolicy>, IQueryable<ImageOptimisationPolicy>> filter =
+            request.Customer.HasValue
+                ? policies => policies.Where(p => p.Customer == request.Customer || p.Global)
+                : policies => policies.Where(p => p.Global);
+        return filter;
     }
 }

--- a/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
@@ -12,10 +12,12 @@ namespace API.Features.Policies.Requests;
 public class GetImageOptimisationPolicy : IRequest<FetchEntityResult<ImageOptimisationPolicy>>
 {
     public string ImageOptimisationPolicyId { get; }
+    public int? Customer { get; }
 
-    public GetImageOptimisationPolicy(string imageOptimisationPolicyId)
+    public GetImageOptimisationPolicy(string imageOptimisationPolicyId, int? customer = null)
     {
         ImageOptimisationPolicyId = imageOptimisationPolicyId;
+        Customer = customer;
     }
 }
 
@@ -32,11 +34,23 @@ public class GetImageOptimisationPolicyHandler : IRequestHandler<GetImageOptimis
     public async Task<FetchEntityResult<ImageOptimisationPolicy>> Handle(GetImageOptimisationPolicy request,
         CancellationToken cancellationToken)
     {
-        var policy = await dlcsContext.ImageOptimisationPolicies.AsNoTracking()
+        var filteredPolicies = GetFilteredPolicies(request);
+
+        var policy = await filteredPolicies
             .SingleOrDefaultAsync(b => b.Id == request.ImageOptimisationPolicyId,
                 cancellationToken);
         return policy == null
             ? FetchEntityResult<ImageOptimisationPolicy>.NotFound()
             : FetchEntityResult<ImageOptimisationPolicy>.Success(policy);
+    }
+
+    private IQueryable<ImageOptimisationPolicy> GetFilteredPolicies(GetImageOptimisationPolicy request)
+    {
+        var imageOptimisationPolicies = dlcsContext.ImageOptimisationPolicies.AsNoTracking();
+
+        imageOptimisationPolicies = request.Customer.HasValue
+            ? imageOptimisationPolicies.Where(p => p.Customer == request.Customer || p.Global)
+            : imageOptimisationPolicies.Where(p => p.Global);
+        return imageOptimisationPolicies;
     }
 }

--- a/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
+++ b/src/protagonist/API/Features/Policies/Requests/GetImageOptimisationPolicy.cs
@@ -49,7 +49,7 @@ public class GetImageOptimisationPolicyHandler : IRequestHandler<GetImageOptimis
         var imageOptimisationPolicies = dlcsContext.ImageOptimisationPolicies.AsNoTracking();
 
         imageOptimisationPolicies = request.Customer.HasValue
-            ? imageOptimisationPolicies.Where(p => p.Customer == request.Customer || p.Global)
+            ? imageOptimisationPolicies.Where(p => p.Customer == request.Customer)
             : imageOptimisationPolicies.Where(p => p.Global);
         return imageOptimisationPolicies;
     }

--- a/src/protagonist/DLCS.HydraModel/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageOptimisationPolicy.cs
@@ -9,22 +9,35 @@ namespace DLCS.HydraModel;
                  "A URI to identify which policy was used at registration time for each of your images. " +
                  "This will be needed if you ever want to re-register from origin (e.g., go for a higher " +
                  "or lower quality, etc).",
-   UriTemplate = "/imageOptimisationPolicies/{0}")]
+   UriTemplate = "/imageOptimisationPolicies/{0}, /customers/{0}/imageOptimisationPolicies/{1}")]
 public class ImageOptimisationPolicy : DlcsResource
 {
     [JsonIgnore]
     public string? ModelId { get; set; }
+    
+    [JsonIgnore]
+    public int? CustomerId { get; set; }
 
     public ImageOptimisationPolicy()
     {
     }
 
-    public ImageOptimisationPolicy(string baseUrl, string imageOptimisationPolicyId, string name, string technicalDetails)
+    public ImageOptimisationPolicy(string baseUrl, string imageOptimisationPolicyId, string name,
+        string technicalDetails, bool global, int? customerId)
     {
         ModelId = imageOptimisationPolicyId;
-        Init(baseUrl, true, imageOptimisationPolicyId);
+        if (customerId.HasValue)
+        {
+            Init(baseUrl, true, customerId, imageOptimisationPolicyId);
+        }
+        else
+        {
+            Init(baseUrl, true, imageOptimisationPolicyId);
+        }
         Name = name;
         TechnicalDetails = technicalDetails;
+        Global = global;
+        CustomerId = customerId;
     }
 
     [RdfProperty(Description = "The human readable name of the image policy",
@@ -34,8 +47,13 @@ public class ImageOptimisationPolicy : DlcsResource
 
     [RdfProperty(Description = "Details of the encoding and tools used. Might not be public.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
-    [JsonProperty(Order = 11, PropertyName = "technicalDetails")]
+    [JsonProperty(Order = 12, PropertyName = "technicalDetails")]
     public string? TechnicalDetails { get; set; }
+
+    [RdfProperty(Description = "Whether policy is global or restricted to single customer",
+        Range = Names.XmlSchema.Boolean, ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 13, PropertyName = "global")]
+    public bool? Global { get; set; }
 }
 
 

--- a/src/protagonist/DLCS.Mock/ApiApp/MockModel.cs
+++ b/src/protagonist/DLCS.Mock/ApiApp/MockModel.cs
@@ -79,7 +79,7 @@ public class MockModel
     {
         return new List<ImageOptimisationPolicy>
         {
-            new ImageOptimisationPolicy(BaseUrl, "fast_lossy", "Fast lossy", "kdu_1")
+            new ImageOptimisationPolicy(BaseUrl, "fast_lossy", "Fast lossy", "kdu_1", true, null)
         };
     }
 

--- a/src/protagonist/DLCS.Model.Tests/Assets/ConverterTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ConverterTests.cs
@@ -74,6 +74,27 @@ public class ConverterTests
         asset.Id.Should().Be(AssetId.FromString("99/55/model-id"));
     }
     
+    [Theory]
+    [InlineData("https://dlcs.io/thumbnailPolicies/thumb100")]
+    [InlineData("thumb100")]
+    public void ToDlcsModel_ThumbnailPolicy_CanBeIdOrFull(string policy)
+    {
+        var hydraImage = new Image { ThumbnailPolicy = policy };
+        var asset = hydraImage.ToDlcsModel(99, 55, "model-id");
+        asset.ThumbnailPolicy.Should().Be("thumb100");
+    }
+
+    [Theory]
+    [InlineData("https://dlcs.io/imageOptimisationPolicies/super-max")]
+    [InlineData("https://dlcs.io/customer/123/imageOptimisationPolicies/super-max")]
+    [InlineData("super-max")]
+    public void ToDlcsModel_ImageOptimisationPolicy_CanBeIdOrFull(string policy)
+    {
+        var hydraImage = new Image { ImageOptimisationPolicy = policy };
+        var asset = hydraImage.ToDlcsModel(99, 55, "model-id");
+        asset.ImageOptimisationPolicy.Should().Be("super-max");
+    }
+    
     [Fact]
     public void ToDlcsModel_All_Fields_Should_Convert()
     {

--- a/src/protagonist/DLCS.Model/Policies/IPolicyRepository.cs
+++ b/src/protagonist/DLCS.Model/Policies/IPolicyRepository.cs
@@ -9,7 +9,7 @@ public interface IPolicyRepository : IThumbnailPolicyRepository
     /// <summary>
     /// Get ImageOptimisationPolicy with specified Id.
     /// </summary>
-    Task<ImageOptimisationPolicy?> GetImageOptimisationPolicy(string imageOptimisationPolicyId,
+    Task<ImageOptimisationPolicy?> GetImageOptimisationPolicy(string imageOptimisationPolicyId, int customerId,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
@@ -17,7 +17,7 @@ public class ImageOptimisationPolicy
     /// <summary>
     /// Customer that this optimisation policy is for
     /// </summary>
-    public int? Customer { get; set; }
+    public int Customer { get; set; }
     
     /// <summary>
     /// If true, optimisation policy is for all customers

--- a/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
@@ -2,10 +2,25 @@
 
 namespace DLCS.Model.Policies;
 
+/// <summary>
+/// Represents set of instructions on how to process and image.
+/// The format of the 'TechnicalDetails' will depend on the downstream system carrying out the changes.
+/// e.g. they may be ElasticTranscoder presets, or a set of instructions for kdu
+/// </summary>
 [DebuggerDisplay("{Name}")]
 public class ImageOptimisationPolicy
 {
     public string Id { get; set; }
     public string Name { get; set; }
     public string[] TechnicalDetails { get; set; }
+    
+    /// <summary>
+    /// Customer that this optimisation policy is for
+    /// </summary>
+    public int? Customer { get; set; }
+    
+    /// <summary>
+    /// If true, optimisation policy is for all customers
+    /// </summary>
+    public bool Global { get; set; }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Customers/CustomerOriginStrategyRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Customers/CustomerOriginStrategyRepositoryTests.cs
@@ -18,6 +18,7 @@ public class CustomerOriginStrategyRepositoryTests
 {
     private readonly DlcsContext dbContext;
     private readonly CustomerOriginStrategyRepository sut;
+    
     public CustomerOriginStrategyRepositoryTests(DlcsDatabaseFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;

--- a/src/protagonist/DLCS.Repository.Tests/Policies/PolicyRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Policies/PolicyRepositoryTests.cs
@@ -1,0 +1,63 @@
+﻿using DLCS.Core.Caching;
+using DLCS.Model.Policies;
+using DLCS.Repository.Policies;
+using LazyCache.Mocks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Test.Helpers.Integration;
+
+namespace DLCS.Repository.Tests.Policies;
+
+[Trait("Category", "Database")]
+[Collection(DatabaseCollection.CollectionName)]
+public class PolicyRepositoryTests
+{
+    private readonly DlcsContext dbContext;
+    private readonly PolicyRepository sut;
+
+    public PolicyRepositoryTests(DlcsDatabaseFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+        dbFixture.CleanUp();
+
+        dbContext.ImageOptimisationPolicies.AddRange(
+            new ImageOptimisationPolicy
+            {
+                Customer = 100, Global = false, Id = "the-default", Name = "Customer Default",
+                TechnicalDetails = new[] { "foo" }
+            }, new ImageOptimisationPolicy
+            {
+                Customer = 0, Global = true, Id = "the-default", Name = "Global Default",
+                TechnicalDetails = new[] { "bar" }
+            }, new ImageOptimisationPolicy
+            {
+                Customer = 999, Global = false, Id = "the-default", Name = "Other Customer Default",
+                TechnicalDetails = new[] { "baz" }
+            });
+        dbContext.SaveChanges();
+
+        var cacheSettings = Options.Create(new CacheSettings());
+        sut = new PolicyRepository(new MockCachingService(), new NullLogger<PolicyRepository>(), cacheSettings,
+            dbContext);
+    }
+
+    [Fact]
+    public async Task GetImageOptimisationPolicy_ReturnsCustomerSpecific_IfDuplicate()
+    {
+        // Act
+        var result = await sut.GetImageOptimisationPolicy("the-default", 100);
+        
+        // Assert
+        result.Name.Should().Be("Customer Default");
+    }
+    
+    [Fact]
+    public async Task GetImageOptimisationPolicy_ReturnsGlobal_IfNoCustomerSpecific()
+    {
+        // Act
+        var result = await sut.GetImageOptimisationPolicy("the-default", 1);
+        
+        // Assert
+        result.Name.Should().Be("Global Default");
+    }
+}

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -400,6 +400,8 @@ public partial class DlcsContext : DbContext
 
         modelBuilder.Entity<ImageOptimisationPolicy>(entity =>
         {
+            entity.HasKey(e => new { e.Id, e.Customer });
+            
             entity.Property(e => e.Id).HasMaxLength(500);
 
             entity.Property(e => e.Name)

--- a/src/protagonist/DLCS.Repository/Migrations/20221122145457_ImageOptimisationPolicy gains customer and global.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20221122145457_ImageOptimisationPolicy gains customer and global.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20221122145457_ImageOptimisationPolicy gains customer and global")]
+    partial class ImageOptimisationPolicygainscustomerandglobal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20221122145457_ImageOptimisationPolicy gains customer and global.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20221122145457_ImageOptimisationPolicy gains customer and global.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class ImageOptimisationPolicygainscustomerandglobal : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Customer",
+                table: "ImageOptimisationPolicies",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Global",
+                table: "ImageOptimisationPolicies",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            // Prior to introducing 'Global' column all policies were global so update to reflect this
+            migrationBuilder.Sql("UPDATE \"ImageOptimisationPolicies\" SET \"Global\" = true;");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Customer",
+                table: "ImageOptimisationPolicies");
+
+            migrationBuilder.DropColumn(
+                name: "Global",
+                table: "ImageOptimisationPolicies");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Migrations/20221122173013_ImageOptimisationPolicy gains composite key.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20221122173013_ImageOptimisationPolicy gains composite key.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20221122173013_ImageOptimisationPolicy gains composite key")]
+    partial class ImageOptimisationPolicygainscompositekey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20221122173013_ImageOptimisationPolicy gains composite key.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20221122173013_ImageOptimisationPolicy gains composite key.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class ImageOptimisationPolicygainscompositekey : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE \"ImageOptimisationPolicies\" SET \"Customer\" = 1 WHERE \"Customer\" IS NULL;");
+            
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ImageOptimisationPolicies",
+                table: "ImageOptimisationPolicies");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Customer",
+                table: "ImageOptimisationPolicies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ImageOptimisationPolicies",
+                table: "ImageOptimisationPolicies",
+                columns: new[] { "Id", "Customer" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_ImageOptimisationPolicies",
+                table: "ImageOptimisationPolicies");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Customer",
+                table: "ImageOptimisationPolicies",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_ImageOptimisationPolicies",
+                table: "ImageOptimisationPolicies",
+                column: "Id");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Policies/PolicyRepository.cs
+++ b/src/protagonist/DLCS.Repository/Policies/PolicyRepository.cs
@@ -50,12 +50,14 @@ public class PolicyRepository : IPolicyRepository
     }
 
     public async Task<ImageOptimisationPolicy?> GetImageOptimisationPolicy(string imageOptimisationPolicyId,
-        CancellationToken cancellationToken = default)
+        int customerId, CancellationToken cancellationToken = default)
     {
         try
         {
             var imageOptimisationPolicies = await GetImageOptimisationPolicies(cancellationToken);
-            return imageOptimisationPolicies.SingleOrDefault(p => p.Id == imageOptimisationPolicyId);
+            return imageOptimisationPolicies
+                .OrderBy(c => c.Global)
+                .FirstOrDefault(p => p.Id == imageOptimisationPolicyId && (p.Global || p.Customer == customerId));
         }
         catch (Exception e)
         {

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -99,7 +99,8 @@ public class AssetIngester : IAssetIngester
 
         if (!string.IsNullOrEmpty(asset.ImageOptimisationPolicy))
         {
-            var optimisationPolicy = await policyRepository.GetImageOptimisationPolicy(asset.ImageOptimisationPolicy);
+            var optimisationPolicy =
+                await policyRepository.GetImageOptimisationPolicy(asset.ImageOptimisationPolicy, asset.Customer);
             asset.WithImageOptimisationPolicy(optimisationPolicy);
         }
     }

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Model.Assets;
 using DLCS.Model.Auth.Entities;
@@ -60,7 +61,7 @@ public class DlcsDatabaseFixture : IAsyncLifetime
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"StoragePolicies\" WHERE \"Id\" not in ('default', 'small')");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"ThumbnailPolicies\" WHERE \"Id\" != 'default'");
         DbContext.Database.ExecuteSqlRaw(
-            "DELETE FROM \"ImageOptimisationPolicies\" WHERE \"Id\" not in ('fast-higher', 'video-max', 'audio-max')");
+            "DELETE FROM \"ImageOptimisationPolicies\" WHERE \"Id\" not in ('fast-higher', 'video-max', 'audio-max', 'cust-default')");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"Images\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"CustomerOriginStrategies\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"CustomerStorage\"");
@@ -122,11 +123,24 @@ public class DlcsDatabaseFixture : IAsyncLifetime
             { Id = "default", Name = "default", Sizes = "800,400,200" });
         await DbContext.ImageOptimisationPolicies.AddRangeAsync(
             new ImageOptimisationPolicy
-                { Id = "video-max", Name = "Video", TechnicalDetails = new[] { "System preset: Webm 720p(webm)" } },
+            {
+                Id = "video-max", Name = "Video", TechnicalDetails = new[] { "System preset: Webm 720p(webm)" },
+                Global = true
+            },
             new ImageOptimisationPolicy
-                { Id = "audio-max", Name = "Audio", TechnicalDetails = new[] { "System preset: Audio MP3 - 128k(mp3)" } },
+            {
+                Id = "audio-max", Name = "Audio", TechnicalDetails = new[] { "System preset: Audio MP3 - 128k(mp3)" },
+                Global = true
+            },
             new ImageOptimisationPolicy
-                { Id = "fast-higher", Name = "Fast higher quality", TechnicalDetails = new[] { "kdu_max" } });
+            {
+                Id = "fast-higher", Name = "Fast higher quality", TechnicalDetails = new[] { "kdu_max" }, Global = true
+            },
+            new ImageOptimisationPolicy
+            {
+                Id = "cust-default", Name = "Customer Scoped", TechnicalDetails = new[] { "default" },
+                Global = false, Customer = 99
+            });
         await DbContext.AuthServices.AddAsync(new AuthService
         {
             Customer = customer, Name = "clickthrough", Id = ClickThroughAuthService,


### PR DESCRIPTION
Small part of changes for #393 , having customer specific imageOptimisationPolicies will enable better control of how images are processed.

Includes:
* Migration to add `bool Global` and `int Customer` fields to `ImageOptimisationPolicy`. Migration sets any current policies to `global=true` and leaves customer `null`.
* Second migration to make `Id` and `Customer` a composite key, which required making `Customer` not-null.
* Modify current `/imageOptimisationPolicies` and `/imageOptimisationPolicies/{id}` to return global only.
* Add `/customer/{custId}/imageOptimisationPolicies` and `/customer/{custId}/imageOptimisationPolicies/{id}`
* Modify Hydra model to reflect changes and set appropriate Id based on customer specific or not.
* Update mapping of Hydra -> Entity model to allow imageOptimisationPolicy to be full URI or name only (keeps functionally equivalent with deliverator).