### PR TITLE
Handle Auth v0.9.4

### DIFF
--- a/src/protagonist/DLCS.AWS/DLCS.AWS.csproj
+++ b/src/protagonist/DLCS.AWS/DLCS.AWS.csproj
@@ -24,7 +24,7 @@
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/protagonist/DLCS.Model/Auth/Entities/AuthService.cs
+++ b/src/protagonist/DLCS.Model/Auth/Entities/AuthService.cs
@@ -2,7 +2,7 @@
 
 namespace DLCS.Model.Auth.Entities;
 
-public partial class AuthService
+public class AuthService
 {
     public string Id { get; set; }
     public int Customer { get; set; }

--- a/src/protagonist/DLCS.Model/Auth/Entities/Role.cs
+++ b/src/protagonist/DLCS.Model/Auth/Entities/Role.cs
@@ -2,7 +2,7 @@
 
 namespace DLCS.Model.Auth.Entities;
 
-public partial class Role
+public class Role
 {
     public string Id { get; set; }
     public int Customer { get; set; }

--- a/src/protagonist/DLCS.Model/Auth/Entities/RoleProvider.cs
+++ b/src/protagonist/DLCS.Model/Auth/Entities/RoleProvider.cs
@@ -5,7 +5,7 @@ namespace DLCS.Model.Auth.Entities;
 /// <summary>
 /// Configuration of how to obtain Role information for a given auth service
 /// </summary>
-public partial class RoleProvider
+public class RoleProvider
 {
     public string Id { get; set; }
     public int Customer { get; set; }

--- a/src/protagonist/DLCS.Model/Auth/IAuthServicesRepository.cs
+++ b/src/protagonist/DLCS.Model/Auth/IAuthServicesRepository.cs
@@ -39,19 +39,4 @@ public interface IAuthServicesRepository
     
     Role CreateRole(string name, int customer, string authServiceId);
     AuthService CreateAuthService(int customerId, string profile, string name, int ttl);
-    
-    void SaveAuthService(AuthService authService);
-    void SaveRole(Role role);
-    
-    // Below this line reproduces Deliverator IAuthServiceStore
-    AuthService Get(string id);
-    AuthService GetChild(string id);
-    AuthService GetChildByCustomerName(int customer, string name);
-    AuthService GetByCustomerName(int customer, string name);
-    IEnumerable<AuthService> GetByCustomerRole(int customer, string role);
-    IEnumerable<AuthService> GetAll();
-    int CountByCustomer(int customer);
-    IEnumerable<AuthService> GetByCustomer(int customer, int skip = -1, int take = -1);
-    void Put(AuthService authService); // implemented as SaveAuthService
-    void Remove(string id);
 }

--- a/src/protagonist/DLCS.Model/DLCS.Model.csproj
+++ b/src/protagonist/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.10" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
   </ItemGroup>
 
 </Project>

--- a/src/protagonist/DLCS.Model/DLCS.Model.csproj
+++ b/src/protagonist/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.3" />
+    <PackageReference Include="iiif-net" Version="0.1.9" />
   </ItemGroup>
 
 </Project>

--- a/src/protagonist/DLCS.Model/DLCS.Model.csproj
+++ b/src/protagonist/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.9" />
+    <PackageReference Include="iiif-net" Version="0.1.10" />
   </ItemGroup>
 
 </Project>

--- a/src/protagonist/DLCS.Repository/Auth/DapperAuthServicesRepository.cs
+++ b/src/protagonist/DLCS.Repository/Auth/DapperAuthServicesRepository.cs
@@ -118,6 +118,7 @@ public class DapperAuthServicesRepository : IDapperConfigRepository, IAuthServic
         }
         
         // All services have a token service so add to collection
+        // TODO - need to determine if this is a 1 or 0 service
         authServices.Add(new AuthService
         {
             Customer = customer,
@@ -136,11 +137,10 @@ public class DapperAuthServicesRepository : IDapperConfigRepository, IAuthServic
             Customer = customer,
             Name = name,
             AuthService = authServiceId,
-            Aliases = String.Empty
+            Aliases = string.Empty
         };
     }
-    
-    
+
     public AuthService CreateAuthService(int customerId, string profile, string name, int ttl)
     {            
         return new AuthService
@@ -150,13 +150,13 @@ public class DapperAuthServicesRepository : IDapperConfigRepository, IAuthServic
             Profile = profile,
             Name = name,
             Ttl = ttl,
-            CallToAction = String.Empty,
-            ChildAuthService = String.Empty,
-            Description = String.Empty,
-            Label = String.Empty,
-            PageDescription = String.Empty,
-            PageLabel = String.Empty,
-            RoleProvider = String.Empty
+            CallToAction = string.Empty,
+            ChildAuthService = string.Empty,
+            Description = string.Empty,
+            Label = string.Empty,
+            PageDescription = string.Empty,
+            PageLabel = string.Empty,
+            RoleProvider = string.Empty
         };
     }
 
@@ -168,68 +168,6 @@ public class DapperAuthServicesRepository : IDapperConfigRepository, IAuthServic
         return $"{fqRolePrefix}/customers/{customer}/roles/{firstCharLowered.ToCamelCase()}";
     }
 
-    // TODO (DG) - are these required?
-    public void SaveAuthService(AuthService authService)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void SaveRole(Role role)
-    {
-        throw new NotImplementedException();
-    }
-
-    // Interface signature from Deliverator IAuthServiceStore reproduced below
-    public AuthService Get(string id)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AuthService GetChild(string id)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AuthService GetChildByCustomerName(int customer, string name)
-    {
-        throw new NotImplementedException();
-    }
-
-    public AuthService GetByCustomerName(int customer, string name)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IEnumerable<AuthService> GetByCustomerRole(int customer, string role)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IEnumerable<AuthService> GetAll()
-    {
-        throw new NotImplementedException();
-    }
-
-    public int CountByCustomer(int customer)
-    {
-        throw new NotImplementedException();
-    }
-
-    public IEnumerable<AuthService> GetByCustomer(int customer, int skip = -1, int take = -1)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void Put(AuthService authService)
-    {
-        throw new NotImplementedException();
-    }
-
-    public void Remove(string id)
-    {
-        throw new NotImplementedException();
-    }
-    
     private const string AuthServiceSql = @"
 WITH RECURSIVE cte_auth AS (
     SELECT p.""Id"", p.""Customer"", p.""Name"", p.""Profile"", p.""Label"", p.""Description"", p.""PageLabel"", p.""PageDescription"", p.""CallToAction"", p.""TTL"", p.""RoleProvider"", p.""ChildAuthService""

--- a/src/protagonist/DLCS.Repository/Auth/DapperAuthServicesRepository.cs
+++ b/src/protagonist/DLCS.Repository/Auth/DapperAuthServicesRepository.cs
@@ -118,7 +118,6 @@ public class DapperAuthServicesRepository : IDapperConfigRepository, IAuthServic
         }
         
         // All services have a token service so add to collection
-        // TODO - need to determine if this is a 1 or 0 service
         authServices.Add(new AuthService
         {
             Customer = customer,

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="iiif-net" Version="0.1.9" />
+    <PackageReference Include="iiif-net" Version="0.1.10" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="iiif-net" Version="0.1.3" />
+    <PackageReference Include="iiif-net" Version="0.1.9" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="iiif-net" Version="0.1.10" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.9" />
+    <PackageReference Include="iiif-net" Version="0.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.3" />
+    <PackageReference Include="iiif-net" Version="0.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.1.10" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="iiif-net" Version="0.1.3" />
+        <PackageReference Include="iiif-net" Version="0.1.9" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="iiif-net" Version="0.1.9" />
+        <PackageReference Include="iiif-net" Version="0.1.10" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="iiif-net" Version="0.1.10" />
+        <PackageReference Include="iiif-net" Version="0.1.11" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />

--- a/src/protagonist/Hydra/Hydra.csproj
+++ b/src/protagonist/Hydra/Hydra.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/protagonist/Orchestrator.Tests/Features/IIIF/IIIFAuthBuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/IIIF/IIIFAuthBuilderTests.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using DLCS.Core.Types;
 using DLCS.Model.Auth;
 using DLCS.Model.Auth.Entities;
 using FakeItEasy;
-using FluentAssertions;
 using IIIF.Auth.V1;
 using IIIF.Presentation.V2.Strings;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,19 +11,30 @@ using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Settings;
-using Xunit;
 
 namespace Orchestrator.Tests.Features.IIIF;
 
 public class IIIFAuthBuilderTests
 {
     private readonly IAuthServicesRepository authServicesRepository;
-    private readonly IIIFAuthBuilder sut;
 
     public IIIFAuthBuilderTests()
     {
         authServicesRepository = A.Fake<IAuthServicesRepository>();
-        sut = new IIIFAuthBuilder(authServicesRepository, new NullLogger<IIIFAuthBuilder>());
+    }
+    
+    private IIIFAuthBuilder GetSut(bool throwIfNotFound = false)
+    {
+        var authOptions = Options.Create(new AuthSettings
+        {
+            SupportedAccessCookieProfiles = new List<string>
+            {
+                "http://iiif.io/api/auth/0/login/clickthrough"
+            },
+            ThrowIfUnsupportedProfile = throwIfNotFound
+        });
+        
+        return new IIIFAuthBuilder(authServicesRepository, authOptions, new NullLogger<IIIFAuthBuilder>());
     }
 
     [Fact]
@@ -33,6 +42,7 @@ public class IIIFAuthBuilderTests
     {
         // Arrange
         var asset = GetAsset();
+        var sut = GetSut();
         
         // Act 
         var result = await sut.GetAuthCookieServiceForAsset(asset);
@@ -41,8 +51,10 @@ public class IIIFAuthBuilderTests
         result.Should().BeNull();
     }
     
-    [Fact]
-    public async Task GetAuthCookieServiceForAsset_ReturnsCookieServiceWithNoChildren_IfNoChildServices()
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/1/login/clickthrough")]
+    [InlineData("http://iiif.io/api/auth/3/clickthrough")]
+    public async Task GetAuthCookieServiceForAsset_ReturnsNull_IfParentProfileUnknown_AndThrowIfUnsupportedFalse(string profile)
     {
         // Arrange
         var asset = GetAsset();
@@ -50,20 +62,109 @@ public class IIIFAuthBuilderTests
         asset.Roles = new List<string> { roleName };
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
-                { new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description" } });
+            {
+                new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description", Profile = profile }
+            });
+        var sut = GetSut();
+        
+        // Act 
+        var result = await sut.GetAuthCookieServiceForAsset(asset);
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/1/login/clickthrough")]
+    [InlineData("http://iiif.io/api/auth/3/clickthrough")]
+    public async Task GetAuthCookieServiceForAsset_Throws_IfParentProfileUnknown_AndThrowIfUnsupportedTrue(string profile)
+    {
+        // Arrange
+        var asset = GetAsset();
+        const string roleName = "secret";
+        asset.Roles = new List<string> { roleName };
+        A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
+            .Returns(new List<AuthService>
+            {
+                new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description", Profile = profile }
+            });
+        var sut = GetSut(true);
+        
+        // Act 
+        Func<Task> action = () => sut.GetAuthCookieServiceForAsset(asset);
+        
+        // Assert
+        await action.Should()
+            .ThrowAsync<ArgumentException>()
+            .WithMessage($"Unsupported AuthService profile type: {profile}");
+    }
+    
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/1/login")]
+    [InlineData("http://iiif.io/api/auth/1/clickthrough")]
+    [InlineData("http://iiif.io/api/auth/1/kiosk")]
+    [InlineData("http://iiif.io/api/auth/1/external")]
+    public async Task GetAuthCookieServiceForAsset_ReturnsCookieServiceWithNoChildren_IfNoChildServices_AuthCookie1(string profile)
+    {
+        // Arrange
+        var asset = GetAsset();
+        const string roleName = "secret";
+        asset.Roles = new List<string> { roleName };
+        A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
+            .Returns(new List<AuthService>
+            {
+                new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description", Profile = profile }
+            });
+        var sut = GetSut();
         
         // Act 
         var result = await sut.GetAuthCookieServiceForAsset(asset);
         
         // Assert
         result.Id.Should().Be("The-Parent");
-        result.Label.LanguageValues
+        var authCookieSvc = result as AuthCookieService;
+        authCookieSvc.Label.LanguageValues
             .Should().HaveCount(1)
             .And.Subject.Should().OnlyContain(v => v.Value == "Parent");
-        result.Description.LanguageValues
+        authCookieSvc.Description.LanguageValues
             .Should().HaveCount(1)
             .And.Subject.Should().OnlyContain(v => v.Value == "Parent Description");
-        result.Service.Should().BeNullOrEmpty();
+        authCookieSvc.Service.Should().BeNullOrEmpty();
+    }
+    
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/0/login", "Auth spec login")]
+    [InlineData("http://iiif.io/api/auth/0/clickthrough", "Auth spec clickthrough")]
+    [InlineData("http://iiif.io/api/auth/0/kiosk", "Auth spec kiosk")]
+    [InlineData("http://iiif.io/api/auth/0/external", "Auth spec external")]
+    [InlineData("http://iiif.io/api/auth/0/login/clickthrough", "Not standard but in supported list")]
+    public async Task GetAuthCookieServiceForAsset_ReturnsCookieServiceWithNoChildren_IfNoChildServices_AuthCookie0(string profile, string reason)
+    {
+        // Arrange
+        var asset = GetAsset();
+        const string roleName = "secret";
+        asset.Roles = new List<string> { roleName };
+        A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
+            .Returns(new List<AuthService>
+            {
+                new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description", Profile = profile }
+            });
+        var sut = GetSut();
+        
+        // Act 
+        var result = await sut.GetAuthCookieServiceForAsset(asset);
+        
+        // Assert
+        result.Id.Should().Be("The-Parent");
+        var authCookieSvc = result as global::IIIF.Auth.V0.AuthCookieService;
+        authCookieSvc.Profile.Should().Be(profile, reason);
+        authCookieSvc.Label.LanguageValues
+            .Should().HaveCount(1)
+            .And.Subject.Should().OnlyContain(v => v.Value == "Parent");
+        authCookieSvc.Description.LanguageValues
+            .Should().HaveCount(1)
+            .And.Subject.Should().OnlyContain(v => v.Value == "Parent Description");
+        authCookieSvc.Service.Should().BeNullOrEmpty();
     }
     
     [Fact]
@@ -79,7 +180,7 @@ public class IIIFAuthBuilderTests
                 new()
                 {
                     Customer = 99, Name = "The-Parent", Label = "Parent", Description = "Parent Description",
-                    Profile = "http://iiif.io/api/auth/1/login/clickthrough"
+                    Profile = "http://iiif.io/api/auth/1/clickthrough"
                 },
                 new()
                 {
@@ -100,30 +201,30 @@ public class IIIFAuthBuilderTests
         {
             Id = "The-Token",
         };
+        var sut = GetSut();
         
         // Act 
         var result = await sut.GetAuthCookieServiceForAsset(asset);
         
         // Assert
         result.Id.Should().Be("The-Parent");
-        result.Label.LanguageValues
+        var authCookieSvc = result as AuthCookieService;
+        authCookieSvc.Label.LanguageValues
             .Should().HaveCount(1)
             .And.Subject.Should().OnlyContain(v => v.Value == "Parent");
-        result.Description.LanguageValues
+        authCookieSvc.Description.LanguageValues
             .Should().HaveCount(1)
             .And.Subject.Should().OnlyContain(v => v.Value == "Parent Description");
 
-        result.Service.Should().HaveCount(2);
-        result.Service[0].Should().BeEquivalentTo(authLogoutService);
-        result.Service[1].Should().BeEquivalentTo(authTokenService);
+        authCookieSvc.Service.Should().HaveCount(2);
+        authCookieSvc.Service[0].Should().BeEquivalentTo(authLogoutService);
+        authCookieSvc.Service[1].Should().BeEquivalentTo(authTokenService);
     }
     
     [Theory]
-    [InlineData("http://iiif.io/api/auth/0/logout")]
     [InlineData("http://iiif.io/api/auth/3/logout")]
-    [InlineData("http://iiif.io/api/auth/0/token")]
     [InlineData("http://iiif.io/api/auth/3/token")]
-    public void GetAuthCookieServiceForAsset_Throws_IfNonLevel1ChildServiceFound(string profile)
+    public async Task GetAuthCookieServiceForAsset_NullChildren_IfNonLevel1ChildServiceFound(string profile)
     {
         // Arrange
         var asset = GetAsset();
@@ -135,18 +236,18 @@ public class IIIFAuthBuilderTests
                 new()
                 {
                     Customer = 99, Name = "The-Parent", Label = "Parent", Description = "Parent Description",
-                    Profile = "http://iiif.io/api/auth/1/login/clickthrough"
+                    Profile = "http://iiif.io/api/auth/1/clickthrough"
                 },
                 new() { Profile = profile },
             });
+        var sut = GetSut();
         
         // Act 
-        Func<Task> action = () => sut.GetAuthCookieServiceForAsset(asset);
+        var result = await sut.GetAuthCookieServiceForAsset(asset);
         
         // Assert
-        action.Should()
-            .ThrowAsync<ArgumentException>()
-            .WithMessage("Encountered unknown auth service for asset 99/1/test-asset");
+        var authCookieSvc = result as AuthCookieService;
+        authCookieSvc.Service.Should().BeNullOrEmpty();
     }
     
     private OrchestrationImage GetAsset() => new() { AssetId = new AssetId(99, 1, "test-asset") };

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -602,15 +602,21 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_Correct)}");
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
+        const string logoutServiceName = "my-logout-service";
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
             deliveryChannels: new[] { "iiif-img" });
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
             Customer = 99, Id = roleName, Name = "test-role", AuthService = authServiceName
         });
-        await dbFixture.DbContext.AuthServices.AddAsync(new AuthService
+        await dbFixture.DbContext.AuthServices.AddRangeAsync(new AuthService
         {
-            Name = "test-service", Customer = 99, Id = authServiceName, Profile = "profile"
+            Name = "test-service", Customer = 99, Id = authServiceName, Profile = "http://iiif.io/api/auth/1/login",
+            Label = "the-label", Description = "the-description", ChildAuthService = logoutServiceName
+        }, new AuthService
+        {
+            Name = "test-service-logout", Customer = 99, Id = logoutServiceName,
+            Profile = "http://iiif.io/api/auth/1/logout",
         });
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -643,15 +649,23 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}");
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
+        const string logoutServiceName = "my-logout-service";
+
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
             deliveryChannels: new[] { "iiif-img" });
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
             Customer = 99, Id = roleName, Name = "test-role", AuthService = authServiceName
         });
-        await dbFixture.DbContext.AuthServices.AddAsync(new AuthService
+
+        await dbFixture.DbContext.AuthServices.AddRangeAsync(new AuthService
         {
-            Name = "test-service", Customer = 99, Id = authServiceName, Profile = "profile"
+            Name = "test-service", Customer = 99, Id = authServiceName, Profile = "http://iiif.io/api/auth/1/login",
+            Label = "the-label", Description = "the-description", ChildAuthService = logoutServiceName
+        }, new AuthService
+        {
+            Name = "test-service-logout", Customer = 99, Id = logoutServiceName,
+            Profile = "http://iiif.io/api/auth/1/logout",
         });
 
         await amazonS3.PutObjectAsync(new PutObjectRequest

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructor.cs
@@ -86,7 +86,11 @@ public class InfoJsonConstructor
         {
             var authCookieServiceForAsset =
                 await iiifAuthBuilder.GetAuthCookieServiceForAsset(orchestrationImage, cancellationToken);
-            if (authCookieServiceForAsset == null) return;
+            if (authCookieServiceForAsset == null)
+            {
+                logger.LogWarning("{AssetId} requires auth but no auth services generated", orchestrationImage.AssetId);
+                return;
+            }
             
             imageService.Service ??= new List<IService>(1);
             imageService.Service.Add(authCookieServiceForAsset);
@@ -105,7 +109,11 @@ public class InfoJsonConstructor
         {
             var authCookieServiceForAsset =
                 await iiifAuthBuilder.GetAuthCookieServiceForAsset(orchestrationImage, cancellationToken);
-            if (authCookieServiceForAsset == null) return;
+            if (authCookieServiceForAsset == null)
+            {
+                logger.LogWarning("{AssetId} requires auth but no auth services generated", orchestrationImage.AssetId);
+                return;
+            }
             
             imageService.Service ??= new List<IService>(1);
             imageService.Service.Add(authCookieServiceForAsset);

--- a/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
@@ -173,16 +173,22 @@ public class GetImageInfoJsonHandler : IRequestHandler<GetImageInfoJson, Descrip
             service.Id =
                 authPathGenerator.GetAuthPathForRequest(assetId.Customer.ToString(), service.Id ?? "_unknown_");
         }
-        
+
         foreach (var service in services ?? Enumerable.Empty<IService>())
         {
             if (service == null) continue;
-            if (service is AuthCookieService cookieService)
+            if (service is AuthCookieService cookieServiceV1)
             {
-                SetAuthId(cookieService);
-                SetServiceIdProperties(assetId, cookieService.Service);
+                SetAuthId(cookieServiceV1);
+                SetServiceIdProperties(assetId, cookieServiceV1.Service);
             }
-            else if (service is AuthLogoutService or AuthTokenService)
+            else if (service is IIIF.Auth.V0.AuthCookieService cookieServiceV0)
+            {
+                SetAuthId(cookieServiceV0);
+                SetServiceIdProperties(assetId, cookieServiceV0.Service);
+            }
+            else if (service is AuthLogoutService or AuthTokenService or IIIF.Auth.V0.AuthLogoutService
+                     or IIIF.Auth.V0.AuthTokenService)
             {
                 SetAuthId(service);
             }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/AuthFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/AuthFactory.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DLCS.Core.Collections;
+using DLCS.Core.Strings;
+using DLCS.Model.Auth.Entities;
+using IIIF;
+using IIIF.Presentation.V2;
+using IIIF.Presentation.V2.Strings;
+using AuthCookie0 = IIIF.Auth.V0.AuthCookieService;
+using AuthCookie1 = IIIF.Auth.V1.AuthCookieService;
+using AuthLogout0 = IIIF.Auth.V0.AuthLogoutService;
+using AuthLogout1 = IIIF.Auth.V1.AuthLogoutService;
+using AuthToken0 = IIIF.Auth.V0.AuthTokenService;
+using AuthToken1 = IIIF.Auth.V1.AuthTokenService;
+
+namespace Orchestrator.Infrastructure.IIIF;
+
+internal static class AuthFactory
+{
+    /// <summary>
+    /// Get AuthCookieService for specified <see cref="AuthService"/>
+    /// </summary>
+    public static IService? ConvertToAuthCookieService(this AuthService authService, IList<string> nonStandard,
+        bool throwIfUnknownProfile)
+    {
+        IService? converted = authService.Profile switch
+        {
+            AuthCookie1.ClickthroughProfile or AuthCookie1.ExternalProfile or AuthCookie1.KioskProfile
+                or AuthCookie1.LoginProfile
+                => new AuthCookie1(authService.Profile)
+                {
+                    Id = authService.Name,
+                    Label = new MetaDataValue(authService.Label),
+                    Description = new MetaDataValue(authService.Description),
+                },
+            AuthCookie0.ClickthroughProfile or AuthCookie0.ExternalProfile or AuthCookie0.KioskProfile
+                or AuthCookie0.LoginProfile
+                => GetAuthCookie0Service(authService),
+            _ => null
+        };
+
+        return HandleConversion(authService, converted, throwIfUnknownProfile, nonStandard, true);
+    }
+
+    private static AuthCookie0 GetAuthCookie0Service(AuthService authService) 
+        => new(authService.Profile)
+        {
+            Id = authService.Name,
+            Label = new MetaDataValue(authService.Label),
+            Description = new MetaDataValue(authService.Description),
+        };
+
+    /// <summary>
+    /// Convert specified <see cref="AuthService"/> to a IIIF child auth service.
+    /// The "Child" part makes this an access token service, logout service etc
+    /// </summary>
+    public static IService? ConvertToIIIFChildAuthService(this AuthService authService, string parentId,
+        bool throwIfUnknownProfile)
+    {
+        IService? childService = authService.Profile switch
+        {
+            AuthLogout1.AuthLogout1Profile => new AuthLogout1 { Id = $"{parentId}/logout" },
+            AuthToken1.AuthToken1Profile => new AuthToken1 { Id = authService.Name },
+            AuthLogout0.AuthLogout0Profile => new AuthLogout0 { Id = $"{parentId}/logout" },
+            AuthToken0.AuthToken0Profile => new AuthToken0 { Id = authService.Name },
+            _ => null
+        };
+
+        return HandleConversion(authService, childService, throwIfUnknownProfile, null, false);
+    }
+
+    private static IService? HandleConversion(AuthService authService, IService? convertedService,
+        bool throwIfUnknownProfile, IList<string>? nonStandard, bool isAccessCookie)
+    {
+        // If we don't have a service - is it a non-standard Profile?
+        if (convertedService == null && !nonStandard.IsNullOrEmpty())
+        {
+            if (nonStandard.Contains(authService.Profile))
+            {
+                convertedService = GetAuthCookie0Service(authService);
+            }
+        }
+
+        // If we still don't have a service bail out, or throw
+        if (convertedService == null)
+        {
+            if (throwIfUnknownProfile)
+            {
+                throw new ArgumentException($"Unsupported AuthService profile type: {authService.Profile}");
+            }
+
+            return null;
+        }
+
+        if (isAccessCookie) return convertedService;
+        
+        if (authService.Label.HasText())
+        {
+            (convertedService as ResourceBase)!.Label = new MetaDataValue(authService.Label);
+        }
+
+        if (authService.Description.HasText())
+        {
+            (convertedService as ResourceBase)!.Description = new MetaDataValue(authService.Description);
+        }
+
+        return convertedService;
+    }
+}

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -188,7 +188,8 @@ public class AuthSettings
     /// <summary>
     /// A list of supported auth profiles for Access Cookie Services that are non-standard.
     /// </summary>
-    public List<string> SupportedAccessCookieProfiles { get; set; } = new();
+    public List<string> SupportedAccessCookieProfiles { get; set; } =
+        new() { "http://iiif.io/api/auth/0/login/clickthrough" };
 
     /// <summary>
     /// A boolean controlling whether to throw an exception if an unsupported auth Profile is encountered, either from

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -83,7 +83,7 @@ public class OrchestratorSettings
     /// render a thumbnail of this size but will aim to get as close as possible.
     /// </summary>
     public int TargetThumbnailSize { get; set; } = 200;
-    
+
     public ProxySettings Proxy { get; set; }
 
     public CacheSettings Caching { get; set; }
@@ -184,6 +184,17 @@ public class AuthSettings
     /// If true the current domain is automatically added to auth token domains.
     /// </summary>
     public bool UseCurrentDomainForCookie { get; set; } = true;
+
+    /// <summary>
+    /// A list of supported auth profiles for Access Cookie Services that are non-standard.
+    /// </summary>
+    public List<string> SupportedAccessCookieProfiles { get; set; } = new();
+
+    /// <summary>
+    /// A boolean controlling whether to throw an exception if an unsupported auth Profile is encountered, either from
+    /// IIIF spec or <see cref="SupportedAccessCookieProfiles"/>. If false then null returned
+    /// </summary>
+    public bool ThrowIfUnsupportedProfile { get; set; } = false;
     
     /// <summary>
     /// URI template configuration for auth paths 

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -59,6 +59,7 @@ public class Startup
             .Configure<ProxySettings>(proxySection)
             .Configure<NamedQueryTemplateSettings>(configuration)
             .Configure<NamedQuerySettings>(configuration.GetSection("NamedQuery"))
+            .Configure<AuthSettings>(configuration.GetSection("Auth"))
             .Configure<PathTemplateOptions>(configuration.GetSection("PathRules"))
             .Configure<CacheSettings>(cachingSection);
 

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -136,9 +136,9 @@ public class DlcsDatabaseFixture : IAsyncLifetime
             });
         await DbContext.AuthServices.AddAsync(new AuthService
         {
-            Customer = customer, Name = "clickthrough", Id = ClickThroughAuthService,
-            Description = "", Label = "", Profile = "", Ttl = 200, PageDescription = "",
-            PageLabel = "", RoleProvider = "", CallToAction = "", ChildAuthService = ""
+            Customer = customer, Name = "clickthrough", Id = ClickThroughAuthService, Description = "", Label = "",
+            Profile = "http://iiif.io/api/auth/1/clickthrough", Ttl = 200, PageDescription = "", PageLabel = "",
+            RoleProvider = "", CallToAction = "", ChildAuthService = ""
         });
         await DbContext.Roles.AddAsync(new Role
         {

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
-    <PackageReference Include="iiif-net" Version="0.1.9" />
+    <PackageReference Include="iiif-net" Version="0.1.10" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
-    <PackageReference Include="iiif-net" Version="0.1.3" />
+    <PackageReference Include="iiif-net" Version="0.1.9" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
-    <PackageReference Include="iiif-net" Version="0.1.10" />
+    <PackageReference Include="iiif-net" Version="0.1.11" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />


### PR DESCRIPTION
Resolves #494 

Add support for Auth 0.9 for backwards compatibility with Deliverator. This can be removed in the future but will ease rolling out to existing customers.

Refactored `IIIFAuthBuilder` and extracted `AuthFactory` from this to build v0 or v1 services. Added a couple of new appSettings to control some auth behaviour:

* `SupportedAccessCookieProfiles` - this is a list of non-standard profiles that the DLCS will recognise. Defaults to `"http://iiif.io/api/auth/0/login/clickthrough"` as this is used in Deliverator.
* `ThrowIfUnsupportedProfile` - specifies whether to throw an exception if an unknown profile encountered. If `false` then `null` is returned; if `true` exception is thrown.

Removed a number of unused methods from `IAuthServicesRepository` - this was a copy of interface from Deliverator but none of the methods are being used. We can add in later as and when required.