### PR TITLE
Do not push images if dependabot action

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -47,4 +47,4 @@ runs:
         builder: ${{ steps.docker-setup-buildx.outputs.name }}
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
-        push: true
+        push: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Dependabot gets a readonly `GITHUB_TOKEN` so jobs are failing with a 403 as it's trying to push to ghcr.

Tweaked the build-push action to only push if job isn't a dependabot job.  Condition found in docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events