### PR TITLE
Fix image detection logic when creating priority batch

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -699,7 +699,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
         await dbContext.SaveChangesAsync();
 
-        // a batch of 3 images
+        // a batch of 3 images - 1 with Family, 1 with DC and 1 with both
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
     ""@type"": ""Collection"",
@@ -708,13 +708,14 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
           ""id"": ""one"",
           ""origin"": ""https://example.org/foo.jpg"",
           ""space"": 2,
+          ""deliveryChannels"": [""iiif-img""],
           ""family"": ""I"",
           ""mediaType"": ""image/jpeg""
         },
         {
           ""id"": ""two"",
           ""origin"": ""https://example.org/foo.png"",
-          ""family"": ""I"",
+          ""deliveryChannels"": [""iiif-img""],
           ""space"": 2,
           ""mediaType"": ""image/png""
         },

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -58,7 +58,8 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         // TODO - we may need to support non-Image assets here 
         if (request.IsPriority)
         {
-            if (request.Assets.Any(a => a.Family != AssetFamily.Image))
+            if (request.Assets.Any(a =>
+                    a.Family != AssetFamily.Image && !a.HasDeliveryChannel(AssetDeliveryChannels.Image)))
             {
                 return ModifyEntityResult<Batch>.Failure("Priority queue only supports image assets",
                     WriteResult.FailedValidation);


### PR DESCRIPTION
Previous logic only checked for `I` family, which has been superseded by delivery-channel. Updated to validate that all object have `I` family and/or `iiif-img` delivery-channel.