### PR TITLE
Update DlcsPathHelpers regex to handle absolute paths

### DIFF
--- a/src/protagonist/DLCS.Core.Tests/DlcsPathHelpersTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/DlcsPathHelpersTests.cs
@@ -51,4 +51,23 @@ public class DlcsPathHelpersTests
         // Assert
         replaced.Should().Be(expected);
     }
+
+    [Theory]
+    [InlineData("https://dlcs.digirati.io/{prefix}/{version}/{customer}/{space}/path/{assetPath}",
+        "https://dlcs.digirati.io/images/first-space/path/200.jpg")]
+    [InlineData("http://dlcs.digirati.io/{prefix}/{version}/{customer}/{space}/path/{assetPath}",
+        "http://dlcs.digirati.io/images/first-space/path/200.jpg")]
+    [InlineData("http://dlcs.digirati.io//{prefix}/{version}/{customer}/{space}/path/{assetPath}",
+        "http://dlcs.digirati.io/images/first-space/path/200.jpg")]
+    public void GeneratePathFromTemplate_RemovesDoubleSlashes(string template, string expected)
+    {
+        // Act
+        var replaced = DlcsPathHelpers.GeneratePathFromTemplate(template,
+            prefix: "images",
+            space: "first-space",
+            assetPath: "200.jpg");
+
+        // Assert
+        replaced.Should().Be(expected);
+    }
 }

--- a/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
+++ b/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
@@ -7,7 +7,7 @@ namespace DLCS.Core;
 /// </summary>
 public static class DlcsPathHelpers
 {
-    private static readonly Regex DoubleSlashRegex = new(@"\/\/+", RegexOptions.Compiled);
+    private static readonly Regex DoubleSlashRegex = new(@"(?<!http[s]?:)\/\/+", RegexOptions.Compiled);
 
     /// <summary>
     /// Replace known slugs in DLCS path template.


### PR DESCRIPTION
Added negative lookbehind to _not_ replace double slashes after http:// or https://