### PR TITLE
Don't notify engine if no assets in list, AND save batch!

### DIFF
--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -141,10 +141,18 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         }
         else
         {
-            // Raise notifications
-            logger.LogDebug("Batch {BatchId} created - sending engine notifications", batch.Id);
-            await assetNotificationSender.SendIngestAssetsRequest(assetNotificationList, request.IsPriority,
-                cancellationToken);
+            if (assetNotificationList.Count > 0)
+            {
+                // Raise notifications
+                logger.LogDebug("Batch {BatchId} created - sending engine notifications", batch.Id);
+                await assetNotificationSender.SendIngestAssetsRequest(assetNotificationList, request.IsPriority,
+                    cancellationToken);
+            }
+            else
+            {
+                logger.LogDebug("There are no assets to ingest (was this batch all File?)");
+            }
+            await dlcsContext.SaveChangesAsync(cancellationToken);
         }
         
         return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);


### PR DESCRIPTION
```
 assetNotificationSender.SendIngestAssetsRequest(assetNotificationList ... )
```

This assumed assetNotificationList had members, which if they are all File family, it won't.

Also, the batch was never being saved here.