### PR TITLE
Make CustomerPathElementRepository name lookup case insensitive

### DIFF
--- a/src/protagonist/DLCS.Model/PathElements/IPathCustomerRepository.cs
+++ b/src/protagonist/DLCS.Model/PathElements/IPathCustomerRepository.cs
@@ -4,5 +4,5 @@ namespace DLCS.Model.PathElements;
 
 public interface IPathCustomerRepository
 {
-    Task<CustomerPathElement> GetCustomer(string customerPart);
+    Task<CustomerPathElement> GetCustomerPathElement(string customerPart);
 }

--- a/src/protagonist/DLCS.Repository.Tests/CustomerPathElementRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/CustomerPathElementRepositoryTests.cs
@@ -1,82 +1,77 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Model.Customers;
 using DLCS.Model.PathElements;
 using FakeItEasy;
-using FluentAssertions;
-using LazyCache;
 using LazyCache.Mocks;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Xunit;
 
 namespace DLCS.Repository.Tests;
 
 public class CustomerPathElementRepositoryTests
 {
-    private readonly ICustomerRepository customerRepository;
-    private readonly ILogger<CustomerPathElementRepository> logger;
-    private readonly IAppCache appCache;
     private readonly CustomerPathElementRepository sut;
     private const int CustomerId = 3;
     private const string CustomerName = "Robert-Paulson";
     
     public CustomerPathElementRepositoryTests()
     {
-        customerRepository = A.Fake<ICustomerRepository>();
+        var customerRepository = A.Fake<ICustomerRepository>();
         A.CallTo(() => customerRepository.GetCustomerIdLookup())
             .Returns(new Dictionary<string, int> {[CustomerName] = CustomerId});
         
-        logger = A.Fake<ILogger<CustomerPathElementRepository>>();
-        appCache = new MockCachingService();
+        var appCache = new MockCachingService();
 
         sut = new CustomerPathElementRepository(appCache, Options.Create(new CacheSettings()), customerRepository,
-            logger);
+            new NullLogger<CustomerPathElementRepository>());
     }
     
     [Fact]
-    public async Task GetCustomer_ById_ReturnsPathElement()
+    public async Task GetCustomerPathElement_ById_ReturnsPathElement()
     {
         // Arrange
         var expected = new CustomerPathElement(CustomerId, CustomerName);
 
         // Act
-        var byId = await sut.GetCustomer(CustomerId.ToString());
+        var byId = await sut.GetCustomerPathElement(CustomerId.ToString());
 
         // Assert
         byId.Should().BeEquivalentTo(expected);
     }
     
     [Fact]
-    public void GetCustomer_ById_ThrowsIfNotFound()
+    public void GetCustomerPathElement_ById_ThrowsIfNotFound()
     {
         // Act
-        Func<Task<CustomerPathElement>> action = () => sut.GetCustomer($"not{CustomerId.ToString()}");
+        Func<Task<CustomerPathElement>> action = () => sut.GetCustomerPathElement($"not{CustomerId.ToString()}");
 
         // Assert
         action.Should().ThrowAsync<KeyNotFoundException>();
     }
     
-    [Fact]
-    public async Task GetCustomer_ByName_ReturnsPathElement()
+    [Theory]
+    [InlineData("Robert-Paulson")]
+    [InlineData("robert-paulson")]
+    [InlineData("ROBERT-PAULSON")]
+    public async Task GetCustomerPathElement_ByName_AnyCase_ReturnsPathElement(string customerName)
     {
         // Arrange
-        var expected = new CustomerPathElement(CustomerId, CustomerName);
+        var expected = new CustomerPathElement(CustomerId, customerName);
 
         // Act
-        var byId = await sut.GetCustomer(CustomerName);
+        var byId = await sut.GetCustomerPathElement(customerName);
 
         // Assert
         byId.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
-    public void GetCustomer_ByName_ThrowsIfNotFound()
+    public void GetCustomerPathElement_ByName_ThrowsIfNotFound()
     {
         // Act
-        Func<Task<CustomerPathElement>> action = () => sut.GetCustomer($"not{CustomerName}");
+        Func<Task<CustomerPathElement>> action = () => sut.GetCustomerPathElement($"not{CustomerName}");
 
         // Assert
         action.Should().ThrowAsync<KeyNotFoundException>();

--- a/src/protagonist/DLCS.Repository/CustomerPathElementRepository.cs
+++ b/src/protagonist/DLCS.Repository/CustomerPathElementRepository.cs
@@ -1,6 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using DLCS.Core.Caching;
-using DLCS.Core.Collections;
 using DLCS.Model.Customers;
 using DLCS.Model.PathElements;
 using LazyCache;
@@ -10,6 +12,14 @@ using Microsoft.Extensions.Options;
 
 namespace DLCS.Repository;
 
+/// <summary>
+/// Class that manages looking up CustomerName to get Id, or vice versa.
+/// </summary>
+/// <remarks>
+/// Internally this has 2 cached lookups values:
+///  Lowercase-Name:Id - this allows us to lookup "Customer", "customer", "CUSTOMER" to get Id
+///  Id:Name - this allows us to use Id to get name as saved in DB 
+/// </remarks>
 public class CustomerPathElementRepository : IPathCustomerRepository
 {
     private readonly ICustomerRepository customerRepository;
@@ -29,44 +39,58 @@ public class CustomerPathElementRepository : IPathCustomerRepository
         cacheSettings = cacheOptions.Value;
     }
 
-    public async Task<CustomerPathElement> GetCustomer(string customerPart)
+    public async Task<CustomerPathElement> GetCustomerPathElement(string customerPart)
     {
         // customerPart can be an int or a string name
-        string customerName = null;
         if (int.TryParse(customerPart, out var customerId))
         {
-            customerName = await GetCustomerName(customerId);
+            var customerName = await GetCustomerName(customerId);
+            return new CustomerPathElement(customerId, customerName);
         }
         else
         {
             customerId = await GetCustomerId(customerPart);
-            if (customerId > 0)
-            {
-                customerName = customerPart;
-            }
+            return new CustomerPathElement(customerId, customerPart);
         }
-        return new CustomerPathElement(customerId, customerName);
     }
 
     private async Task<int> GetCustomerId(string customerName)
     {
-        var readOnlyMap = await EnsureDictionary();
-        return readOnlyMap.Forward[customerName];
+        var idLookup = await GetIdLookup();
+        return idLookup[customerName.ToLower()];
     }
 
     private async Task<string> GetCustomerName(int customerId)
     {
-        var readOnlyMap = await EnsureDictionary();
-        return readOnlyMap.Reverse[customerId];
+        var nameLookup = await GetNameLookup();
+        return nameLookup[customerId];
     }
 
-    private Task<ReadOnlyMap<string, int>> EnsureDictionary()
+    private Task<Dictionary<string, int>> GetIdLookup()
+        => GetLookupResult(
+            "CustomerIdLookup",
+            customerIdLookup => customerIdLookup.ToDictionary(kvp => kvp.Key.ToLower(), kvp => kvp.Value));
+
+    private Task<Dictionary<int, string>> GetNameLookup()
+        => GetLookupResult(
+            "CustomerNameLookup",
+            customerIdLookup => customerIdLookup.ToDictionary(kvp => kvp.Value, kvp => kvp.Key));
+
+    /// <summary>
+    /// Id:Name and Name:Id lookup are the same data reversed. This method takes a transform function to convert from
+    /// Name:Id to relevant shape to cache 
+    /// </summary>
+    /// <param name="cacheKey"></param>
+    /// <param name="transformer"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns>Transformed object</returns>
+    private Task<T> GetLookupResult<T>(string cacheKey, Func<Dictionary<string, int>, T> transformer)
     {
-        const string key = "CustomerPathElementRepository_CustomerLookup";
-        return appCache.GetOrAddAsync(key, async () =>
+        return appCache.GetOrAddAsync(cacheKey, async () =>
         {
-            logger.LogDebug("Refreshing customer name/id lookup from database");
-            return new ReadOnlyMap<string, int>(await customerRepository.GetCustomerIdLookup());
+            logger.LogDebug("Refreshing customer lookup {CacheKey} from database", cacheKey);
+            var customerIdLookup = await customerRepository.GetCustomerIdLookup();
+            return transformer(customerIdLookup);
         }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long, priority: CacheItemPriority.High));
     }
 }

--- a/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
@@ -25,7 +25,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/thumbs/99/1/the-astronaut";
         var customer = new CustomerPathElement(99, "Test-Customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("99"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("99"))
             .Returns(customer);
 
         // Act
@@ -49,7 +49,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/thumbs/test-customer/1/the-astronaut";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("test-customer"))
             .Returns(customer);
 
         // Act
@@ -73,7 +73,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/iiif-img/test-customer/1/the-astronaut/full/!800,400/0/default.jpg";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("test-customer"))
             .Returns(customer);
 
         // Act
@@ -98,7 +98,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/iiif-img/test-customer/1/the-astronaut/full/%5E!800,400/0/default.jpg";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("test-customer"))
             .Returns(customer);
 
         // Act
@@ -123,7 +123,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/iiif-img/v33/1/the-astronaut/full/!800,400/0/default.jpg";
         var customer = new CustomerPathElement(99, "v33");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("v33"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("v33"))
             .Returns(customer);
 
         // Act
@@ -150,7 +150,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         var path = $"/iiif-img/{customerPathValue}/1/the-astronaut/full/!800,400/0/default.jpg";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer(A<string>._)).Returns(customer);
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement(A<string>._)).Returns(customer);
 
         // Act
         var imageRequest = await sut.Parse<ImageAssetDeliveryRequest>(path);
@@ -178,7 +178,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         var path = $"/iiif-img/{version}/{customerPathValue}/1/the-astronaut/full/!800,400/0/default.jpg";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer(A<string>._)).Returns(customer);
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement(A<string>._)).Returns(customer);
 
         // Act
         var imageRequest = await sut.Parse<ImageAssetDeliveryRequest>(path);
@@ -217,7 +217,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/iiif-av/test-customer/1/the-astronaut/full/full/max/max/0/default.mp4";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("test-customer"))
             .Returns(customer);
 
         // Act
@@ -244,7 +244,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         var path = $"/iiif-av/{customerPathValue}/1/the-astronaut/full/full/max/max/0/default.mp4";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer(A<string>._)).Returns(customer);
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement(A<string>._)).Returns(customer);
 
         // Act
         var imageRequest = await sut.Parse<TimeBasedAssetDeliveryRequest>(path);
@@ -270,7 +270,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         const string path = "/file/test-customer/1/the-astronaut";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer("test-customer"))
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("test-customer"))
             .Returns(customer);
 
         // Act
@@ -296,7 +296,7 @@ public class AssetDeliveryPathParserTests
         // Arrange
         var path = $"/file/{customerPathValue}/1/the-astronaut";
         var customer = new CustomerPathElement(99, "test-customer");
-        A.CallTo(() => pathCustomerRepository.GetCustomer(A<string>._)).Returns(customer);
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement(A<string>._)).Returns(customer);
 
         // Act
         var imageRequest = await sut.Parse<FileAssetDeliveryRequest>(path);

--- a/src/protagonist/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
+++ b/src/protagonist/DLCS.Web/Requests/AssetDelivery/AssetDeliveryPathParser.cs
@@ -89,7 +89,7 @@ public class AssetDeliveryPathParser : IAssetDeliveryPathParser
             GenerateBasePath(request.RoutePrefix, request.CustomerPathValue, space, isVersioned, versionCandidate);
 
         // TODO - should we verify Space exists here?
-        request.Customer = await pathCustomerRepository.GetCustomer(request.CustomerPathValue);
+        request.Customer = await pathCustomerRepository.GetCustomerPathElement(request.CustomerPathValue);
 
         request.NormalisedBasePath =
             GenerateBasePath(request.RoutePrefix, request.Customer.Id.ToString(), space, isVersioned,

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -156,7 +156,7 @@ public class ImageRequestHandlerTests
         context.Request.Path = "/iiif-img/2/2/test-image/full/!200,200/0/default.jpg";
 
         var roles = new List<string> { "role" };
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
                 { Roles = roles, RequiresAuth = true, Channels = AvailableDeliveryChannel.Image });
@@ -186,7 +186,7 @@ public class ImageRequestHandlerTests
 
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
             {
@@ -214,7 +214,7 @@ public class ImageRequestHandlerTests
 
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
             {
@@ -247,7 +247,7 @@ public class ImageRequestHandlerTests
         context.Request.Path = $"/iiif-img/2/2/test-image{iiifRequest}0/default.jpg";
 
         var roles = new List<string> { "role" };
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
@@ -272,7 +272,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
@@ -298,7 +298,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
@@ -328,7 +328,7 @@ public class ImageRequestHandlerTests
 
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
             .Returns(new OrchestrationImage
             {
@@ -363,7 +363,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = path;
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
             
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -403,7 +403,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = path;
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
             
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -443,7 +443,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = path;
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
 
         var settings = CreateOrchestratorSettings();
@@ -474,7 +474,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = path;
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
 
         var settings = CreateOrchestratorSettings();
@@ -501,7 +501,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = "/iiif-img/v10/2/2/test-image/full/90,/0/default.jpg";
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
 
         var settings = CreateOrchestratorSettings();
@@ -530,7 +530,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = path;
 
-        A.CallTo(() => customerRepository.GetCustomer("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         A.CallTo(() => customHeaderRepository.GetForCustomer(2)).Returns(new List<CustomHeader>
         {
             new() { Space = 2, Role = null, Key = "x-test-header", Value = "test" },

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Requests/NamedQueryResultGenerator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Requests/NamedQueryResultGenerator.cs
@@ -24,7 +24,7 @@ public class NamedQueryResultGenerator
     public async Task<PathElementNamedQueryResultContainer<T>> GetNamedQueryResult<T>(IBaseNamedQueryRequest request)
         where T : ParsedNamedQuery
     {
-        var customerPathElement = await pathCustomerRepository.GetCustomer(request.CustomerPathValue);
+        var customerPathElement = await pathCustomerRepository.GetCustomerPathElement(request.CustomerPathValue);
 
         var namedQueryResult =
             await namedQueryConductor.GetNamedQueryResult<T>(request.NamedQuery,


### PR DESCRIPTION
Resolves #476 

Main changes internal to `CustomerPathElementRepository` - rather than cache a `ReadOnlyMap<string, int>` revert to caching 2 different objects - `Dictionary<int, string>` and `Dictionary<string, int>` - the former uses the values directly from DB and the latter a lowercase name as the key to case-insensitive lookup. Didn't reuse a `ReadOnlyMap` with lowercase name as it would always return lowercase name, rather than "as in db" version.

The way this is implemented could lead to the 2 lookups getting out of sync but the chance of this is very small as the data seldom changes.

Most other changes related to renaing `CustomerPathElementRepository.GetCustomer` ->`CustomerPathElementRepository.GetCustomerPathElement`