### PR TITLE
Weco snagging

### DIFF
--- a/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using API.Features.Assets;
@@ -9,6 +10,7 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
+using DLCS.Repository.Entities;
 using LazyCache.Mocks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -48,8 +50,9 @@ public class ApiAssetRepositoryTests
             Options.Create(new CacheSettings()),
             new NullLogger<DapperAssetRepository>()
         );
+        var entityCounterRepo = new EntityCounterRepository(dbContext);
 
-        sut = new ApiAssetRepository(dbContext, dapperAssetRepository);
+        sut = new ApiAssetRepository(dbContext, dapperAssetRepository, entityCounterRepo);
 
         dbFixture.CleanUp();
     }
@@ -76,6 +79,70 @@ public class ApiAssetRepositoryTests
     }
     
     [Fact]
+    public async Task AssetRepository_Saves_New_Asset_IncrementsCounter_CountersDoNotExist()
+    {
+        var assetId = AssetId.FromString($"1010/99/{nameof(AssetRepository_Saves_New_Asset_IncrementsCounter_CountersDoNotExist)}");
+        var newAsset = new Asset(assetId)
+        {
+            Reference1 = "I am new", Origin = "https://example.org/image1.tiff",
+            DeliveryChannel = Array.Empty<string>()
+        };
+    
+        var result = AssetPreparer.PrepareAssetForUpsert(null, newAsset, false, false);
+        result.Success.Should().BeTrue();
+
+        // Act
+        await sut.Save(newAsset, false, CancellationToken.None);
+
+        // Assert
+        var dbAsset = await contextForTests.Images.FindAsync(assetId);
+        dbAsset.Reference1.Should().Be("I am new");
+        dbAsset.Reference2.Should().Be("");
+        dbAsset.MediaType.Should().Be("unknown");
+
+        var customerCounter = await contextForTests.EntityCounters.SingleAsync(ec =>
+            ec.Customer == 0 && ec.Type == "customer-images" && ec.Scope == "1010");
+        customerCounter.Next.Should().Be(1);
+        var spaceCounter = await contextForTests.EntityCounters.SingleAsync(ec =>
+            ec.Customer == 1010 && ec.Type == "space-images" && ec.Scope == "99");
+        spaceCounter.Next.Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task AssetRepository_Saves_New_Asset_IncrementsCounter_CountersExist()
+    {
+        var assetId = AssetId.FromString($"10120/99/{nameof(AssetRepository_Saves_New_Asset_IncrementsCounter_CountersExist)}");
+        var newAsset = new Asset(assetId)
+        {
+            Reference1 = "I am new", Origin = "https://example.org/image1.tiff",
+            DeliveryChannel = Array.Empty<string>()
+        };
+        var customerCounter = await contextForTests.EntityCounters.AddAsync(
+            new EntityCounter { Customer = 0, Scope = "10120", Next = 100, Type = "customer-images" });
+        var spaceCounter = await contextForTests.EntityCounters.AddAsync(
+            new EntityCounter { Customer = 10120, Scope = "99", Next = 10, Type = "space-images" });
+        await contextForTests.SaveChangesAsync();
+    
+        var result = AssetPreparer.PrepareAssetForUpsert(null, newAsset, false, false);
+        result.Success.Should().BeTrue();
+
+        // Act
+        await sut.Save(newAsset, false, CancellationToken.None);
+
+        // Assert
+        var dbAsset = await contextForTests.Images.FindAsync(assetId);
+        dbAsset.Reference1.Should().Be("I am new");
+        dbAsset.Reference2.Should().Be("");
+        dbAsset.MediaType.Should().Be("unknown");
+        
+        await dbContext.Entry(customerCounter.Entity).ReloadAsync();
+        customerCounter.Entity.Next.Should().Be(101);
+        
+        await dbContext.Entry(spaceCounter.Entity).ReloadAsync();
+        spaceCounter.Entity.Next.Should().Be(11);
+    }
+    
+    [Fact]
     public async Task AssetRepository_Saves_New_Asset_UsingResultFromPreparer()
     {
         var assetId = AssetId.FromString($"100/10/{nameof(AssetRepository_Saves_New_Asset_UsingResultFromPreparer)}");
@@ -89,7 +156,7 @@ public class ApiAssetRepositoryTests
 
         await sut.Save(result.UpdatedAsset!, false, CancellationToken.None);
 
-        var dbAsset = await dbContext.Images.FindAsync(assetId);
+        var dbAsset = await contextForTests.Images.FindAsync(assetId);
         dbAsset.Reference1.Should().Be("I am new");
         dbAsset.Reference2.Should().Be("");
         dbAsset.MediaType.Should().Be("unknown");
@@ -125,6 +192,47 @@ public class ApiAssetRepositoryTests
         dbAsset.Entity.Reference2.Should().Be("I am original 2");
     }
     
+    [Fact]
+    public async Task AssetRepository_Saves_Existing_Asset_DoesNotIncrementCounters()
+    {
+        // Arrange
+        var assetId = AssetId.FromString($"1100/10/{nameof(AssetRepository_Saves_Existing_Asset)}");
+        var dbAsset =
+            await contextForTests.Images.AddTestAsset(assetId, ref1: "I am original 1",
+                ref2: "I am original 2");
+        var customerCounter = await contextForTests.EntityCounters.AddAsync(
+            new EntityCounter { Customer = 0, Scope = "1100", Next = 100, Type = "customer-images" });
+        var spaceCounter = await contextForTests.EntityCounters.AddAsync(
+            new EntityCounter { Customer = 1100, Scope = "10", Next = 10, Type = "space-images" });
+        await contextForTests.SaveChangesAsync();
+        await contextForTests.SaveChangesAsync();
+
+        var existingAsset = await dbContext.Images.FirstAsync(a => a.Id == assetId);
+        var patch = new Asset
+        {
+            Id = assetId,
+            Reference1 = "I am changed",
+            Customer = 99,
+            Space = 1
+        };
+        
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, patch, false, false);
+        result.Success.Should().BeTrue();
+    
+        // Act
+        await sut.Save(existingAsset, true, CancellationToken.None);
+
+        await contextForTests.Entry(dbAsset.Entity).ReloadAsync();
+        dbAsset.Entity.Reference1.Should().Be("I am changed");
+        dbAsset.Entity.Reference2.Should().Be("I am original 2");
+        
+        await dbContext.Entry(customerCounter.Entity).ReloadAsync();
+        customerCounter.Entity.Next.Should().Be(100);
+        
+        await dbContext.Entry(spaceCounter.Entity).ReloadAsync();
+        spaceCounter.Entity.Next.Should().Be(10);
+    }
+
     [Fact]
     public async Task AssetRepository_Saves_Existing_Asset_UsingResultFromPreparer()
     {

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -15,6 +15,7 @@ using DLCS.Core.Types;
 using DLCS.HydraModel;
 using DLCS.Model.Messaging;
 using DLCS.Repository;
+using DLCS.Repository.Entities;
 using DLCS.Repository.Messaging;
 using FakeItEasy;
 using Hydra.Collections;
@@ -728,10 +729,10 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var customerStorage = await dbContext.CustomerStorages.AddTestCustomerStorage(space: 0, numberOfImages: 200,
             sizeOfStored: 2000L, sizeOfThumbs: 2000L);
         var customerImagesCounter = await dbContext.EntityCounters.SingleAsync(ec =>
-            ec.Customer == 0 && ec.Scope == "99" && ec.Type == "customer-images");
+            ec.Customer == 0 && ec.Scope == "99" && ec.Type == KnownEntityCounters.CustomerImages);
         var currentCustomerImageCount = customerImagesCounter.Next;
         var spaceImagesCounter = await dbContext.EntityCounters.SingleAsync(ec =>
-            ec.Customer == 99 && ec.Scope == "1" && ec.Type == "space-images");
+            ec.Customer == 99 && ec.Scope == "1" && ec.Type == KnownEntityCounters.SpaceImages);
         var currentSpaceImagesCounter = spaceImagesCounter.Next;
         await dbContext.SaveChangesAsync();
         
@@ -763,12 +764,12 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // EntityCounter for customer images reduced
         var dbCustomerCounter = await dbContext.EntityCounters.SingleAsync(ec =>
-            ec.Customer == 0 && ec.Scope == "99" && ec.Type == "customer-images");
+            ec.Customer == 0 && ec.Scope == "99" && ec.Type == KnownEntityCounters.CustomerImages);
         dbCustomerCounter.Next.Should().Be(currentCustomerImageCount - 1);
         
         // EntityCounter for space images reduced
         var dbSpaceCounter = await dbContext.EntityCounters.SingleAsync(ec =>
-            ec.Customer == 99 && ec.Scope == "1" && ec.Type == "space-images");
+            ec.Customer == 99 && ec.Scope == "1" && ec.Type == KnownEntityCounters.SpaceImages);
         dbSpaceCounter.Next.Should().Be(currentSpaceImagesCounter - 1);
         
         // TODO - test for notification raised once implemented

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -8,14 +8,12 @@ using API.Tests.Integration.Infrastructure;
 using DLCS.HydraModel;
 using DLCS.Repository;
 using DLCS.Repository.Entities;
-using FluentAssertions;
 using Hydra;
 using Hydra.Collections;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
-using Xunit;
 
 namespace API.Tests.Integration;
 

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -7,6 +7,7 @@ using API.Client;
 using API.Tests.Integration.Infrastructure;
 using DLCS.HydraModel;
 using DLCS.Repository;
+using DLCS.Repository.Entities;
 using FluentAssertions;
 using Hydra;
 using Hydra.Collections;
@@ -96,7 +97,6 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         }
     }
 
-
     [Fact]
     public async Task Create_Space_Updates_EntityCounters()
     {
@@ -134,7 +134,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         currentCounter.Next.Should().Be(next + 1);
         var spaceImageCounter = await dbContext.EntityCounters.SingleOrDefaultAsync(
             ec => 
-                ec.Type == "space-images" && 
+                ec.Type == KnownEntityCounters.SpaceImages && 
                 ec.Customer == customerId.Value && 
                 ec.Scope == next.ToString());
         spaceImageCounter.Should().NotBeNull();

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -23,7 +23,6 @@
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-      <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.15.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -34,8 +34,8 @@ public static class AssetConverter
         
         var image = new Image(urlRoots.BaseUrl, dbAsset.Customer, dbAsset.Space, modelId)
         {
-            InfoJson = $"{urlRoots.ResourceRoot}iiif-img/{dbAsset.Id}",
-            ThumbnailInfoJson = $"{urlRoots.ResourceRoot}thumbs/{dbAsset.Id}",
+            InfoJson = $"{urlRoots.ResourceRoot}iiif-img/{dbAsset.Id}/info.json",
+            ThumbnailInfoJson = $"{urlRoots.ResourceRoot}thumbs/{dbAsset.Id}/info.json",
             Created = dbAsset.Created,
             Origin = dbAsset.Origin,
             InitialOrigin = dbAsset.InitialOrigin,

--- a/src/protagonist/API/Features/Application/Requests/SetupApplication.cs
+++ b/src/protagonist/API/Features/Application/Requests/SetupApplication.cs
@@ -2,6 +2,7 @@
 using API.Features.Customer.Requests;
 using DLCS.Model;
 using DLCS.Repository;
+using DLCS.Repository.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -51,7 +52,7 @@ public class SetupApplicationHandler : IRequestHandler<SetupApplication, CreateA
         await dbContext.Customers.AddAsync(adminCustomer, cancellationToken);
         var updateCount = await dbContext.SaveChangesAsync(cancellationToken);
 
-        await entityCounterRepository.Create(adminCustomer.Id, "space", adminCustomer.Id.ToString());
+        await entityCounterRepository.Create(adminCustomer.Id, KnownEntityCounters.CustomerSpaces, adminCustomer.Id.ToString());
 
         return updateCount == 1
             ? CreateApiKeyResult.Success(apiKey, apiSecret)

--- a/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
+++ b/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
@@ -1,9 +1,9 @@
 using DLCS.Core;
-using DLCS.Core.Guard;
 using DLCS.Core.Types;
 using DLCS.Model;
 using DLCS.Model.Assets;
 using DLCS.Repository;
+using DLCS.Repository.Assets;
 using DLCS.Repository.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -81,8 +81,11 @@ public class ApiAssetRepository : IApiAssetRepository
 
         await dlcsContext.SaveChangesAsync(cancellationToken);
 
-        // Reload the asset from GetAsset to refresh cache
-        var refreshedAsset = await GetAsset(asset.Id, true);
-        return refreshedAsset.ThrowIfNull(nameof(refreshedAsset))!;
+        if (assetRepository is AssetRepositoryCachingBase cachingBase)
+        {
+            cachingBase.FlushCache(asset.Id);
+        }
+
+        return asset;
     }
 }

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -3,6 +3,7 @@ using DLCS.Model;
 using DLCS.Model.Auth;
 using DLCS.Model.Processing;
 using DLCS.Repository;
+using DLCS.Repository.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -67,7 +68,7 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
         result.Customer = await CreateCustomer(request, cancellationToken, newModelId);
 
         // create an entity counter for space IDs [CreateCustomerSpaceEntityCounterBehaviour]
-        await entityCounterRepository.Create(result.Customer.Id, "space", result.Customer.Id.ToString());
+        await entityCounterRepository.Create(result.Customer.Id, KnownEntityCounters.CustomerSpaces, result.Customer.Id.ToString());
 
         // Create a clickthrough auth service [CreateClickthroughAuthServiceBehaviour]
         var clickThrough = authServicesRepository.CreateAuthService(
@@ -157,7 +158,7 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
         DLCS.Model.Customers.Customer existingCustomerWithId;
         do
         {
-            var next = await entityCounterRepository.GetNext(0, "customer", "0");
+            var next = await entityCounterRepository.GetNext(0, KnownEntityCounters.Customers, "0");
             newModelId = Convert.ToInt32(next);
             existingCustomerWithId = await dbContext.Customers.SingleOrDefaultAsync(c => c.Id == newModelId);
         } while (existingCustomerWithId != null);

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -75,10 +75,11 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
 
         bool updateFailed = false;
         var failureMessage = string.Empty;
-        var batch = await batchRepository.CreateBatch(request.CustomerId, request.Assets, cancellationToken);
-        
+
         await using var transaction = 
             await dlcsContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
+        
+        var batch = await batchRepository.CreateBatch(request.CustomerId, request.Assets, cancellationToken);
 
         var assetNotificationList = new List<Asset>(request.Assets.Count);
         try
@@ -107,14 +108,16 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
                 }
                 else
                 {
+                    logger.LogDebug(
+                        "Asset {AssetId} of Batch {BatchId} does not require engine notification. Marking as complete",
+                        asset.Id, batch.Id);
                     batch.Completed += 1;
                 }
             }
-
+            
             if (batch.Completed > 0)
             {
-                dlcsContext.Batches.Attach(batch);
-                dlcsContext.Entry(batch).State = EntityState.Modified;
+                await dlcsContext.SaveChangesAsync(cancellationToken);
             }
 
             if (!updateFailed)
@@ -131,11 +134,13 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
 
         if (updateFailed)
         {
-            await transaction.RollbackAsync(cancellationToken);
-            
-            dlcsContext.Batches.Remove(batch);
-            await dlcsContext.SaveChangesAsync(cancellationToken);
-            
+            // If the token is already cancelled don't use it - we want these to succeed regardless. Will be rolled
+            // back when disposed
+            if (!cancellationToken.IsCancellationRequested)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+            }
+
             return ModifyEntityResult<Batch>.Failure(failureMessage, WriteResult.Error);
         }
         else

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscodeOutput.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscodeOutput.cs
@@ -13,6 +13,8 @@ public class TranscodeOutput
     /// Status of output (Progressing|Complete|Warning|Error)
     /// </summary>
     public string Status { get; set; }
+    
+    public string StatusDetail { get; set; }
     public long Duration { get; set; }
     public long? DurationMillis { get; set; }
     public int Width { get; set; }

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -118,9 +118,6 @@ public static class AssetPreparer
                 requiresReingest = true; // YES, because we've changed the way this image should be processed
             }
 
-            // This is ONLY true if we need engine to set the permissions on S3 for redirects.
-            // It is not true if orchestrator proxies requests for open AV.
-            // See https://github.com/dlcs/protagonist/issues/452
             if (updateAsset.MaxUnauthorised.HasValue && updateAsset.MaxUnauthorised != existingAsset.MaxUnauthorised)
             {
                 requiresReingest = true;

--- a/src/protagonist/DLCS.Model/Assets/IThumbRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IThumbRepository.cs
@@ -10,4 +10,9 @@ public interface IThumbRepository
     /// Get a list of all open thumbnails for specified image.
     /// </summary>
     Task<List<int[]>?> GetOpenSizes(AssetId assetId);
+    
+    /// <summary>
+    /// Get a list of all available thumbnails for specified image, regardless of whether open or auth
+    /// </summary>
+    Task<List<int[]>?> GetAllSizes(AssetId assetId);
 }

--- a/src/protagonist/DLCS.Model/IEntityCounterRepository.cs
+++ b/src/protagonist/DLCS.Model/IEntityCounterRepository.cs
@@ -8,14 +8,23 @@ namespace DLCS.Model;
 /// <remarks>This is identical to IEntityCounterStore in Deliverator</remarks>
 public interface IEntityCounterRepository
 {
+    /// <summary>
+    /// Create a new EntityCounter record with specified value.
+    /// </summary>
     Task Create(int customer, string entityType, string scope, long initialValue = 1);
-    Task<bool> Exists(int customer, string entityType, string scope);
-    Task<long> Get(int customer, string entityType, string scope, long initialValue = 1);
+    
+    /// <summary>
+    /// Increment stored EntityCounter, and return 'next' value (stored/new value + 1)
+    /// </summary>
     Task<long> GetNext(int customer, string entityType, string scope, long initialValue = 1);
-    Task Reset(int customer, string entityType, string scope);
-    Task Set(int customer, string entityType, string scope, long value);
-    Task Remove(int customer, string entityType, string scope);
-
-    Task<long> Increment(int customer, string entityType, string scope, long initialValue = 1);
+    
+    /// <summary>
+    /// Increment stored EntityCounter, and return new value
+    /// </summary>
+    Task<long> Increment(int customer, string entityType, string scope, long initialValue = 0);
+    
+    /// <summary>
+    /// Decrement stored EntityCounter, and return new value
+    /// </summary>
     Task<long> Decrement(int customer, string entityType, string scope, long initialValue = 1);
 }

--- a/src/protagonist/DLCS.Model/IEntityCounterRepository.cs
+++ b/src/protagonist/DLCS.Model/IEntityCounterRepository.cs
@@ -3,8 +3,9 @@ using System.Threading.Tasks;
 namespace DLCS.Model;
 
 /// <summary>
-/// This is identical to IEntityCounterStore in Deliverator
+/// Repo for interacting with EntityCounters
 /// </summary>
+/// <remarks>This is identical to IEntityCounterStore in Deliverator</remarks>
 public interface IEntityCounterRepository
 {
     Task Create(int customer, string entityType, string scope, long initialValue = 1);

--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbRepositoryTests.cs
@@ -1,0 +1,164 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using DLCS.AWS.S3;
+using DLCS.AWS.S3.Models;
+using DLCS.Core.Types;
+using DLCS.Repository.Assets;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Test.Helpers;
+
+namespace DLCS.Repository.Tests.Assets;
+
+public class ThumbRepositoryTests
+{
+    private readonly IBucketReader bucketReader;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly ThumbRepository sut;
+    private readonly ObjectInBucket objectInBucket;
+    private const string Open = @"{""o"": [[683,1024],[267,400],[133,200],[67,100]],""a"": []}";
+    private const string Auth = @"{""o"": [],""a"": [[683,1024],[267,400],[133,200],[67,100]]}";
+    
+    // Note - this is unachievable but confirms ordering
+    private const string Mixed = @"{""o"": [[683,1024],[67,100]],""a"": [[267,400],[133,200]]}";
+
+    public ThumbRepositoryTests()
+    {
+        bucketReader = A.Fake<IBucketReader>();
+        storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
+        sut = new ThumbRepository(bucketReader, storageKeyGenerator, new NullLogger<ThumbRepository>());
+
+        objectInBucket = new ObjectInBucket("bucket", "key");
+        A.CallTo(() => storageKeyGenerator.GetThumbsSizesJsonLocation(A<AssetId>._))
+            .Returns(objectInBucket);
+    }
+
+    [Fact]
+    public async Task GetOpenSizes_Null_IfNoSizesJsonFound()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, null, null));
+        
+        // Act
+        var result = await sut.GetOpenSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task GetOpenSizes_ReturnsOpenSizes()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Open.ToMemoryStream(), null));
+        var expected = new List<int[]>
+        {
+            new[] { 683, 1024 }, new[] { 267, 400 }, new[] { 133, 200 }, new[] { 67, 100 }
+        };
+        
+        // Act
+        var result = await sut.GetOpenSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetOpenSizes_ReturnsOpenSizes_IfMixed()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Mixed.ToMemoryStream(), null));
+        var expected = new List<int[]> { new[] { 683, 1024 }, new[] { 67, 100 } };
+        
+        // Act
+        var result = await sut.GetOpenSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetOpenSizes_ReturnsEmpty_IfNoOpen()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Auth.ToMemoryStream(), null));
+        
+        // Act
+        var result = await sut.GetOpenSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task GetAllSizes_Null_IfNoSizesJsonFound()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, null, null));
+        
+        // Act
+        var result = await sut.GetAllSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task GetAllSizes_ReturnsAllSizes_AllOpen()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Open.ToMemoryStream(), null));
+        var expected = new List<int[]>
+        {
+            new[] { 683, 1024 }, new[] { 267, 400 }, new[] { 133, 200 }, new[] { 67, 100 }
+        };
+        
+        // Act
+        var result = await sut.GetAllSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetAllSizes_ReturnsAllSizesOrdered_Mixed()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Mixed.ToMemoryStream(), null));
+        var expected = new List<int[]>
+        {
+            new[] { 683, 1024 }, new[] { 267, 400 }, new[] { 133, 200 }, new[] { 67, 100 }
+        };
+        
+        // Act
+        var result = await sut.GetAllSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetAllSizes_ReturnsAllSizesOrdered_AllAuth()
+    {
+        // Arrange
+        A.CallTo(() => bucketReader.GetObjectFromBucket(objectInBucket, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(objectInBucket, Auth.ToMemoryStream(), null));
+        var expected = new List<int[]>
+        {
+            new[] { 683, 1024 }, new[] { 267, 400 }, new[] { 133, 200 }, new[] { 67, 100 }
+        };
+        
+        // Act
+        var result = await sut.GetAllSizes(new AssetId(1, 10, "foo"));
+        
+        // Assert
+        result.Should().BeEquivalentTo(expected);
+    }
+}

--- a/src/protagonist/DLCS.Repository.Tests/Entities/EntityCounterRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Entities/EntityCounterRepositoryTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Linq;
+using DLCS.Repository.Entities;
+using Test.Helpers.Integration;
+
+namespace DLCS.Repository.Tests.Entities;
+
+[Trait("Category", "Database")]
+[Collection(DatabaseCollection.CollectionName)]
+public class EntityCounterRepositoryTests
+{
+    private readonly DlcsContext dbContext;
+    
+    private readonly EntityCounterRepository sut;
+    public EntityCounterRepositoryTests(DlcsDatabaseFixture dbFixture)
+    {
+        dbContext = dbFixture.DbContext;
+
+        sut = new EntityCounterRepository(dbContext);
+        
+        dbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task Create_AddsEntityCounter()
+    {
+        // Arrange
+        const string scope = nameof(Create_AddsEntityCounter);
+        var expected = new EntityCounter
+        {
+            Customer = 1, Next = 1, Scope = scope, Type = $"{scope}_type"
+        };
+        
+        // Act
+        await sut.Create(1, $"{scope}_type", scope);
+        
+        // Assert
+        var saved = dbContext.EntityCounters.Single(ec => ec.Scope == scope);
+        saved.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task Create_Throws_IfRecordAlreadyExists_SameTypeScopeCustomer()
+    {
+        // NOTE - this tests behaviour rather than the behaviour being correct
+        
+        // Arrange
+        const string scope = nameof(Create_Throws_IfRecordAlreadyExists_SameTypeScopeCustomer);
+        dbContext.EntityCounters.Add(new EntityCounter
+        {
+            Customer = 1, Next = 9999, Scope = scope, Type = $"{scope}_type"
+        });
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        Func<Task> action = () => sut.Create(1, $"{scope}_type", scope);
+        
+        // Assert
+        await action.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Increment_UpdatesExistingRecord_AndReturnsNextValue()
+    {
+        // Arrange
+        const string scope = nameof(Increment_UpdatesExistingRecord_AndReturnsNextValue);
+        dbContext.EntityCounters.Add(new EntityCounter
+        {
+            Customer = 1, Next = 10, Scope = scope, Type = $"{scope}_type"
+        });
+        await dbContext.SaveChangesAsync();
+        
+        // Act
+        var next = await sut.Increment(1, $"{scope}_type", scope);
+        
+        // Assert
+        next.Should().Be(11, "returns incremented 'next'");
+        
+        var dbCounter = dbContext.EntityCounters.Single(ec => ec.Scope == scope);
+        dbCounter.Next.Should().Be(11, "increments DB 'next'");
+    }
+    
+    [Fact]
+    public async Task Increment_CreatesRecord_AndReturnsNextValue()
+    {
+        // Arrange
+        const string scope = nameof(Increment_CreatesRecord_AndReturnsNextValue);
+
+        // Act
+        var next = await sut.Increment(1, $"{scope}_type", scope);
+        
+        // Assert
+        next.Should().Be(1);
+        
+        var dbCounter = dbContext.EntityCounters.Single(ec => ec.Scope == scope);
+        dbCounter.Next.Should().Be(1);
+    }
+    
+    [Fact]
+    public async Task Decrement_UpdatesExistingRecord_AndReturnsNextValue()
+    {
+        // Arrange
+        const string scope = nameof(Decrement_UpdatesExistingRecord_AndReturnsNextValue);
+        dbContext.EntityCounters.Add(new EntityCounter
+        {
+            Customer = 1, Next = 10, Scope = scope, Type = $"{scope}_type"
+        });
+        await dbContext.SaveChangesAsync();
+        
+        // Act
+        var next = await sut.Decrement(1, $"{scope}_type", scope);
+        
+        // Assert
+        next.Should().Be(9, "returns decremented 'next'");
+        
+        var dbCounter = dbContext.EntityCounters.Single(ec => ec.Scope == scope);
+        dbCounter.Next.Should().Be(9, "decremented DB 'next'");
+    }
+    
+    [Fact]
+    public async Task Decrement_CreatesRecord_AndReturnsNextValue()
+    {
+        // Arrange
+        const string scope = nameof(Decrement_CreatesRecord_AndReturnsNextValue);
+
+        // Act
+        var next = await sut.Decrement(1, $"{scope}_type", scope);
+        
+        // Assert
+        next.Should().Be(0);
+        
+        var dbCounter = dbContext.EntityCounters.Single(ec => ec.Scope == scope);
+        dbCounter.Next.Should().Be(0);
+    }
+}

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -91,7 +91,7 @@ public class AssetRepository : AssetRepositoryCachingBase
             bool notFound = true;
             foreach (var entry in dbEx.Entries)
             {
-                var databaseValues = entry.GetDatabaseValues();
+                var databaseValues = await entry.GetDatabaseValuesAsync();
                 if (databaseValues != null)
                 {
                     notFound = false;

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -7,6 +7,7 @@ using DLCS.Core.Types;
 using DLCS.Model;
 using DLCS.Model.Assets;
 using DLCS.Model.Storage;
+using DLCS.Repository.Entities;
 using LazyCache;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -81,8 +82,8 @@ public class AssetRepository : AssetRepositoryCachingBase
                 return ResultStatus<DeleteResult>.Unsuccessful(DeleteResult.NotFound);
             }
             
-            await entityCounterRepository.Decrement(customer, "space-images", space.ToString());
-            await entityCounterRepository.Decrement(0, "customer-images", customer.ToString());
+            await entityCounterRepository.Decrement(customer, KnownEntityCounters.SpaceImages, space.ToString());
+            await entityCounterRepository.Decrement(0, KnownEntityCounters.CustomerImages, customer.ToString());
             return ResultStatus<DeleteResult>.Successful(DeleteResult.Deleted);
         }
         catch (DbUpdateConcurrencyException dbEx)

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
@@ -39,6 +39,8 @@ public abstract class AssetRepositoryCachingBase : IAssetRepository
         
         return DeleteAssetFromDatabase(assetId);
     }
+    
+    public void FlushCache(AssetId assetId) => AppCache.Remove(GetCacheKey(assetId));
 
     /// <summary>
     /// Delete asset from database

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -31,9 +31,8 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
             Submitted = DateTime.UtcNow,
             Superseded = false
         };
-
-        // Note - use Dapper to avoid calling .SaveChanges() and commiting any outstanding changes in dbcontext
-        batch.Id = await this.ExecuteScalarAsync<int>(CreateBatchSql, new { Customer = customerId, Count = assets.Count });
+        DlcsContext.Batches.Add(batch);
+        await DlcsContext.SaveChangesAsync(cancellationToken);
 
         foreach (var asset in assets)
         {
@@ -42,10 +41,4 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
 
         return batch;
     }
-    
-    private const string CreateBatchSql = @"
-INSERT INTO ""Batches"" (""Customer"", ""Submitted"", ""Count"", ""Completed"", ""Errors"", ""Superseded"")
-VALUES (@Customer, now() at time zone 'utc', @Count, 0, 0, false)
-RETURNING ""Id"";
-";
 }

--- a/src/protagonist/DLCS.Repository/Assets/ThumbRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/ThumbRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
@@ -15,9 +16,9 @@ public class ThumbRepository : IThumbRepository
     private readonly IStorageKeyGenerator storageKeyGenerator;
 
     public ThumbRepository(
-        ILogger<ThumbRepository> logger,
         IBucketReader bucketReader,
-        IStorageKeyGenerator storageKeyGenerator)
+        IStorageKeyGenerator storageKeyGenerator, 
+        ILogger<ThumbRepository> logger)
     {
         this.logger = logger;
         this.bucketReader = bucketReader;
@@ -26,15 +27,31 @@ public class ThumbRepository : IThumbRepository
     
     public async Task<List<int[]>?> GetOpenSizes(AssetId assetId)
     {
-        ObjectInBucket sizesList = storageKeyGenerator.GetThumbsSizesJsonLocation(assetId);
+        var thumbnailSizes = await GetThumbnailSizes(assetId);
+        return thumbnailSizes?.Open;
+    }
+
+    public async Task<List<int[]>?> GetAllSizes(AssetId assetId)
+    {
+        var thumbnailSizes = await GetThumbnailSizes(assetId);
+
+        return thumbnailSizes?.Open
+            .Union(thumbnailSizes.Auth)
+            .OrderByDescending(wh => wh[0]).ToList();
+    }
+    
+    private async Task<ThumbnailSizes?> GetThumbnailSizes(AssetId assetId)
+    {
+        var sizesList = storageKeyGenerator.GetThumbsSizesJsonLocation(assetId);
 
         var thumbnailSizesObject = await bucketReader.GetObjectFromBucket(sizesList);
         var thumbnailSizes = await thumbnailSizesObject.DeserializeFromJson<ThumbnailSizes>();
         if (thumbnailSizes == null)
         {
             logger.LogError("Could not find sizes file for asset '{Asset}'", assetId);
-            return null;
+            return thumbnailSizes;
         }
-        return thumbnailSizes.Open;
+
+        return thumbnailSizes;
     }
 }

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="6.0.5" />
     <PackageReference Include="Npgsql" Version="6.0.5" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.20.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/protagonist/DLCS.Repository/DapperRepository.cs
+++ b/src/protagonist/DLCS.Repository/DapperRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Configuration;
@@ -34,73 +35,98 @@ public interface IDapperConfigRepository : IDapperRepository
 
 public static class DapperRepositoryX
 {
-    public static async Task ExecuteSqlAsync(this IDapperRepository repository, string sql, object? param = null)
-    {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        await connection.ExecuteAsync(sql, param);
-    }
-
     public static async Task<T?> QueryFirstOrDefaultAsync<T>(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QueryFirstOrDefaultAsync<T?>(sql, param);
+        return await HandleCommand<T?>(repository,
+            dbConnection => dbConnection.QueryFirstOrDefaultAsync<T?>(sql, param));
     }
 
     public static async Task<dynamic?> QueryFirstOrDefaultAsync(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QuerySingleOrDefaultAsync(sql, param);
+        return await HandleCommand<dynamic?>(repository,
+            dbConnection => dbConnection.QuerySingleOrDefaultAsync(sql, param));
     }
 
     public static async Task<T?> QuerySingleOrDefaultAsync<T>(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QueryFirstOrDefaultAsync<T>(sql, param);
+        return await HandleCommand<T>(repository,
+            dbConnection => dbConnection.QueryFirstOrDefaultAsync<T>(sql, param));
     }
 
     public static async Task<dynamic?> QuerySingleOrDefaultAsync(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QuerySingleOrDefaultAsync(sql, param);
+        return await HandleCommand<dynamic?>(repository,
+            dbConnection => dbConnection.QuerySingleOrDefaultAsync(sql, param));
     }
 
     public static async Task<T> QuerySingleAsync<T>(this IDapperRepository repository, string sql, object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QuerySingleAsync<T>(sql, param);
+        return await HandleCommand<T>(repository,
+            dbConnection => dbConnection.QuerySingleAsync<T>(sql, param));
     }
 
     public static async Task<IEnumerable<T>> QueryAsync<T>(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QueryAsync<T>(sql, param);
+        return await HandleCommand<IEnumerable<T>>(repository,
+            dbConnection => dbConnection.QueryAsync<T>(sql, param));
     }
 
     public static async Task<IEnumerable<dynamic>> QueryAsync(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.QueryAsync(sql, param);
+        return await HandleCommand<IEnumerable<dynamic>>(repository,
+            dbConnection => dbConnection.QueryAsync(sql, param));
     }
 
     public static async Task<T> ExecuteScalarAsync<T>(this IDapperRepository repository, string sql,
         object? param = null)
     {
-        await using var connection = await GetOpenNpgSqlConnection(repository);
-        return await connection.ExecuteScalarAsync<T>(sql, param);
+        return await HandleCommand<T>(repository,
+            dbConnection => dbConnection.ExecuteScalarAsync<T>(sql, param));
     }
 
-    private static Task<NpgsqlConnection> GetOpenNpgSqlConnection(IDapperRepository dapperRepository)
-        => dapperRepository switch
+    private static async Task<T> HandleCommand<T>(IDapperRepository repository, Func<DbConnection, Task<T>> handler)
+    {
+        bool isDisposable = false;
+        DbConnection? dbConnection = null;
+        try
         {
-            IDapperContextRepository contextRepo => contextRepo.DlcsContext.GetOpenNpgSqlConnection(),
-            IDapperConfigRepository configRepo => DatabaseConnectionManager.GetOpenNpgSqlConnection(configRepo
-                .Configuration),
+            var (connection, isNew) = await GetOpenNpgSqlConnection(repository);
+            isDisposable = isNew;
+            dbConnection = connection;
+            return await handler(connection);
+        }
+        finally
+        {
+            if (isDisposable && dbConnection != null)
+            {
+                await dbConnection.DisposeAsync();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Get an open NpgSqlConnection. This will be from DbContext if present, else created new.
+    /// </summary>
+    /// <param name="dapperRepository"></param>
+    /// <returns>
+    /// Open NpgSqlConnection object and boolean representing whether this connection was created or already in use.
+    /// If created then it can be disposed, else it will be disposed of along with DbContext
+    /// </returns>
+    /// <exception cref="InvalidCastException"></exception>
+    private static async Task<(NpgsqlConnection connection, bool wasCreated)> GetOpenNpgSqlConnection(IDapperRepository dapperRepository)
+    {
+        return dapperRepository switch
+        {
+            IDapperContextRepository contextRepo => (await contextRepo.DlcsContext.GetOpenNpgSqlConnection(), false),
+            IDapperConfigRepository configRepo => (
+                await DatabaseConnectionManager.GetOpenNpgSqlConnection(configRepo.Configuration), true),
             _ => throw new InvalidCastException("Cannot get source of Db connection from IDapperRepository")
         };
+    }
 }

--- a/src/protagonist/DLCS.Repository/DatabaseConnectionManager.cs
+++ b/src/protagonist/DLCS.Repository/DatabaseConnectionManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Data;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
@@ -37,8 +38,8 @@ public static class DatabaseConnectionManager
     /// <returns>Open <see cref="NpgsqlConnection"/> connection.</returns>
     public static async Task<NpgsqlConnection> GetOpenNpgSqlConnection(this DlcsContext dlcsContext)
     {
-        var connection = new NpgsqlConnection(dlcsContext.Database.GetConnectionString());
-        await connection.OpenAsync();
-        return connection;
+        var connection = dlcsContext.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open) await connection.OpenAsync();
+        return (NpgsqlConnection)connection;
     }
 }

--- a/src/protagonist/DLCS.Repository/Entities/EntityCounter.cs
+++ b/src/protagonist/DLCS.Repository/Entities/EntityCounter.cs
@@ -2,10 +2,52 @@
 
 namespace DLCS.Repository.Entities;
 
-public partial class EntityCounter
+/// <summary>
+/// EntityCounters are used to keep track of various counts across the application
+/// </summary>
+public class EntityCounter
 {
+    /// <summary>
+    /// The general type of counter (e.g. customers, customer spaces, images in space, images for customer).
+    /// </summary>
+    /// <remarks>See <see cref="KnownEntityCounters"/></remarks>
     public string Type { get; set; }
+    
+    /// <summary>
+    /// Id of any additional scopes for entity-counter (e.g. for space-images this would be spaceId)
+    /// </summary>
     public string Scope { get; set; }
+    
+    /// <summary>
+    /// The next valid value for entity-counter
+    /// </summary>
     public long Next { get; set; }
+    
+    /// <summary>
+    /// The Id of customer this counter pertains to - 0 if global
+    /// </summary>
     public int Customer { get; set; }
+}
+
+public static class KnownEntityCounters
+{
+    /// <summary>
+    /// Entity counter for the number of images in a single space.
+    /// </summary>
+    public const string SpaceImages = "space-images";
+    
+    /// <summary>
+    /// Entity counter for the number of images for a customer.
+    /// </summary>
+    public const string CustomerImages = "customer-images";
+    
+    /// <summary>
+    /// Entity counter for the number of spaces for a customer.
+    /// </summary>
+    public const string CustomerSpaces = "space";
+    
+    /// <summary>
+    /// Entity counter for the number of all customers in DLCS.
+    /// </summary>
+    public const string Customers = "customer";
 }

--- a/src/protagonist/DLCS.Repository/Entities/EntityCounterRepository.cs
+++ b/src/protagonist/DLCS.Repository/Entities/EntityCounterRepository.cs
@@ -63,7 +63,6 @@ public class EntityCounterRepository : IDapperContextRepository, IEntityCounterR
         await Set(customer, entityType, scope, 0);
     }
 
-
     public async Task Remove(int customer, string entityType, string scope)
     {
         var entityCounter = await GetEntityCounter(customer, entityType, scope);

--- a/src/protagonist/DLCS.Repository/Entities/EntityCounterRepository.cs
+++ b/src/protagonist/DLCS.Repository/Entities/EntityCounterRepository.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Model;
 using Microsoft.EntityFrameworkCore;
@@ -42,7 +43,7 @@ public class EntityCounterRepository : IDapperContextRepository, IEntityCounterR
     }
     
     private Task<bool> Exists(int customer, string entityType, string scope) =>
-        DlcsContext.EntityCounters.AsNoTracking().AnyAsync(ec =>
+        DlcsContext.EntityCounters.AnyAsync(ec =>
             ec.Customer == customer && ec.Type == entityType && ec.Scope == scope);
     
     private async Task EnsureCounter(int customer, string entityType, string scope, long initialValue)
@@ -54,11 +55,10 @@ public class EntityCounterRepository : IDapperContextRepository, IEntityCounterR
         }
     }
     
-    // Dapper section, for queries that return a modified counter in one operation
     private async Task<long> LongUpdate(string sql, int customer, string entityType, string scope, long initialValue = 1)
     {
         await EnsureCounter(customer, entityType, scope, initialValue);
-        return await this.QuerySingleAsync<long>(sql, new {customer, entityType, scope});
+        return await this.QuerySingleAsync<long>(sql, new { customer, entityType, scope });
     }
 
     private const string GetNextSql = @"

--- a/src/protagonist/DLCS.Repository/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/AssetNotificationSender.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Model.Processing;
@@ -50,6 +51,8 @@ public class AssetNotificationSender : IAssetNotificationSender
     public async Task<int> SendIngestAssetsRequest(IReadOnlyList<Asset> assets, bool isPriority,
         CancellationToken cancellationToken = default)
     {
+        if (assets.IsNullOrEmpty()) return 0;
+        
         // Preemptively increment the queue size - if there's a particularly large batch the engine could have picked
         // up a few prior to this returning
         var queue = isPriority ? QueueNames.Priority : QueueNames.Default;

--- a/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
+++ b/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
@@ -53,7 +53,6 @@ public class CustomerStorageRepository : IStorageRepository
         await dlcsContext.SaveChangesAsync(cancellationToken);
 
         return storageForSpace;
-
     }
 
     public async Task<CustomerStorageSummary> GetCustomerStorageSummary(

--- a/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
+++ b/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
@@ -414,6 +414,6 @@ public class EngineAssetRepositoryTests
         success.Should().BeTrue();
         
         var updatedItem = await dbContext.Images.AsNoTracking().SingleAsync(a => a.Id == assetId);
-        updatedItem.Error.Should().Be("Unable to find batch associated with image");
+        updatedItem.Error.Should().Be("Unable to update batch associated with image");
     }
 }

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -115,7 +115,7 @@ public class EngineAssetRepository : IEngineAssetRepository
     {
         int rowsUpdated;
         
-        var queryable = dlcsContext.Batches.Where(b => b.Id == asset.Batch.Value);
+        var queryable = dlcsContext.Batches.Where(b => b.Id == asset.Batch!.Value);
         if (string.IsNullOrEmpty(asset.Error))
         {
             rowsUpdated = await queryable

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -2,6 +2,7 @@ using System.Data;
 using DLCS.Core.Strings;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using DLCS.Model.Storage;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,6 +23,9 @@ public class EngineAssetRepository : IEngineAssetRepository
         bool ingestFinished, CancellationToken cancellationToken = default)
     {
         var hasBatch = (asset.Batch ?? 0) != 0;
+
+        logger.LogDebug("Updating ingested asset {AssetId}. HasBatch:{HasBatch}, Finished:{Finished}", asset.Id,
+            hasBatch, ingestFinished);
 
         try
         {
@@ -109,22 +113,23 @@ public class EngineAssetRepository : IEngineAssetRepository
 
     private async Task UpdateBatch(Asset asset, CancellationToken cancellationToken)
     {
-        var batch = await dlcsContext.Batches.FindAsync(new object[] { asset.Batch!.Value },
-            cancellationToken: cancellationToken);
-
-        if (batch == null)
-        {
-            asset.Error = "Unable to find batch associated with image";
-            return;
-        }
-
+        int rowsUpdated;
+        
+        var queryable = dlcsContext.Batches.Where(b => b.Id == asset.Batch.Value);
         if (string.IsNullOrEmpty(asset.Error))
         {
-            batch.Completed += 1;
+            rowsUpdated = await queryable
+                .UpdateFromQueryAsync(b => new Batch { Completed = b.Completed + 1 }, cancellationToken);
         }
         else
         {
-            batch.Errors += 1;
+            rowsUpdated = await queryable
+                .UpdateFromQueryAsync(b => new Batch { Errors = b.Errors + 1 }, cancellationToken);
+        }
+        
+        if (rowsUpdated == 0)
+        {
+            asset.Error = "Unable to update batch associated with image";
         }
     }
 
@@ -154,23 +159,22 @@ public class EngineAssetRepository : IEngineAssetRepository
         }
     }
 
-    private async Task<int> TryFinishBatch(int batchId, CancellationToken cancellationToken) 
-        => await dlcsContext.Database.ExecuteSqlInterpolatedAsync(
-            $"UPDATE \"Batches\" SET \"Finished\"=now() WHERE \"Id\" = {batchId} and \"Completed\"+\"Errors\"=\"Count\" ",
-            cancellationToken);
+    private Task<int> TryFinishBatch(int batchId, CancellationToken cancellationToken)
+        => dlcsContext.Batches
+            .Where(b => b.Id == batchId && b.Count == b.Completed + b.Errors)
+            .UpdateFromQueryAsync(b => new Batch { Finished = DateTime.UtcNow }, cancellationToken);
 
     private async Task IncreaseCustomerStorage(ImageStorage imageStorage, CancellationToken cancellationToken)
     {
         try
         {
-            await dlcsContext.Database.ExecuteSqlInterpolatedAsync(
-                $@"
-UPDATE ""CustomerStorage"" 
-SET     
-    ""TotalSizeOfStoredImages""= ""TotalSizeOfStoredImages"" + {imageStorage.Size},
-    ""TotalSizeOfThumbnails""= ""TotalSizeOfThumbnails"" + {imageStorage.ThumbnailSize}
-WHERE ""Customer"" = {imageStorage.Customer} AND ""Space"" = 0",
-                cancellationToken);
+            await dlcsContext.CustomerStorages
+                .Where(cs => cs.Customer == imageStorage.Customer && cs.Space == 0)
+                .UpdateFromQueryAsync(cs => new CustomerStorage
+                {
+                    TotalSizeOfStoredImages = cs.TotalSizeOfStoredImages + imageStorage.Size,
+                    TotalSizeOfThumbnails = cs.TotalSizeOfThumbnails + imageStorage.ThumbnailSize
+                }, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/protagonist/Engine/Ingest/Timebased/Completion/TimebasedIngestorCompletion.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Completion/TimebasedIngestorCompletion.cs
@@ -40,17 +40,17 @@ public class TimebasedIngestorCompletion : ITimebasedIngestorCompletion
 
         var assetIsOpen = !asset.RequiresAuth;
 
-        var errors = new StringBuilder();
+        var errors = new List<string>();
         var transcodeSuccess = true;
         
         if (!transcodeResult.IsComplete())
         {
             transcodeSuccess = false;
-            errors.AppendLine(
-                $"Transcode failed with status: {transcodeResult.State}. Error: {transcodeResult.ErrorCode ?? "unknown"}.");
+            errors.Add(
+                $"Transcode failed with status: {transcodeResult.State}. Error: {transcodeResult.ErrorCode ?? "unknown"}");
         }
 
-        var copyTasks = CopyTranscodeOutputs(transcodeResult, cancellationToken, transcodeSuccess, errors, asset, assetIsOpen);
+        var copyTasks = CopyTranscodeOutputs(transcodeResult, errors, asset, assetIsOpen, cancellationToken);
 
         await DeleteInputFile(transcodeResult);
         
@@ -70,13 +70,13 @@ public class TimebasedIngestorCompletion : ITimebasedIngestorCompletion
             if (cr.Result == LargeObjectStatus.Success) continue;
             if (cr is { Result: LargeObjectStatus.SourceNotFound, DestinationExists: true }) continue;
             
-            errors.AppendLine($"Copying ElasticTranscoder output failed with reason: {cr.Result}");
+            errors.Add($"Copying ElasticTranscoder output failed with reason: {cr.Result}");
             transcodeSuccess = false;
         }
         
-        if (errors.Length > 0)
+        if (errors.Count > 0)
         {
-            asset.Error = errors.ToString();
+            asset.Error = string.Join("|", errors);
         }
         
         var dbUpdateSuccess = await CompleteAssetInDatabase(asset, size, cancellationToken);
@@ -84,31 +84,30 @@ public class TimebasedIngestorCompletion : ITimebasedIngestorCompletion
         return transcodeSuccess && dbUpdateSuccess;
     }
 
-    private List<Task<LargeObjectCopyResult>> CopyTranscodeOutputs(TranscodeResult transcodeResult, CancellationToken cancellationToken,
-        bool transcodeSuccess, StringBuilder errors, Asset asset, bool assetIsOpen)
+    private List<Task<LargeObjectCopyResult>> CopyTranscodeOutputs(TranscodeResult transcodeResult,
+        List<string> errors, Asset asset, bool assetIsOpen,
+        CancellationToken cancellationToken)
     {
         bool dimensionsUpdated = false;
         var transcodeOutputs = transcodeResult.Outputs;
         var copyTasks = new List<Task<LargeObjectCopyResult>>(transcodeOutputs.Count);
-        if (transcodeSuccess)
+
+        foreach (var transcodeOutput in transcodeOutputs)
         {
-            foreach (var transcodeOutput in transcodeOutputs)
+            if (!transcodeOutput.IsComplete())
             {
-                if (!transcodeOutput.IsComplete())
-                {
-                    logger.LogWarning("Received incomplete {Status} for ElasticTranscoder output for {OutputKey}",
-                        transcodeOutput.Status, transcodeOutput.Key);
-                    errors.AppendLine(
-                        $"Transcode output for {transcodeOutput.Key} has status {transcodeOutput.Status}");
-                    continue;
-                }
-
-                SetAssetDimensions(asset, dimensionsUpdated, transcodeOutput);
-                dimensionsUpdated = true;
-
-                // Move assets from elastic transcoder-output bucket to main bucket
-                copyTasks.Add(CopyTranscodeOutputToStorage(transcodeOutput, asset.Id, assetIsOpen, cancellationToken));
+                logger.LogWarning("Received incomplete {Status} for ElasticTranscoder output for {OutputKey}",
+                    transcodeOutput.Status, transcodeOutput.Key);
+                errors.Add(
+                    $"Transcode output for {transcodeOutput.Key} has status {transcodeOutput.Status} with detail {transcodeOutput.StatusDetail}");
+                continue;
             }
+
+            SetAssetDimensions(asset, dimensionsUpdated, transcodeOutput);
+            dimensionsUpdated = true;
+
+            // Move assets from elastic transcoder-output bucket to main bucket
+            copyTasks.Add(CopyTranscodeOutputToStorage(transcodeOutput, asset.Id, assetIsOpen, cancellationToken));
         }
 
         return copyTasks;

--- a/src/protagonist/Engine/Ingest/Timebased/TranscodeCompleteHandler.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TranscodeCompleteHandler.cs
@@ -37,12 +37,15 @@ public class TranscodeCompleteHandler : IMessageHandler
             return false;
         }
 
+        logger.LogTrace("Received Message {MessageId} for {AssetId}", message.MessageId, assetId);
+
         var transcodeResult = new TranscodeResult(elasticTranscoderMessage);
 
         var success =
             await timebasedIngestorCompletion.CompleteSuccessfulIngest(assetId, transcodeResult, cancellationToken);
-        
-        logger.LogInformation("Message {MessageId} handled with result {IngestResult}", message.MessageId, success);
+
+        logger.LogInformation("Message {MessageId} handled for {AssetId} with result {IngestResult}", message.MessageId,
+            assetId, success);
         
         // TODO - return false so that the message is deleted from the queue in all instances.
         // This shouldn't be the case and can be revisited at a later date as it will need logic of how Batch.Errors is

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -199,6 +199,26 @@ public class MemoryAssetTrackerTests
     }
     
     [Theory]
+    [InlineData("iiif-img")]
+    [InlineData("iiif-img,file")]
+    public async Task GetOrchestrationAssetT_SetsOpenThumbsToEmpty_IfNullReturned(string deliveryChannel)
+    {
+        // Arrange
+        var assetId = new AssetId(1, 1, "otis");
+        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        {
+            DeliveryChannel = deliveryChannel.Split(","), Height = 10, Width = 50, MaxUnauthorised = -1
+        });
+        A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
+
+        // Act
+        var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result.OpenThumbs.Should().BeEmpty();
+    }
+    
+    [Theory]
     [InlineData("iiif-av")]
     [InlineData("file")]
     [InlineData("iiif-av,file")]

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Caching;
@@ -136,7 +137,7 @@ public class MemoryAssetTracker : IAssetTracker
                 Width = asset.Width ?? 0,
                 Height = asset.Height ?? 0,
                 MaxUnauthorised = asset.MaxUnauthorised ?? 0,
-                OpenThumbs = getOpenThumbs.Result, // TODO - reorganise thumb layout + create missing eventually
+                OpenThumbs = getOpenThumbs.Result ?? new List<int[]>(), // TODO - reorganise thumb layout + create missing eventually
             });
         }
         

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
@@ -1,13 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
+using DLCS.Model.Assets;
 using IIIF;
-using IIIF.ImageApi;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
+using Microsoft.Extensions.Logging;
 using Orchestrator.Assets;
 using Orchestrator.Infrastructure.IIIF;
+using Version = IIIF.ImageApi.Version;
 
 namespace Orchestrator.Features.Images.ImageServer;
 
@@ -19,33 +23,45 @@ public class InfoJsonConstructor
 {
     private readonly IIIFAuthBuilder iiifAuthBuilder;
     private readonly IImageServerClient imageServerClient;
+    private readonly IThumbRepository thumbRepository;
+    private readonly ILogger<InfoJsonConstructor> logger;
 
     public InfoJsonConstructor(
         IIIFAuthBuilder iiifAuthBuilder,
-        IImageServerClient imageServerClient)
+        IImageServerClient imageServerClient,
+        IThumbRepository thumbRepository,
+        ILogger<InfoJsonConstructor> logger)
     {
         this.iiifAuthBuilder = iiifAuthBuilder;
         this.imageServerClient = imageServerClient;
+        this.thumbRepository = thumbRepository;
+        this.logger = logger;
     }
 
     public async Task<JsonLdBase?> BuildInfoJsonFromImageServer(OrchestrationImage orchestrationImage,
         IIIF.ImageApi.Version version,
         CancellationToken cancellationToken = default)
     {
-        // Get info.json from downstream image server and add related services to it
+        var getSizesTask = GetSizes(orchestrationImage);
+
+        // Get info.json from downstream image server and add dlcs-known elements (services, thumbs) to it
         // TODO - handle 501 etc from downstream image-server
         if (version == Version.V2)
         {
             var imageServer2 =
                 await imageServerClient.GetInfoJson<ImageService2>(orchestrationImage, version, cancellationToken);
+            if (imageServer2 == null) return null;
             await UpdateImageService(imageServer2, orchestrationImage, cancellationToken);
+            imageServer2.Sizes = await getSizesTask;
             return imageServer2;
         }
         else
         {
             var imageServer3 =
                 await imageServerClient.GetInfoJson<ImageService3>(orchestrationImage, version, cancellationToken);
+            if (imageServer3 == null) return null;
             await UpdateImageService(imageServer3, orchestrationImage, cancellationToken);
+            imageServer3.Sizes = await getSizesTask;
             return imageServer3;
         }
     }
@@ -85,6 +101,24 @@ public class InfoJsonConstructor
             
             imageService.Service ??= new List<IService>(1);
             imageService.Service.Add(authCookieServiceForAsset);
+        }
+    }
+
+    private async Task<List<Size>> GetSizes(OrchestrationImage orchestrationImage)
+    {
+        // TODO - handle thumbs not being fetched. Return the info.json with image-server provided sizes?
+        try
+        {
+            var thumbs = await thumbRepository.GetAllSizes(orchestrationImage.AssetId);
+
+            return thumbs.IsNullOrEmpty()
+                ? Enumerable.Empty<Size>().ToList()
+                : thumbs.Select(s => Size.FromArray(s)).ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting size for info.json for {Asset}", orchestrationImage.AssetId);
+            return Enumerable.Empty<Size>().ToList();
         }
     }
 }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
 using DLCS.Core.Streams;
-using DLCS.Model.Storage;
 using IIIF;
 using IIIF.ImageApi;
 using IIIF.ImageApi.V2;
@@ -57,7 +56,7 @@ public class InfoJsonService
             JsonLdBase deserialisedInfoJson = version == Version.V2
                 ? infoJson.FromJsonStream<ImageService2>()
                 : infoJson.FromJsonStream<ImageService3>();
-            logger.LogDebug("Found info.json version {Version} for {AssetId}", version, orchestrationImage.AssetId);
+            logger.LogTrace("Found info.json version {Version} for {AssetId}", version, orchestrationImage.AssetId);
             return new InfoJsonResponse(deserialisedInfoJson, false);
         }
 

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -149,11 +149,12 @@ public static class DatabaseTestDataPopulation
         });
 
     public static ValueTask<EntityEntry<Batch>> AddTestBatch(this DbSet<Batch> batch, int id, int customer = 99,
-        int count = 1, int completed = 0, int errors = 0, DateTime? submitted = null, bool superseded = false)
+        int count = 1, int completed = 0, int errors = 0, DateTime? submitted = null, bool superseded = false,
+        DateTime? finished = null)
         => batch.AddAsync(new Batch
         {
             Id = id, Customer = customer, Submitted = submitted ?? DateTime.UtcNow, Completed = completed,
-            Count = count, Errors = errors, Superseded = superseded
+            Count = count, Errors = errors, Superseded = superseded, Finished = finished
         });
 
     public static ValueTask<EntityEntry<CustomerStorage>> AddTestCustomerStorage(

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -93,19 +93,19 @@ public class DlcsDatabaseFixture : IAsyncLifetime
             });
         await DbContext.EntityCounters.AddRangeAsync(new EntityCounter
         {
-            Type = "space",
+            Type = KnownEntityCounters.CustomerSpaces,
             Customer = customer,
             Scope = customer.ToString(),
             Next = 1
         }, new EntityCounter
         {
-            Type = "space-images",
+            Type = KnownEntityCounters.SpaceImages,
             Customer = customer,
             Scope = "1",
             Next = 1
         }, new EntityCounter
         {
-            Type = "customer-images",
+            Type = KnownEntityCounters.CustomerImages,
             Customer = 0,
             Scope = customer.ToString(),
             Next = 1

--- a/src/protagonist/Thumbs/ReorganisingThumbRepository.cs
+++ b/src/protagonist/Thumbs/ReorganisingThumbRepository.cs
@@ -43,7 +43,19 @@ public class ReorganisingThumbRepository : IThumbRepository
 
         return await wrappedThumbRepository.GetOpenSizes(assetId);
     }
-        
+
+    public async Task<List<int[]>?> GetAllSizes(AssetId assetId)
+    {
+        var newLayoutResult = await EnsureNewLayout(assetId);
+        if (newLayoutResult == ReorganiseResult.AssetNotFound)
+        {
+            logger.LogDebug("Requested asset not found for asset '{Asset}'", assetId);
+            return null;
+        }
+
+        return await wrappedThumbRepository.GetAllSizes(assetId);
+    }
+
     private Task<ReorganiseResult> EnsureNewLayout(AssetId assetId)
     {
         var currentSettings = settings.CurrentValue;


### PR DESCRIPTION
Various fixes identified when testing weco deployment

## info.json sizes

Use thumbnail sizes in infojson. 

These overwrite the suggestions returned from image-server. 

If thumbnails cannot be returned the image-server values are used. Add **all** thumbnail sizes, regardless of open or auth. These are read from the `s.json` file stored in S3 rather than the thumbnailPolicy, so - "as-is" rather than "should-be".

## Increment entity counters

EntityCounters were not being incremented when assets are being ingested. Altered save logic in `ApiAssetRepository` to increment `customer-space` and `space-images` counters on asset creation.

Added `KnownEntityCounters` which has the used entity-counter types. These are strings for now - if we want to persist when EC logic then we should have helper methods (ie `IncrementSpaceCounter`) rather than relying on caller knowing the correct `Customer` and `Scope` values to use per type.

Also removed unused methods in EntityCounter repo as these had been copied from Deliverator but are not being used - we can add them back in if needed in the future.

## Handle NullRef exception if no open thumbs

Default cached `OrchestrationImage.OpenThumbs` to empty list if not thumbs found. Avoids nullRefException in orchestrator.

## InfoJson links

Updated `InfoJson` and `ThumbnailInfoJson` fields on Asset API hydramodel to contain `/info.json` prefix as without this it'll result in a 302 response.

## Transaction / DB Changes

Rework `DapperRepository` helpers to ensure that transactions started in EF work with Dapper.

Tweak `EngineAssetRepository` to only create a Transaction when updating Asset + Batch if there is currently no transaction running. This worked okay as it was but nested transactions are not ideal.

## Update Statements

Reworked some `UPDATE tbl SET col = col + 1` style logic, both direct SQL queries and loading + updating, to use [UpdateFromQuery](https://entityframework-extensions.net/update-from-query) method from linked nuget package. Noticed issue when ingesting 20+ items, where `Batch.Complete` would be less than expected, issue was due to batch being loaded + updated rather than in 1 query. Using LINQ will make transition to proper cases postgres table syntax easier.

Using this in `CustomerQueueRepository` removed need for repository.

## Simplify Batch creation

The above change allowed `CreateBatchOfImages` to use EF for batch creation within a transaction. This simplified rollback/commit logic.

Modified to only call `transaction.Rollback()` if `cancellationToken` **not** cancelled. Ultimately this is unnecessary because it's implicitly called when disposing of the transaction but it helps to keep it explicit.

## Elastic Transcoder Failures

Better handling of ElasticTranscoder failure notifications - log each outputs failure status in addition to general failure. This can result in a long error message but better for troubleshooting.

This change requires ET error notifications to be configured in AWS.