### PR TITLE
Implement delete handler

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,13 +32,13 @@ Utils/
 **/Properties/launchSettings.json
 
 # build results
-[Dd]ebug/
-[Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
-x64/
-x86/
-bld/
-[Bb]in/
-[Oo]bj/
-[Ll]og/
+**/[Dd]ebug/
+**/[Dd]ebugPublic/
+**/[Rr]elease/
+**/[Rr]eleases/
+**/x64/
+**/x86/
+**/bld/
+**/[Bb]in/
+**/[Oo]bj/
+**/[Ll]og/

--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -105,6 +105,18 @@ jobs:
           context: "./src/protagonist"
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  build-push-deletehandler:
+    runs-on: ubuntu-latest
+    needs: test-dotnet
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/docker-build-and-push
+        with:
+          image-name: "deletehandler"
+          dockerfile: "Dockerfile.DeleteHandler"
+          context: "./src/protagonist"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   build-push-compositehandler:
     runs-on: ubuntu-latest
     needs: test-compositehandler

--- a/Dockerfile.DeleteHandler
+++ b/Dockerfile.DeleteHandler
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+
+COPY ["DeleteHandler/DeleteHandler.csproj", "DeleteHandler/"]
+COPY ["DLCS.AWS/DLCS.AWS.csproj", "DLCS.AWS/"]
+COPY ["DLCS.Core/DLCS.Core.csproj", "DLCS.Core/"]
+COPY ["DLCS.Model/DLCS.Model.csproj", "DLCS.Model/"]
+
+RUN dotnet restore "DeleteHandler/DeleteHandler.csproj"
+
+COPY . .
+WORKDIR "/src/DeleteHandler"
+RUN dotnet build "DeleteHandler.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "DeleteHandler.csproj" -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist
+LABEL org.opencontainers.image.description="Background processor to handle assets deleted from DLCS"
+
+WORKDIR /app
+EXPOSE 80
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "DeleteHandler.dll"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In addition to the above there are a number of `*.Tests` classes for automated t
 * Orchestrator - reverse proxy that serves user requests (WIP).
 * Portal - administration UI for managing assets (WIP).
 * Thumbs - simplified handling of thumbnail requests.
+* DeleteHandler - monitors queue for notifications + deletes asset derivatives on receipt.
 
 ## Technology :robot:
 

--- a/src/protagonist/DLCS.AWS.Tests/SQS/Models/QueueMessageXTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SQS/Models/QueueMessageXTests.cs
@@ -46,7 +46,8 @@ public class QueueMessageXTests
         contents.ToJsonString().Should().BeEquivalentTo(expected);
     }
 
-    [Fact] public void GetMessageContents_ReturnsNull_IfSnsOrigin_AndBodyNotJson()
+    [Fact] 
+    public void GetMessageContents_ReturnsNull_IfSnsOrigin_AndBodyNotJson()
     {
         // Arrange
         var body = new JsonObject

--- a/src/protagonist/DLCS.AWS.Tests/SQS/Models/QueueMessageXTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SQS/Models/QueueMessageXTests.cs
@@ -1,0 +1,72 @@
+﻿using System.Text.Json.Nodes;
+using DLCS.AWS.SQS;
+
+namespace DLCS.AWS.Tests.SQS.Models;
+
+public class QueueMessageXTests
+{
+    [Fact]
+    public void GetMessageContents_ReturnsBody_IfSqsOrigin()
+    {
+        // Arrange
+        var body = new JsonObject { ["foo"] = "bar" };
+        var queueMessage = new QueueMessage { Body = body };
+        
+        // Act
+        var contents = queueMessage.GetMessageContents();
+        
+        // Assert
+        contents.Should().BeEquivalentTo(body);
+    }
+    
+    [Fact]
+    public void GetMessageContents_ReturnsBody_IfSnsOrigin()
+    {
+        // Arrange
+        var expected = new JsonObject { ["foo"] = "bar" }.ToJsonString();
+
+        var body = new JsonObject
+        {
+            ["Type"] = "Notification",
+            ["MessageId"] = "1715cbc2-2aa2-5dc3-b8f6-97faca42118a",
+            ["Message"] = expected,
+            ["TopicArn"] = "arn:aws:sns:eu-west-1:123456789012:my-topic-name",
+            ["Timestamp"] = "2023-01-11T16:06:56.524Z",
+            ["SignatureVersion"] = "1",
+            ["Signature"] = "123123",
+            ["SigningCertURL"] = "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-123123123.pem",
+            ["UnsubscribeUrl"] = "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe..."
+        };
+        var queueMessage = new QueueMessage { Body = body };
+        
+        // Act
+        var contents = queueMessage.GetMessageContents();
+        
+        // Assert
+        contents.ToJsonString().Should().BeEquivalentTo(expected);
+    }
+
+    [Fact] public void GetMessageContents_ReturnsNull_IfSnsOrigin_AndBodyNotJson()
+    {
+        // Arrange
+        var body = new JsonObject
+        {
+            ["Type"] = "Notification",
+            ["MessageId"] = "1715cbc2-2aa2-5dc3-b8f6-97faca42118a",
+            ["Message"] = "hello-world",
+            ["TopicArn"] = "arn:aws:sns:eu-west-1:123456789012:my-topic-name",
+            ["Timestamp"] = "2023-01-11T16:06:56.524Z",
+            ["SignatureVersion"] = "1",
+            ["Signature"] = "123123",
+            ["SigningCertURL"] = "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-123123123.pem",
+            ["UnsubscribeUrl"] = "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe..."
+        };
+        var queueMessage = new QueueMessage { Body = body };
+        
+        // Act
+        var contents = queueMessage.GetMessageContents();
+        
+        // Assert
+        contents.Should().BeNull();
+    }
+}

--- a/src/protagonist/DLCS.AWS/Configuration/AWSConfiguration.cs
+++ b/src/protagonist/DLCS.AWS/Configuration/AWSConfiguration.cs
@@ -5,7 +5,6 @@ using Amazon.S3;
 using Amazon.SQS;
 using DLCS.AWS.Settings;
 using DLCS.Core.Guard;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -21,7 +20,7 @@ public static class AWSConfiguration
     /// Setup AWS environment by configuring appropriate services.
     /// </summary>
     public static AwsBuilder SetupAWS(this IServiceCollection services, IConfiguration configuration,
-        IWebHostEnvironment environment)
+        IHostEnvironment environment)
     {
         IConfigurationSection? configurationSection = configuration.GetSection("AWS");
         services.Configure<AWSSettings>(configurationSection);

--- a/src/protagonist/DLCS.AWS/S3/IBucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/IBucketWriter.cs
@@ -50,6 +50,12 @@ public interface IBucketWriter
     /// </summary>
     /// <param name="toDelete">List of objects to delete</param>
     Task DeleteFromBucket(params ObjectInBucket[] toDelete);
+
+    /// <summary>
+    /// Delete "folder" from underlying storage, this will be the specified root and any child elements.
+    /// </summary>
+    /// <param name="root">Root object to delete</param>
+    Task DeleteFolder(ObjectInBucket root);
 }
 
 /// <summary>

--- a/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
@@ -4,7 +4,6 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
 using DLCS.AWS.S3.Models;
-using DLCS.Core;
 using Microsoft.Extensions.Logging;
 
 namespace DLCS.AWS.S3;

--- a/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
@@ -252,6 +252,57 @@ public class S3BucketWriter : IBucketWriter
         }
     }
 
+    public async Task DeleteFolder(ObjectInBucket root)
+    {
+        // NOTE - this is based on the S3DirectoryInfo.Delete method that was removed from SDK
+        try
+        {
+            var listObjectsRequest = new ListObjectsRequest
+            {
+                BucketName = root.Bucket,
+                Prefix = root.Key
+            };
+
+            var deleteObjectsRequest = new DeleteObjectsRequest
+            {
+                BucketName = root.Bucket
+            };
+
+            ListObjectsResponse listObjectsResponse;
+            do
+            {
+                listObjectsResponse = await s3Client.ListObjectsAsync(listObjectsRequest);
+                foreach (var item in listObjectsResponse.S3Objects.OrderBy(x => x.Key))
+                {
+                    deleteObjectsRequest.AddKey(item.Key);
+                    if (deleteObjectsRequest.Objects.Count == 1000)
+                    {
+                        await s3Client.DeleteObjectsAsync(deleteObjectsRequest);
+                        deleteObjectsRequest.Objects.Clear();
+                    }
+
+                    listObjectsRequest.Marker = item.Key;
+                }
+            } while (listObjectsResponse.IsTruncated);
+
+            if (deleteObjectsRequest.Objects.Count > 0)
+            {
+                await s3Client.DeleteObjectsAsync(deleteObjectsRequest);
+            }
+        }
+        catch (AmazonS3Exception e)
+        {
+            logger.LogWarning("S3 Error encountered. Message:'{Message}' when deleting folder '{Folder}' from bucket",
+                e.Message, root);
+        }
+        catch (Exception e)
+        {
+            logger.LogWarning(e,
+                "Unknown encountered on server. Message:'{Message}' when deleting folder '{Folder}' from bucket",
+                e.Message, root);
+        }
+    }
+
     private async Task<PutObjectResponse?> WriteToBucketInternal(PutObjectRequest putRequest,
         CancellationToken cancellationToken = default)
     {

--- a/src/protagonist/DLCS.AWS/SQS/Models/QueueMessage.cs
+++ b/src/protagonist/DLCS.AWS/SQS/Models/QueueMessage.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Newtonsoft.Json;
 
 namespace DLCS.AWS.SQS;
 
@@ -27,3 +28,42 @@ public class QueueMessage
     /// </summary>
     public string QueueName { get; set; }
 }
+
+public static class QueueMessageX
+{
+    /// <summary>
+    /// Get a <see cref="JsonObject"/> representing the contents of the message as raised by source system. This helps
+    /// when the message can be from SNS->SQS, SNS->SQS with RawDelivery or SQS directly.
+    /// 
+    /// If originating from SNS and Raw Message Delivery is disabled (default) then the <see cref="QueueMessage"/>
+    /// object will have additional fields about topic etc, and the message will be embedded in a "Message" property.
+    /// e.g. { "Type": "Notification", "MessageId": "1234", "Message": { \"key\": \"value\" } }
+    /// 
+    /// If originating from SQS, or from SNS with Raw Message Delivery enabled, the <see cref="QueueMessage"/> Body
+    /// property will contain the full message only.
+    /// e.g. { "key": "value" }
+    /// </summary>
+    /// <remarks>See https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html </remarks>
+    public static JsonObject? GetMessageContents(this QueueMessage queueMessage)
+    {
+        const string messageKey = "Message";
+        if (queueMessage.Body.ContainsKey("TopicArn") && queueMessage.Body.ContainsKey(messageKey))
+        {
+            // From SNS without Raw Message Delivery
+            try
+            {
+                var value = queueMessage.Body[messageKey]!.GetValue<string>();
+
+                var jsonNode = JsonNode.Parse(value);
+                return jsonNode?.AsObject();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        // From SQS or SNS with Raw Message Delivery
+        return queueMessage.Body;
+    }
+} 

--- a/src/protagonist/DLCS.AWS/SQS/QueueHandlerResolver.cs
+++ b/src/protagonist/DLCS.AWS/SQS/QueueHandlerResolver.cs
@@ -29,6 +29,6 @@ public static class ResolverExtensions
     /// <returns>Modified <see cref="IServiceCollection"/></returns>
     public static IServiceCollection AddDefaultQueueHandler<T>(this IServiceCollection serviceCollection)
         where T : IMessageHandler
-        => serviceCollection.AddSingleton<QueueHandlerResolver<SingleHandler>>(provider =>
+        => serviceCollection.AddScoped<QueueHandlerResolver<SingleHandler>>(provider =>
             _ => provider.GetRequiredService<T>());
 }

--- a/src/protagonist/DLCS.AWS/SQS/QueueHandlerResolver.cs
+++ b/src/protagonist/DLCS.AWS/SQS/QueueHandlerResolver.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace DLCS.AWS.SQS;
 
 /// <summary>
@@ -6,3 +8,27 @@ namespace DLCS.AWS.SQS;
 /// <param name="messageType">Type of message to be handled.</param>
 public delegate IMessageHandler QueueHandlerResolver<in TMessageType>(TMessageType messageType)
     where TMessageType : Enum;
+
+
+/// <summary>
+/// Message handlers are found by an enum, this is a stand-in enum for when we have a single listener 
+/// </summary>
+internal enum SingleHandler
+{
+    Default
+}
+
+public static class ResolverExtensions
+{
+    /// <summary>
+    /// Convenience method for when there is a single handler type, configures <see cref="QueueHandlerResolver{T}"/> in
+    /// DI container to always return that type
+    /// </summary>
+    /// <param name="serviceCollection">Current serviceCollection</param>
+    /// <typeparam name="T">Type of message handler</typeparam>
+    /// <returns>Modified <see cref="IServiceCollection"/></returns>
+    public static IServiceCollection AddDefaultQueueHandler<T>(this IServiceCollection serviceCollection)
+        where T : IMessageHandler
+        => serviceCollection.AddSingleton<QueueHandlerResolver<SingleHandler>>(provider =>
+            _ => provider.GetRequiredService<T>());
+}

--- a/src/protagonist/DLCS.AWS/SQS/SqsListenerManager.cs
+++ b/src/protagonist/DLCS.AWS/SQS/SqsListenerManager.cs
@@ -44,6 +44,12 @@ public class SqsListenerManager
                 subscribedToQueue);
         listeners.Add(listener);
     }
+
+    public async Task SetupDefaultQueue(string? queueName)
+    {
+        await AddQueueListener(queueName, SingleHandler.Default);
+        StartListening();
+    } 
     
     public void StartListening()
     {

--- a/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
@@ -30,6 +30,11 @@ public class SQSSettings
     public string? TranscodeCompleteQueueName { get; set; }
     
     /// <summary>
+    /// Name of queue for handling notifications that assets have been deleted
+    /// </summary>
+    public string? DeleteNotificationQueueName { get; set; }
+    
+    /// <summary>
     /// The duration (in seconds) for which the call waits for a message to arrive in the queue before returning
     /// </summary>
     public int WaitTimeSecs { get; set; } = 20;

--- a/src/protagonist/DLCS.Core/Types/AssetId.cs
+++ b/src/protagonist/DLCS.Core/Types/AssetId.cs
@@ -100,7 +100,7 @@ public class AssetId
         return Equals((AssetId)obj);
     }
 
-    public static bool operator ==(AssetId assetId1, AssetId assetId2)
+    public static bool operator ==(AssetId? assetId1, AssetId? assetId2)
     {
         if (assetId1 is null)
         {

--- a/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
@@ -1,0 +1,119 @@
+﻿using System.Text.Json.Nodes;
+using DeleteHandler.Infrastructure;
+using DLCS.AWS.S3;
+using DLCS.AWS.SQS;
+using DLCS.Core.Exceptions;
+using DLCS.Core.FileSystem;
+using DLCS.Core.Types;
+using DLCS.Model.Templates;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DeleteHandler;
+
+/// <summary>
+/// Handler for SQS messages notifying of asset deletion
+/// </summary>
+public class AssetDeletedHandler : IMessageHandler
+{
+    private readonly DeleteHandlerSettings handlerSettings;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly IBucketWriter bucketWriter;
+    private readonly IFileSystem fileSystem;
+    private readonly ILogger<AssetDeletedHandler> logger;
+
+    public AssetDeletedHandler(
+        IStorageKeyGenerator storageKeyGenerator,
+        IBucketWriter bucketWriter,
+        IFileSystem fileSystem,
+        IOptions<DeleteHandlerSettings> handlerSettings,
+        ILogger<AssetDeletedHandler> logger)
+    {
+        this.storageKeyGenerator = storageKeyGenerator;
+        this.bucketWriter = bucketWriter;
+        this.fileSystem = fileSystem;
+        this.logger = logger;
+        this.handlerSettings = handlerSettings.Value;
+    }
+    
+    public async Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken = default)
+    {
+        var assetId = TryGetAssetId(message);
+        if (assetId == null) return true;
+
+        logger.LogDebug("Processing delete notification for {AssetId}", assetId);
+
+        await DeleteThumbnails(assetId);
+        await DeleteTileOptimised(assetId);
+        DeleteFromNas(assetId);
+
+        return true;
+    }
+
+    private async Task DeleteThumbnails(AssetId assetId)
+    {
+        if (string.IsNullOrEmpty(handlerSettings.AWS.S3.ThumbsBucket))
+        {
+            logger.LogDebug("No thumbsBucket configured - thumbnails will not be deleted. {AssetId}", assetId);
+            return;
+        }
+
+        var thumbsKey = storageKeyGenerator.GetThumbnailsRoot(assetId);
+        logger.LogInformation("Deleting thumbs from {ThumbnailRoot} for {AssetId}", thumbsKey, assetId);
+        await bucketWriter.DeleteFromBucket(thumbsKey);
+    }
+    
+    private async Task DeleteTileOptimised(AssetId assetId)
+    {
+        if (string.IsNullOrEmpty(handlerSettings.AWS.S3.StorageBucket))
+        {
+            logger.LogDebug("No storageBucket configured - tile-optimised derivative will not be deleted. {AssetId}",
+                assetId);
+            return;
+        }
+
+        var storageKey = storageKeyGenerator.GetStorageLocation(assetId);
+        logger.LogInformation("Deleting tile-optimised key from {StorageKey} for {AssetId}", storageKey, assetId);
+        await bucketWriter.DeleteFromBucket(storageKey);
+    }
+    
+    private void DeleteFromNas(AssetId assetId)
+    {
+        if (string.IsNullOrEmpty(handlerSettings.ImageFolderTemplate))
+        {
+            logger.LogDebug("No ImageFolderTemplate configured - NAS file will not be deleted");
+            return;
+        }
+
+        var imagePath = TemplatedFolders.GenerateFolderTemplate(handlerSettings.ImageFolderTemplate, assetId);
+        logger.LogInformation("Deleting file: {StorageKey} for {AssetId}", imagePath, assetId);
+        fileSystem.DeleteFile(imagePath);
+    }
+
+    private AssetId? TryGetAssetId(QueueMessage message)
+    {
+        var messageBody = message.GetMessageContents();
+        if (messageBody == null)
+        {
+            logger.LogWarning("Received message but unable to parse contents. {Body}", message.Body.ToJsonString());
+            return null;
+        }
+        
+        if (!messageBody.TryGetPropertyValue("id", out var idProperty))
+        {
+            logger.LogWarning("Received message body with no 'id' property. {Body}", message.Body.ToJsonString());
+            return null;
+        }
+
+        try
+        {
+            return AssetId.FromString(idProperty!.GetValue<string>());
+        }
+        catch (InvalidAssetIdException assetIdEx)
+        {
+            logger.LogError(assetIdEx, "Unable to process delete notification as assetId is not valid");
+        }
+        
+        return null;
+    }
+}

--- a/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using DeleteHandler.Infrastructure;
+﻿using DeleteHandler.Infrastructure;
 using DLCS.AWS.S3;
 using DLCS.AWS.SQS;
 using DLCS.Core.Exceptions;
@@ -81,7 +80,7 @@ public class AssetDeletedHandler : IMessageHandler
     {
         if (string.IsNullOrEmpty(handlerSettings.ImageFolderTemplate))
         {
-            logger.LogDebug("No ImageFolderTemplate configured - NAS file will not be deleted");
+            logger.LogDebug("No ImageFolderTemplate configured - NAS file will not be deleted. {AssetId}", assetId);
             return;
         }
 

--- a/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/DeleteHandler/AssetDeletedHandler.cs
@@ -57,9 +57,9 @@ public class AssetDeletedHandler : IMessageHandler
             return;
         }
 
-        var thumbsKey = storageKeyGenerator.GetThumbnailsRoot(assetId);
-        logger.LogInformation("Deleting thumbs from {ThumbnailRoot} for {AssetId}", thumbsKey, assetId);
-        await bucketWriter.DeleteFromBucket(thumbsKey);
+        var thumbsRoot = storageKeyGenerator.GetThumbnailsRoot(assetId);
+        logger.LogInformation("Deleting thumbs from {ThumbnailRoot} for {AssetId}", thumbsRoot, assetId);
+        await bucketWriter.DeleteFolder(thumbsRoot);
     }
     
     private async Task DeleteTileOptimised(AssetId assetId)

--- a/src/protagonist/DeleteHandler/DeleteHandler.csproj
+++ b/src/protagonist/DeleteHandler/DeleteHandler.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DeleteHandler/DeleteHandler.csproj
+++ b/src/protagonist/DeleteHandler/DeleteHandler.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+      <PackageReference Include="Serilog" Version="2.10.0" />
+      <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+      <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DLCS.AWS\DLCS.AWS.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/protagonist/DeleteHandler/DeleteHandler.csproj
+++ b/src/protagonist/DeleteHandler/DeleteHandler.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
@@ -18,6 +19,21 @@
 
     <ItemGroup>
       <ProjectReference Include="..\DLCS.AWS\DLCS.AWS.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="appsettings-Development-Example.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="Properties\launchSettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/src/protagonist/DeleteHandler/Infrastructure/DeleteHandlerSettings.cs
+++ b/src/protagonist/DeleteHandler/Infrastructure/DeleteHandlerSettings.cs
@@ -1,0 +1,16 @@
+﻿using DLCS.AWS.Settings;
+
+namespace DeleteHandler.Infrastructure;
+
+public class DeleteHandlerSettings
+{
+    /// <summary>
+    /// Folder template for where image assets are downloaded to
+    /// </summary>
+    public string? ImageFolderTemplate { get; set; }
+    
+    /// <summary>
+    /// AWS config
+    /// </summary>
+    public AWSSettings AWS { get; set; }
+}

--- a/src/protagonist/DeleteHandler/Infrastructure/DeleteQueueMonitor.cs
+++ b/src/protagonist/DeleteHandler/Infrastructure/DeleteQueueMonitor.cs
@@ -1,0 +1,47 @@
+﻿using DLCS.AWS.Settings;
+using DLCS.AWS.SQS;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DeleteHandler.Infrastructure;
+
+/// <summary>
+/// Background worker that monitors SQS queue for delete notifications
+/// </summary>
+public class DeleteQueueMonitor : BackgroundService
+{
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+    private readonly IOptions<AWSSettings> awsSettings;
+    private readonly SqsListenerManager sqsListenerManager;
+    private readonly ILogger<DeleteQueueMonitor> logger;
+
+    public DeleteQueueMonitor(SqsListenerManager sqsListenerManager, ILogger<DeleteQueueMonitor> logger,
+        IHostApplicationLifetime hostApplicationLifetime, IOptions<AWSSettings> awsSettings)
+    {
+        this.sqsListenerManager = sqsListenerManager;
+        this.logger = logger;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+        this.awsSettings = awsSettings;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Starting DeleteQueueMonitor");
+        
+        await sqsListenerManager.SetupDefaultQueue(awsSettings.Value.SQS.DeleteNotificationQueueName);
+        hostApplicationLifetime.ApplicationStopping.Register(OnStopping);
+    }
+    
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        logger.LogWarning("Stopping DeleteQueueMonitor");
+        return Task.CompletedTask;
+    }
+    
+    private void OnStopping()
+    {
+        sqsListenerManager.StopListening();
+        logger.LogInformation("Stopping listening to queues");
+    }
+}

--- a/src/protagonist/DeleteHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/DeleteHandler/Infrastructure/ServiceCollectionX.cs
@@ -1,0 +1,41 @@
+﻿using DLCS.AWS.Configuration;
+using DLCS.AWS.S3;
+using DLCS.AWS.SQS;
+using DLCS.Core.FileSystem;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DeleteHandler.Infrastructure;
+
+public static class ServiceCollectionX
+{
+    /// <summary>
+    /// Configure AWS services. Generic, non project-specific
+    /// </summary>
+    public static IServiceCollection AddAws(this IServiceCollection services,
+        IConfiguration configuration, IHostEnvironment hostEnvironment)
+    {
+        services
+            .AddSingleton<IBucketWriter, S3BucketWriter>()
+            .AddSingleton<IStorageKeyGenerator, S3StorageKeyGenerator>()
+            .AddSingleton<SqsListenerManager>()
+            .AddTransient(typeof(SqsListener<>))
+            .AddSingleton<SqsQueueUtilities>()
+            .SetupAWS(configuration, hostEnvironment)
+            .WithAmazonS3()
+            .WithAmazonSQS();
+        
+        return services;
+    }
+
+    /// <summary>
+    /// Configure BackgroundWorker + handler services
+    /// </summary>
+    public static IServiceCollection AddQueueMonitoring(this IServiceCollection services)
+        => services
+            .AddScoped<AssetDeletedHandler>()
+            .AddDefaultQueueHandler<AssetDeletedHandler>()
+            .AddSingleton<IFileSystem, FileSystem>()
+            .AddHostedService<DeleteQueueMonitor>();
+}

--- a/src/protagonist/DeleteHandler/Program.cs
+++ b/src/protagonist/DeleteHandler/Program.cs
@@ -1,12 +1,6 @@
-﻿using DLCS.AWS.Configuration;
-using DLCS.AWS.S3;
-using DLCS.AWS.Settings;
-using DLCS.AWS.SQS;
-using Microsoft.Extensions.Configuration;
+﻿using DeleteHandler.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Serilog;
 
 namespace DeleteHandler;
@@ -39,95 +33,12 @@ public class Program
             .ConfigureServices((hostContext, services) =>
             {
                 services
-                    .AddAws(hostContext.Configuration, hostContext.HostingEnvironment);
+                    .Configure<DeleteHandlerSettings>(hostContext.Configuration)
+                    .AddAws(hostContext.Configuration, hostContext.HostingEnvironment)
+                    .AddQueueMonitoring();
             })
             .UseSerilog((hostingContext, loggerConfiguration)
                 => loggerConfiguration
                     .ReadFrom.Configuration(hostingContext.Configuration)
             );
-}
-
-public static class ServiceCollectionX
-{
-    /// <summary>
-    /// Configure AWS services. Generic, non project-specific
-    /// </summary>
-    public static IServiceCollection AddAws(this IServiceCollection services,
-        IConfiguration configuration, IHostEnvironment hostEnvironment)
-    {
-        services
-            .AddSingleton<IBucketWriter, S3BucketWriter>()
-            .AddSingleton<IStorageKeyGenerator, S3StorageKeyGenerator>()
-            .AddSingleton<SqsListenerManager>()
-            .AddTransient(typeof(SqsListener<>))
-            .AddSingleton<SqsQueueUtilities>()
-            .SetupAWS(configuration, hostEnvironment)
-            .WithAmazonS3()
-            .WithAmazonSQS();
-        
-        return services;
-    }
-
-    public static IServiceCollection AddQueueMonitoring(this IServiceCollection services)
-        => services
-            .AddScoped<AssetDeletedHandler>()
-            .AddDefaultQueueHandler<AssetDeletedHandler>()
-            .AddHostedService<DeleteQueueMonitor>();
-}
-
-public class AssetDeletedHandler : IMessageHandler
-{
-    public Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken = default)
-    {
-        /*
-         * Delete storage jp2
-         * Delete thumbnails
-         * Delete from hot-disk
-         * Purge varnish?
-         * Purge CF?
-         */
-        throw new NotImplementedException();
-    }
-}
-
-public class DeleteQueueMonitor : BackgroundService
-{
-    private readonly IHostApplicationLifetime hostApplicationLifetime;
-    private readonly IOptions<AWSSettings> awsSettings;
-    private readonly SqsListenerManager sqsListenerManager;
-    private readonly ILogger<DeleteQueueMonitor> logger;
-
-    public DeleteQueueMonitor(SqsListenerManager sqsListenerManager, ILogger<DeleteQueueMonitor> logger,
-        IHostApplicationLifetime hostApplicationLifetime, IOptions<AWSSettings> awsSettings)
-    {
-        this.sqsListenerManager = sqsListenerManager;
-        this.logger = logger;
-        this.hostApplicationLifetime = hostApplicationLifetime;
-        this.awsSettings = awsSettings;
-    }
-
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        logger.LogInformation("Starting DeleteQueueMonitor");
-        
-        await sqsListenerManager.SetupDefaultQueue(awsSettings.Value.SQS.DeleteNotificationQueueName);
-        hostApplicationLifetime.ApplicationStopping.Register(OnStopping);
-    }
-    
-    public override Task StopAsync(CancellationToken cancellationToken)
-    {
-        logger.LogWarning("Stopping DeleteQueueMonitor");
-        return Task.CompletedTask;
-    }
-    
-    private void OnStopping()
-    {
-        sqsListenerManager.StopListening();
-        logger.LogInformation("Stopping listening to queues");
-    }
-}
-
-public class DeleteHandlerSettings
-{
-    public string? ImageFolderTemplate { get; set; }
 }

--- a/src/protagonist/DeleteHandler/Program.cs
+++ b/src/protagonist/DeleteHandler/Program.cs
@@ -1,0 +1,133 @@
+﻿using DLCS.AWS.Configuration;
+using DLCS.AWS.S3;
+using DLCS.AWS.Settings;
+using DLCS.AWS.SQS;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+namespace DeleteHandler;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .Enrich.FromLogContext()
+            .WriteTo.Console()
+            .CreateLogger();
+
+        try
+        {
+            await CreateHostBuilder(args).Build().RunAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Fatal(ex, "Application start-up failed");
+        }
+        finally
+        {
+            Log.CloseAndFlush();
+        }
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((hostContext, services) =>
+            {
+                services
+                    .AddAws(hostContext.Configuration, hostContext.HostingEnvironment);
+            })
+            .UseSerilog((hostingContext, loggerConfiguration)
+                => loggerConfiguration
+                    .ReadFrom.Configuration(hostingContext.Configuration)
+            );
+}
+
+public static class ServiceCollectionX
+{
+    /// <summary>
+    /// Configure AWS services. Generic, non project-specific
+    /// </summary>
+    public static IServiceCollection AddAws(this IServiceCollection services,
+        IConfiguration configuration, IHostEnvironment hostEnvironment)
+    {
+        services
+            .AddSingleton<IBucketWriter, S3BucketWriter>()
+            .AddSingleton<IStorageKeyGenerator, S3StorageKeyGenerator>()
+            .AddSingleton<SqsListenerManager>()
+            .AddTransient(typeof(SqsListener<>))
+            .AddSingleton<SqsQueueUtilities>()
+            .SetupAWS(configuration, hostEnvironment)
+            .WithAmazonS3()
+            .WithAmazonSQS();
+        
+        return services;
+    }
+
+    public static IServiceCollection AddQueueMonitoring(this IServiceCollection services)
+        => services
+            .AddScoped<AssetDeletedHandler>()
+            .AddDefaultQueueHandler<AssetDeletedHandler>()
+            .AddHostedService<DeleteQueueMonitor>();
+}
+
+public class AssetDeletedHandler : IMessageHandler
+{
+    public Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken = default)
+    {
+        /*
+         * Delete storage jp2
+         * Delete thumbnails
+         * Delete from hot-disk
+         * Purge varnish?
+         * Purge CF?
+         */
+        throw new NotImplementedException();
+    }
+}
+
+public class DeleteQueueMonitor : BackgroundService
+{
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+    private readonly IOptions<AWSSettings> awsSettings;
+    private readonly SqsListenerManager sqsListenerManager;
+    private readonly ILogger<DeleteQueueMonitor> logger;
+
+    public DeleteQueueMonitor(SqsListenerManager sqsListenerManager, ILogger<DeleteQueueMonitor> logger,
+        IHostApplicationLifetime hostApplicationLifetime, IOptions<AWSSettings> awsSettings)
+    {
+        this.sqsListenerManager = sqsListenerManager;
+        this.logger = logger;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+        this.awsSettings = awsSettings;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Starting DeleteQueueMonitor");
+        
+        await sqsListenerManager.SetupDefaultQueue(awsSettings.Value.SQS.DeleteNotificationQueueName);
+        hostApplicationLifetime.ApplicationStopping.Register(OnStopping);
+    }
+    
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        logger.LogWarning("Stopping DeleteQueueMonitor");
+        return Task.CompletedTask;
+    }
+    
+    private void OnStopping()
+    {
+        sqsListenerManager.StopListening();
+        logger.LogInformation("Stopping listening to queues");
+    }
+}
+
+public class DeleteHandlerSettings
+{
+    public string? ImageFolderTemplate { get; set; }
+}

--- a/src/protagonist/DeleteHandler/Properties/launchSettings.json
+++ b/src/protagonist/DeleteHandler/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+﻿{
+  "profiles": {
+    "DeleteHandler": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/protagonist/DeleteHandler/appsettings-Development-Example.json
+++ b/src/protagonist/DeleteHandler/appsettings-Development-Example.json
@@ -1,0 +1,13 @@
+﻿{
+    "AWS": {
+        "Region": "eu-west-1",
+        "S3": {
+            "ThumbsBucket": "thumbs-bucket",
+            "StorageBucket": "storage-bucket"
+        },
+        "SQS": {
+            "DeleteNotificationQueueName": "delete-notification"
+        }
+    },
+    "ImageFolderTemplate": "/nas/{customer}/{space}/{image-dir}/{image}.jp2"
+}

--- a/src/protagonist/DeleteHandler/appsettings.json
+++ b/src/protagonist/DeleteHandler/appsettings.json
@@ -1,0 +1,22 @@
+﻿{
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console"
+      }
+    ],
+    "Properties": {
+      "ApplicationName": "DeleteHandler"
+    }
+  }
+}

--- a/src/protagonist/DeleteHandlerTests/AssetDeletedHandlerTests.cs
+++ b/src/protagonist/DeleteHandlerTests/AssetDeletedHandlerTests.cs
@@ -1,0 +1,218 @@
+﻿using System.Text.Json.Nodes;
+using Amazon.S3;
+using Amazon.S3.Model;
+using DeleteHandler;
+using DeleteHandler.Infrastructure;
+using DLCS.AWS.S3;
+using DLCS.AWS.S3.Models;
+using DLCS.AWS.Settings;
+using DLCS.AWS.SQS;
+using DLCS.Core.FileSystem;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Test.Helpers;
+using Test.Helpers.Integration;
+using Test.Helpers.Storage;
+
+namespace DeleteHandlerTests;
+
+public class AssetDeletedHandlerTests
+{
+    private readonly DeleteHandlerSettings handlerSettings;
+    private readonly IBucketWriter bucketWriter;
+    private readonly FakeFileSystem fakeFileSystem;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+
+    public AssetDeletedHandlerTests()
+    {
+        handlerSettings = new DeleteHandlerSettings
+        {
+            AWS = new AWSSettings
+            {
+                S3 = new S3Settings
+                {
+                    StorageBucket = LocalStackFixture.StorageBucketName,
+                    ThumbsBucket = LocalStackFixture.ThumbsBucketName
+                }
+            },
+            ImageFolderTemplate = "/nas/{customer}/{space}/{image-dir}/{image}.jp2"
+        };
+        storageKeyGenerator = new S3StorageKeyGenerator(Options.Create(handlerSettings.AWS));
+        bucketWriter = A.Fake<IBucketWriter>();
+        fakeFileSystem = new FakeFileSystem();
+    }
+
+    public AssetDeletedHandler GetSut()
+        => new(storageKeyGenerator, bucketWriter, fakeFileSystem, Options.Create(handlerSettings),
+            new NullLogger<AssetDeletedHandler>());
+
+    [Fact]
+    public async Task Handle_ReturnsTrue_IfInvalidFormat()
+    {
+        // Arrange
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["not-id"] = "foo" }
+        };
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        fakeFileSystem.DeletedFiles.Should().BeEmpty();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_ReturnsTrue_IfInvalidAssetId()
+    {
+        // Arrange
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["id"] = "foo" }
+        };
+        
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        fakeFileSystem.DeletedFiles.Should().BeEmpty();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DeletesThumbs_Origin_AndNasFile()
+    {
+        // Arrange
+        const string assetId = "1/99/foo";
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["id"] = assetId }
+        };
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        
+        // File deleted from local disk
+        fakeFileSystem.DeletedFiles.Should().ContainSingle(s => s == "/nas/1/99/foo/foo.jp2");
+        
+        // Thumbs deleted
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            ))).MustHaveHappened();
+        
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.StorageBucketName && a[0].Key == assetId
+            ))).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteFile_IfSettingEmpty()
+    {
+        // Arrange
+        const string assetId = "1/99/foo";
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["id"] = assetId }
+        };
+        handlerSettings.ImageFolderTemplate = null;
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        
+        // File deleted from local disk
+        fakeFileSystem.DeletedFiles.Should().BeEmpty();
+        
+        // Thumbs deleted
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            ))).MustHaveHappened();
+        
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.StorageBucketName && a[0].Key == assetId
+            ))).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteThumbs_IfSettingEmpty()
+    {
+        // Arrange
+        const string assetId = "1/99/foo";
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["id"] = assetId }
+        };
+        handlerSettings.AWS.S3.ThumbsBucket = "";
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        
+        // File deleted from local disk
+        fakeFileSystem.DeletedFiles.Should().ContainSingle(s => s == "/nas/1/99/foo/foo.jp2");
+        
+        // Thumbs deleted
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            ))).MustNotHaveHappened();
+        
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.StorageBucketName && a[0].Key == assetId
+            ))).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteStorage_IfSettingEmpty()
+    {
+        // Arrange
+        const string assetId = "1/99/foo";
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["id"] = assetId }
+        };
+        handlerSettings.AWS.S3.StorageBucket = "";
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        
+        // File deleted from local disk
+        fakeFileSystem.DeletedFiles.Should().ContainSingle(s => s == "/nas/1/99/foo/foo.jp2");
+        
+        // Thumbs deleted
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            ))).MustHaveHappened();
+        
+        A.CallTo(() =>
+            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
+                a[0].Bucket == LocalStackFixture.StorageBucketName && a[0].Key == assetId
+            ))).MustNotHaveHappened();
+    }
+}

--- a/src/protagonist/DeleteHandlerTests/AssetDeletedHandlerTests.cs
+++ b/src/protagonist/DeleteHandlerTests/AssetDeletedHandlerTests.cs
@@ -43,7 +43,7 @@ public class AssetDeletedHandlerTests
         fakeFileSystem = new FakeFileSystem();
     }
 
-    public AssetDeletedHandler GetSut()
+    private AssetDeletedHandler GetSut()
         => new(storageKeyGenerator, bucketWriter, fakeFileSystem, Options.Create(handlerSettings),
             new NullLogger<AssetDeletedHandler>());
 
@@ -107,8 +107,8 @@ public class AssetDeletedHandlerTests
         
         // Thumbs deleted
         A.CallTo(() =>
-            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
-                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
+                a.Bucket == LocalStackFixture.ThumbsBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
         
         A.CallTo(() =>
@@ -140,8 +140,8 @@ public class AssetDeletedHandlerTests
         
         // Thumbs deleted
         A.CallTo(() =>
-            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
-                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
+                a.Bucket == LocalStackFixture.ThumbsBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
         
         A.CallTo(() =>
@@ -173,8 +173,8 @@ public class AssetDeletedHandlerTests
         
         // Thumbs deleted
         A.CallTo(() =>
-            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
-                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
+                a.Bucket == LocalStackFixture.ThumbsBucketName && a.Key == $"{assetId}/"
             ))).MustNotHaveHappened();
         
         A.CallTo(() =>
@@ -206,8 +206,8 @@ public class AssetDeletedHandlerTests
         
         // Thumbs deleted
         A.CallTo(() =>
-            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(a =>
-                a[0].Bucket == LocalStackFixture.ThumbsBucketName && a[0].Key == $"{assetId}/"
+            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
+                a.Bucket == LocalStackFixture.ThumbsBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
         
         A.CallTo(() =>

--- a/src/protagonist/DeleteHandlerTests/DeleteHandlerTests.csproj
+++ b/src/protagonist/DeleteHandlerTests/DeleteHandlerTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\DeleteHandler\DeleteHandler.csproj" />
+      <ProjectReference Include="..\Test.Helpers\Test.Helpers.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/protagonist/DeleteHandlerTests/Usings.cs
+++ b/src/protagonist/DeleteHandlerTests/Usings.cs
@@ -1,0 +1,2 @@
+global using FluentAssertions;
+global using Xunit;

--- a/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
@@ -10,6 +10,7 @@ using Engine.Settings;
 using Engine.Tests.Integration;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
+using Test.Helpers;
 using Test.Helpers.Settings;
 
 namespace Engine.Tests.Ingest.Persistence;

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -14,6 +14,7 @@ using Engine.Tests.Integration.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Stubbery;
+using Test.Helpers;
 using Test.Helpers.Integration;
 using Test.Helpers.Storage;
 
@@ -252,26 +253,6 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var storage = await dbContext.ImageStorages.SingleOrDefaultAsync(a => a.Id == assetId);
         storage.Should().BeNull();
-    }
-}
-
-public class FakeFileSystem : IFileSystem
-{
-    public List<string> CreatedDirectories = new();
-    public List<string> DeletedDirectories = new();
-    public List<string> DeletedFiles = new();
-
-    public void CreateDirectory(string path) => CreatedDirectories.Add(path);
-
-    public void DeleteDirectory(string path, bool recursive, bool swallowError = true) => DeletedDirectories.Add(path);
-
-    public void DeleteFile(string path, bool swallowError = true) => DeletedFiles.Add(path);
-
-    public bool FileExists(string path) => true;
-    public long GetFileSize(string path) => 10;
-    public void SetLastWriteTimeUtc(string path, DateTime dateTime)
-    {
-        // no-op
     }
 }
 

--- a/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
@@ -14,6 +14,7 @@ using Engine.Tests.Integration.Infrastructure;
 using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Stubbery;
+using Test.Helpers;
 using Test.Helpers.Integration;
 using Test.Helpers.Storage;
 

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
@@ -1,6 +1,5 @@
 ﻿using DLCS.Core.Types;
 using DLCS.Model.Templates;
-using Orchestrator.Assets;
 
 namespace Orchestrator.Settings;
 

--- a/src/protagonist/Test.Helpers/FakeFileSystem.cs
+++ b/src/protagonist/Test.Helpers/FakeFileSystem.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using DLCS.Core.FileSystem;
+
+namespace Test.Helpers;
+
+public class FakeFileSystem : IFileSystem
+{
+    public List<string> CreatedDirectories = new();
+    public List<string> DeletedDirectories = new();
+    public List<string> DeletedFiles = new();
+
+    public void CreateDirectory(string path) => CreatedDirectories.Add(path);
+
+    public void DeleteDirectory(string path, bool recursive, bool swallowError = true) => DeletedDirectories.Add(path);
+
+    public void DeleteFile(string path, bool swallowError = true) => DeletedFiles.Add(path);
+
+    public bool FileExists(string path) => true;
+    public long GetFileSize(string path) => 10;
+    public void SetLastWriteTimeUtc(string path, DateTime dateTime)
+    {
+        // no-op
+    }
+}

--- a/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
+++ b/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
@@ -166,6 +166,11 @@ public class TestBucketWriter : IBucketWriter
 
         return Task.CompletedTask;
     }
+
+    public Task DeleteFolder(ObjectInBucket root)
+    {
+        throw new NotImplementedException();
+    }
 }
 
 public class BucketObject

--- a/src/protagonist/protagonist.sln
+++ b/src/protagonist/protagonist.sln
@@ -67,6 +67,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests", "Engine.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteHandler", "DeleteHandler\DeleteHandler.csproj", "{A8760A1D-8E1B-4822-954C-41188BD9745F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteHandlerTests", "DeleteHandlerTests\DeleteHandlerTests.csproj", "{E0663AC2-FCCC-4660-999F-53AF37F8C63F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -189,6 +191,10 @@ Global
 		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0663AC2-FCCC-4660-999F-53AF37F8C63F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0663AC2-FCCC-4660-999F-53AF37F8C63F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0663AC2-FCCC-4660-999F-53AF37F8C63F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0663AC2-FCCC-4660-999F-53AF37F8C63F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -216,5 +222,6 @@ Global
 		{4C6F55F9-2C1B-46D5-8F86-865EA84DA917} = {820EE99A-E129-44EF-A7BD-519BCE6167D3}
 		{EF411F9A-C628-4786-92D4-D40A3EDE7222} = {89603DC1-C3AD-49C8-A412-D556AE6483D6}
 		{A8760A1D-8E1B-4822-954C-41188BD9745F} = {820EE99A-E129-44EF-A7BD-519BCE6167D3}
+		{E0663AC2-FCCC-4660-999F-53AF37F8C63F} = {89603DC1-C3AD-49C8-A412-D556AE6483D6}
 	EndGlobalSection
 EndGlobal

--- a/src/protagonist/protagonist.sln
+++ b/src/protagonist/protagonist.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine", "Engine\Engine.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests", "Engine.Tests\Engine.Tests.csproj", "{EF411F9A-C628-4786-92D4-D40A3EDE7222}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeleteHandler", "DeleteHandler\DeleteHandler.csproj", "{A8760A1D-8E1B-4822-954C-41188BD9745F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -183,6 +185,10 @@ Global
 		{EF411F9A-C628-4786-92D4-D40A3EDE7222}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF411F9A-C628-4786-92D4-D40A3EDE7222}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF411F9A-C628-4786-92D4-D40A3EDE7222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8760A1D-8E1B-4822-954C-41188BD9745F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -209,5 +215,6 @@ Global
 		{CE569F21-B117-4F99-A28B-6F7C0DA5EEA9} = {89603DC1-C3AD-49C8-A412-D556AE6483D6}
 		{4C6F55F9-2C1B-46D5-8F86-865EA84DA917} = {820EE99A-E129-44EF-A7BD-519BCE6167D3}
 		{EF411F9A-C628-4786-92D4-D40A3EDE7222} = {89603DC1-C3AD-49C8-A412-D556AE6483D6}
+		{A8760A1D-8E1B-4822-954C-41188BD9745F} = {820EE99A-E129-44EF-A7BD-519BCE6167D3}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
New project that listens to SQS queue and, on receipt of message, will delete:

1. Thumbnails
2. Image from "Storage" bucket (JP2)
3. JP2 from local storage.

Each of the above steps will only run if the relevant appSetting value is populated, this is to allow flexibility in how we deploy - e.g. we may have 1 instance that has NAS mounted so deletes from fast-storage and X Fargate instances handling 1+2.

`AssetDeletedHandlerTests` are unlike the other integration tests in sln as we cannot use `WebApplicationFactory<>` method as it uses different hosting model - use mocks instead.

This handles messages in format `{ "id": "1/2/foo" }`. Added `QueueMessage.GetMessageContents()` to avoid handlers needing to know how the image arrived (via SNS->SQS with our without 'raw message delivery' or directly to SQS).

Reused SQS classes from `DLCS.AWS` but added some helpers as this project has a single listener, rather than different possible listeners like Engine.

This is currently used for deliverator so will need expanded to handle Protagonist resources (e.g. `T` assets, info.json etc).