### PR TITLE
Replace Dotnet.Testcontainers with TestContainers nuget package

### DIFF
--- a/src/protagonist/Portal.Tests/Portal.Tests.csproj
+++ b/src/protagonist/Portal.Tests/Portal.Tests.csproj
@@ -9,7 +9,6 @@
 
     <ItemGroup>
       <PackageReference Include="AngleSharp" Version="0.16.1" />
-      <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
       <PackageReference Include="FluentAssertions" Version="6.6.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/src/protagonist/Test.Helpers/Integration/LocalStackFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/LocalStackFixture.cs
@@ -5,8 +5,8 @@ using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.SQS;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Modules;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace Test.Helpers.Integration;

--- a/src/protagonist/Test.Helpers/Test.Helpers.csproj
+++ b/src/protagonist/Test.Helpers/Test.Helpers.csproj
@@ -7,12 +7,12 @@
     <ItemGroup>
       <PackageReference Include="AWSSDK.S3" Version="3.7.9.34" />
       <PackageReference Include="AWSSDK.SQS" Version="3.7.2.84" />
-      <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
       <PackageReference Include="FakeItEasy" Version="7.3.1" />
       <PackageReference Include="FluentAssertions" Version="6.6.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.5" />
       <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+      <PackageReference Include="Testcontainers" Version="2.3.0" />
       <PackageReference Include="xunit" Version="2.4.1" />
       <PackageReference Include="Yarp.ReverseProxy" Version="1.1.0" />
     </ItemGroup>


### PR DESCRIPTION
Former was deprecated and replaced by latter. Ran into issue detailed https://github.com/testcontainers/testcontainers-dotnet/issues/431 Slight change in when ConnectionString is assigned for postgres container led to change in DlcsDatabaseFixture