### PR TITLE
maxUnauthorised change becomes a requiresReingest operation

### DIFF
--- a/src/protagonist/API/Features/Image/ImagesController.cs
+++ b/src/protagonist/API/Features/Image/ImagesController.cs
@@ -178,7 +178,8 @@ public class ImagesController : HydraController
         // any existing assets yet.
         return images.Members.Any(image => 
             image.Origin.HasText() || 
-            image.ImageOptimisationPolicy.HasText()
+            image.ImageOptimisationPolicy.HasText() ||
+            image.MaxUnauthorised.HasValue
             );
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -107,6 +107,14 @@ public static class AssetPreparer
             {
                 requiresReingest = true; // YES, because we've changed the way this image should be processed
             }
+
+            // This is ONLY true if we need engine to set the permissions on S3 for redirects.
+            // It is not true if orchestrator proxies requests for open AV.
+            // See https://github.com/dlcs/protagonist/issues/452
+            if (updateAsset.MaxUnauthorised.HasValue && updateAsset.MaxUnauthorised != existingAsset.MaxUnauthorised)
+            {
+                requiresReingest = true;
+            }
         }
 
         var workingAsset = existingAsset ?? updateAsset;


### PR DESCRIPTION
Adds maxunauthorised as something that will cause an error if changed in a batch patch operation.

This is more likely to catch people out as it's an int, so more likely to arrive in a payload with a default `0` value when the caller didn't intend to set it.
