### PR TITLE
Rename DeliveratorApiClient to ApiClient

### DIFF
--- a/src/protagonist/API.Client/DlcsClient.cs
+++ b/src/protagonist/API.Client/DlcsClient.cs
@@ -217,11 +217,6 @@ public class DlcsClient : IDlcsClient
         return patched;
     }
 
-    public Task<bool> ReingestAsset(int requestSpaceId, string requestImageId)
-    {
-        throw new NotImplementedException();
-    }
-
     private HttpContent ApiBody(JsonLdBase apiObject)
     {
         var jsonString = JsonConvert.SerializeObject(apiObject, jsonSerializerSettings);

--- a/src/protagonist/API.Client/IDlcsClient.cs
+++ b/src/protagonist/API.Client/IDlcsClient.cs
@@ -23,7 +23,4 @@ public interface IDlcsClient
     Task<bool> DeletePortalUser(string portalUserId);
     Task<Image?> DirectIngestImage(int spaceId, string imageId, Image asset);
     Task<HydraCollection<Image>> PatchImages(HydraCollection<Image> images, int spaceId);
-    
-    
-    Task<bool> ReingestAsset(int requestSpaceId, string requestImageId);
 }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -169,7 +169,6 @@ public class ImageController : HydraController
     public Task<IActionResult> ReingestAsset([FromRoute] int customerId, [FromRoute] int spaceId,
         [FromRoute] string imageId, CancellationToken cancellationToken)
     {
-        // TODO - return the { "success": true } response for backward compat
         var reingestRequest = new ReingestAsset(customerId, spaceId, imageId);
         return HandleUpsert(reingestRequest, 
             asset => asset.ToHydra(GetUrlRoots()), 

--- a/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
 using Orchestrator.Features.Images.Orchestration;
-using Orchestrator.Infrastructure.Deliverator;
+using Orchestrator.Infrastructure.API;
 using Orchestrator.Settings;
 using Test.Helpers;
 using Test.Helpers.Settings;

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/API/ApiClientTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/API/ApiClientTests.cs
@@ -12,20 +12,20 @@ using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Orchestrator.Infrastructure.Deliverator;
+using Orchestrator.Infrastructure.API;
 using Orchestrator.Settings;
 using Test.Helpers.Http;
 using Xunit;
 
-namespace Orchestrator.Tests.Infrastructure.Deliverator;
+namespace Orchestrator.Tests.Infrastructure.API;
 
-public class DeliveratorApiClientTests
+public class ApiClientTests
 {
     private readonly ControllableHttpMessageHandler httpHandler;
     private readonly ICustomerRepository customerRepository;
-    private readonly DeliveratorApiClient sut;
+    private readonly ApiClient sut;
 
-    public DeliveratorApiClientTests()
+    public ApiClientTests()
     {
         httpHandler = new ControllableHttpMessageHandler();
         var httpClient = new HttpClient(httpHandler);
@@ -36,8 +36,8 @@ public class DeliveratorApiClientTests
         A.CallTo(() => encryption.Encrypt(A<string>._)).Returns("encrypted");
         customerRepository = A.Fake<ICustomerRepository>();
 
-        sut = new DeliveratorApiClient(httpClient, new DlcsApiAuth(encryption), customerRepository, options,
-            new NullLogger<DeliveratorApiClient>());
+        sut = new ApiClient(httpClient, new DlcsApiAuth(encryption), customerRepository, options,
+            new NullLogger<ApiClient>());
     }
     
     [Fact]

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
-using Orchestrator.Infrastructure.Deliverator;
+using Orchestrator.Infrastructure.API;
 using Orchestrator.Settings;
 
 namespace Orchestrator.Features.Images.Orchestration;
@@ -110,7 +110,6 @@ public class ImageOrchestrator : IImageOrchestrator
             throw new ApplicationException($"Unable to reingest Asset '{assetId}' from origin");
         }
 
-        // TODO - does this want to be a 'get' with an extra param to refresh?
         var orchestrationImage = await assetTracker.RefreshCachedAsset<OrchestrationImage>(assetId);
 
         if (orchestrationImage == null)

--- a/src/protagonist/Orchestrator/Infrastructure/API/ApiClient.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/API/ApiClient.cs
@@ -3,8 +3,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using API.Client;
-using DLCS.Core.Encryption;
 using DLCS.Core.Types;
 using DLCS.Model.Customers;
 using DLCS.Web.Auth;
@@ -14,25 +12,25 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Orchestrator.Settings;
 
-namespace Orchestrator.Infrastructure.Deliverator;
+namespace Orchestrator.Infrastructure.API;
 
 /// <summary>
-/// Implementation of IDlcsApiClient using Deliverator API
+/// Implementation of IDlcsApiClient
 /// </summary>
-public class DeliveratorApiClient : IDlcsApiClient
+public class ApiClient : IDlcsApiClient
 {
     private readonly HttpClient httpClient;
     private readonly DlcsApiAuth dlcsApiAuth;
     private readonly ICustomerRepository customerRepository;
     private readonly OrchestratorSettings orchestratorSettings;
-    private readonly ILogger<DeliveratorApiClient> logger;
+    private readonly ILogger<ApiClient> logger;
 
-    public DeliveratorApiClient(
+    public ApiClient(
         HttpClient httpClient, 
         DlcsApiAuth dlcsApiAuth,
         ICustomerRepository customerRepository,
         IOptions<OrchestratorSettings> orchestratorSettings,
-        ILogger<DeliveratorApiClient> logger)
+        ILogger<ApiClient> logger)
     {
         this.httpClient = httpClient;
         this.dlcsApiAuth = dlcsApiAuth;
@@ -43,13 +41,11 @@ public class DeliveratorApiClient : IDlcsApiClient
 
     public async Task<bool> ReingestAsset(AssetId assetId, CancellationToken cancellationToken = default)
     {
-        // TODO - alter this to use Protagonist API
         try
         {
             var url = $"/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/reingest";
             var request = new HttpRequestMessage(HttpMethod.Post, url);
             
-            // TODO - need to post something, but not an empty body
             request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
 
             if (!await SetApiAuth(assetId.Customer, request)) return false;

--- a/src/protagonist/Orchestrator/Infrastructure/API/IDlcsApiClient.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/API/IDlcsApiClient.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using DLCS.Core.Types;
 
-namespace Orchestrator.Infrastructure.Deliverator;
+namespace Orchestrator.Infrastructure.API;
 
 public interface IDlcsApiClient
 {

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orchestrator.Assets;
 using Orchestrator.Features.Images.ImageServer;
 using Orchestrator.Features.Images.Orchestration;
-using Orchestrator.Infrastructure.Deliverator;
+using Orchestrator.Infrastructure.API;
 using Orchestrator.Infrastructure.ReverseProxy;
 using Orchestrator.Settings;
 
@@ -70,7 +70,7 @@ public static class ServiceCollectionX
         services
             .AddSingleton<DlcsApiAuth>()
             .AddSingleton<IEncryption, SHA256>()
-            .AddHttpClient<IDlcsApiClient, DeliveratorApiClient>(client =>
+            .AddHttpClient<IDlcsApiClient, ApiClient>(client =>
             {
                 client.DefaultRequestHeaders.WithRequestedBy();
                 client.BaseAddress = apiRoot;


### PR DESCRIPTION
For #397. Chose to just rename the current `DeliveratorApiClient` and leave implementation intact.

Didn't reuse the `API.Client/DlcsClient` as it is unnecessary to pull in that full interface just to call reingest. As detailed in #397, the `DlcsClient` uses a `ClaimsPrincipal`, which doesn't fit how Orchestrator handles auth separate interface was cleaner.