### PR TITLE
Prevent excess reingest-on-orchestration requests

### DIFF
--- a/compose/docker-compose.local.yml
+++ b/compose/docker-compose.local.yml
@@ -6,14 +6,6 @@ volumes:
   dlcs_localstack_tmp: {}
 
 services:
-  # iip:
-  #   image: ghcr.io/dlcs/iipsrv-openjpeg:2.4.0
-  #   ports:
-  #     - "5025:8080"
-  #   volumes:
-  #     - $HOME\Docker\scratch:/nas
-  #   entrypoint: /operations.sh
-
   cantaloupe:
     image: ghcr.io/dlcs/cantaloupe:5.0.5
     ports:

--- a/src/protagonist/DLCS.Model/Assets/ImageLocation.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageLocation.cs
@@ -4,9 +4,24 @@ using DLCS.Core.Types;
 
 namespace DLCS.Model.Assets;
 
+/// <summary>
+/// Record indicating where this Image can be found in storage.
+/// Only used for "Image" types ('iiif-img' delivery channel) 
+/// </summary>
 public class ImageLocation
 {
+    /// <summary>
+    /// The Id of asset
+    /// </summary>
     public AssetId Id { get; set; }
+    
+    /// <summary>
+    /// The s3:// URI where this the image-server source file can be found
+    /// </summary>
     public string S3 { get; set; }
+    
+    /// <summary>
+    /// Currently unused
+    /// </summary>
     public string Nas { get; set; }
 }

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -263,7 +263,7 @@ public class MemoryAssetTrackerTests
     [Theory]
     [InlineData("iiif-img")]
     [InlineData("iiif-img,file")]
-    public async Task GetOrchestrationAssetT_Reingest_True_IfCreatedAfterCutOff(string deliveryChannel)
+    public async Task GetOrchestrationAssetT_Reingest_False_IfCreatedAfterCutOff(string deliveryChannel)
     {
         // Arrange
         var assetId = new AssetId(1, 1, "otis");

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
 using FakeItEasy;
-using FluentAssertions;
 using LazyCache.Mocks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
-using Xunit;
+using Orchestrator.Settings;
 
 namespace Orchestrator.Tests.Assets;
 
@@ -30,8 +28,21 @@ public class MemoryAssetTrackerTests
         A.CallTo(() => customerOriginStrategyRepository.GetCustomerOriginStrategy(A<AssetId>._, A<string>._))
             .Returns(Task.FromResult(new CustomerOriginStrategy { Id = "_default_", Strategy = OriginStrategyType.Default }));
 
-        sut = new MemoryAssetTracker(assetRepository, new MockCachingService(), thumbRepository,
-            customerOriginStrategyRepository, Options.Create(new CacheSettings()),
+        sut = GetSut();
+    }
+
+    private MemoryAssetTracker GetSut(DateTime? emptyImageLocationCreatedDate = null)
+    {
+        var orchestratorSettings = new OrchestratorSettings
+        {
+            Caching = new CacheSettings(),
+            ReingestOnOrchestration = new ReingestOnOrchestrationSettings
+            {
+                EmptyImageLocationCreatedDate = emptyImageLocationCreatedDate
+            }
+        };
+        return new MemoryAssetTracker(assetRepository, new MockCachingService(), thumbRepository,
+            customerOriginStrategyRepository, Options.Create(orchestratorSettings),
             new NullLogger<MemoryAssetTracker>());
     }
 
@@ -203,6 +214,7 @@ public class MemoryAssetTrackerTests
         result.Width.Should().Be(50);
         result.MaxUnauthorised.Should().Be(-1);
         result.OpenThumbs.Should().BeEquivalentTo(sizes);
+        result.Reingest.Should().BeFalse();
     }
     
     [Theory]
@@ -215,7 +227,7 @@ public class MemoryAssetTrackerTests
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
             DeliveryChannels = deliveryChannel.Split(","), Height = 10, Width = 50, MaxUnauthorised = -1,
-            Origin = "test"
+            Origin = "test", Created = DateTime.Today
         });
         A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
 
@@ -224,6 +236,50 @@ public class MemoryAssetTrackerTests
         
         // Assert
         result.OpenThumbs.Should().BeEmpty();
+    }
+    
+    [Theory]
+    [InlineData("iiif-img")]
+    [InlineData("iiif-img,file")]
+    public async Task GetOrchestrationAssetT_Reingest_True_IfCreatedBeforeCutOff(string deliveryChannel)
+    {
+        // Arrange
+        var assetId = new AssetId(1, 1, "otis");
+        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        {
+            DeliveryChannels = deliveryChannel.Split(","), Height = 10, Width = 50, MaxUnauthorised = -1,
+            Origin = "test", Created = DateTime.Today.AddDays(-1)
+        });
+        A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
+
+        // Act
+        var localSut = GetSut(DateTime.Today);
+        var result = await localSut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result.Reingest.Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData("iiif-img")]
+    [InlineData("iiif-img,file")]
+    public async Task GetOrchestrationAssetT_Reingest_True_IfCreatedAfterCutOff(string deliveryChannel)
+    {
+        // Arrange
+        var assetId = new AssetId(1, 1, "otis");
+        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        {
+            DeliveryChannels = deliveryChannel.Split(","), Height = 10, Width = 50, MaxUnauthorised = -1,
+            Origin = "test", Created = DateTime.Today.AddDays(1)
+        });
+        A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
+
+        // Act
+        var localSut = GetSut(DateTime.Today);
+        var result = await localSut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result.Reingest.Should().BeFalse();
     }
     
     [Theory]

--- a/src/protagonist/Orchestrator.Tests/Assets/OrchestrationAssetTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/OrchestrationAssetTests.cs
@@ -1,0 +1,42 @@
+﻿using Orchestrator.Assets;
+
+namespace Orchestrator.Tests.Assets;
+
+public class OrchestrationAssetTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsNotFound_True_IfS3LocationEmpty_AndReingestFalse(string s3Location)
+    {
+        // Arrange
+        var orchestrationAsset = new OrchestrationImage { Reingest = false, S3Location = s3Location };
+        
+        // Assert
+        orchestrationAsset.IsNotFound().Should().BeTrue();
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsNotFound_False_IfS3LocationEmpty_ButReingestTrue(string s3Location)
+    {
+        // Arrange
+        var orchestrationAsset = new OrchestrationImage { Reingest = true, S3Location = s3Location };
+        
+        // Assert
+        orchestrationAsset.IsNotFound().Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IsNotFound_False_IfS3LocationHasValue(bool reingest)
+    {
+        // Arrange
+        var orchestrationAsset = new OrchestrationImage { Reingest = reingest, S3Location = "s3://" };
+        
+        // Assert
+        orchestrationAsset.IsNotFound().Should().BeFalse();
+    }
+}

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1365,11 +1365,11 @@ public class FakeImageOrchestrator : IImageOrchestrator
 {
     public static List<AssetId> OrchestratedImages { get; } = new();
 
-    public Task EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
+    public Task<OrchestrationResult> EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default)
     {
         OrchestratedImages.Add(orchestrationImage.AssetId);
-        return Task.CompletedTask;
+        return Task.FromResult(OrchestrationResult.Orchestrated);
     }
 }
 

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1313,6 +1313,62 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.Headers.Should().ContainKey("x-test-key").WhoseValue.Should().BeEquivalentTo("foo bar");
     }
     
+    [Fact]
+    public async Task Get_Returns404_IfRedirectsImageServer_ButOrchestratorNotFound()
+    {
+        // Arrange
+        var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfRedirectsImageServer_ButOrchestratorNotFound)}");
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": []}",
+        });
+
+        FakeImageOrchestrator.ConfiguredResponse[id] = OrchestrationResult.NotFound;
+
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
+            deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
+        await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,100,100/200,200/0/default.jpg");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_Returns500_IfRedirectsImageServer_ButOrchestratorError()
+    {
+        // Arrange
+        var id = AssetId.FromString($"99/1/{nameof(Get_Returns500_IfRedirectsImageServer_ButOrchestratorError)}");
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": []}",
+        });
+
+        FakeImageOrchestrator.ConfiguredResponse[id] = OrchestrationResult.Error;
+
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
+            deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
+        await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,100,100/200,200/0/default.jpg");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+    }
+    
     [Theory]
     [InlineData("/info.json")]
     [InlineData("/full/max/0/default.jpg")]
@@ -1365,11 +1421,16 @@ public class FakeImageOrchestrator : IImageOrchestrator
 {
     public static List<AssetId> OrchestratedImages { get; } = new();
 
+    public static Dictionary<AssetId, OrchestrationResult> ConfiguredResponse { get; } = new();
+
     public Task<OrchestrationResult> EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default)
     {
         OrchestratedImages.Add(orchestrationImage.AssetId);
-        return Task.FromResult(OrchestrationResult.Orchestrated);
+        var orchestrationResult = ConfiguredResponse.TryGetValue(orchestrationImage.AssetId, out var res)
+            ? res
+            : OrchestrationResult.Orchestrated;
+        return Task.FromResult(orchestrationResult);
     }
 }
 

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -11,6 +11,7 @@ using LazyCache;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Orchestrator.Settings;
 
 namespace Orchestrator.Assets;
 
@@ -25,17 +26,18 @@ public class MemoryAssetTracker : IAssetTracker
     private readonly IThumbRepository thumbRepository;
     private readonly ICustomerOriginStrategyRepository customerOriginStrategyRepository;
     private readonly ILogger<MemoryAssetTracker> logger;
+    private readonly ReingestOnOrchestrationSettings reingestSettings;
 
     // Null object to store in cache for short duration
     private static readonly OrchestrationAsset NullOrchestrationAsset =
         new() { AssetId = new AssetId(-1, -1, "__notfound__") };
-
+    
     public MemoryAssetTracker(
         IAssetRepository assetRepository,
         IAppCache appCache,
         IThumbRepository thumbRepository,
         ICustomerOriginStrategyRepository customerOriginStrategyRepository,
-        IOptions<CacheSettings> cacheOptions,
+        IOptions<OrchestratorSettings> orchestratorOptions,
         ILogger<MemoryAssetTracker> logger)
     {
         this.assetRepository = assetRepository;
@@ -43,7 +45,8 @@ public class MemoryAssetTracker : IAssetTracker
         this.thumbRepository = thumbRepository;
         this.customerOriginStrategyRepository = customerOriginStrategyRepository;
         this.logger = logger;
-        cacheSettings = cacheOptions.Value;
+        cacheSettings = orchestratorOptions.Value.Caching;
+        reingestSettings = orchestratorOptions.Value.ReingestOnOrchestration;
     }
 
     public async Task<OrchestrationAsset?> GetOrchestrationAsset(AssetId assetId)
@@ -134,14 +137,17 @@ public class MemoryAssetTracker : IAssetTracker
             var getOpenThumbs = thumbRepository.GetOpenSizes(assetId);
 
             await Task.WhenAll(getImageLocation, getOpenThumbs);
+
+            var imageLocation = getImageLocation.Result;
             
             orchestrationAsset = new OrchestrationImage
             {
-                S3Location = getImageLocation.Result?.S3, // TODO - error handling
+                S3Location = imageLocation?.S3,
                 Width = asset.Width ?? 0,
                 Height = asset.Height ?? 0,
                 MaxUnauthorised = asset.MaxUnauthorised ?? 0,
-                OpenThumbs = getOpenThumbs.Result ?? new List<int[]>(), // TODO - reorganise thumb layout + create missing eventually
+                OpenThumbs = getOpenThumbs.Result ?? new List<int[]>(),
+                Reingest = GetReingestFlag(asset, imageLocation),
             };
         }
         else
@@ -159,5 +165,14 @@ public class MemoryAssetTracker : IAssetTracker
         }
         
         return SetDefaults(orchestrationAsset);
+    }
+    
+    private bool GetReingestFlag(Asset asset, ImageLocation? imageLocation)
+    {
+        // Reingest on the fly if no S3Location and image was created prior to EmptyImageLocationCreatedDate
+        if (!string.IsNullOrEmpty(imageLocation?.S3)) return false;
+        if (!reingestSettings.EmptyImageLocationCreatedDate.HasValue) return false;
+
+        return (asset.Created ?? DateTime.UtcNow) <= reingestSettings.EmptyImageLocationCreatedDate.Value;
     }
 }

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -78,7 +78,14 @@ public class OrchestrationImage : OrchestrationAsset
     /// <summary>
     /// Does this image need to be reingested on the fly?
     /// </summary>
+    /// <remarks>This can only be true for legacy images with missing ImageLocation value</remarks>
     public bool Reingest { get; set; }
+
+    /// <summary>
+    /// Get value indicating that this item should return a 404 as it has never been successfully processed
+    /// </summary>
+    /// <remarks>If the item has no S3Location AND it won't be reingested on the fly then it is 404</remarks>
+    public bool IsNotFound() => string.IsNullOrEmpty(S3Location) && !Reingest;
 }
 
 [Flags]

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -71,9 +71,14 @@ public class OrchestrationImage : OrchestrationAsset
     public List<int[]> OpenThumbs { get; set; } = new();
     
     /// <summary>
-    /// Get or set Asset location in S3 
+    /// Get or set location in S3 where image-server source is located 
     /// </summary>
     public string? S3Location { get; set; }
+    
+    /// <summary>
+    /// Does this image need to be reingested on the fly?
+    /// </summary>
+    public bool Reingest { get; set; }
 }
 
 [Flags]

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -84,6 +84,12 @@ public class ImageRequestHandler
             return new StatusCodeResult(HttpStatusCode.NotFound);
         }
 
+        if (orchestrationImage.IsNotFound())
+        {
+            logger.LogDebug("Request for {Path}: asset never been processed", httpContext.Request.Path);
+            return new StatusCodeResult(HttpStatusCode.NotFound);
+        }
+
         var proxyActionResult = await HandleRequestInternal(httpContext, orchestrationImage, assetRequest);
         if (proxyActionResult is StatusCodeResult) return proxyActionResult;
 

--- a/src/protagonist/Orchestrator/Features/Images/ImageRouteHandlers.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRouteHandlers.cs
@@ -74,7 +74,20 @@ public static class ImageRouteHandlers
 
         if (proxyActionResult is ProxyImageServerResult proxyImageServer)
         {
-            await imageOrchestrator.EnsureImageOrchestrated(proxyImageServer.OrchestrationImage, httpContext.RequestAborted);
+            var orchestrationResult =
+                await imageOrchestrator.EnsureImageOrchestrated(proxyImageServer.OrchestrationImage,
+                    httpContext.RequestAborted);
+            
+            if (orchestrationResult == OrchestrationResult.NotFound)
+            {
+                HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.NotFound));
+                return;
+            }
+            if (orchestrationResult == OrchestrationResult.Error)
+            {
+                HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.InternalServerError));
+                return;
+            }
         }
 
         var proxyAction = proxyActionResult as ProxyActionResult; 

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
@@ -49,11 +49,18 @@ public class YarpImageServerClient : IImageServerClient
         if (string.IsNullOrEmpty(imageServerPath)) return null;
         
         // Orchestrate the image to verify that image-server will be able to generate an info.json 
-        await orchestrator.EnsureImageOrchestrated(orchestrationImage, cancellationToken);
+        var orchestrationResult = await orchestrator.EnsureImageOrchestrated(orchestrationImage, cancellationToken);
+
+        if (orchestrationResult == OrchestrationResult.NotFound) return null;
+        if (orchestrationResult == OrchestrationResult.Error)
+        {
+            logger.LogError("Error getting info.json for {AssetId}, error Orchestrating", orchestrationImage.AssetId);
+            return null;
+        }
             
         try
         {
-            logger.LogDebug("Getting info.json for {AssetId} from image-server", orchestrationImage.AssetId);
+            logger.LogTrace("Getting info.json for {AssetId} from image-server", orchestrationImage.AssetId);
             await using var infoJson = await httpClient.GetStreamAsync(imageServerPath, cancellationToken);
             return infoJson.FromJsonStream<TImageService>();
         }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/YarpImageServerClient.cs
@@ -47,6 +47,7 @@ public class YarpImageServerClient : IImageServerClient
     {
         var imageServerPath = GetInfoJsonPath(orchestrationImage, version);
         if (string.IsNullOrEmpty(imageServerPath)) return null;
+        if (orchestrationImage.IsNotFound()) return null;
         
         // Orchestrate the image to verify that image-server will be able to generate an info.json 
         var orchestrationResult = await orchestrator.EnsureImageOrchestrated(orchestrationImage, cancellationToken);

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -19,8 +19,31 @@ namespace Orchestrator.Features.Images.Orchestration;
 
 public interface IImageOrchestrator
 {
-    Task EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
+    Task<OrchestrationResult> EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default);
+}
+
+public enum OrchestrationResult
+{
+    /// <summary>
+    /// Asset was already orchestrated to fask-disk
+    /// </summary>
+    AlreadyOrchestrated,
+    
+    /// <summary>
+    /// Asset was moved from slow storage -> fast-disk
+    /// </summary>
+    Orchestrated,
+    
+    /// <summary>
+    /// Asset could not be found for serving. E.g. could be a new asset queued for ingestion but not yet complete
+    /// </summary>
+    NotFound,
+    
+    /// <summary>
+    /// An error was encountered orchestrating asset
+    /// </summary>
+    Error,
 }
 
 /// <summary>
@@ -55,38 +78,59 @@ public class ImageOrchestrator : IImageOrchestrator
         this.dlcsApiClient = dlcsApiClient;
         this.logger = logger;
     }
-    
-    public async Task EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
+
+    public async Task<OrchestrationResult> EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default)
     {
         var assetId = orchestrationImage.AssetId;
 
+        var orchestrationResult = OrchestrationResult.AlreadyOrchestrated;
+
         await appCache.GetOrAddAsync(CacheKeys.GetOrchestrationCacheKey(assetId), async _ =>
         {
-            await OrchestrateImageInternal(orchestrationImage, assetId, cancellationToken);
-            // TODO - catch exceptions and cache a short lived value??
+            try
+            {
+                orchestrationResult = await OrchestrateImageInternal(orchestrationImage, assetId, cancellationToken);
+            }
+            catch (Exception)
+            {
+                orchestrationResult = OrchestrationResult.Error;
+            }
+
             return true;
-        }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(priority: CacheItemPriority.High));
+        }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(
+            duration: orchestrationResult == OrchestrationResult.Error ? CacheDuration.Short : CacheDuration.Default,
+            priority: orchestrationResult == OrchestrationResult.Error
+                ? CacheItemPriority.Low
+                : CacheItemPriority.High));
+
+        return orchestrationResult;
     }
 
-    private async Task OrchestrateImageInternal(OrchestrationImage? orchestrationImage, AssetId assetId, 
+    private async Task<OrchestrationResult> OrchestrateImageInternal(OrchestrationImage orchestrationImage, AssetId assetId, 
         CancellationToken cancellationToken)
     {
-        logger.LogDebug("Populating orchestration cache for '{AssetId}'", assetId);
+        logger.LogTrace("Populating orchestration cache for '{AssetId}'", assetId);
 
         var targetPath = orchestratorSettings.CurrentValue.GetImageLocalPath(assetId);
         if (DoesFileForAssetExist(targetPath))
         {
-            logger.LogDebug("File for '{AssetId}' already on disk. no-op", assetId);
-            return;
+            logger.LogTrace("File for '{AssetId}' already on disk. no-op", assetId);
+            return OrchestrationResult.AlreadyOrchestrated;
         }
-
-        if (string.IsNullOrEmpty(orchestrationImage?.S3Location))
+        
+        if (orchestrationImage.Reingest)
         {
             orchestrationImage = await ReingestImage(assetId, cancellationToken);
         }
+
+        if (string.IsNullOrEmpty(orchestrationImage.S3Location))
+        {
+             return OrchestrationResult.NotFound;
+        }
         
         await SaveImageToFastDisk(orchestrationImage, targetPath, cancellationToken);
+        return OrchestrationResult.Orchestrated;
     }
     
     private bool DoesFileForAssetExist(string targetPath)

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -99,8 +99,10 @@ public class ImageOrchestrator : IImageOrchestrator
 
             return true;
         }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(
-            duration: orchestrationResult == OrchestrationResult.Error ? CacheDuration.Short : CacheDuration.Default,
-            priority: orchestrationResult == OrchestrationResult.Error
+            duration: orchestrationResult is OrchestrationResult.Error or OrchestrationResult.NotFound
+                ? CacheDuration.Short
+                : CacheDuration.Default,
+            priority: orchestrationResult is OrchestrationResult.Error or OrchestrationResult.NotFound
                 ? CacheItemPriority.Low
                 : CacheItemPriority.High));
 

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -29,7 +29,7 @@ public class OrchestratorSettings
     /// </summary>
     /// <remarks>
     /// Ideally the Orchestrator should be agnostic to this but, for now at least, the downstream image server will
-    /// be useful to know for toggling some functionality (for now at least)
+    /// be useful to know for toggling some functionality
     /// </remarks>
     public ImageServer ImageServer { get; set; } = ImageServer.Cantaloupe;
 
@@ -51,7 +51,7 @@ public class OrchestratorSettings
     /// <summary>
     /// If true, requests for info.json will cause image to be orchestrated.
     /// </summary>
-    public bool OrchestrateOnInfoJson { get; set; }
+    public bool OrchestrateOnInfoJson { get; set; } = true;
 
     /// <summary>
     /// If <see cref="OrchestrateOnInfoJson"/> is true, this is the max number of requests that will be honoured
@@ -84,13 +84,15 @@ public class OrchestratorSettings
     /// </summary>
     public int TargetThumbnailSize { get; set; } = 200;
 
-    public ProxySettings Proxy { get; set; }
+    public ReingestOnOrchestrationSettings ReingestOnOrchestration { get; set; } = new();
 
-    public CacheSettings Caching { get; set; }
+    public ProxySettings Proxy { get; set; } = new();
 
-    public AuthSettings Auth { get; set; }
+    public CacheSettings Caching { get; set; } = new();
 
-    public NamedQuerySettings NamedQuery { get; set; }
+    public AuthSettings Auth { get; set; } = new();
+
+    public NamedQuerySettings NamedQuery { get; set; } = new();
 }
 
 public class ProxySettings
@@ -308,4 +310,18 @@ public class ImageServerConfig
             return defaultVersionPathTemplate;
         }
     }
+}
+
+/// <summary>
+/// Settings related to reingesting on orchestration
+/// </summary>
+public class ReingestOnOrchestrationSettings
+{
+    /// <summary>
+    /// This date controls how images without ImageLocation.S3 are handled.
+    /// For Images created after this date, return a 404
+    /// For Images created before this date, reingest  
+    /// </summary>
+    /// <remarks>See https://github.com/dlcs/protagonist/issues/505</remarks>
+    public DateTime? EmptyImageLocationCreatedDate { get; set; }
 }

--- a/src/protagonist/Orchestrator/appsettings.json
+++ b/src/protagonist/Orchestrator/appsettings.json
@@ -47,7 +47,6 @@
       }
     }
   },
-  "OrchestrateOnInfoJson": true,
   "ImageServerPathConfig": {
     "IIPImage": {
       "Separator": "/",


### PR DESCRIPTION
Fixes #505 

Modified API calls to _not_ update or create an `ImageLocation` record when saving asset. This was already being handled by the Engine upon completion.

Updated `OrchestrationImage` object to have a `bool Reingest` property - this is set to `true` if `ImageLocation.S3` is empty AND the image was created before a date specified in config. This date is necessary as Deliverator handled ImageLocation.S3 differently, moving forward a missing/null `ImageLocation.S3` will mean we have never successfully ingested this image. However, previously it meant that an update has happened which has cleared it so we may want to reingest.

Also added `OrchestrationImage.IsNotFound()`, this shortcuts requests in orchestration image handling and avoids forwarding requests to special-server when it may not exist (because we don't orchestrated before forwarding to s-s).

Made a few changes to `ImageOrchestrator`:
* It now returns an enum value indicating status. This has been somewhat replaced by `OrchestrationImage.IsNotFound()` but it is handy to have so leaving in. It also offers a safety check to return 404 if reingest somehow fails.
* Object is cached for a shorter duration if `IsNotFound() == true` or if there was an orchestration error.

Modified `YarpImageServerClient` to use above `ImageOrchestrator` enum to return more informative status code when generating initial info.json file from image-server.

Other unrelated changes:
* Default `OrchestrateOnInfoJson = true` in appSetting rather than config as that matches other implementations.
* Remove IIP from docker-compsoe file.