### PR TITLE
Return empty control file if request parameters valid

### DIFF
--- a/src/protagonist/DLCS.Repository/NamedQueries/Models/ControlFile.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Models/ControlFile.cs
@@ -51,6 +51,18 @@ public class ControlFile
     /// </summary>
     [JsonProperty("roles")]
     public List<string>? Roles { get; set; }
+    
+    /// <summary>
+    /// Null object control file
+    /// </summary>
+    public static readonly ControlFile Empty = new()
+    {
+        Created = DateTime.MinValue,
+        SizeBytes = 0,
+        ItemCount = 0,
+        Key = string.Empty,
+        Roles = new List<string>(0)
+    };
 
     /// <summary>
     /// Check if this is control file is stale (in process for longer than X secs)

--- a/src/protagonist/Orchestrator.Tests/Integration/PdfTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/PdfTests.cs
@@ -412,16 +412,23 @@ public class PdfTests: IClassFixture<ProtagonistAppFactory<Startup>>
     }
 
     [Fact]
-    public async Task GetPdfControlFile_Returns404_IfNQValidButNoControlFile()
+    public async Task GetPdfControlFile_Returns200_WithEmptyControlFile_IfNQValidButNoControlFile()
     {
         // Arrange
         const string path = "pdf-control/99/test-pdf/any-ref/1/2";
+        var pdfControlFile = new PdfControlFile(new ControlFile
+        {
+            Created = DateTime.MinValue, InProcess = false, Exists = false, Key = string.Empty, ItemCount = 0,
+            SizeBytes = 0, Roles = new List<string>(0)
+        });
+        var pdfControlFileJson = JsonConvert.SerializeObject(pdfControlFile);
             
         // Act
         var response = await httpClient.GetAsync(path);
             
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be(pdfControlFileJson);
     }
 
     [Fact]

--- a/src/protagonist/Orchestrator.Tests/Integration/ZipTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ZipTests.cs
@@ -342,16 +342,18 @@ public class ZipTests: IClassFixture<ProtagonistAppFactory<Startup>>
     }
 
     [Fact]
-    public async Task GetZipControlFile_Returns404_IfNQValidButNoControlFile()
+    public async Task GetZipControlFile_Returns200_WithEmptyControlFile_IfNQValidButNoControlFile()
     {
         // Arrange
         const string path = "zip-control/99/test-zip/any-ref/1/2";
+        var controlFileJson = JsonConvert.SerializeObject(ControlFile.Empty);
         
         // Act
         var response = await httpClient.GetAsync(path);
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadAsStringAsync()).Should().Be(controlFileJson);
     }
 
     [Fact]

--- a/src/protagonist/Orchestrator/Features/PDF/Requests/GetPdfControlFileForNamedQuery.cs
+++ b/src/protagonist/Orchestrator/Features/PDF/Requests/GetPdfControlFileForNamedQuery.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Model.Assets.NamedQueries;
 using DLCS.Repository.NamedQueries;
@@ -50,7 +52,7 @@ public class GetPdfControlFileForNamedQueryHandler : IRequestHandler<GetPdfContr
 
         var controlFile =
             await namedQueryStorageService.GetControlFile(namedQueryResult.ParsedQuery, cancellationToken);
-        return controlFile == null ? null : new PdfControlFile(controlFile);
+        return new PdfControlFile(controlFile ?? ControlFile.Empty);
     }
 }
 

--- a/src/protagonist/Orchestrator/Features/Zip/Requests/GetZipControlFileForNamedQuery.cs
+++ b/src/protagonist/Orchestrator/Features/Zip/Requests/GetZipControlFileForNamedQuery.cs
@@ -48,6 +48,6 @@ public class GetZipControlFileForNamedQueryHandler : IRequestHandler<GetZipContr
         if (namedQueryResult.ParsedQuery is null or { IsFaulty: true }) return null;
 
         var controlFile = await namedQueryStorageService.GetControlFile(namedQueryResult.ParsedQuery, cancellationToken);
-        return controlFile;
+        return controlFile ?? ControlFile.Empty;
     }
 }


### PR DESCRIPTION
For #376.

Return a 200 and empty control-file from `/zip-control/` and `/pdf-control/` if the specified request is valid but there is no control file found. This helps to differentiate between a valid control file request and an incorrect/invalid request.