### PR TITLE
Allow editing ImageOptimisationPolicy

### DIFF
--- a/src/protagonist/DLCS.Core.Tests/ChangeManagerTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/ChangeManagerTests.cs
@@ -143,7 +143,7 @@ public class ChangeManagerTests
     }
     
     [Fact]
-    public void ApplyChanges_ReplacesChanges()
+    public void ApplyChanges_IgnoresMatchingValues()
     {
         // Arrange
         var existingObject = new ChangeTest
@@ -151,14 +151,50 @@ public class ChangeManagerTests
             StringVal = "default string",
             NullableStringVal = "default nullable string",
             NullableLongVal = 123,
+            NullableDateTimeVal = DateTime.Today
+        };
+
+        var candidateChanges = new ChangeTest
+        {
+            StringVal = "default string",
+            NullableStringVal = "default nullable string",
+            NullableLongVal = 123,
+            NullableDateTimeVal = DateTime.Today
+        };
+        
+        var expected = new ChangeTest
+        {
+            StringVal = "default string",
+            NullableStringVal = "default nullable string",
+            NullableLongVal = 123,
+            NullableDateTimeVal = DateTime.Today
+        };
+        
+        // Act
+        var changeCount = existingObject.ApplyChanges(candidateChanges);
+        
+        // Assert
+        existingObject.Should().BeEquivalentTo(expected);
+        changeCount.Should().Be(0);
+    }
+    
+    [Fact]
+    public void ApplyChanges_ReplacesChanges()
+    {
+        // Arrange
+        var existingObject = new ChangeTest
+        {
+            StringVal = "default string",
+            NullableStringVal = "default nullable string",
+            NullableLongVal = null,
             NullableDateTimeVal = DateTime.Today.AddDays(2)
         };
 
         var candidateChanges = new ChangeTest
         {
             StringVal = "default string",
-            NullableLongVal = 0,
             NullableStringVal = "",
+            NullableLongVal = 0,
             NullableDateTimeVal = DateTime.Today,
         };
         

--- a/src/protagonist/DLCS.Core/ChangeManager.cs
+++ b/src/protagonist/DLCS.Core/ChangeManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 
 namespace DLCS.Core;
 
@@ -53,7 +54,12 @@ public static class ChangeManager
             if (candidateValue == null) continue;
             
             var existingValue = prop.GetValue(toUpdate);
-            if (existingValue != candidateValue)
+
+            var valuesAreEqual = prop.PropertyType.IsValueType
+                ? existingValue?.Equals(candidateValue) ?? false
+                : existingValue == candidateValue;
+            
+            if (!valuesAreEqual)
             {
                 changesApplied++;
                 prop.SetValue(toUpdate, candidateValue);

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -252,12 +252,6 @@ public static class AssetPreparer
                 return AssetPreparationResult.Failure("Batch cannot be edited.");
             }
 
-            if (updateAsset.ImageOptimisationPolicy != null &&
-                updateAsset.ImageOptimisationPolicy != existingAsset.ImageOptimisationPolicy)
-            {
-                return AssetPreparationResult.Failure("ImageOptimisationPolicy cannot be edited.");
-            }
-
             if (updateAsset.ThumbnailPolicy != null && updateAsset.ThumbnailPolicy != existingAsset.ThumbnailPolicy)
             {
                 return AssetPreparationResult.Failure("ThumbnailPolicy cannot be edited.");


### PR DESCRIPTION
For issue #477 

Removed restriction on editing ImageOptimisationPolicy. 

In addition to this I updated how differences are calculated in `ChangeManager.ApplyChanges<T>` method. Value types were always being marked as a change so modified to use [`ValueType.Equals()`](https://learn.microsoft.com/en-us/dotnet/api/system.valuetype.equals?view=net-6.0) rather than `==` for value types. This doesn't have any affect on how things are stored but means that the returned change count is correct - this currently isn't used but we may in the future.