### PR TITLE
Update setup-buildx-action version and pin buildkit version

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -21,7 +21,10 @@ runs:
     - id: checkout
       uses: actions/checkout@v2
     - id: docker-setup-buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
     - id: docker-meta
       uses: docker/metadata-action@v3
       with:


### PR DESCRIPTION
This is an attempt to make the builds more reliable and avoid issue with
"failed to copy: io: read/write on closed pipe"
see: https://github.com/docker/build-push-action/issues/761#issuecomment-1398918693