### PR TITLE
Better handling of Optimised Origins

### DIFF
--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -45,7 +45,7 @@ services:
       - .env
 
   fireball:
-    image: fractos/fireball:1304a21459c2b6157abc46d3808512b578bd78b5
+    image: ghcr.io/dlcs/fireball:03f76e5893ae95ee22c307e2dadec1ab033cdb79
     ports:
       - "5030:80"
     environment:
@@ -57,15 +57,15 @@ services:
     env_file:
       - .env
 
-  # appetiser:
-  #   image: digirati/appetiser:latest
-  #   ports:
-  #     - "5031:80"
-  #   volumes:
-  #     - $HOME\Docker\scratch:/scratch
-  #     - $HOME\.aws:/root/.aws
-  #   env_file:
-  #     - .env
+  appetiser:
+    image: digirati/appetiser:latest
+    ports:
+      - "5031:80"
+    volumes:
+      - $HOME\Docker\scratch:/scratch
+      - $HOME\.aws:/root/.aws
+    env_file:
+      - .env
 
   thumbs:
     build:

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using API.Features.Image.Validation;
+using DLCS.Model.Policies;
 using FluentValidation.TestHelper;
 using AssetFamily = DLCS.HydraModel.AssetFamily;
 
@@ -162,5 +163,27 @@ public class HydraImageValidatorTests
         result
             .ShouldHaveValidationErrorFor(a => a.MediaType)
             .WithErrorMessage("Timebased assets must have mediaType starting video/ or audio/");
+    }
+    
+    [Theory]
+    [InlineData(AssetFamily.Timebased)]
+    [InlineData(AssetFamily.File)]
+    public void UseOriginalPolicy_NotImage(AssetFamily family)
+    {
+        var model = new DLCS.HydraModel.Image
+            { Family = family, ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId };
+        var result = sut.TestValidate(model);
+        result
+            .ShouldHaveValidationErrorFor(a => a.Family)
+            .WithErrorMessage("ImageOptimisationPolicy 'use-original' only valid for Image family");
+    }
+    
+    [Fact]
+    public void UseOriginalPolicy_Image()
+    {
+        var model = new DLCS.HydraModel.Image
+            { Family = AssetFamily.Image, ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId };
+        var result = sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.Family);
     }
 }

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -17,7 +17,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Family).NotEmpty().WithMessage("Family must be specified");
 
         // ImageOptimisationPolicy dependant validation
-        When(a => ImageOptimisationPolicyX.IsNoOpIdentifier(a.ImageOptimisationPolicy) && a.Family != AssetFamily.File,
+        When(a => KnownImageOptimisationPolicy.IsNoOpIdentifier(a.ImageOptimisationPolicy) && a.Family != AssetFamily.File,
                 () =>
                 {
                     When(a => !MIMEHelper.IsAudio(a.MediaType), () =>
@@ -46,6 +46,12 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
                 RuleFor(a => a.Height).Empty().WithMessage("Should not include height");
                 RuleFor(a => a.Duration).Empty().WithMessage("Should not include duration");
             });
+
+        RuleFor(a => a.Family)
+            .Must(family => family == AssetFamily.Image)
+            .When(a => KnownImageOptimisationPolicy.IsUseOriginalIdentifier(a.ImageOptimisationPolicy))
+            .WithMessage(
+                $"ImageOptimisationPolicy '{KnownImageOptimisationPolicy.UseOriginalId}' only valid for Image family");
 
         // System edited fields
         RuleFor(a => a.Batch).Empty().WithMessage("Should not include batch");

--- a/src/protagonist/DLCS.Model.Tests/Policies/ImageOptimisationPolicyXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Policies/ImageOptimisationPolicyXTests.cs
@@ -32,12 +32,47 @@ public class ImageOptimisationPolicyXTests
     [InlineData(null)]
     public void IsNoOpIdentifier_False(string id)
     {
-        ImageOptimisationPolicyX.IsNoOpIdentifier(id).Should().BeFalse();
+        KnownImageOptimisationPolicy.IsNoOpIdentifier(id).Should().BeFalse();
     }
     
     [Fact]
     public void IsNoOpIdentifier_True()
     {
-        ImageOptimisationPolicyX.IsNoOpIdentifier("none").Should().BeTrue();
+        KnownImageOptimisationPolicy.IsNoOpIdentifier("none").Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("video-max")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void IsUseOriginal_False(string id)
+    {
+        var policy = new ImageOptimisationPolicy { Id = id };
+
+        policy.IsUseOriginal().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsUseOriginal_True()
+    {
+        var policy = new ImageOptimisationPolicy { Id = "use-original" };
+
+        policy.IsUseOriginal().Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("video-max")]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void IsUseOriginalIdentifier_False(string id)
+    {
+        KnownImageOptimisationPolicy.IsUseOriginalIdentifier(id).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsUseOriginalIdentifier_True()
+    {
+        KnownImageOptimisationPolicy.IsUseOriginalIdentifier("use-original").Should().BeTrue();
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -177,7 +177,7 @@ public static class AssetPreparer
         // If we have an existing Asset and we are not allowed nonApiUpdates
         if (existingAsset != null && allowNonApiUpdates == false)
         {
-            bool isNoOpPolicy = ImageOptimisationPolicyX.IsNoOpIdentifier(existingAsset.ImageOptimisationPolicy);
+            bool isNoOpPolicy = KnownImageOptimisationPolicy.IsNoOpIdentifier(existingAsset.ImageOptimisationPolicy);
             
             if (updateAsset.Width.HasValue && updateAsset.Width != 0 && updateAsset.Width != existingAsset.Width)
             {

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -226,13 +226,11 @@ public static class AssetPreparer
             if (updateAsset.ImageOptimisationPolicy != null &&
                 updateAsset.ImageOptimisationPolicy != existingAsset.ImageOptimisationPolicy)
             {
-                // I think it should be editable though, and doing so should trigger a re-ingest.
                 return AssetPreparationResult.Failure("ImageOptimisationPolicy cannot be edited.");
             }
 
             if (updateAsset.ThumbnailPolicy != null && updateAsset.ThumbnailPolicy != existingAsset.ThumbnailPolicy)
             {
-                // And this one DEFINITELY should be editable!
                 return AssetPreparationResult.Failure("ThumbnailPolicy cannot be edited.");
             }
 

--- a/src/protagonist/DLCS.Model/Customers/CustomerOriginStrategy.cs
+++ b/src/protagonist/DLCS.Model/Customers/CustomerOriginStrategy.cs
@@ -39,4 +39,10 @@ public class CustomerOriginStrategy
     /// Signifies that this is fast and stable enough to be treated like DLCS' own storage
     /// </summary>
     public bool Optimised { get; set; }
+    
+    /// <summary>
+    /// Allows control over the order in which CustomerOriginStrategies are checked.
+    /// Lower numbers are checked first, first matching record is chosen. 
+    /// </summary>
+    public int Order { get; set; }
 }

--- a/src/protagonist/DLCS.Model/Customers/CustomerOriginStrategy.cs
+++ b/src/protagonist/DLCS.Model/Customers/CustomerOriginStrategy.cs
@@ -4,13 +4,39 @@ using System.Diagnostics;
 
 namespace DLCS.Model.Customers;
 
+/// <summary>
+/// CustomerOriginStrategy controls how the DLCS fetches images from Origin
+/// </summary>
 [DebuggerDisplay("Cust:{Customer}, {Strategy} - {Regex}")]
-public partial class CustomerOriginStrategy
+public class CustomerOriginStrategy
 {
+    /// <summary>
+    /// Unique identifier, random guid
+    /// </summary>
     public string Id { get; set; }
+    
+    /// <summary>
+    /// Customer Id
+    /// </summary>
     public int Customer { get; set; }
+    
+    /// <summary>
+    /// Regex used against Asset Origin to determine if this is a matching strategy 
+    /// </summary>
     public string Regex { get; set; }
+    
+    /// <summary>
+    /// How the Asset should be fetched from origin 
+    /// </summary>
     public OriginStrategyType Strategy { get; set; }
+    
+    /// <summary>
+    /// Optional credentials used for some <see cref="OriginStrategyType"/>
+    /// </summary>
     public string Credentials { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Signifies that this is fast and stable enough to be treated like DLCS' own storage
+    /// </summary>
     public bool Optimised { get; set; }
 }

--- a/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ImageOptimisationPolicy.cs
@@ -10,8 +10,19 @@ namespace DLCS.Model.Policies;
 [DebuggerDisplay("{Name}")]
 public class ImageOptimisationPolicy
 {
+    /// <summary>
+    /// Unique identifier for policy, e.g. "fast-higher", "video-max" etc
+    /// </summary>
     public string Id { get; set; }
+    
+    /// <summary>
+    /// Friendly name for policy
+    /// </summary>
     public string Name { get; set; }
+    
+    /// <summary>
+    /// A collection of strings, contents are relevant to target technology
+    /// </summary>
     public string[] TechnicalDetails { get; set; }
     
     /// <summary>
@@ -25,10 +36,13 @@ public class ImageOptimisationPolicy
     public bool Global { get; set; }
 }
 
-public static class ImageOptimisationPolicyX
+public static class KnownImageOptimisationPolicy
 {
     // Id of imageOptimisationPolicy for no-op
-    private const string NoneId = "none";
+    public const string NoneId = "none";
+    
+    // Id of imageOptimisationPolicy for use-original. Signifies source image is tile-ready
+    public const string UseOriginalId = "use-original";
 
     /// <summary>
     /// Check if this policy is the special no-op/no-transcode policy
@@ -38,7 +52,15 @@ public static class ImageOptimisationPolicyX
     /// <summary>
     /// Check if specified policy Id is the special no-op/no-transcode policy
     /// </summary>
-    /// <param name="policyId"></param>
-    /// <returns></returns>
     public static bool IsNoOpIdentifier(string? policyId) => policyId == NoneId;
+    
+    /// <summary>
+    /// Check if this policy is the special 'use-original' policy
+    /// </summary>
+    public static bool IsUseOriginal(this ImageOptimisationPolicy policy) => policy.Id == UseOriginalId;
+    
+    /// <summary>
+    /// Check if specified policy Id is the special 'use-original' policy
+    /// </summary>
+    public static bool IsUseOriginalIdentifier(string? policyId) => policyId == UseOriginalId;
 }

--- a/src/protagonist/DLCS.Repository.Tests/Customers/CustomerOriginStrategyRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Customers/CustomerOriginStrategyRepositoryTests.cs
@@ -87,18 +87,23 @@ public class CustomerOriginStrategyRepositoryTests
     public async Task GetCustomerOriginStrategy_ReturnsStrategyForOrigin()
     {
         // Arrange
-        var expected = new CustomerOriginStrategy()
+        var expected = new CustomerOriginStrategy
         {
             Customer = 5, Id = "matching", Regex = "http[s]?://matching.io/(.*)",
-            Strategy = OriginStrategyType.S3Ambient
+            Strategy = OriginStrategyType.S3Ambient, Order = 10
         };
         var originStrategies = new List<CustomerOriginStrategy>
         {
-            expected,
             new()
             {
                 Customer = 5, Id = "not_matching", Regex = "http[s]?://(.*).test.example",
-                Strategy = OriginStrategyType.S3Ambient
+                Strategy = OriginStrategyType.S3Ambient, Order = 5
+            },
+            expected,
+            new()
+            {
+                Customer = 5, Id = "matching_but_lower_priority", Regex = "https://matching.io/(.*)",
+                Strategy = OriginStrategyType.S3Ambient, Order = 15
             }
         };
         await dbContext.CustomerOriginStrategies.AddRangeAsync(originStrategies);

--- a/src/protagonist/DLCS.Repository/Customers/CustomerOriginStrategyBase.cs
+++ b/src/protagonist/DLCS.Repository/Customers/CustomerOriginStrategyBase.cs
@@ -88,6 +88,7 @@ public class CustomerOriginStrategyRepository : ICustomerOriginStrategyRepositor
     private Task<List<CustomerOriginStrategy>> GetCustomerOriginStrategiesFromDb(int customer)
         => dbContext.CustomerOriginStrategies.AsNoTracking()
             .Where(cos => cos.Customer == customer)
+            .OrderBy(cos => cos.Order)
             .ToListAsync();
 
     // NOTE(DG): This CustomerOriginStrategy is for assets uploaded directly via the portal
@@ -97,7 +98,9 @@ public class CustomerOriginStrategyRepository : ICustomerOriginStrategyRepositor
             Customer = customer,
             Id = "_default_portal_",
             Regex = s3OriginRegex,
-            Strategy = OriginStrategyType.S3Ambient
+            Strategy = OriginStrategyType.S3Ambient,
+            Order = 999,
+            Optimised = true,
         };
 
     private static CustomerOriginStrategy? FindMatchingStrategy(

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -609,6 +609,19 @@ public partial class DlcsContext : DbContext
                 .IsRequired()
                 .HasMaxLength(1000);
         });
+
+        modelBuilder.Entity<ImageOptimisationPolicy>().HasData(
+            new ImageOptimisationPolicy
+            {
+                Id = "none", Customer = 1, Global = true, Name = "No optimisation/transcoding",
+                TechnicalDetails = new[] { "no-op" }
+            },
+            new ImageOptimisationPolicy
+            {
+                Id = "use-original", Customer = 1, Global = true, Name = "Use original for image-server",
+                TechnicalDetails = new[] { "use-original" }
+            }
+        );
         
         OnModelCreatingPartial(modelBuilder);
     }

--- a/src/protagonist/DLCS.Repository/Migrations/20230131184757_CustomerOriginStrategy gains Order.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20230131184757_CustomerOriginStrategy gains Order.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20230131184757_CustomerOriginStrategy gains Order")]
+    partial class CustomerOriginStrategygainsOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20230131184757_CustomerOriginStrategy gains Order.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20230131184757_CustomerOriginStrategy gains Order.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class CustomerOriginStrategygainsOrder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Order",
+                table: "CustomerOriginStrategies",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Order",
+                table: "CustomerOriginStrategies");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Migrations/20230315153946_Create use-original policy.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20230315153946_Create use-original policy.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20230315153946_Create use-original policy")]
+    partial class Createuseoriginalpolicy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20230315153946_Create use-original policy.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20230315153946_Create use-original policy.cs
@@ -4,7 +4,7 @@
 
 namespace DLCS.Repository.Migrations
 {
-    public partial class Createnotranscodepolicy : Migration
+    public partial class Createuseoriginalpolicy : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
@@ -13,7 +13,7 @@ namespace DLCS.Repository.Migrations
                 columns: new[] { "Customer", "Id", "Global", "Name", "TechnicalDetails" },
                 values: new object[,]
                 {
-                    { 1, "none", true, "No optimisation/transcoding", "no-op" },
+                    { 1, "use-original", true, "Use original for image-server", "use-original" }
                 });
         }
 
@@ -22,7 +22,7 @@ namespace DLCS.Repository.Migrations
             migrationBuilder.DeleteData(
                 table: "ImageOptimisationPolicies",
                 keyColumns: new[] { "Customer", "Id" },
-                keyValues: new object[] { 1, "none" });
+                keyValues: new object[] { 1, "use-original" });
         }
     }
 }

--- a/src/protagonist/DLCS.Web/Handlers/TimingHandler.cs
+++ b/src/protagonist/DLCS.Web/Handlers/TimingHandler.cs
@@ -22,13 +22,13 @@ public class TimingHandler : DelegatingHandler
         CancellationToken cancellationToken)
     {
         var sw = Stopwatch.StartNew();
-        logger.LogDebug("Calling {Uri}..", request.RequestUri);
+        logger.LogDebug("Calling {HttpMethod} {Uri}..", request.Method, request.RequestUri);
         
         var result = await base.SendAsync(request, cancellationToken);
         
         sw.Stop();
-        logger.LogDebug("Request to {Uri} completed with status {StatusCode} in {Elapsed}ms", request.RequestUri,
-            result.StatusCode, sw.ElapsedMilliseconds);
+        logger.LogDebug("Request to {HttpMethod} {Uri} completed with status {StatusCode} in {Elapsed}ms",
+            request.Method, request.RequestUri, result.StatusCode, sw.ElapsedMilliseconds);
         return result;
     }
 }

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
@@ -194,7 +194,7 @@ public class AppetiserClientTests
         await sut.ProcessImage(context);
 
         // Assert
-        bucketWriter.ShouldHaveKey("1/2/test").WithFilePath("dest/test.jp2");
+        bucketWriter.ShouldHaveKey("1/2/test").WithFilePath("dest/test.jp2").WithContentType("image/jp2");
         context.ImageLocation.S3.Should().Be(expected);
     }
 
@@ -210,14 +210,14 @@ public class AppetiserClientTests
         httpHandler.SetResponse(response);
 
         const string locationOnDisk = "/file/on/disk";
-        var context = GetIngestionContext("/1/2/test", "image/jp2", imageOptimisationPolicy: "use-original");
+        var context = GetIngestionContext("/1/2/test", "image/jpg", imageOptimisationPolicy: "use-original");
         context.AssetFromOrigin.Location = locationOnDisk;
 
         // Act
         await sut.ProcessImage(context);
 
         // Assert
-        bucketWriter.ShouldHaveKey("1/2/test").WithFilePath(locationOnDisk);
+        bucketWriter.ShouldHaveKey("1/2/test").WithFilePath(locationOnDisk).WithContentType("image/jpg");
     }
 
     [Fact]
@@ -309,7 +309,7 @@ public class AppetiserClientTests
     private static IngestionContext GetIngestionContext(string assetId = "/1/2/something",
         string contentType = "image/jpg", string imageOptimisationPolicy = "fast-high", bool optimised = false)
     {
-        var asset = new Asset { Id = AssetId.FromString(assetId), Customer = 1, Space = 2 };
+        var asset = new Asset { Id = AssetId.FromString(assetId), Customer = 1, Space = 2, MediaType = contentType};
         asset
             .WithImageOptimisationPolicy(new ImageOptimisationPolicy
             {

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
@@ -17,7 +17,7 @@ public class ImageProcessorFlagsTests
         var context = new IngestionContext(new Asset());
         
         // Act
-        Action action = () => new AppetiserClient.ImageProcessorFlags(context);
+        Action action = () => new AppetiserClient.ImageProcessorFlags(context, "");
         
         // Asset
         action.Should().Throw<ArgumentNullException>();
@@ -33,12 +33,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(false, false, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
         flags.OriginIsImageServerReady.Should().BeFalse();
         flags.SaveInDlcsStorage.Should().BeTrue();
+        flags.ImageServerFilePath.Should().Be("/path/to/generated.jp2");
     }
 
     [Theory]
@@ -51,12 +52,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(false, true, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
         flags.OriginIsImageServerReady.Should().BeFalse();
         flags.SaveInDlcsStorage.Should().BeTrue();
+        flags.ImageServerFilePath.Should().Be("/path/to/generated.jp2");
     }
 
     [Theory]
@@ -68,12 +70,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(true, false, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeTrue();
         flags.OriginIsImageServerReady.Should().BeTrue();
         flags.SaveInDlcsStorage.Should().BeTrue();
+        flags.ImageServerFilePath.Should().Be("/path/to/original");
     }
     
     [Theory]
@@ -84,12 +87,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(true, false, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
         flags.OriginIsImageServerReady.Should().BeTrue();
         flags.SaveInDlcsStorage.Should().BeTrue();
+        flags.ImageServerFilePath.Should().Be("/path/to/original");
     }
 
     [Theory]
@@ -101,12 +105,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(true, true, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeTrue();
         flags.OriginIsImageServerReady.Should().BeTrue();
         flags.SaveInDlcsStorage.Should().BeFalse();
+        flags.ImageServerFilePath.Should().Be("/path/to/original");
     }
     
     [Theory]
@@ -117,12 +122,13 @@ public class ImageProcessorFlagsTests
         var context = GetContext(true, true, mediaType);
         
         // Act
-        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        var flags = new AppetiserClient.ImageProcessorFlags(context, "/path/to/generated.jp2");
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
         flags.OriginIsImageServerReady.Should().BeTrue();
         flags.SaveInDlcsStorage.Should().BeFalse();
+        flags.ImageServerFilePath.Should().Be("/path/to/original");
     }
     
     private IngestionContext GetContext(bool useOriginal, bool isOptimised, string mediaType = "image/jpeg")
@@ -133,7 +139,8 @@ public class ImageProcessorFlagsTests
 
         var assetFromOrigin = new AssetFromOrigin(asset.Id, 123, "wherever", mediaType)
         {
-            CustomerOriginStrategy = new CustomerOriginStrategy { Optimised = isOptimised }
+            CustomerOriginStrategy = new CustomerOriginStrategy { Optimised = isOptimised },
+            Location = "/path/to/original"
         };
         
         return new IngestionContext(asset).WithAssetFromOrigin(assetFromOrigin);

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
@@ -1,0 +1,141 @@
+﻿using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Customers;
+using DLCS.Model.Policies;
+using Engine.Ingest;
+using Engine.Ingest.Image.Appetiser;
+using Engine.Ingest.Persistence;
+
+namespace Engine.Tests.Ingest.Image.Appetiser;
+
+public class ImageProcessorFlagsTests
+{
+    [Fact]
+    public void Ctor_Throws_IfAssetFromOriginNull()
+    {
+        // Arrange
+        var context = new IngestionContext(new Asset());
+        
+        // Act
+        Action action = () => new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/jp2")]
+    [InlineData("image/jpx")]
+    public void Ctor_DoNotUseOriginal_NotOptimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(false, false, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeFalse();
+        flags.GeneratedToDlcs.Should().BeTrue();
+        flags.OriginToDlcs.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("image/jpeg")]
+    [InlineData("image/jp2")]
+    [InlineData("image/jpx")]
+    public void Ctor_DoNotUseOriginal_Optimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(false, true, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeFalse();
+        flags.GeneratedToDlcs.Should().BeTrue();
+        flags.OriginToDlcs.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("image/jp2")]
+    [InlineData("image/jpx")]
+    public void Ctor_UseOriginalJP2_NotOptimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(true, false, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeTrue();
+        flags.GeneratedToDlcs.Should().BeFalse();
+        flags.OriginToDlcs.Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("image/jpeg")]
+    public void Ctor_UseOriginalNotJP2_NotOptimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(true, false, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeFalse();
+        flags.GeneratedToDlcs.Should().BeFalse();
+        flags.OriginToDlcs.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("image/jp2")]
+    [InlineData("image/jpx")]
+    public void Ctor_UseOriginalJP2_Optimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(true, true, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeTrue();
+        flags.GeneratedToDlcs.Should().BeFalse();
+        flags.OriginToDlcs.Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData("image/jpeg")]
+    public void Ctor_UseOriginalNotJP2_Optimised(string mediaType)
+    {
+        // Arrange
+        var context = GetContext(true, true, mediaType);
+        
+        // Act
+        var flags = new AppetiserClient.ImageProcessorFlags(context);
+        
+        // Asset
+        flags.GenerateDerivativesOnly.Should().BeFalse();
+        flags.GeneratedToDlcs.Should().BeFalse();
+        flags.OriginToDlcs.Should().BeFalse();
+    }
+    
+    private IngestionContext GetContext(bool useOriginal, bool isOptimised, string mediaType = "image/jpeg")
+    {
+        var asset = new Asset(new AssetId(1, 2, "foo"))
+            .WithImageOptimisationPolicy(new ImageOptimisationPolicy
+                { Id = useOriginal ? "use-original" : "fast-higher" });
+
+        var assetFromOrigin = new AssetFromOrigin(asset.Id, 123, "wherever", mediaType)
+        {
+            CustomerOriginStrategy = new CustomerOriginStrategy { Optimised = isOptimised }
+        };
+        
+        return new IngestionContext(asset).WithAssetFromOrigin(assetFromOrigin);
+    }
+}

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/ImageProcessorFlagsTests.cs
@@ -37,8 +37,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
-        flags.GeneratedToDlcs.Should().BeTrue();
-        flags.OriginToDlcs.Should().BeFalse();
+        flags.OriginIsImageServerReady.Should().BeFalse();
+        flags.SaveInDlcsStorage.Should().BeTrue();
     }
 
     [Theory]
@@ -55,8 +55,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
-        flags.GeneratedToDlcs.Should().BeTrue();
-        flags.OriginToDlcs.Should().BeFalse();
+        flags.OriginIsImageServerReady.Should().BeFalse();
+        flags.SaveInDlcsStorage.Should().BeTrue();
     }
 
     [Theory]
@@ -72,8 +72,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeTrue();
-        flags.GeneratedToDlcs.Should().BeFalse();
-        flags.OriginToDlcs.Should().BeTrue();
+        flags.OriginIsImageServerReady.Should().BeTrue();
+        flags.SaveInDlcsStorage.Should().BeTrue();
     }
     
     [Theory]
@@ -88,8 +88,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
-        flags.GeneratedToDlcs.Should().BeFalse();
-        flags.OriginToDlcs.Should().BeTrue();
+        flags.OriginIsImageServerReady.Should().BeTrue();
+        flags.SaveInDlcsStorage.Should().BeTrue();
     }
 
     [Theory]
@@ -105,8 +105,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeTrue();
-        flags.GeneratedToDlcs.Should().BeFalse();
-        flags.OriginToDlcs.Should().BeFalse();
+        flags.OriginIsImageServerReady.Should().BeTrue();
+        flags.SaveInDlcsStorage.Should().BeFalse();
     }
     
     [Theory]
@@ -121,8 +121,8 @@ public class ImageProcessorFlagsTests
         
         // Asset
         flags.GenerateDerivativesOnly.Should().BeFalse();
-        flags.GeneratedToDlcs.Should().BeFalse();
-        flags.OriginToDlcs.Should().BeFalse();
+        flags.OriginIsImageServerReady.Should().BeTrue();
+        flags.SaveInDlcsStorage.Should().BeFalse();
     }
     
     private IngestionContext GetContext(bool useOriginal, bool isOptimised, string mediaType = "image/jpeg")

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -108,7 +108,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         updatedAsset.Height.Should().Be(200);
         updatedAsset.Ingesting.Should().BeFalse();
         updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
-        updatedAsset.MediaType.Should().Be("application/jpeg");
+        updatedAsset.MediaType.Should().Be("application/tiff");
         updatedAsset.Error.Should().BeEmpty();
 
         var location = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);
@@ -157,7 +157,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         updatedAsset.Height.Should().Be(200);
         updatedAsset.Ingesting.Should().BeFalse();
         updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
-        updatedAsset.MediaType.Should().Be("application/jpeg");
+        updatedAsset.MediaType.Should().Be("application/tiff");
         updatedAsset.Error.Should().BeEmpty();
 
         var location = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -17,6 +17,7 @@ using DLCS.Repository.Policies;
 using DLCS.Repository.Processing;
 using DLCS.Repository.Storage;
 using DLCS.Repository.Strategy.DependencyInjection;
+using DLCS.Web.Handlers;
 using Engine.Data;
 using Engine.Ingest;
 using Engine.Ingest.Image;
@@ -97,11 +98,12 @@ public static class ServiceCollectionX
 
         if (engineSettings.ImageIngest != null)
         {
-            services.AddHttpClient<IImageProcessor, AppetiserClient>(client =>
-            {
-                client.BaseAddress = engineSettings.ImageIngest.ImageProcessorUrl;
-                client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
-            });
+            services.AddTransient<TimingHandler>()
+                .AddHttpClient<IImageProcessor, AppetiserClient>(client =>
+                {
+                    client.BaseAddress = engineSettings.ImageIngest.ImageProcessorUrl;
+                    client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
+                }).AddHttpMessageHandler<TimingHandler>();
 
             services.AddHttpClient<OrchestratorClient>(client =>
             {

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -166,7 +166,7 @@ public class AppetiserClient : IImageProcessor
     private async Task ProcessResponse(IngestionContext context, AppetiserResponseModel responseModel, 
         ImageProcessorFlags processorFlags)
     {
-        UpdateImageSize(context.Asset, responseModel);
+        UpdateImageDimensions(context.Asset, responseModel);
 
         var imageLocation = await ProcessOriginImage(context, processorFlags);
 
@@ -177,7 +177,7 @@ public class AppetiserClient : IImageProcessor
         context.WithLocation(imageLocation).WithStorage(imageStorage);
     }
 
-    private static void UpdateImageSize(Asset asset, AppetiserResponseModel responseModel)
+    private static void UpdateImageDimensions(Asset asset, AppetiserResponseModel responseModel)
     {
         asset.Height = responseModel.Height;
         asset.Width = responseModel.Width;

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -206,7 +206,7 @@ public class AppetiserClient : IImageProcessor
         var imageServerFile = processorFlags.ImageServerFilePath;
 
         // Not optimised - upload JP2 to S3 and set ImageLocation to new bucket 
-        var contentType = MIMEHelper.GetContentTypeForExtension(imageServerFile.EverythingAfterLast('.'));
+        var contentType = processorFlags.OriginIsImageServerReady ? context.Asset.MediaType : MIMEHelper.JP2;
         if (!await bucketWriter.WriteFileToBucket(targetStorageLocation, imageServerFile, contentType))
         {
             throw new ApplicationException(

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -53,6 +53,7 @@ public class AppetiserClient : IImageProcessor
         try
         {
             var flags = new ImageProcessorFlags(context);
+            logger.LogDebug("Got flags '{Flags}' for {AssetId}", flags, context.AssetId);
             var responseModel = await CallImageProcessor(context, flags);
             await ProcessResponse(context, responseModel, flags);
             return true;
@@ -275,6 +276,9 @@ public class AppetiserClient : IImageProcessor
         /// Indicates that the Origin file is suitable for use as image-server source
         /// </summary>
         public bool OriginIsImageServerReady { get; }
+
+        public override string ToString() =>
+            $"derivative-only:{GenerateDerivativesOnly},save:{SaveInDlcsStorage},image-server-ready:{OriginIsImageServerReady}";
 
         public ImageProcessorFlags(IngestionContext ingestionContext)
         {

--- a/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestorCompletion.cs
+++ b/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestorCompletion.cs
@@ -33,11 +33,6 @@ public class ImageIngestorCompletion : IImageIngestorCompletion
     /// </summary>
     public async Task<bool> CompleteIngestion(IngestionContext context, bool ingestSuccessful, string? sourceTemplate)
     {
-        if (context.AssetFromOrigin != null && context.AssetFromOrigin.ContentType.HasText())
-        {
-            context.Asset.MediaType = context.AssetFromOrigin.ContentType;
-        }
-        
         var dbUpdateSuccess =
             await assetRepository.UpdateIngestedAsset(context.Asset, context.ImageLocation, context.ImageStorage);
         

--- a/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
+++ b/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
@@ -128,7 +128,7 @@ public class TestBucketWriter : IBucketWriter
         if (forBucket.HasText() && dest.Bucket != forBucket)
             throw new InvalidOperationException("Operation for different bucket");
 
-        Operations[dest.Key] = new BucketObject { Contents = content, Bucket = dest.Bucket };
+        Operations[dest.Key] = new BucketObject { Contents = content, Bucket = dest.Bucket, ContentType = contentType };
         return Task.FromResult(true);
     }
 
@@ -137,7 +137,8 @@ public class TestBucketWriter : IBucketWriter
         if (forBucket.HasText() && dest.Bucket != forBucket)
             throw new InvalidOperationException("Operation for different bucket");
 
-        Operations[dest.Key] = new BucketObject { ContentStream = content, Bucket = dest.Bucket };
+        Operations[dest.Key] = new BucketObject
+            { ContentStream = content, Bucket = dest.Bucket, ContentType = contentType };
         return Task.FromResult(true);
     }
 
@@ -147,7 +148,8 @@ public class TestBucketWriter : IBucketWriter
         if (forBucket.HasText() && dest.Bucket != forBucket)
             throw new InvalidOperationException("Operation for different bucket");
 
-        Operations[dest.Key] = new BucketObject { FilePath = filePath, Bucket = dest.Bucket };
+        Operations[dest.Key] = new BucketObject
+            { FilePath = filePath, Bucket = dest.Bucket, ContentType = contentType };
         return Task.FromResult(true);
     }
 
@@ -181,6 +183,7 @@ public class BucketObject
     public string Bucket { get; set; }
 
     public Stream ContentStream { get; set; }
+    public string ContentType { get; set; }
 
     /// <summary>
     /// Assert object has expected file path.
@@ -202,7 +205,20 @@ public class BucketObject
     {
         if (Contents != contents)
         {
-            throw new AssertionFailedException($"FilePath expected {contents} but was {Contents}");
+            throw new AssertionFailedException($"Contents expected {contents} but was {Contents}");
+        }
+
+        return this;
+    }
+    
+    /// <summary>
+    /// Assert object has expected contents.
+    /// </summary>
+    public BucketObject WithContentType(string contentType)
+    {
+        if (ContentType != contentType)
+        {
+            throw new AssertionFailedException($"ContentType expected {contentType} but was {ContentType}");
         }
 
         return this;


### PR DESCRIPTION
For #64, see [ADR 0005-optimised-origin](https://github.com/dlcs/protagonist/blob/develop/docs/adr/0005-optimised-origin.md) for more info. 

Introduced new `use-original` ImageOptimisationPolicy as per RFC. 

Main manual tests were driven by table in above ADR - validating that ImageLocation + ImageStorage are correct, image is/isn't uploaded to S3 and we can view asset via Orchestrator.

## `AppetiserClient`

Majority of changes are within `AppetiserClient`. To aid processing I added an class `ImageProcessorFlags` that contains various properties to control both what call is made to Appetiser and how the results are handled. These are documented in class but highlighting below for clarity as these are the dials we have for processing an image:

* `OriginIsImageServerReady` - indicates that the Origin file is suitable for use as image-server source. `true` if policy is `use-original`. Used to determine path and mediaType for upload.
* `ImageServerFilePath` - local file-path of file to upload to DLCS storage (_if_ we are saving). Downloaded Origin file if `true`, else appetiser generated JPEG2000.
* `GenerateDerivativesOnly` - if `true` then we only generate thumbnails (so, no JPEG2000). Is only `true` if policy is `use-original` _and_ the media type is "image/jp2" or "image/jpx" - the latter from Deliverator so left in for now.
* `SaveInDlcsStorage` - indicates whether we want to save the Origin or Derivative file. If `false` then nothing is saved in DLCS storage.

## DB/Storage Changes

`ImageStorage` record will always store the size of generated thumbnails but we now only store file size if we save file to DLCS storage.

`ImageLocation` record will always store the S3 location of where the file can be orchestrated, or special-served, from.

Updated `DlcsContext` to use seed data for adding `use-original` policy. Also modelled `none` policy in this manner. Rewrote previous "Create no-transcode policy" migration to use `migrationBuilder.InsertData()` and `migrationBuilder.DeleteData()` rather than `migrationBuilder.Sql()` - this is to avoid hardcoded SQL and ease transitioning to proper cased postgres tables in the future. _This has been tested in dev environment to validate it doesn't break existing migration_.

## Other

Renamed `ImageOptimisationPolicyX` -> `KnownImageOptimisationPolicy` and introduced helper to identify `use-original` policies, similar to no-op policy.

Added a `CustomerOriginStrategy.Order` field to allow control over order of precedence.

Updated `ImageIngestorCompletion` to _not_ overwrite the supplied media-type. Originally if we received a media-type from the Origin it would be used but media-type has more meaning in upcoming tickets so removing now.

Updated docker-image and re-enabled appetiser in local docker-compose.