### PR TITLE
Exclude image request with pct: size from thumbs handling consideration

### DIFF
--- a/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
@@ -18,7 +18,7 @@ public class ImageRequestXTests
     {
         // Arrange
         var imageRequest = new ImageRequest
-            { Format = format, Quality = "default", Rotation = new RotationParameter() };
+            { Format = format, Quality = "default", Rotation = new RotationParameter(), Size = new SizeParameter() };
 
         // Act
         var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
@@ -34,7 +34,8 @@ public class ImageRequestXTests
     public void IsCandidateForThumbHandling_False_IfNonDefaultQuality(string quality)
     {
         // Arrange
-        var imageRequest = new ImageRequest { Format = "jpg", Quality = quality, Rotation = new RotationParameter() };
+        var imageRequest = new ImageRequest
+            { Format = "jpg", Quality = quality, Rotation = new RotationParameter(), Size = new SizeParameter() };
 
         // Act
         var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
@@ -54,7 +55,10 @@ public class ImageRequestXTests
     {
         // Arrange
         var imageRequest = new ImageRequest
-            { Format = "jpg", Quality = "default", Rotation = RotationParameter.Parse(rotation) };
+        {
+            Format = "jpg", Quality = "default", Rotation = RotationParameter.Parse(rotation),
+            Size = new SizeParameter()
+        };
 
         // Act
         var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
@@ -67,11 +71,11 @@ public class ImageRequestXTests
     [Theory]
     [InlineData("default")]
     [InlineData("color")]
-    public void IsCandidateForThumbHandling_True_IfJpg_Default_NoRotation(string quality)
+    public void IsCandidateForThumbHandling_True_IfJpg_Default_NoRotation_NotPctSize(string quality)
     {
         // Arrange
         var imageRequest = new ImageRequest
-            { Format = "jpg", Quality = quality, Rotation = new RotationParameter() };
+            { Format = "jpg", Quality = quality, Rotation = new RotationParameter(), Size = new SizeParameter() };
 
         // Act
         var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
@@ -79,5 +83,23 @@ public class ImageRequestXTests
         // Assert
         canHandle.Should().BeTrue();
         message.Should().BeNull();
+    }
+    
+    [Fact]
+    public void IsCandidateForThumbHandling_False_IfPercentSize()
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+        {
+            Format = "jpg", Quality = "default", Rotation = new RotationParameter(),
+            Size = SizeParameter.Parse("pct:24")
+        };
+
+        // Act
+        var canHandle = imageRequest.IsCandidateForThumbHandling(out var message);
+
+        // Assert
+        canHandle.Should().BeFalse();
+        message.Should().Be("Requested pct: size value not supported");
     }
 }

--- a/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
+++ b/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
@@ -6,7 +6,7 @@ namespace DLCS.Web.IIIF;
 public static class ImageRequestX
 {
     private const string DefaultQuality = "default";
-    public const string ColorQuality = "color";
+    private const string ColorQuality = "color";
     private const string JpgFormat = "jpg";
 
     /// <summary>
@@ -34,7 +34,13 @@ public static class ImageRequestX
 
         if (request.Rotation is not { Angle: 0, Mirror: not true })
         {
-            invalidMessage = $"Requested rotation value not supported, use '0'";
+            invalidMessage = "Requested rotation value not supported, use '0'";
+            return false;
+        }
+
+        if (request.Size.PercentScale.HasValue)
+        {
+            invalidMessage = "Requested pct: size value not supported";
             return false;
         }
 


### PR DESCRIPTION
This is partial handling of #436, basic handling which discounts any image-requests from thumb handling consideration if the size is `pct:X` 

I initially went down the path of calculating % size and checking if thumb was available but this got a little bit more complex than intended as we have to rewrite the path before proxying to `/thumbs/`, taking into account whether it's going to a thumbs service that supports resizing or not. Will put #436 back into TODO as this is MVP handling.