### PR TITLE
Handle images smaller than thumbnail-policy

### DIFF
--- a/src/protagonist/DLCS.Core.Tests/Guard/GuardXTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/Guard/GuardXTests.cs
@@ -32,6 +32,31 @@ public class GuardXTests
         actual.Should().Be(val);
     }
     
+    [Fact]
+    public void ThrowIfNull_NullableStruct_Throws_IfArgumentNull()
+    {
+        // Act
+        Action action = () => GuardX.ThrowIfNull<int?>(null, "foo");
+        
+        // Assert
+        action.Should()
+            .Throw<ArgumentNullException>()
+            .WithMessage("Value cannot be null. (Parameter 'foo')");
+    } 
+    
+    [Fact]
+    public void ThrowIfNull_NullableStruct_ReturnsProvidedValue_IfNotNull()
+    {
+        // Arrange
+        int? val = 12345;
+        
+        // Act
+        var actual = val.ThrowIfNull(nameof(val));
+        
+        // Assert
+        actual.Should().Be(val);
+    }
+    
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/src/protagonist/DLCS.Core/Guard/GuardX.cs
+++ b/src/protagonist/DLCS.Core/Guard/GuardX.cs
@@ -9,7 +9,7 @@ namespace DLCS.Core.Guard;
 public static class GuardX
 {
     /// <summary>
-    /// Throw <see cref="ArgumentNullException"/> if provided string is null.
+    /// Throw <see cref="ArgumentNullException"/> if provided object is null.
     /// </summary>
     /// <param name="argument">Argument to check.</param>
     /// <param name="argName">Name of argument.</param>
@@ -25,7 +25,26 @@ public static class GuardX
 
         return argument;
     }
-    
+
+    /// <summary>
+    /// Throw <see cref="ArgumentNullException"/> if provided object is null.
+    /// </summary>
+    /// <param name="argument">Argument to check.</param>
+    /// <param name="argName">Name of argument.</param>
+    /// <typeparam name="T">Type of argument to check.</typeparam>
+    /// <returns>Passed argument, if not null.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if provided argument is null.</exception>
+    public static T ThrowIfNull<T>(this T? argument, string argName)
+        where T : struct
+    {
+        if (!argument.HasValue)
+        {
+            throw new ArgumentNullException(argName);
+        }
+
+        return argument.Value;
+    }
+
     /// <summary>
     /// Throw <see cref="ArgumentNullException"/> if provided value is null, empty or whitespace.
     /// </summary>

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Policies;
 using FluentAssertions;
@@ -174,6 +173,34 @@ public class AssetXTests
         maxDimensions.maxBoundedSize.Should().Be(200);
         maxDimensions.maxAvailableWidth.Should().Be(100);
         maxDimensions.maxAvailableHeight.Should().Be(200);
+    }
+    
+    [Fact]
+    public void GetAvailableThumbSizes_HandlesImageBeingSmallerThanThumbnail()
+    {
+        // Arrange
+        var thumbnailPolicy = new ThumbnailPolicy
+        {
+            Id = "TestPolicy",
+            Name = "TestPolicy",
+            Sizes = "800,400,200,100"
+        };
+
+        var asset = new Asset { Width = 300, Height = 150 };
+        
+        // Act
+        var sizes = asset.GetAvailableThumbSizes(thumbnailPolicy, out var maxDimensions, true);
+        
+        // Assert
+        sizes.Should().BeEquivalentTo(new List<Size>
+        {
+            new(300, 150),
+            new(200, 100),
+            new(100, 50),
+        });
+        maxDimensions.maxBoundedSize.Should().Be(300);
+        maxDimensions.maxAvailableWidth.Should().Be(300);
+        maxDimensions.maxAvailableHeight.Should().Be(150);
     }
     
     [Fact]

--- a/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailPolicyTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailPolicyTests.cs
@@ -20,7 +20,22 @@ public class ThumbnailPolicyTests
         };
         
         // Assert
-        thumbnailPolicy.SizeList.Should().BeEquivalentTo(new List<int> {800, 400, 200, 100});
+        thumbnailPolicy.SizeList.Should().BeEquivalentTo(new List<int> { 800, 400, 200, 100 });
+    }
+    
+    [Fact]
+    public void SizesList_ReturnsCommaDelimitedSizes_InOrder_IfHasSizes()
+    {
+        // Arrange
+        var thumbnailPolicy = new ThumbnailPolicy
+        {
+            Id = "TestPolicy",
+            Name = "TestPolicy",
+            Sizes = "800,200,100,400"
+        };
+        
+        // Assert
+        thumbnailPolicy.SizeList.Should().BeEquivalentTo(new List<int> { 800, 400, 200, 100 });
     }
     
     [Theory]
@@ -37,6 +52,6 @@ public class ThumbnailPolicyTests
         };
         
         // Assert
-        thumbnailPolicy.SizeList.Should().BeNull();
+        thumbnailPolicy.SizeList.Should().BeEmpty();
     }
 }

--- a/src/protagonist/DLCS.Model/Policies/ThumbnailPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/ThumbnailPolicy.cs
@@ -8,19 +8,32 @@ namespace DLCS.Model.Policies;
 [DebuggerDisplay("{Name}: {Sizes}")]
 public class ThumbnailPolicy
 {
-    private List<int>? sizeList = null;
+    private IReadOnlyCollection<int>? sizeList;
 
     public string Id { get; set; }
     public string Name { get; set; }
     public string Sizes { get; set; }
 
-    public List<int> SizeList
+    /// <summary>
+    /// Get a list of available sizes, ordered from largest -> smallest
+    /// </summary>
+    public IReadOnlyCollection<int> SizeList
     {
         get
         {
-            if (sizeList == null && !string.IsNullOrEmpty(Sizes))
+            if (sizeList != null) return sizeList;
+            
+            if (string.IsNullOrEmpty(Sizes))
             {
-                sizeList = Sizes.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToList();
+                sizeList = new List<int>();
+            }
+            else
+            {
+                sizeList = Sizes
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(int.Parse)
+                    .OrderByDescending(s => s)
+                    .ToList();
             }
             return sizeList;
         }

--- a/src/protagonist/DLCS.Repository/Assets/Thumbs/ThumbsManager.cs
+++ b/src/protagonist/DLCS.Repository/Assets/Thumbs/ThumbsManager.cs
@@ -24,6 +24,7 @@ public abstract class ThumbsManager
         BucketWriter = bucketWriter;
         StorageKeyGenerator = storageKeyGenerator;
     }
+    
     protected static Size GetMaxAvailableThumb(Asset asset, ThumbnailPolicy policy)
     {
         var _ = asset.GetAvailableThumbSizes(policy, out var maxDimensions);

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -1,0 +1,203 @@
+﻿using DLCS.AWS.S3;
+using DLCS.AWS.S3.Models;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Policies;
+using Engine.Ingest.Image;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Test.Helpers.Storage;
+
+namespace Engine.Tests.Ingest.Image;
+
+public class ThumbCreatorTests
+{
+    private readonly TestBucketWriter bucketWriter;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly ThumbCreator sut; 
+    
+    public ThumbCreatorTests()
+    {
+        bucketWriter = new TestBucketWriter();
+        storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
+
+        A.CallTo(() => storageKeyGenerator.GetLargestThumbnailLocation(A<AssetId>._))
+            .ReturnsLazily((AssetId assetId) => new ObjectInBucket("thumbs-bucket", $"{assetId}/low.jpg"));
+        A.CallTo(() => storageKeyGenerator.GetThumbsSizesJsonLocation(A<AssetId>._))
+            .ReturnsLazily((AssetId assetId) => new ObjectInBucket("thumbs-bucket", $"{assetId}/s.json"));
+        A.CallTo(() => storageKeyGenerator.GetThumbnailLocation(A<AssetId>._, A<int>._, A<bool>._))
+            .ReturnsLazily((AssetId assetId, int size, bool open) =>
+            {
+                var authSlug = open ? "o" : "a";
+                return new ObjectInBucket("thumbs-bucket", $"{assetId}/{authSlug}/{size}.jpg");
+            });
+
+        sut = new ThumbCreator(bucketWriter, storageKeyGenerator, new NullLogger<ThumbCreator>());
+    }
+
+    [Fact]
+    public async Task CreateNewThumbs_NoOp_IfThumbsToProcessEmpty()
+    {
+        // Arrange
+        var asset = new Asset(new AssetId(10, 20, "foo"));
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, Array.Empty<ImageOnDisk>());
+        
+        // Assert
+        thumbsCreated.Should().Be(0);
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_NoOp_IfExpectedThumbsEmpty()
+    {
+        // Arrange
+        var asset = new Asset(new AssetId(10, 20, "foo"))
+        {
+            Width = 40, Height = 50
+        };
+        asset.WithThumbnailPolicy(new ThumbnailPolicy { Sizes = string.Empty });
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, new[]
+        {
+            new ImageOnDisk
+            {
+                Height = 10, Path = "here", Width = 10
+            }
+        });
+        
+        // Assert
+        thumbsCreated.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_AllOpen_NormalisedSizes()
+    {
+        // Arrange
+        var asset = new Asset(new AssetId(10, 20, "foo"))
+        {
+            Width = 3030, Height = 5000
+        };
+        asset.WithThumbnailPolicy(new ThumbnailPolicy { Sizes = "1000,500,100" });
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" }, // Should be 303, simulate rounding error
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(3);
+
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/low.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/1000.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        
+        // verify that s.json uses the calculated size, rather than size returned from processor
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents("{\"o\":[[606,1000],[303,500],[61,100]],\"a\":[]}");
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_LargestAuth_NormalisedSizes()
+    {
+        // Arrange
+        var asset = new Asset(new AssetId(10, 20, "foo"))
+        {
+            Width = 3030, Height = 5000, MaxUnauthorised = 700
+        };
+        asset.WithThumbnailPolicy(new ThumbnailPolicy { Sizes = "1000,500,100" });
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(3);
+
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/low.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/a/1000.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        
+        // verify that s.json uses the calculated size, rather than size returned from processor
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents("{\"o\":[[303,500],[61,100]],\"a\":[[606,1000]]}");
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_ImageSmallerThanThumbnail_NormalisedSizes()
+    {
+        // Arrange
+        var asset = new Asset(new AssetId(10, 20, "foo"))
+        {
+            Width = 266, Height = 440
+        };
+        asset.WithThumbnailPolicy(new ThumbnailPolicy { Sizes = "1000,500,100" });
+
+        // NOTE - this mimics the payload that Appetiser would send back
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 266, Height = 440, Path = "1000.jpg" },
+            new() { Width = 266, Height = 440, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(2);
+
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/low.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/440.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        
+        // verify that s.json uses the calculated size, rather than size returned from processor
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents("{\"o\":[[266,440],[60,100]],\"a\":[]}");
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+    }
+}

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -56,7 +56,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Stubbed appetiser
         var appetiserResponse = new AppetiserResponseModel
         {
-            Height = 200, Width = 340, Thumbs = new[]
+            Height = 1000, Width = 500, Thumbs = new[]
             {
                 new ImageOnDisk { Height = 800, Width = 400, Path = "/path/to/800.jpg" },
                 new ImageOnDisk { Height = 400, Width = 200, Path = "/path/to/400.jpg" },
@@ -107,8 +107,8 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Database records updated
         var updatedAsset = await dbContext.Images.SingleAsync(a => a.Id == assetId);
-        updatedAsset.Width.Should().Be(340);
-        updatedAsset.Height.Should().Be(200);
+        updatedAsset.Width.Should().Be(500);
+        updatedAsset.Height.Should().Be(1000);
         updatedAsset.Ingesting.Should().BeFalse();
         updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
         updatedAsset.MediaType.Should().Be("image/tiff");
@@ -157,8 +157,8 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Database records updated
         var updatedAsset = await dbContext.Images.SingleAsync(a => a.Id == assetId);
-        updatedAsset.Width.Should().Be(340);
-        updatedAsset.Height.Should().Be(200);
+        updatedAsset.Width.Should().Be(500);
+        updatedAsset.Height.Should().Be(1000);
         updatedAsset.Ingesting.Should().BeFalse();
         updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
         updatedAsset.MediaType.Should().Be("image/tiff");

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -256,7 +256,7 @@ public class AppetiserClient : IImageProcessor
 
     private void SetThumbsOnDiskLocation(IngestionContext context, AppetiserResponseModel responseModel)
     {
-        // Update the location of all thumbs to be full path on disk.
+        // Update the location of all thumbs to be full path on disk, relative to orchestrator
         var partialTemplate = TemplatedFolders.GenerateFolderTemplate(engineSettings.ImageIngest.ThumbsTemplate,
             context.AssetId, root: engineSettings.ImageIngest.GetRoot());
         foreach (var thumb in responseModel.Thumbs)

--- a/src/protagonist/Engine/Ingest/Image/IThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/IThumbCreator.cs
@@ -10,5 +10,5 @@ public interface IThumbCreator
     /// <param name="asset">Asset thumbnails are for</param>
     /// <param name="thumbsToProcess">List of jpgs on disk that are to be copied to S3</param>
     /// <returns></returns>
-    Task CreateNewThumbs(Asset asset, IReadOnlyList<ImageOnDisk> thumbsToProcess);
+    Task<int> CreateNewThumbs(Asset asset, IReadOnlyList<ImageOnDisk> thumbsToProcess);
 }

--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -1,6 +1,7 @@
 using DLCS.AWS.S3;
 using DLCS.Core;
 using DLCS.Core.Threading;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Assets.Thumbs;
@@ -10,31 +11,56 @@ namespace Engine.Ingest.Image;
 
 public class ThumbCreator : ThumbsManager, IThumbCreator
 {
+    private readonly ILogger<ThumbCreator> logger;
     private readonly AsyncKeyedLock asyncLocker = new();
 
     public ThumbCreator(
         IBucketWriter bucketWriter,
-        IStorageKeyGenerator storageKeyGenerator) : base(bucketWriter, storageKeyGenerator)
+        IStorageKeyGenerator storageKeyGenerator,
+        ILogger<ThumbCreator> logger) : base(bucketWriter, storageKeyGenerator)
     {
+        this.logger = logger;
     }
 
-    public async Task CreateNewThumbs(Asset asset, IReadOnlyList<ImageOnDisk> thumbsToProcess)
+    public async Task<int> CreateNewThumbs(Asset asset, IReadOnlyList<ImageOnDisk> thumbsToProcess)
     {
-        if (thumbsToProcess.Count == 0) return;
         var assetId = asset.Id;
-            
-        using var processLock = await asyncLocker.LockAsync($"create:{assetId}");
+
+        if (thumbsToProcess.Count == 0)
+        {
+            logger.LogDebug("No thumbs to process for {AssetId}, aborting", assetId);
+            return 0;
+        }
+        
+        var expectedSizes = asset.GetAvailableThumbSizes(asset.FullThumbnailPolicy!, out var maxDimensions, true);
+        if (expectedSizes.Count == 0)
+        {
+            logger.LogDebug("No expected thumb sizes for {AssetId}, aborting", assetId);
+            return 0;
+        }
+
+        var imageShape = expectedSizes[0].GetShape();
+        var maxAvailableThumb = Size.Square(maxDimensions.maxBoundedSize);
         var thumbnailSizes = new ThumbnailSizes(thumbsToProcess.Count);
-        var maxAvailableThumb = GetMaxAvailableThumb(asset, asset.FullThumbnailPolicy);
-            
-        // this is the largest thumb, regardless of being available or not.
-        var largestThumb = asset.FullThumbnailPolicy.SizeList[0];
-            
+        var processedWidths = new List<int>(thumbsToProcess.Count);
+        
+        using var processLock = await asyncLocker.LockAsync($"create:{assetId}");
+
+        // First is always largest
+        bool processingLargest = true;
         foreach (var thumbCandidate in thumbsToProcess)
         {
-            var thumb = new Size(thumbCandidate.Width, thumbCandidate.Height);
-            bool isOpen;
+            // Safety check for duplicate
+            if (processedWidths.Contains(thumbCandidate.Width))
+            {
+                logger.LogDebug("Thumbnail {Width},{Height} has already been processed for asset {AssetId}",
+                    thumbCandidate.Width, thumbCandidate.Height, assetId);
+                continue;
+            }
 
+            var thumb = GetThumbnailSize(thumbCandidate, imageShape, expectedSizes, assetId);
+            
+            bool isOpen;
             if (thumb.IsConfinedWithin(maxAvailableThumb))
             {
                 thumbnailSizes.AddOpen(thumb);
@@ -45,19 +71,50 @@ public class ThumbCreator : ThumbsManager, IThumbCreator
                 thumbnailSizes.AddAuth(thumb);
                 isOpen = false;
             }
+            
+            await UploadThumbs(processingLargest, assetId, thumbCandidate, thumb, isOpen);
 
-            var currentMax = thumb.MaxDimension;
-            if (currentMax == largestThumb)
-            {
-                // The largest thumb always goes to low.jpg as well as the 'normal' place
-                var lowKey = StorageKeyGenerator.GetLargestThumbnailLocation(assetId);
-                await BucketWriter.WriteFileToBucket(lowKey, thumbCandidate.Path, MIMEHelper.JPEG);
-            }
-
-            var thumbKey = StorageKeyGenerator.GetThumbnailLocation(assetId, thumb.MaxDimension, isOpen);
-            await BucketWriter.WriteFileToBucket(thumbKey, thumbCandidate.Path, MIMEHelper.JPEG);
+            processingLargest = false;
+            processedWidths.Add(thumbCandidate.Width);
         }
             
         await CreateSizesJson(assetId, thumbnailSizes);
+        return thumbnailSizes.Count;
+    }
+
+    /// <summary>
+    /// Find matching size from pre-calculated thumbs. We use these rather than sizes returned by image-processor to
+    /// avoid rounding issues
+    /// </summary>
+    private Size GetThumbnailSize(ImageOnDisk imageOnDisk, ImageShape imageShape, IEnumerable<Size> expectedSizes,
+        AssetId assetId)
+    {
+        try
+        {
+            return imageShape == ImageShape.Landscape
+                ? expectedSizes.Single(s => s.Width == imageOnDisk.Width)
+                : expectedSizes.Single(s => s.Height == imageOnDisk.Height);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogError("Unable to find expected thumbnail size {Width},{Height} for asset {AssetId}. {Path}",
+                imageOnDisk.Width, imageOnDisk.Height, assetId, imageOnDisk.Path);
+            throw new ApplicationException(
+                $"Unable to find expected thumbnail size {imageOnDisk.Width},{imageOnDisk.Height}", ex);
+        }
+    }
+
+    private async Task UploadThumbs(bool processingLargest, AssetId assetId, ImageOnDisk thumbCandidate, Size thumb,
+        bool isOpen)
+    {
+        if (processingLargest)
+        {
+            // The largest thumb always goes to low.jpg as well as the 'normal' place
+            var lowKey = StorageKeyGenerator.GetLargestThumbnailLocation(assetId);
+            await BucketWriter.WriteFileToBucket(lowKey, thumbCandidate.Path, MIMEHelper.JPEG);
+        }
+
+        var thumbKey = StorageKeyGenerator.GetThumbnailLocation(assetId, thumb.MaxDimension, isOpen);
+        await BucketWriter.WriteFileToBucket(thumbKey, thumbCandidate.Path, MIMEHelper.JPEG);
     }
 }


### PR DESCRIPTION
Resolves #415 and resolves #32

Fix for #415 was to replicates a hotfix made straight to main branch (#414) where the logic in `ThumbReorganiser` was updated to not look at the expected sizes from the thumbnailPolicy, but instead to look at what sizes are actually available.

Main change is to ensure that we handle an image with dimensions smaller than a required size in thumbnail policy. If this happens we will create as large an image as we can, even if it doesn't match a thumbnail size, without scaling up.

E.g. policy `800,400,200,100` for image with w,h of 300,150 would create thumbs of size:
* 300,150
* 200,100
* 100,50

Handling for this was in a few different places, detailed below.

**`AssetX.GetAvailableThumbSizes()`**

Previously this was returning a number of sizes equal to the number of sizes in thumbnail policy. E.g., for above example it would return `[[300,150],[300,150],[200,100],[100,50]]` and always returned a `maxBoundedSize` equal to the largest thumbnail (so `800` for above).

Modified this to not return duplicate sizes and return the actual max size.

**`ThumbCreator.CreateNewThumbs()`**

This now calls the above method to get a list of all possible sizes. It then iterates through the returned sizes from Appetiser, for each one it gets the sizes from above list to avoid rounding error previously seen between dotnet + python code.

Similar to how `GetAvailableThumbSizes()` previously worked, Appetiser returns an array of size equal to number of sizes requested. This can lead to duplicates which are ignored.

`s.json` will reflect the actual size of thumbnails uploaded (based on results of `GetAvailableThumbSizes()`) - this will in turn be used to generate info.json and advertise these sizes as the ones available.