### PR TITLE
Set content-type header for /file/ requests

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -293,7 +293,7 @@ public class MemoryAssetTrackerTests
     [InlineData("iiif-av,file", false)]
     [InlineData("iiif-img,file", true)]
     [InlineData("iiif-img,file", false)]
-    public async Task GetOrchestrationAssetT_SetsOptimised_IfFileDeliveryChannel(string deliveryChannel, bool optimised)
+    public async Task GetOrchestrationAssetT_SetsOptimisedAndMediaType_IfFileDeliveryChannel(string deliveryChannel, bool optimised)
     {
         // Arrange
         var assetId = new AssetId(1, 1, "go!");
@@ -302,13 +302,16 @@ public class MemoryAssetTrackerTests
                 { Id = "_default_", Strategy = OriginStrategyType.Default, Optimised = optimised }));
         
         A.CallTo(() => assetRepository.GetAsset(assetId))
-            .Returns(new Asset { DeliveryChannels = deliveryChannel.Split(","), Origin = "test" });
+            .Returns(new Asset
+            {
+                DeliveryChannels = deliveryChannel.Split(","), Origin = "test", MediaType = "audio/mpeg"
+            });
         
         // Act
         var result = await sut.GetOrchestrationAsset<OrchestrationAsset>(assetId);
         
         // Assert
         result.OptimisedOrigin.Should().Be(optimised);
+        result.MediaType.ToString().Should().Be("audio/mpeg");
     }
-
 }

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -10,6 +10,7 @@ using DLCS.Model.Customers;
 using LazyCache;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Orchestrator.Assets;
 
@@ -154,6 +155,7 @@ public class MemoryAssetTracker : IAssetTracker
             var cos = await customerOriginStrategyRepository.GetCustomerOriginStrategy(assetId, origin);
             orchestrationAsset.Origin = origin;
             orchestrationAsset.OptimisedOrigin = cos.Optimised;
+            orchestrationAsset.MediaType = new StringValues(asset.MediaType ?? "application/octet-stream");
         }
         
         return SetDefaults(orchestrationAsset);

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using DLCS.Core.Types;
+using Microsoft.Extensions.Primitives;
 
 namespace Orchestrator.Assets;
 
@@ -40,6 +41,11 @@ public class OrchestrationAsset
     /// A list of which delivery channels this asset is available on
     /// </summary>
     public AvailableDeliveryChannel Channels { get; set; } = AvailableDeliveryChannel.NotSet;
+    
+    /// <summary>
+    /// Get or set the asset media-type
+    /// </summary>
+    public StringValues? MediaType { get; set; }
 }
 
 public class OrchestrationImage : OrchestrationAsset

--- a/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
@@ -90,7 +90,9 @@ public class FileRequestHandler
         }
 
         var proxyPath = proxyPathGenerator.GetProxyPath(proxyTarget, !orchestrationAsset.OptimisedOrigin ?? true);
-        return new ProxyActionResult(ProxyDestination.S3, orchestrationAsset.RequiresAuth, proxyPath);
+        var proxyActionResult = new ProxyActionResult(ProxyDestination.S3, orchestrationAsset.RequiresAuth, proxyPath);
+        proxyActionResult.Headers.Add("Content-Type", orchestrationAsset.MediaType!.Value);
+        return proxyActionResult;
     }
     
     private async Task<bool> IsAuthenticated(FileAssetDeliveryRequest assetRequest, OrchestrationAsset asset,

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
@@ -92,6 +92,12 @@ public class PathRewriteTransformer : HttpTransformer
             httpContext.Response.Headers.Remove("link");
             httpContext.Response.Headers.Remove("server");
         }
+
+        if (proxyAction.Target == ProxyDestination.S3)
+        {
+            httpContext.Response.Headers.Remove("x-amz-tagging-count");
+            httpContext.Response.Headers.Remove("x-amz-storage-class");
+        }
     }
 
     private Uri GetNewDestination(string destinationPrefix)


### PR DESCRIPTION
Adding "content-type" header to ProxyResponse will mean that this is set via the `PathRewriteTransformer`