### PR TITLE
Reingest requests clears batch from Image

### DIFF
--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -52,7 +52,7 @@ public class ImageController : HydraController
     ///
     /// PUT requests always trigger reingesting of asset - in general batch processing should be preferred.
     ///
-    /// Image assets are ingested synchronously. Timebased assets are ingested asynchronously.
+    /// Image assets are ingested synchronously. Timebased + File assets are ingested asynchronously.
     /// </summary>
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>

--- a/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
@@ -86,6 +86,7 @@ public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityR
     
     private async Task<Asset> MarkAssetAsIngesting(CancellationToken cancellationToken, Asset asset)
     {
+        asset.Batch = 0;
         asset.SetFieldsForIngestion();
         var assetAfterSave = await assetRepository.Save(asset, true, cancellationToken);
         return assetAfterSave;


### PR DESCRIPTION
Fixes #506 

On completion, Engine will increment batch Completed/Error count if `Image.Batch > 0`. A `/reingest` request now sets Batch = 0 to avoid incrementing count.