### PR TITLE
Handle alternative path templates per host

### DIFF
--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -57,20 +57,20 @@ services:
     env_file:
       - .env
 
-  appetiser:
-    image: digirati/appetiser:latest
-    ports:
-      - "5031:80"
-    volumes:
-      - $HOME\Docker\scratch:/scratch
-      - $HOME\.aws:/root/.aws
-    env_file:
-      - .env
+  # appetiser:
+  #   image: digirati/appetiser:latest
+  #   ports:
+  #     - "5031:80"
+  #   volumes:
+  #     - $HOME\Docker\scratch:/scratch
+  #     - $HOME\.aws:/root/.aws
+  #   env_file:
+  #     - .env
 
   thumbs:
     build:
-      context: ../
-      dockerfile: Dockerfile.Thumbs
+      context: ../src/protagonist
+      dockerfile: ..\..\Dockerfile.Thumbs
     ports:
       - "5019:80"
     env_file:

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -15,6 +15,7 @@ using DLCS.Repository.NamedQueries.Infrastructure;
 using DLCS.Web.Auth;
 using DLCS.Web.Configuration;
 using DLCS.Web.Handlers;
+using DLCS.Web.Logging;
 using FluentValidation;
 using Hydra;
 using Microsoft.AspNetCore.Builder;
@@ -135,7 +136,10 @@ public class Startup
             .HandlePathBase(pathBase, logger)
             .UseSwaggerWithUI("DLCS API", pathBase, "v2")
             .UseRouting()
-            .UseSerilogRequestLogging()
+            .UseSerilogRequestLogging(opts =>
+            {
+                opts.GetLevel = LogHelper.ExcludeHealthChecks;
+            })
             .UseCors("CorsPolicy")
             .UseAuthentication()
             .UseAuthorization()

--- a/src/protagonist/API/appsettings.json
+++ b/src/protagonist/API/appsettings.json
@@ -7,7 +7,8 @@
       "Default": "Debug",
       "Override": {
         "Microsoft": "Warning",
-        "System": "Warning"
+        "System": "Warning",
+        "HealthChecks": "Warning"
       }
     },
     "WriteTo": [

--- a/src/protagonist/DLCS.Core.Tests/DlcsPathHelpersTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/DlcsPathHelpersTests.cs
@@ -1,7 +1,4 @@
-﻿using FluentAssertions;
-using Xunit;
-
-namespace DLCS.Core.Tests;
+﻿namespace DLCS.Core.Tests;
 
 public class DlcsPathHelpersTests
 {
@@ -26,7 +23,30 @@ public class DlcsPathHelpersTests
         const string expected = "dlcs.digirati.io/images/18/first-space/path/200.jpg";
         
         // Act
-        var replaced = DlcsPathHelpers.GeneratePathFromTemplate(template, "images", "18", "first-space", "200.jpg");
+        var replaced = DlcsPathHelpers.GeneratePathFromTemplate(template,
+            prefix: "images",
+            customer: "18",
+            space: "first-space",
+            assetPath: "200.jpg");
+        
+        // Assert
+        replaced.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GeneratePathFromTemplate_ReplacesExpectedElements_Versioned()
+    {
+        // Arrange
+        const string template = "dlcs.digirati.io/{prefix}/{version}/{customer}/{space}/path/{assetPath}";
+        const string expected = "dlcs.digirati.io/images/v99/18/first-space/path/200.jpg";
+        
+        // Act
+        var replaced = DlcsPathHelpers.GeneratePathFromTemplate(template,
+            prefix: "images",
+            customer: "18",
+            space: "first-space",
+            version: "v99",
+            assetPath: "200.jpg");
         
         // Assert
         replaced.Should().Be(expected);

--- a/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
+++ b/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
@@ -25,4 +25,19 @@ public static class DlcsPathHelpers
             .Replace("{customer}", customer ?? string.Empty)
             .Replace("{space}", space ?? string.Empty)
             .Replace("{assetPath}", assetPath ?? string.Empty);
+    
+    /// <summary>
+    /// Replace known slugs in DLCS auth path template.
+    /// </summary>
+    /// <param name="template">DLCS auth path template, including slugs to replace</param>
+    /// /// <param name="customer">Value to replace {customer} with</param>
+    /// <param name="behaviour">Value to replace {behaviour} with</param>
+    /// <returns>Template with string replacements made</returns>
+    public static string GenerateAuthPathFromTemplate(
+        string template, 
+        string? customer = null, 
+        string? behaviour = null) =>
+        template
+            .Replace("{customer}", customer ?? string.Empty)
+            .Replace("{behaviour}", behaviour ?? string.Empty);
 }

--- a/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
+++ b/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
@@ -1,30 +1,38 @@
-﻿namespace DLCS.Core;
+﻿using System.Text.RegularExpressions;
+
+namespace DLCS.Core;
 
 /// <summary>
 /// A collection of methods to make dealing with DLCS paths, and path replacements, easier
 /// </summary>
 public static class DlcsPathHelpers
 {
+    private static readonly Regex DoubleSlashRegex = new(@"\/\/+", RegexOptions.Compiled);
+
     /// <summary>
     /// Replace known slugs in DLCS path template.
     /// </summary>
     /// <param name="template">DLCS path template, including slugs to replace</param>
     /// <param name="prefix">Value to replace {prefix} with</param>
+    /// <param name="version">Value to replace {version} with</param>
     /// <param name="customer">Value to replace {customer} with</param>
     /// <param name="space">Value to replace {space} with</param>
     /// <param name="assetPath">Value to replace {assetPath} with</param>
     /// <returns>Template with string replacements made</returns>
     public static string GeneratePathFromTemplate(
-        string template, 
-        string? prefix = null, 
-        string? customer = null, 
+        string template,
+        string? prefix = null,
+        string? version = null,
+        string? customer = null,
         string? space = null,
-        string? assetPath = null) =>
-        template
-            .Replace("{prefix}", prefix ?? string.Empty)
-            .Replace("{customer}", customer ?? string.Empty)
-            .Replace("{space}", space ?? string.Empty)
-            .Replace("{assetPath}", assetPath ?? string.Empty);
+        string? assetPath = null)
+        => DoubleSlashRegex.Replace(
+            template
+                .Replace("{prefix}", prefix ?? string.Empty)
+                .Replace("{version}", version ?? string.Empty)
+                .Replace("{customer}", customer ?? string.Empty)
+                .Replace("{space}", space ?? string.Empty)
+                .Replace("{assetPath}", assetPath ?? string.Empty), "/");
     
     /// <summary>
     /// Replace known slugs in DLCS auth path template.

--- a/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/BaseAssetRequestTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/BaseAssetRequestTests.cs
@@ -26,4 +26,29 @@ public class BaseAssetRequestTests
         assetImageId.Space.Should().Be(4);
         assetImageId.Asset.Should().Be("my-asset");
     }
+
+    [Fact]
+    public void CloneBasicPathElements_CreatesClone()
+    {
+        // Arrange
+        var baseRequest = new BasicPathElements
+        {
+            CustomerPathValue = "1234",
+            Space = 4,
+            AssetPath = "10/10/consideration",
+            VersionPathValue = "v9",
+            RoutePrefix = "iiif-img",
+        };
+        
+        // Act
+        var clone = baseRequest.CloneBasicPathElements();
+        
+        // Assert
+        clone.Should().NotBe(baseRequest);
+        clone.CustomerPathValue.Should().Be(baseRequest.CustomerPathValue);
+        clone.Space.Should().Be(baseRequest.Space);
+        clone.AssetPath.Should().Be(baseRequest.AssetPath);
+        clone.RoutePrefix.Should().Be(baseRequest.RoutePrefix);
+        clone.VersionPathValue.Should().Be(baseRequest.VersionPathValue);
+    }
 }

--- a/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -16,58 +16,6 @@ public class ConfigDrivenAssetPathGeneratorTests
     [Theory]
     [InlineData("123")]
     [InlineData("test-customer")]
-    public void GetPathForRequest_Default(string customerPathValue)
-    {
-        // Arrange
-        var sut = GetSut("default.com");
-        var request = new BaseAssetRequest
-        {
-            Customer = new CustomerPathElement(123, "test-customer"),
-            CustomerPathValue = customerPathValue,
-            Space = 10,
-            AssetPath = "path/to/asset",
-            BasePath = "thumbs/123/10",
-            RoutePrefix = "thumbs"
-        };
-
-        var expected = $"/thumbs/{customerPathValue}/10/path/to/asset";
-        
-        // Act
-        var actual = sut.GetPathForRequest(request);
-        
-        // Assert
-        actual.Should().Be(expected);
-    }
-    
-    [Theory]
-    [InlineData("123")]
-    [InlineData("test-customer")]
-    public void GetPathForRequest_Override(string customerPathValue)
-    {
-        // Arrange
-        var sut = GetSut("test.example.com");
-        var request = new BaseAssetRequest
-        {
-            Customer = new CustomerPathElement(123, "test-customer"),
-            CustomerPathValue = customerPathValue,
-            Space = 10,
-            AssetPath = "path/to/asset",
-            BasePath = "thumbs/123/10",
-            RoutePrefix = "thumbs"
-        };
-
-        var expected = "/thumbs/path/to/asset";
-        
-        // Act
-        var actual = sut.GetPathForRequest(request);
-        
-        // Assert
-        actual.Should().Be(expected);
-    }
-    
-    [Theory]
-    [InlineData("123")]
-    [InlineData("test-customer")]
     public void GetFullPathForRequest_Default(string customerPathValue)
     {
         // Arrange
@@ -112,6 +60,32 @@ public class ConfigDrivenAssetPathGeneratorTests
         
         // Act
         var actual = sut.GetFullPathForRequest(request);
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData("123")]
+    [InlineData("test-customer")]
+    public void GetFullPathForRequest_OverrideAvailable_ButIgnoredIfNativeFormatRequested(string customerPathValue)
+    {
+        // Arrange
+        var sut = GetSut("test.example.com");
+        var request = new BaseAssetRequest
+        {
+            Customer = new CustomerPathElement(123, "test-customer"),
+            CustomerPathValue = customerPathValue,
+            Space = 10,
+            AssetPath = "path/to/asset",
+            BasePath = "thumbs/123/10",
+            RoutePrefix = "thumbs"
+        };
+
+        var expected = $"https://test.example.com/thumbs/{customerPathValue}/10/path/to/asset";
+        
+        // Act
+        var actual = sut.GetFullPathForRequest(request, true);
         
         // Assert
         actual.Should().Be(expected);
@@ -176,6 +150,39 @@ public class ConfigDrivenAssetPathGeneratorTests
                     assetRequest.RoutePrefix, 
                     assetRequest.CustomerPathValue, 
                     "2000", "not-asset"));
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData("123")]
+    [InlineData("test-customer")]
+    public void GetFullPathForRequest_PathGenerator_OverrideAvailable_ButIgnoredIfNativeFormatRequested(string customerPathValue)
+    {
+        // Arrange
+        var sut = GetSut("test.example.com");
+        var request = new BaseAssetRequest
+        {
+            Customer = new CustomerPathElement(123, "test-customer"),
+            CustomerPathValue = customerPathValue,
+            Space = 10,
+            AssetPath = "path/to/asset",
+            BasePath = "thumbs/123/10",
+            RoutePrefix = "thumbs"
+        };
+
+        var expected = $"https://test.example.com/thumbs/{customerPathValue}/2000/not-asset";
+
+        // Act
+        var actual = sut.GetFullPathForRequest(request,
+            (assetRequest, template) =>
+                DlcsPathHelpers.GeneratePathFromTemplate(
+                    template, 
+                    assetRequest.RoutePrefix, 
+                    assetRequest.CustomerPathValue, 
+                    "2000", "not-asset"),
+            true);
         
         // Assert
         actual.Should().Be(expected);

--- a/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -117,7 +117,8 @@ public class ConfigDrivenAssetPathGeneratorTests
                     template, 
                     assetRequest.RoutePrefix, 
                     assetRequest.CustomerPathValue, 
-                    "2000", "not-asset"));
+                    space: "2000",
+                    assetPath: "not-asset"));
         
         // Assert
         actual.Should().Be(expected);
@@ -149,7 +150,8 @@ public class ConfigDrivenAssetPathGeneratorTests
                     template, 
                     assetRequest.RoutePrefix, 
                     assetRequest.CustomerPathValue, 
-                    "2000", "not-asset"));
+                    space: "2000",
+                    assetPath: "not-asset"));
         
         // Assert
         actual.Should().Be(expected);
@@ -181,7 +183,8 @@ public class ConfigDrivenAssetPathGeneratorTests
                     template, 
                     assetRequest.RoutePrefix, 
                     assetRequest.CustomerPathValue, 
-                    "2000", "not-asset"),
+                    space: "2000",
+                    assetPath: "not-asset"),
             true);
         
         // Assert

--- a/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
+++ b/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using DLCS.Web.Response;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
 
 namespace DLCS.Web.Configuration;
 
@@ -75,4 +77,20 @@ public static class ApplicationBuilderX
         services.AddSingleton<IHttpMessageHandlerBuilderFilter, HeaderPropagationMessageHandlerBuilderFilter>();
         return services;
     }
+    
+    /// <summary>
+    /// Parse OverridesAsJson appSetting to strongly typed dictionary
+    /// </summary>
+    public static IServiceCollection HandlePathTemplates(this IServiceCollection services)
+        => services.PostConfigure<PathTemplateOptions>(opts =>
+        {
+            if (!string.IsNullOrEmpty(opts.OverridesAsJson))
+            {
+                var overridesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(opts.OverridesAsJson);
+                foreach (var (key, value) in overridesDict)
+                {
+                    opts.Overrides.Add(key, value);
+                }
+            }
+        });
 }

--- a/src/protagonist/DLCS.Web/Logging/LogHelper.cs
+++ b/src/protagonist/DLCS.Web/Logging/LogHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Serilog.Events;
+
+namespace DLCS.Web.Logging;
+
+public static class LogHelper
+{
+    /// <summary>
+    /// Set log level to Verbose for health-check requests
+    /// </summary>
+    /// <remarks>
+    /// See https://andrewlock.net/using-serilog-aspnetcore-in-asp-net-core-3-excluding-health-check-endpoints-from-serilog-request-logging/#using-a-custom-log-level-for-health-check-endpoint-requests
+    /// </remarks>
+    public static LogEventLevel ExcludeHealthChecks(HttpContext ctx, double _, Exception? ex) 
+        => ex != null
+            ? LogEventLevel.Error 
+            : ctx.Response.StatusCode > 499 
+                ? LogEventLevel.Error 
+                : IsHealthCheckEndpoint(ctx) // Not an error, check if it was a health check
+                    ? LogEventLevel.Verbose // Was a health check, use Verbose
+                    : LogEventLevel.Information;
+    
+    private static bool IsHealthCheckEndpoint(HttpContext ctx)
+    {
+        var endpoint = ctx.GetEndpoint();
+        if (endpoint != null) // same as !(endpoint is null)
+        {
+            return string.Equals(
+                endpoint.DisplayName, 
+                "Health checks",
+                StringComparison.Ordinal);
+        }
+        // No endpoint, so not a health check endpoint
+        return false;
+    }
+}

--- a/src/protagonist/DLCS.Web/Requests/AssetDelivery/BasicPathElements.cs
+++ b/src/protagonist/DLCS.Web/Requests/AssetDelivery/BasicPathElements.cs
@@ -3,6 +3,7 @@
 public class BasicPathElements : IBasicPathElements
 {
     public string RoutePrefix { get; set; }
+    public string? VersionPathValue { get; set; }
     public string CustomerPathValue { get; set; }
     public int Space { get; set; }
     public string AssetPath { get; set; }

--- a/src/protagonist/DLCS.Web/Requests/AssetDelivery/IBasicPathElements.cs
+++ b/src/protagonist/DLCS.Web/Requests/AssetDelivery/IBasicPathElements.cs
@@ -11,6 +11,11 @@ public interface IBasicPathElements
     public string RoutePrefix { get; }
     
     /// <summary>
+    /// Optional version value, e.g. "v2", "v3" 
+    /// </summary>
+    public string? VersionPathValue { get; }
+    
+    /// <summary>
     /// The "customer" value from request (int or string value). 
     /// </summary>
     public string CustomerPathValue { get; }
@@ -27,4 +32,22 @@ public interface IBasicPathElements
     /// file-identifier
     /// </summary>
     public string AssetPath { get; }
+}
+
+public static class BasicPathElementsX
+{
+    /// <summary>
+    /// Get a new <see cref="BasicPathElements"/> object created from current <see cref="IBasicPathElements"/> object
+    /// </summary>
+    /// <param name="elements"><see cref="IBasicPathElements"/> to clone</param>
+    /// <returns>New <see cref="BasicPathElements"/> object</returns>
+    public static BasicPathElements CloneBasicPathElements(this IBasicPathElements elements)
+    => new()
+    {
+        Space = elements.Space,
+        AssetPath = elements.AssetPath,
+        RoutePrefix = elements.RoutePrefix,
+        CustomerPathValue = elements.CustomerPathValue,
+        VersionPathValue = elements.VersionPathValue
+    };
 }

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using DLCS.Core;
 using DLCS.Web.Requests;
 using DLCS.Web.Requests.AssetDelivery;
+using IIIF.Presentation.V3.Content;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -44,11 +45,11 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
     private string GetPathForRequestInternal(IBasicPathElements assetRequest, PathGenerator pathGenerator,
         bool fullRequest, bool useNativeFormat)
     {
-        const string dlcsNativeFormat = "/{prefix}/{customer}/{space}/{assetPath}";
-        
         var request = httpContextAccessor.HttpContext.Request;
         var host = request.Host.Value ?? string.Empty;
-        var template = useNativeFormat ? dlcsNativeFormat : pathTemplateOptions.GetPathTemplateForHost(host);
+        var template = useNativeFormat
+            ? PathTemplateOptions.DefaultPathFormat
+            : pathTemplateOptions.GetPathTemplateForHost(host);
 
         var path = pathGenerator(assetRequest, template);
 
@@ -56,10 +57,11 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
     }
 
     // Default path replacements
-    private string GeneratePathFromTemplate(IBasicPathElements assetRequest, string template) 
+    private string GeneratePathFromTemplate(IBasicPathElements assetRequest, string template)
         => DlcsPathHelpers.GeneratePathFromTemplate(template,
             prefix: assetRequest.RoutePrefix,
             customer: assetRequest.CustomerPathValue,
+            version: assetRequest.VersionPathValue,
             space: assetRequest.Space.ToString(),
             assetPath: assetRequest.AssetPath);
 }

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -2,8 +2,6 @@
 using DLCS.Web.Requests;
 using DLCS.Web.Requests.AssetDelivery;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace DLCS.Web.Response;
@@ -12,7 +10,7 @@ namespace DLCS.Web.Response;
 /// Generate paths related to running Dlcs instance using appSettings config for rules.
 /// </summary>
 /// <remarks>
-/// This class uses <see cref="PathTemplateOptions"/> to determine different URL patterns for different hostnames,
+/// This class uses <see cref="PathOverrides"/> to determine different URL patterns for different hostnames,
 /// this allows e.g. "id" values on manifests to use different URL structures than the default DLCS paths.
 /// e.g. /images/{image}/ rather than default of /iiif-img/{cust}/{space}/{image} 
 /// </remarks>
@@ -21,40 +19,43 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
     private readonly IHttpContextAccessor httpContextAccessor;
     private readonly PathTemplateOptions pathTemplateOptions;
 
-    public ConfigDrivenAssetPathGenerator(IOptions<PathTemplateOptions> pathTemplateOptions,
+    public ConfigDrivenAssetPathGenerator(
+        IOptions<PathTemplateOptions> pathTemplateOptions,
         IHttpContextAccessor httpContextAccessor)
     {
         this.httpContextAccessor = httpContextAccessor;
         this.pathTemplateOptions = pathTemplateOptions.Value;
     }
 
-    public string GetPathForRequest(IBasicPathElements assetRequest)
-        => GetForPath(assetRequest, false);
+    public string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
+        => GetForPath(assetRequest, true, useNativeFormat);
 
-    public string GetFullPathForRequest(IBasicPathElements assetRequest)
-        => GetForPath(assetRequest, true);
+    public string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator,
+        bool useNativeFormat = false)
+        => GetPathForRequestInternal(assetRequest, pathGenerator, true, useNativeFormat);
 
-    public string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator)
-        => GetPathForRequestInternal(assetRequest, pathGenerator, true);
-
-    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest)
+    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat)
         => GetPathForRequestInternal(
             assetRequest, 
             (request, template) => GeneratePathFromTemplate(request, template),
-            fullRequest);
+            fullRequest,
+            useNativeFormat);
     
     private string GetPathForRequestInternal(IBasicPathElements assetRequest, PathGenerator pathGenerator,
-        bool fullRequest)
+        bool fullRequest, bool useNativeFormat)
     {
+        const string dlcsNativeFormat = "/{prefix}/{customer}/{space}/{assetPath}";
+        
         var request = httpContextAccessor.HttpContext.Request;
         var host = request.Host.Value ?? string.Empty;
-        var template = pathTemplateOptions.GetPathTemplateForHost(host);
+        var template = useNativeFormat ? dlcsNativeFormat : pathTemplateOptions.GetPathTemplateForHost(host);
 
         var path = pathGenerator(assetRequest, template);
 
         return fullRequest ? request.GetDisplayUrl(path) : path;
     }
 
+    // Default path replacements
     private string GeneratePathFromTemplate(IBasicPathElements assetRequest, string template) 
         => DlcsPathHelpers.GeneratePathFromTemplate(template,
             prefix: assetRequest.RoutePrefix,
@@ -62,3 +63,4 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
             space: assetRequest.Space.ToString(),
             assetPath: assetRequest.AssetPath);
 }
+

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -10,7 +10,7 @@ namespace DLCS.Web.Response;
 /// Generate paths related to running Dlcs instance using appSettings config for rules.
 /// </summary>
 /// <remarks>
-/// This class uses <see cref="PathOverrides"/> to determine different URL patterns for different hostnames,
+/// This class uses <see cref="PathTemplateOptions"/> to determine different URL patterns for different hostnames,
 /// this allows e.g. "id" values on manifests to use different URL structures than the default DLCS paths.
 /// e.g. /images/{image}/ rather than default of /iiif-img/{cust}/{space}/{image} 
 /// </remarks>

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using DLCS.Core;
 using DLCS.Web.Requests;
 using DLCS.Web.Requests.AssetDelivery;
-using IIIF.Presentation.V3.Content;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -27,6 +26,9 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
         this.httpContextAccessor = httpContextAccessor;
         this.pathTemplateOptions = pathTemplateOptions.Value;
     }
+    
+    public string GetRelativePathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
+        => GetForPath(assetRequest, false, useNativeFormat);
 
     public string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
         => GetForPath(assetRequest, true, useNativeFormat);

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -13,6 +13,15 @@ public delegate string PathGenerator(IBasicPathElements assetRequest, string tem
 public interface IAssetPathGenerator
 {
     /// <summary>
+    /// Generate path for specified <see cref="BaseAssetRequest"/> excluding host.
+    /// Uses default template replacements.
+    /// </summary>
+    /// <param name="assetRequest"></param>
+    /// <param name="useNativeFormat"></param>
+    /// <returns></returns>
+    string GetRelativePathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false);
+    
+    /// <summary>
     /// Generate full path for specified <see cref="IBasicPathElements"/>, including host.
     /// Uses default template replacements.
     /// </summary>
@@ -29,3 +38,16 @@ public interface IAssetPathGenerator
     string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator,
         bool useNativeFormat = false);
 }
+
+// DONE
+// GetFullyQualifiedId - versioned, always standard path, IIIFCanvasFactory.GetFullyQualifiedId ln 246
+// GetFullQualifiedImagePath - not versioned, always standard path, IIIFCanvasFactory.GetFullQualifiedImagePath ln 233
+// GetFullyQualifiedId - versioned, always standard path, GetManifestForAsset.GetFullyQualifiedId ln 124
+
+// NOT DONE
+// GetImageId - versioned, use replacements, GetImageInfoJson.GetImageId ln 161
+// GetFullImagePath - versioned, use replacements. ThumbsMiddleware.GetFullImagePath ln 183
+
+/*
+ * Have I broken Thumbs handling by having 1 generic setting in parameterStore?
+ */

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -3,7 +3,7 @@
 namespace DLCS.Web.Response;
 
 /// <summary>
-/// Delegate that takes AssetRequest and appropriate host and returns path string
+/// Delegate that uses values in <see cref="IBasicPathElements"/> to make replacements in given template
 /// </summary>
 public delegate string PathGenerator(IBasicPathElements assetRequest, string template);
 
@@ -12,22 +12,18 @@ public delegate string PathGenerator(IBasicPathElements assetRequest, string tem
 /// </summary>
 public interface IAssetPathGenerator
 {
-    /// <summary>
-    /// Generate path for specified <see cref="BaseAssetRequest"/> excluding host.
+    /// Generate full path for specified <see cref="IBasicPathElements"/>, including host.
     /// Uses default template replacements.
-    /// </summary>
-    string GetPathForRequest(IBasicPathElements assetRequest);
-
+    /// <param name="assetRequest"><see cref="IBasicPathElements"/></param>
+    /// <param name="useNativeFormat"></param>
+    /// <returns></returns>
+    string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false);
+    
     /// <summary>
-    /// Generate full path for specified <see cref="BaseAssetRequest"/>, including host.
-    /// Uses default template replacements. 
-    /// </summary>
-    string GetFullPathForRequest(IBasicPathElements assetRequest);
-
-    /// <summary>
-    /// Generate full path for specified <see cref="BaseAssetRequest"/>, using provided delegate to generate
+    /// Generate full path for specified <see cref="IBasicPathElements"/>, using provided delegate to generate
     /// path element.
     /// This can be useful for constructing paths that do not use the default path elements.
     /// </summary>
-    string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator);
+    string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator,
+        bool useNativeFormat = false);
 }

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -12,8 +12,10 @@ public delegate string PathGenerator(IBasicPathElements assetRequest, string tem
 /// </summary>
 public interface IAssetPathGenerator
 {
+    /// <summary>
     /// Generate full path for specified <see cref="IBasicPathElements"/>, including host.
     /// Uses default template replacements.
+    /// </summary>
     /// <param name="assetRequest"><see cref="IBasicPathElements"/></param>
     /// <param name="useNativeFormat"></param>
     /// <returns></returns>

--- a/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
@@ -8,9 +8,14 @@ namespace DLCS.Web.Response;
 public class PathTemplateOptions
 {
     /// <summary>
+    /// The default path format for DLCS
+    /// </summary>
+    internal const string DefaultPathFormat = "/{prefix}/{version}/{customer}/{space}/{assetPath}";
+
+    /// <summary>
     /// Default path template if no overrides found.
     /// </summary>
-    public string Default { get; set; } = "/{prefix}/{customer}/{space}/{assetPath}";
+    public string Default { get; set; } = DefaultPathFormat;
 
     /// <summary>
     /// Collection of path template overrides, keyed by hostname.

--- a/src/protagonist/Engine/Startup.cs
+++ b/src/protagonist/Engine/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using DLCS.Core.Caching;
 using DLCS.Web.Configuration;
+using DLCS.Web.Logging;
 using Engine.Infrastructure;
 using Engine.Settings;
 using Serilog;
@@ -43,7 +44,10 @@ public class Startup
         }
 
         app.UseRouting()
-            .UseSerilogRequestLogging()
+            .UseSerilogRequestLogging(opts =>
+            {
+                opts.GetLevel = LogHelper.ExcludeHealthChecks;
+            })
             .UseCors()
             .UseEndpoints(endpoints =>
             {

--- a/src/protagonist/Orchestrator.Tests/Features/Auth/Paths/ConfigDrivenAuthPathGeneratorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Auth/Paths/ConfigDrivenAuthPathGeneratorTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using DLCS.Web.Response;
+using FakeItEasy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Orchestrator.Features.Auth.Paths;
+using Orchestrator.Settings;
+
+namespace Orchestrator.Tests.Features.Auth.Paths;
+
+public class ConfigDrivenAuthPathGeneratorTests
+{
+    [Fact]
+    public void GetAuthPathForRequest_Default()
+    {
+        // Arrange
+        var sut = GetSut("default.com");
+        var expected = "https://default.com/auth/99/test-auth";
+        
+        // Act
+        var actual = sut.GetAuthPathForRequest("99", "test-auth");
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetAuthPathForRequest_Override()
+    {
+        // Arrange
+        var sut = GetSut("test.example.com");
+        var expected = "https://test.example.com/authentication_99/test-auth";
+        
+        // Act
+        var actual = sut.GetAuthPathForRequest("99", "test-auth");
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    private ConfigDrivenAuthPathGenerator GetSut(string host)
+    {
+        var context = new DefaultHttpContext();
+        var request = context.Request;
+        var contextAccessor = A.Fake<IHttpContextAccessor>();
+        A.CallTo(() => contextAccessor.HttpContext).Returns(context);
+        request.Host = new HostString(host);
+        request.Scheme = "https";
+
+        var options = Options.Create(new OrchestratorSettings
+        {
+            Auth = new AuthSettings
+            {
+                AuthPathRules = new PathTemplateOptions
+                {
+                    Default = "/auth/{customer}/{behaviour}",
+                    Overrides = new Dictionary<string, string>
+                    {
+                        ["test.example.com"] = "/authentication_{customer}/{behaviour}"
+                    }
+                }
+            }
+        });
+
+        return new ConfigDrivenAuthPathGenerator(options, contextAccessor);
+    }
+}

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -101,6 +101,31 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Theory]
+    [InlineData("/iiif-img/2/1/image", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/2/1/image/", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image/", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image", "/const_value/v2/2/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image/", "/const_value/v2/2/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image/", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image", "/const_value/v2/display-name/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image/", "/const_value/v2/display-name/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image/", "/const_value/display-name/image/info.json")]
+    public async Task Get_ImageRoot_RedirectsToInfoJson_CustomPathValues(string path, string expected)
+    {
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", "my-proxy.com");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
+        response.Headers.Location.Should().Be(expected);
+    }
+    
+    [Theory]
     [InlineData("/iiif-img/v3/2/1/image", "/iiif-img/2/1/image/info.json")]
     [InlineData("/iiif-img/v3/2/1/image/", "/iiif-img/2/1/image/info.json")]
     [InlineData("/iiif-img/v3/display-name/1/image", "/iiif-img/display-name/1/image/info.json")]

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -160,7 +160,6 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}");
-        var rewrittenPathId = $"{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}/99";
         await dbFixture.DbContext.Images.AddTestAsset(id);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -179,7 +178,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         // Verify correct info.json returned
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["@id"].ToString().Should().Be($"http://my-proxy.com/iiif-img/v2/{rewrittenPathId}");
+        jsonResponse["@id"].ToString().Should()
+            .Be($"http://my-proxy.com/const_value/v2/99/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/image/2/context.json");
 
         // With correct headers/status
@@ -194,7 +194,9 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             await amazonS3.GetObjectAsync(LocalStackFixture.StorageBucketName, $"info/Cantaloupe/v2/{id}/info.json");
         var s3InfoJson = JObject.Parse(s3InfoJsonObject.ResponseStream.GetContentString());
         s3InfoJson["@id"].ToString().Should()
-            .NotBe($"http://my-proxy.com/iiif-img/v2/{rewrittenPathId}", "Stored Id is placeholder only");
+            .NotBe(
+                $"http://my-proxy.com/const_value/v2/99/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}",
+                "Stored Id is placeholder only");
         s3InfoJson["@context"].ToString().Should().Be("http://iiif.io/api/image/2/context.json");
     }
     
@@ -241,7 +243,6 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules)}");
-        var rewrittenPathId = $"{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules)}/99";
         await dbFixture.DbContext.Images.AddTestAsset(id);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -266,7 +267,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         // Verify correct info.json returned
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["@id"].ToString().Should().Be($"http://my-proxy.com/iiif-img/v2/{rewrittenPathId}");
+        jsonResponse["@id"].ToString().Should()
+            .Be($"http://my-proxy.com/const_value/v2/99/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules)}");
         jsonResponse["@context"].ToString().Should().Be("_this_proves_s3_origin_");
 
         // With correct headers/status
@@ -348,7 +350,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["id"].ToString().Should().Be($"http://my-proxy.com/iiif-img/{rewrittenPathId}");
+        jsonResponse["id"].ToString().Should()
+            .Be($"http://my-proxy.com/const_value/99/{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/image/3/context.json");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.CacheControl.Public.Should().BeTrue();
@@ -563,7 +566,6 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}");
-        var rewrittenPathId = $"{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}/99";
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500);
@@ -593,7 +595,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var responseStream = await response.Content.ReadAsStreamAsync();
         var infoJson = responseStream.FromJsonStream<ImageService3>();
 
-        infoJson.Id.Should().Be($"http://my-proxy.com/iiif-img/{rewrittenPathId}");
+        infoJson.Id.Should()
+            .Be($"http://my-proxy.com/const_value/99/{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}");
         infoJson.Service.Single().Id.Should().Be("http://my-proxy.com/auth/test-service");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         response.Headers.CacheControl.Public.Should().BeFalse();

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -354,8 +354,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV3_Correct_ViaConneg_CustomPathRules()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}");
-        var rewrittenPathId = $"{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}/99";
+        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}"); 
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/image/3/context.json\"";
         await dbFixture.DbContext.Images.AddTestAsset(id);
 

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -128,11 +128,10 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     }
         
     [Fact]
-    public async Task Get_ManifestForImage_ReturnsManifest_CustomPathRules()
+    public async Task Get_ManifestForImage_ReturnsManifest_CustomPathRules_Ignored()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest_CustomPathRules)}");
-        var rewrittenPathId = $"{nameof(Get_ManifestForImage_ReturnsManifest_CustomPathRules)}/99";
+        var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest_CustomPathRules_Ignored)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
         await dbFixture.DbContext.SaveChangesAsync();
             
@@ -145,9 +144,9 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
-        jsonResponse["@id"].ToString().Should().Be($"http://my-proxy.com/iiif-manifest/v2/{rewrittenPathId}");
+        jsonResponse["@id"].ToString().Should().Be($"http://my-proxy.com/iiif-manifest/v2/{id}");
         jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
-            .Should().StartWith($"http://my-proxy.com/thumbs/{nameof(Get_ManifestForImage_ReturnsManifest_CustomPathRules)}");
+            .Should().StartWith($"http://my-proxy.com/thumbs/{id}/full");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.CacheControl.Public.Should().BeTrue();

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -19,6 +19,12 @@
       }
     }
   },
+  "PathRules": {
+    "Default": "/{prefix}/{customer}/{space}/{assetPath}",
+    "Overrides": {
+      "my-proxy.com": "/{prefix}/{assetPath}/{customer}"
+    }
+  },
   "ImageServerPathConfig": {
     "IIPImage": {
       "PathTemplate": "/nas/{customer}/{space}/{image-dir}/{image}.jp2"

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -37,7 +37,12 @@
     "FireballRoot": "http://127.0.0.1:5020"
   },
   "Auth": {
-    "AuthServicesUriTemplate": "https://localhost/auth/{customer}/{behaviour}"
+    "AuthPathRules": {
+      "Default": "/auth/{customer}/{behaviour}",
+      "Overrides": {
+        "my-proxy.com": "/auth/{behaviour}"
+      }
+    }
   },
   "S3OriginRegex": "http\\:\\/\\/test\\-dlcs\\-storage\\-origin\\.s3\\.amazonaws\\.com\\/.*",
   "ImageFolderTemplateImageServer": "/nas/{customer}/{space}/{image-dir}/{image}.jp2",

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -20,9 +20,9 @@
     }
   },
   "PathRules": {
-    "Default": "/{prefix}/{customer}/{space}/{assetPath}",
+    "Default": "/{prefix}/{version}/{customer}/{space}/{assetPath}",
     "Overrides": {
-      "my-proxy.com": "/{prefix}/{assetPath}/{customer}"
+      "my-proxy.com": "/const_value/{version}/{customer}/{assetPath}"
     }
   },
   "ImageServerPathConfig": {

--- a/src/protagonist/Orchestrator/Features/Auth/Paths/ConfigDrivenAuthPathGenerator.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/Paths/ConfigDrivenAuthPathGenerator.cs
@@ -1,0 +1,31 @@
+﻿using DLCS.Core;
+using DLCS.Web.Requests;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Orchestrator.Settings;
+
+namespace Orchestrator.Features.Auth.Paths;
+
+public class ConfigDrivenAuthPathGenerator : IAuthPathGenerator
+{
+    private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly OrchestratorSettings orchestratorSettings;
+
+    public ConfigDrivenAuthPathGenerator(
+        IOptions<OrchestratorSettings> orchestratorSettings,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        this.httpContextAccessor = httpContextAccessor;
+        this.orchestratorSettings = orchestratorSettings.Value;
+    }
+    
+    public string GetAuthPathForRequest(string customer, string behaviour)
+    {
+        var request = httpContextAccessor.HttpContext.Request;
+        var host = request.Host.Value ?? string.Empty;
+        var template = orchestratorSettings.Auth.AuthPathRules.GetPathTemplateForHost(host);
+
+        var path = DlcsPathHelpers.GenerateAuthPathFromTemplate(template, customer, behaviour);
+        return request.GetDisplayUrl(path);
+    }
+}

--- a/src/protagonist/Orchestrator/Features/Auth/Paths/IAuthPathGenerator.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/Paths/IAuthPathGenerator.cs
@@ -1,0 +1,9 @@
+﻿namespace Orchestrator.Features.Auth.Paths;
+
+public interface IAuthPathGenerator
+{
+    /// <summary>
+    /// Generate full auth path using specified params for template replacement
+    /// </summary>
+    string GetAuthPathForRequest(string customer, string behaviour);
+}

--- a/src/protagonist/Orchestrator/Features/Images/ImageController.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageController.cs
@@ -2,6 +2,8 @@
 using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Web.IIIF;
+using DLCS.Web.Requests.AssetDelivery;
+using DLCS.Web.Response;
 using IIIF.ImageApi;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -17,6 +19,7 @@ namespace Orchestrator.Features.Images;
 [ApiController]
 public class ImageController : IIIFAssetControllerBase
 {
+    private readonly IAssetPathGenerator assetPathGenerator;
     private const string CanonicalInfoJsonRoute = "info_json_canonical";
     private readonly OrchestratorSettings orchestratorSettings;
 
@@ -24,8 +27,10 @@ public class ImageController : IIIFAssetControllerBase
         IMediator mediator, 
         IOptions<CacheSettings> cacheSettings,
         ILogger<ImageController> logger,
+        IAssetPathGenerator assetPathGenerator,
         IOptions<OrchestratorSettings> orchestratorSettings) : base(mediator, cacheSettings, logger)
     {
+        this.assetPathGenerator = assetPathGenerator;
         this.orchestratorSettings = orchestratorSettings.Value;
     }
 
@@ -35,8 +40,11 @@ public class ImageController : IIIFAssetControllerBase
     /// <returns></returns>
     [Route("{customer}/{space}/{image}", Name = "image_only")]
     [HttpGet]
-    public IActionResult ImageOnly()
-        => RedirectToInfoJson();
+    public IActionResult ImageOnly(
+        [FromRoute] string customer,
+        [FromRoute] int space,
+        [FromRoute] string image)
+        => ImageOnlyVersioned(customer, space, image);
     
     /// <summary>
     /// Index request for image root, redirects to info.json.
@@ -45,23 +53,30 @@ public class ImageController : IIIFAssetControllerBase
     /// <returns></returns>
     [Route("{version:regex(^v2|v3$)}/{customer}/{space}/{image}", Name = "image_only_versioned")]
     [HttpGet]
-    public IActionResult ImageOnlyVersioned()
+    public IActionResult ImageOnlyVersioned(
+        [FromRoute] string customer,
+        [FromRoute] int space,
+        [FromRoute] string image)
     {
         var requestedVersion = Request.GetIIIFImageApiVersionFromRoute();
+        
+        var basicPathElements = new BasicPathElements
+        {
+            RoutePrefix = "iiif-img",
+            Space = space,
+            VersionPathValue = requestedVersion?.ToString().ToLower(),
+            CustomerPathValue = customer,
+            AssetPath = $"{image}/info.json",
+        };
 
         // Requesting image-only for canonical version, redirect to canonical info.json
         if (IsCanonicalRequest(requestedVersion))
         {
-            var routeUrl = Url.RouteUrl(CanonicalInfoJsonRoute, new
-            {
-                customer = Request.RouteValues["customer"],
-                space = Request.RouteValues["space"],
-                image = Request.RouteValues["image"]
-            })!;
-            return this.SeeAlsoResult(routeUrl);
+            basicPathElements.VersionPathValue = null;
         }
-        
-        return RedirectToInfoJson();
+
+        var infoJson = assetPathGenerator.GetRelativePathForRequest(basicPathElements);
+        return this.SeeAlsoResult(infoJson);
     }
 
     /// <summary>
@@ -92,18 +107,25 @@ public class ImageController : IIIFAssetControllerBase
     /// <returns>IIIF info.json for specified manifest.</returns>
     [Route("{version:regex(^v2|v3$)}/{customer}/{space}/{image}/info.json", Name = "info_json_versioned")]
     [HttpGet]
-    public async Task<IActionResult> InfoJsonVersioned([FromQuery] bool noOrchestrate = false,
+    public async Task<IActionResult> InfoJsonVersioned(
+        [FromRoute] string customer,
+        [FromRoute] int space,
+        [FromRoute] string image,
+        [FromQuery] bool noOrchestrate = false,
         CancellationToken cancellationToken = default)
     {
         var requestedVersion = Request.GetIIIFImageApiVersionFromRoute();
         if (IsCanonicalRequest(requestedVersion))
         {
-            return RedirectToRoute(CanonicalInfoJsonRoute, new
+            var basicPathElements = new BasicPathElements
             {
-                customer = Request.RouteValues["customer"],
-                space = Request.RouteValues["space"],
-                image = Request.RouteValues["image"]
-            });
+                RoutePrefix = "iiif-img",
+                Space = space,
+                CustomerPathValue = customer,
+                AssetPath = image,
+            };
+            var canonicalRoute = assetPathGenerator.GetRelativePathForRequest(basicPathElements);
+            return Redirect(canonicalRoute);
         }
 
         if (!requestedVersion.HasValue)

--- a/src/protagonist/Orchestrator/Features/Images/ImageController.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageController.cs
@@ -122,7 +122,7 @@ public class ImageController : IIIFAssetControllerBase
                 RoutePrefix = "iiif-img",
                 Space = space,
                 CustomerPathValue = customer,
-                AssetPath = image,
+                AssetPath = $"{image}/info.json",
             };
             var canonicalRoute = assetPathGenerator.GetRelativePathForRequest(basicPathElements);
             return Redirect(canonicalRoute);

--- a/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core;
 using DLCS.Core.Types;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
@@ -159,19 +158,14 @@ public class GetImageInfoJsonHandler : IRequestHandler<GetImageInfoJson, Descrip
     }
 
     private string GetImageId(GetImageInfoJson request)
-        => assetPathGenerator.GetFullPathForRequest(
-            request.AssetRequest,
-            (assetRequest, template) =>
-            {
-                var baseAssetRequest = assetRequest as BaseAssetRequest;
-                return DlcsPathHelpers.GeneratePathFromTemplate(
-                    template,
-                    baseAssetRequest.VersionedRoutePrefix,
-                    baseAssetRequest.CustomerPathValue,
-                    baseAssetRequest.Space.ToString(),
-                    baseAssetRequest.AssetId);
-            });
-    
+    {
+        var baseRequest = request.AssetRequest.CloneBasicPathElements();
+        
+        // We want the image id only, without "/info.json"
+        baseRequest.AssetPath = request.AssetRequest.AssetId;
+        return assetPathGenerator.GetFullPathForRequest(baseRequest);
+    }
+
     private void SetServiceIdProperties(AssetId assetId, List<IService>? services)
     {
         void SetAuthId(IService service)

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Web.Requests.AssetDelivery;
@@ -10,14 +9,11 @@ using IIIF;
 using IIIF.Presentation;
 using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3.Strings;
-using IIIF.Serialisation;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.Mediatr;
 using Orchestrator.Models;
-using Orchestrator.Settings;
 using IIIF2 = IIIF.Presentation.V2;
 using IIIF3 = IIIF.Presentation.V3;
 using Version = IIIF.Presentation.Version;
@@ -122,17 +118,6 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
     }
 
     private string GetFullyQualifiedId(BaseAssetRequest baseAssetRequest)
-        => assetPathGenerator.GetFullPathForRequest(
-            baseAssetRequest,
-            (assetRequest, template) =>
-            {
-                var request = assetRequest as BaseAssetRequest;
-                return DlcsPathHelpers.GeneratePathFromTemplate(
-                    template,
-                    request.VersionedRoutePrefix,
-                    request.CustomerPathValue,
-                    request.Space.ToString(),
-                    request.AssetId);
-            }, true);
+        => assetPathGenerator.GetFullPathForRequest(baseAssetRequest, true);
 
 }

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -133,6 +133,6 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
                     request.CustomerPathValue,
                     request.Space.ToString(),
                     request.AssetId);
-            });
+            }, true);
 
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -240,7 +240,7 @@ public class IIIFCanvasFactory
             RoutePrefix = isThumb ? orchestratorSettings.Proxy.ThumbsPath : orchestratorSettings.Proxy.ImagePath,
             CustomerPathValue = customerPathElement.Id.ToString(),
         };
-        return assetPathGenerator.GetFullPathForRequest(request);
+        return assetPathGenerator.GetFullPathForRequest(request, true);
     }
 
     private string GetFullyQualifiedId(Asset asset, CustomerPathElement customerPathElement,
@@ -262,7 +262,7 @@ public class IIIFCanvasFactory
             RoutePrefix = $"{routePrefix}{versionPart}",
             CustomerPathValue = customerPathElement.Id.ToString(),
         };
-        return assetPathGenerator.GetFullPathForRequest(imageRequest);
+        return assetPathGenerator.GetFullPathForRequest(imageRequest, true);
     }
 
     private List<IService> GetImageServices(Asset asset, CustomerPathElement customerPathElement)

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -259,7 +259,8 @@ public class IIIFCanvasFactory
         {
             Space = asset.Space,
             AssetPath = asset.Id.Asset,
-            RoutePrefix = $"{routePrefix}{versionPart}",
+            VersionPathValue = versionPart,
+            RoutePrefix = routePrefix,
             CustomerPathValue = customerPathElement.Id.ToString(),
         };
         return assetPathGenerator.GetFullPathForRequest(imageRequest, true);

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Caching;
+using DLCS.Web.Response;
 
 namespace Orchestrator.Settings;
 
@@ -160,9 +161,9 @@ public class AuthSettings
     public bool UseCurrentDomainForCookie { get; set; } = true;
     
     /// <summary>
-    /// URI template for auth services
+    /// URI template configuration for auth paths 
     /// </summary>
-    public string AuthServicesUriTemplate { get; set; }
+    public PathTemplateOptions AuthPathRules { get; set; }
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -89,7 +89,8 @@ public class Startup
             .ConfigureHealthChecks(proxySection, configuration)
             .AddAws(configuration, webHostEnvironment)
             .AddHeaderPropagation()
-            .AddInfoJsonClient();
+            .AddInfoJsonClient()
+            .HandlePathTemplates();
         
         // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
         services.Configure<ForwardedHeadersOptions>(opts =>

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -6,6 +6,7 @@ using DLCS.Repository.Auth;
 using DLCS.Repository.NamedQueries;
 using DLCS.Repository.Strategy.DependencyInjection;
 using DLCS.Web.Configuration;
+using DLCS.Web.Logging;
 using DLCS.Web.Middleware;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
@@ -143,7 +144,10 @@ public class Startup
             .UseForwardedHeaders()
             .UseRouting()
             .UseOptions()
-            .UseSerilogRequestLogging()
+            .UseSerilogRequestLogging(opts =>
+            {
+                opts.GetLevel = LogHelper.ExcludeHealthChecks;
+            })
             .UseCors("CorsPolicy")
             .UseAuthorization()
             .UseEndpoints(endpoints =>

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -56,6 +56,7 @@ public class Startup
             .Configure<ProxySettings>(proxySection)
             .Configure<NamedQueryTemplateSettings>(configuration)
             .Configure<NamedQuerySettings>(configuration.GetSection("NamedQuery"))
+            .Configure<PathTemplateOptions>(configuration.GetSection("PathRules"))
             .Configure<CacheSettings>(cachingSection);
 
         var orchestratorSettings = configuration.Get<OrchestratorSettings>();

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Orchestrator.Features.Auth;
+using Orchestrator.Features.Auth.Paths;
 using Orchestrator.Features.Images;
 using Orchestrator.Features.TimeBased;
 using Orchestrator.Infrastructure;
@@ -71,6 +72,7 @@ public class Startup
             .AddScoped<ISessionAuthService, SessionAuthService>()
             .AddScoped<AuthCookieManager>()
             .AddSingleton<AssetRequestProcessor>()
+            .AddScoped<IAuthPathGenerator, ConfigDrivenAuthPathGenerator>()
             .AddScoped<IAssetAccessValidator, AssetAccessValidator>()
             .AddScoped<IRoleProviderService, HttpAwareRoleProviderService>()
             .AddScoped<IIIFAuthBuilder>()

--- a/src/protagonist/Orchestrator/appSettings-Development-Example.json
+++ b/src/protagonist/Orchestrator/appSettings-Development-Example.json
@@ -52,6 +52,12 @@
       "127.0.0.1"
     ]
   },
+  "PathRules": {
+    "Default": "/{prefix}/{customer}/{space}/{assetPath}",
+    "Overrides": {
+      "my-proxy.com": "/{prefix}/{assetPath}"
+    }
+  },
   "Caching": {
     "TimeToLive": {
       "Memory": {

--- a/src/protagonist/Orchestrator/appsettings.json
+++ b/src/protagonist/Orchestrator/appsettings.json
@@ -23,6 +23,11 @@
       "ApplicationName": "Orchestrator"
     }
   },
+  "Auth": {
+    "AuthPathRules": {
+      "Default": "/auth/{customer}/{behaviour}"
+    }
+  },
   "Proxy": {
     "ThumbsPath": "thumbs",
     "ImagePath": "iiif-img",

--- a/src/protagonist/Orchestrator/readme.md
+++ b/src/protagonist/Orchestrator/readme.md
@@ -113,6 +113,25 @@ To facilitate using proxy servers to receive alternative URLs that are then rewr
 
 As an convenience you can specify "PathRules:OverridesAsJson" appSetting that includes a string-based config. This makes it easier to configure via environment variables etc
 
+#### Auth PathTemplates
+
+There is a similar config block availabe for authentication under the `"Auth"` key.
+
+For auth the path replacements are simpler:
+* `customer` is the customer the auth service is for
+* `behaviour` is the name of the auth service.
+
+```
+"Auth": {
+  "AuthPathRules": {
+    "Default": "/auth/{customer}/{behaviour}",
+    "Overrides": {
+      "exclude-space.com": "/auth/{behaviour}"
+    }
+  }
+},
+```
+
 ### Versioned Requests
 
 `DefaultIIIFImageVersion` and `DefaultIIIFPresentationVersion` specify the default IIIF Image and Presentation API's supported.

--- a/src/protagonist/Orchestrator/readme.md
+++ b/src/protagonist/Orchestrator/readme.md
@@ -87,6 +87,32 @@ E.g., the following shows IIPImage supports v2 only and Cantaloupe supports v2 +
 }
 ```
 
+### PathTemplates
+
+The default path template for requests is `/{prefix}/{customer}/{space}/{assetPath}`, where:
+
+* `prefix` is route path (e.g. `iiif-manifest`, `iiif-av`, `iiif-img`) and includes version.
+* `customer` and `space` are self explanatory
+* `assetPath` is the asset identifier plus any specific elements for the current request - e.g. for image requests it will contain the full IIIF image request.
+
+By default the above format is reflected on info.json and single-item manifests.
+
+To facilitate using proxy servers to receive alternative URLs that are then rewritten to standard DLCS URLs, overrides to the default rules can be specified. These are used when outputting any self-referencing URIs (e.g. info.json `id` element).
+
+> For the below to work the expectation is that the `x-forwarded-host` header is set in the proxy.
+
+```
+"PathRules": {
+  "Default": "/{prefix}/{customer}/{space}/{assetPath}",
+  "Overrides": {
+    "exclude-space.com": "/{prefix}/{customer}/extra/{assetPath}/",
+    "customer-specific.io": "/{prefix}/{assetPath}"
+  }
+}
+```
+
+As an convenience you can specify "PathRules:OverridesAsJson" appSetting that includes a string-based config. This makes it easier to configure via environment variables etc
+
 ### Versioned Requests
 
 `DefaultIIIFImageVersion` and `DefaultIIIFPresentationVersion` specify the default IIIF Image and Presentation API's supported.

--- a/src/protagonist/Thumbs/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Thumbs/Infrastructure/ServiceCollectionX.cs
@@ -67,20 +67,4 @@ public static class ServiceCollectionX
 
         return services;
     }
-
-    /// <summary>
-    /// Parse OverridesAsJson appSetting to strongly typed dictionary
-    /// </summary>
-    public static IServiceCollection HandlePathTemplates(this IServiceCollection services)
-        => services.PostConfigure<PathTemplateOptions>(opts =>
-        {
-            if (!string.IsNullOrEmpty(opts.OverridesAsJson))
-            {
-                var overridesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(opts.OverridesAsJson);
-                foreach (var (key, value) in overridesDict)
-                {
-                    opts.Overrides.Add(key, value);
-                }
-            }
-        });
 }

--- a/src/protagonist/Thumbs/Startup.cs
+++ b/src/protagonist/Thumbs/Startup.cs
@@ -5,6 +5,7 @@ using DLCS.Model.PathElements;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Customers;
+using DLCS.Web.Configuration;
 using DLCS.Web.Logging;
 using DLCS.Web.Middleware;
 using DLCS.Web.Requests.AssetDelivery;

--- a/src/protagonist/Thumbs/Startup.cs
+++ b/src/protagonist/Thumbs/Startup.cs
@@ -5,6 +5,7 @@ using DLCS.Model.PathElements;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Customers;
+using DLCS.Web.Logging;
 using DLCS.Web.Middleware;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
@@ -74,6 +75,10 @@ public class Startup
             app.UseDeveloperExceptionPage();
         }
 
+        app.UseSerilogRequestLogging(opts =>
+        {
+            opts.GetLevel = LogHelper.ExcludeHealthChecks;
+        });
         app.UseRouting();
         // TODO: Consider better caching solutions
         app.UseResponseCaching();

--- a/src/protagonist/Thumbs/ThumbsMiddleware.cs
+++ b/src/protagonist/Thumbs/ThumbsMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
@@ -182,19 +181,17 @@ public class ThumbsMiddleware
 
     private string GetFullImagePath(ImageAssetDeliveryRequest imageAssetDeliveryRequest, Version requestedVersion)
     {
-        var isCanonical = IsCanonical(requestedVersion);
-        return pathGenerator.GetFullPathForRequest(
-            imageAssetDeliveryRequest,
-            (assetRequest, template) =>
-            {
-                var baseAssetRequest = assetRequest as BaseAssetRequest;
-                return DlcsPathHelpers.GeneratePathFromTemplate(
-                    template,
-                    isCanonical ? baseAssetRequest.RoutePrefix : baseAssetRequest.VersionedRoutePrefix,
-                    baseAssetRequest.CustomerPathValue,
-                    baseAssetRequest.Space.ToString(),
-                    baseAssetRequest.AssetId);
-            });
+        var baseRequest = imageAssetDeliveryRequest.CloneBasicPathElements();
+        
+        // We want the image id only, without "/info.json"
+        baseRequest.AssetPath = imageAssetDeliveryRequest.AssetId;
+
+        if (IsCanonical(requestedVersion))
+        {
+            baseRequest.VersionPathValue = null;
+        }
+        
+        return pathGenerator.GetFullPathForRequest(baseRequest);
     }
 
     private bool IsCanonical(Version requestedVersion)


### PR DESCRIPTION
For #331, allows custom paths to be output for specific domains. This logic already existed for setting info.json id value for `thumbs`.

For adding to `orchestrator` I wired up the relevant `PathTemplateOptions` options class, this allows Orchestrator to use `ConfigDrivenAssetPathGenerator` which will consult options for host-specific config.

This is used to set `"id"`/`"@id"` in info.json, this is rewritten after being fetched from S3 so won't be saved/served with incorrect Id.

For IIIF manifests (single-item and NQ) we _don't_ want to alter the format of the id values, the expectation is these skeleton manifests serve as the basis for another system to alter. To handle this use-case I added a `bool useNativeFormat` parameter to the `IAssetPathGenerator` methods - this defaults to `false` but when `true` it will use the nativeFormat - note that this is _not_ the "default" configured value, rather it's a hardcoded path (the default could be something else assuming all requests will be going via a proxy).

Removed `IAssetPathGenerator.GetPathForRequest` method as this was no longer used, it generated a relative rather than absolute path.

The only other value that we rewrite is auth service Ids on info.json. Rather than conflate the different asset + auth path-templates, which adds complexity to the methods used to fetch appropriate template, I opted to add a separate `PathTemplateOptions` to the existing `"Auth"` config key, e.g.

```
"Auth": {
    "AuthPathRules": {
      "Default": "/auth/{customer}/{behaviour}",
      "Overrides": {
        "my-proxy.com": "/auth/{behaviour}"
      }
    }
}
```

This is read and handled by `ConfigDrivenAuthPathGenerator : IAuthPathGenerator`.

> Initially I did conflate the different values to have config like:
>
> ```
> "PathOverrides": {
>    "Image": "/{prefix}/{customer}/{space}/{assetPath}",
>    "Auth": "/auth/{customer}/{behaviour}",
>    "Overrides": {
>      "my-proxy.com": {
>        "Image": "/image/{assetPath}",
>        "Auth": "/auth/{customer}/{behaviour}"
>      }
>    }
>  },
> ```
> but it made consuming quite cumbersome - we may need to revisit later though, if we want DLCS to be able to produce fully-formed manifests