### PR TITLE
Ignore query params in info.json redirect

### DIFF
--- a/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/AssetDelivery/AssetDeliveryPathParserTests.cs
@@ -42,6 +42,34 @@ public class AssetDeliveryPathParserTests
         thumbnailRequest.AssetPath.Should().Be("the-astronaut");
         thumbnailRequest.AssetId.Should().Be("the-astronaut");
     }
+    
+    [Theory]
+    [InlineData("/thumbs/99/1/the-astronaut?foo=bar")]
+    [InlineData("/thumbs/99/1/the-astronaut?foo=bar&baz=qux")]
+    [InlineData("/thumbs/99/1/the-astronaut#test")]
+    [InlineData("/thumbs/99/1/the-astronaut#test?foo=bar")]
+    [InlineData("/thumbs/99/1/the-astronaut?foo=bar#test")]
+    public async Task Parse_ImageRequest_WithAdditionalParams_ReturnsCorrectRequest(string path)
+    {
+        // Arrange
+        var customer = new CustomerPathElement(99, "Test-Customer");
+        A.CallTo(() => pathCustomerRepository.GetCustomerPathElement("99"))
+            .Returns(customer);
+
+        // Act
+        var thumbnailRequest = await sut.Parse<ImageAssetDeliveryRequest>(path);
+        
+        // Assert
+        thumbnailRequest.RoutePrefix.Should().Be("thumbs");
+        thumbnailRequest.VersionedRoutePrefix.Should().Be("thumbs");
+        thumbnailRequest.VersionPathValue.Should().BeNull();
+        thumbnailRequest.CustomerPathValue.Should().Be("99");
+        thumbnailRequest.Customer.Should().Be(customer);
+        thumbnailRequest.BasePath.Should().Be("/thumbs/99/1/");
+        thumbnailRequest.Space.Should().Be(1);
+        thumbnailRequest.AssetPath.Should().Be("the-astronaut");
+        thumbnailRequest.AssetId.Should().Be("the-astronaut");
+    }
 
     [Fact]
     public async Task Parse_ImageRequest_WithCustomerName_ReturnsCorrectRequest()

--- a/src/protagonist/DLCS.Web.Tests/Requests/HttpRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Requests/HttpRequestXTests.cs
@@ -21,7 +21,6 @@ public class HttpRequestXTests
         test.Should().Be("aaa");
     }
     
-    
     [Fact]
     public void GetFirstQueryParamValue_Ignores_Further_Values()
     {
@@ -36,7 +35,6 @@ public class HttpRequestXTests
         test.Should().Be("aaa");
     }
     
-    
     [Fact]
     public void GetFirstQueryParamValueAsInt_Finds_Int()
     {
@@ -49,5 +47,200 @@ public class HttpRequestXTests
         
         // assert
         test.Should().Be(12);
+    }
+
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WhenCalledWithDefaultParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WhenCalledWithDefaultParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WhenCalledWithPath()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/my-path/one/two?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl("/my-path/one/two");
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WhenCalledWithWithPath()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2/my-path/one/two?foo=bar";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl("/my-path/one/two");
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl(includeQueryParams: false);
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetDisplayUrl_WithPathBase_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2";
+
+        // Act
+        var result = httpRequest.GetDisplayUrl(includeQueryParams: false);
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetBaseUrl_ReturnsFullUrl_WithoutQueryParam()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example";
+
+        // Act
+        var result = httpRequest.GetBaseUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetBaseUrl_WithPathBase_ReturnsFullUrl_WithoutQueryParam_WhenCalledWithDoNotIncludeQueryParams()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2";
+
+        // Act
+        var result = httpRequest.GetBaseUrl();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetJsonLdId_Correct()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/anything";
+
+        // Act
+        var result = httpRequest.GetJsonLdId();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void GetJsonLdId_WithPathBase_Correct()
+    {
+        // Arrange
+        var httpRequest = new DefaultHttpContext().Request;
+        httpRequest.Path = new PathString("/anything");
+        httpRequest.QueryString = new QueryString("?foo=bar");
+        httpRequest.Host = new HostString("test.example");
+        httpRequest.PathBase = new PathString("/v2");
+        httpRequest.Scheme = "https";
+
+        const string expected = "https://test.example/v2/anything";
+
+        // Act
+        var result = httpRequest.GetJsonLdId();
+        
+        // Assert
+        result.Should().Be(expected);
     }
 }

--- a/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using DLCS.Core;
 using DLCS.Model.PathElements;
 using DLCS.Web.Requests.AssetDelivery;
@@ -94,10 +95,10 @@ public class ConfigDrivenAssetPathGeneratorTests
     [Theory]
     [InlineData("123")]
     [InlineData("test-customer")]
-    public void GetFullPathForRequest_PathGenerator_Default(string customerPathValue)
+    public void GetFullPathForRequest_Default_QueryParam(string customerPathValue)
     {
         // Arrange
-        var sut = GetSut("default.com");
+        var sut = GetSut("default.com", req => req.QueryString = new QueryString("?foo=bar"));
         var request = new BaseAssetRequest
         {
             Customer = new CustomerPathElement(123, "test-customer"),
@@ -108,17 +109,10 @@ public class ConfigDrivenAssetPathGeneratorTests
             RoutePrefix = "thumbs"
         };
 
-        var expected = $"https://default.com/thumbs/{customerPathValue}/2000/not-asset";
+        var expected = $"https://default.com/thumbs/{customerPathValue}/10/path/to/asset?foo=bar";
         
         // Act
-        var actual = sut.GetFullPathForRequest(request,
-            (assetRequest, template) =>
-                DlcsPathHelpers.GeneratePathFromTemplate(
-                    template, 
-                    assetRequest.RoutePrefix, 
-                    assetRequest.CustomerPathValue, 
-                    space: "2000",
-                    assetPath: "not-asset"));
+        var actual = sut.GetFullPathForRequest(request);
         
         // Assert
         actual.Should().Be(expected);
@@ -127,10 +121,10 @@ public class ConfigDrivenAssetPathGeneratorTests
     [Theory]
     [InlineData("123")]
     [InlineData("test-customer")]
-    public void GetFullPathForRequest_PathGenerator_Override(string customerPathValue)
+    public void GetFullPathForRequest_Default_QueryParam_OmittedIfIncludeFalse(string customerPathValue)
     {
         // Arrange
-        var sut = GetSut("test.example.com");
+        var sut = GetSut("default.com", req => req.QueryString = new QueryString("?foo=bar"));
         var request = new BaseAssetRequest
         {
             Customer = new CustomerPathElement(123, "test-customer"),
@@ -141,57 +135,16 @@ public class ConfigDrivenAssetPathGeneratorTests
             RoutePrefix = "thumbs"
         };
 
-        var expected = "https://test.example.com/thumbs/not-asset";
+        var expected = $"https://default.com/thumbs/{customerPathValue}/10/path/to/asset";
         
         // Act
-        var actual = sut.GetFullPathForRequest(request,
-            (assetRequest, template) =>
-                DlcsPathHelpers.GeneratePathFromTemplate(
-                    template, 
-                    assetRequest.RoutePrefix, 
-                    assetRequest.CustomerPathValue, 
-                    space: "2000",
-                    assetPath: "not-asset"));
-        
-        // Assert
-        actual.Should().Be(expected);
-    }
-    
-    [Theory]
-    [InlineData("123")]
-    [InlineData("test-customer")]
-    public void GetFullPathForRequest_PathGenerator_OverrideAvailable_ButIgnoredIfNativeFormatRequested(string customerPathValue)
-    {
-        // Arrange
-        var sut = GetSut("test.example.com");
-        var request = new BaseAssetRequest
-        {
-            Customer = new CustomerPathElement(123, "test-customer"),
-            CustomerPathValue = customerPathValue,
-            Space = 10,
-            AssetPath = "path/to/asset",
-            BasePath = "thumbs/123/10",
-            RoutePrefix = "thumbs"
-        };
-
-        var expected = $"https://test.example.com/thumbs/{customerPathValue}/2000/not-asset";
-
-        // Act
-        var actual = sut.GetFullPathForRequest(request,
-            (assetRequest, template) =>
-                DlcsPathHelpers.GeneratePathFromTemplate(
-                    template, 
-                    assetRequest.RoutePrefix, 
-                    assetRequest.CustomerPathValue, 
-                    space: "2000",
-                    assetPath: "not-asset"),
-            true);
+        var actual = sut.GetFullPathForRequest(request, includeQueryParams: false);
         
         // Assert
         actual.Should().Be(expected);
     }
 
-    private ConfigDrivenAssetPathGenerator GetSut(string host)
+    private ConfigDrivenAssetPathGenerator GetSut(string host, Action<HttpRequest> requestModifier = null)
     {
         var context = new DefaultHttpContext();
         var request = context.Request;
@@ -199,6 +152,7 @@ public class ConfigDrivenAssetPathGeneratorTests
         A.CallTo(() => contextAccessor.HttpContext).Returns(context);
         request.Host = new HostString(host);
         request.Scheme = "https";
+        requestModifier?.Invoke(request);
 
         var options = Options.Create(new PathTemplateOptions
         {

--- a/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
+++ b/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
@@ -13,16 +13,19 @@ public static class HttpRequestX
     /// </summary>
     /// <param name="request">HttpRequest to generate display URL for</param>
     /// <param name="path">Path to append to URL</param>
+    /// <param name="includeQueryParams">If true, query params are included in path. Else they are omitted</param>
     /// <returns>Full URL, including scheme, host, pathBase, path and queryString</returns>
     /// <remarks>
     /// based on Microsoft.AspNetCore.Http.Extensions.UriHelper.GetDisplayUrl(this HttpRequest request)
     /// </remarks>
-    public static string GetDisplayUrl(this HttpRequest request, string? path = null)
+    public static string GetDisplayUrl(this HttpRequest request, string? path = null, bool includeQueryParams = true)
     {
         var host = request.Host.Value ?? string.Empty;
         var scheme = request.Scheme ?? string.Empty;
         var pathBase = request.PathBase.Value ?? string.Empty;
-        var queryString = request.QueryString.Value ?? string.Empty;
+        var queryString = includeQueryParams
+            ? request.QueryString.Value ?? string.Empty
+            : string.Empty;
         var pathElement = path ?? string.Empty;
 
         // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
@@ -38,39 +41,18 @@ public static class HttpRequestX
             .Append(queryString)
             .ToString();
     }
-    
+
     /// <summary>
     /// Generate a display URL, deriving values from specified HttpRequest. Omitting path and query string
     /// </summary>
-    /// <remarks> Similar to GetDisplayUrl but omits path and query string</remarks>
     public static string GetBaseUrl(this HttpRequest request)
-    {
-        var host = request.Host.Value ?? string.Empty;
-        var scheme = request.Scheme ?? string.Empty;
-        var pathBase = request.PathBase.Value ?? string.Empty;
-
-        // PERF: Calculate string length to allocate correct buffer size for StringBuilder.
-        var length = scheme.Length + SchemeDelimiter.Length + host.Length
-                     + pathBase.Length;
-
-        return new StringBuilder(length)
-            .Append(scheme)
-            .Append(SchemeDelimiter)
-            .Append(host)
-            .Append(pathBase)
-            .ToString();
-    }
+        => request.GetDisplayUrl(path: null, includeQueryParams: false);
 
     /// <summary>
     /// Generate the "@id" property for a JSON-LD API response.
     /// </summary>
-    /// <param name="request"></param>
-    /// <returns></returns>
-    public static string GetJsonLdId(this HttpRequest request)
-    {
-        return GetDisplayUrl(request, request.Path);
-    }
-    
+    public static string GetJsonLdId(this HttpRequest request) => GetDisplayUrl(request, request.Path, false);
+
     public static string? GetFirstQueryParamValue(this HttpRequest request, string paramName)
     {
         if (request.Query.ContainsKey(paramName))

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -28,24 +28,22 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
     }
     
     public string GetRelativePathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
-        => GetForPath(assetRequest, false, useNativeFormat);
+        => GetForPath(assetRequest, false, useNativeFormat, false);
 
-    public string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
-        => GetForPath(assetRequest, true, useNativeFormat);
+    public string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false,
+        bool includeQueryParams = true)
+        => GetForPath(assetRequest, true, useNativeFormat, includeQueryParams);
 
-    public string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator,
-        bool useNativeFormat = false)
-        => GetPathForRequestInternal(assetRequest, pathGenerator, true, useNativeFormat);
-
-    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat)
+    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat, bool includeQueryParams)
         => GetPathForRequestInternal(
             assetRequest, 
             (request, template) => GeneratePathFromTemplate(request, template),
             fullRequest,
-            useNativeFormat);
+            useNativeFormat,
+            includeQueryParams);
     
     private string GetPathForRequestInternal(IBasicPathElements assetRequest, PathGenerator pathGenerator,
-        bool fullRequest, bool useNativeFormat)
+        bool fullRequest, bool useNativeFormat, bool includeQueryParams)
     {
         var request = httpContextAccessor.HttpContext.Request;
         var host = request.Host.Value ?? string.Empty;
@@ -55,7 +53,7 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
 
         var path = pathGenerator(assetRequest, template);
 
-        return fullRequest ? request.GetDisplayUrl(path) : path;
+        return fullRequest ? request.GetDisplayUrl(path, includeQueryParams) : path;
     }
 
     // Default path replacements

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -14,40 +14,22 @@ public interface IAssetPathGenerator
 {
     /// <summary>
     /// Generate path for specified <see cref="BaseAssetRequest"/> excluding host.
-    /// Uses default template replacements.
     /// </summary>
-    /// <param name="assetRequest"></param>
-    /// <param name="useNativeFormat"></param>
-    /// <returns></returns>
+    /// <param name="assetRequest"><see cref="IBasicPathElements"/> for current request</param>
+    /// <param name="useNativeFormat">
+    /// If true, native DLCS path /{prefix}/{version}/{customer}/{space}/{assetPath} used. Else path can differ by path.
+    /// </param>
     string GetRelativePathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false);
-    
+
     /// <summary>
     /// Generate full path for specified <see cref="IBasicPathElements"/>, including host.
     /// Uses default template replacements.
     /// </summary>
-    /// <param name="assetRequest"><see cref="IBasicPathElements"/></param>
-    /// <param name="useNativeFormat"></param>
-    /// <returns></returns>
-    string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false);
-    
-    /// <summary>
-    /// Generate full path for specified <see cref="IBasicPathElements"/>, using provided delegate to generate
-    /// path element.
-    /// This can be useful for constructing paths that do not use the default path elements.
-    /// </summary>
-    string GetFullPathForRequest(IBasicPathElements assetRequest, PathGenerator pathGenerator,
-        bool useNativeFormat = false);
+    /// <param name="assetRequest"><see cref="IBasicPathElements"/> for current request</param>
+    /// <param name="useNativeFormat">
+    /// If true, native DLCS path /{prefix}/{version}/{customer}/{space}/{assetPath} used. Else path can differ by path.
+    /// </param>
+    /// <param name="includeQueryParams">If true, query params are included in path. Else they are omitted</param>
+    string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false,
+        bool includeQueryParams = true);
 }
-
-// DONE
-// GetFullyQualifiedId - versioned, always standard path, IIIFCanvasFactory.GetFullyQualifiedId ln 246
-// GetFullQualifiedImagePath - not versioned, always standard path, IIIFCanvasFactory.GetFullQualifiedImagePath ln 233
-// GetFullyQualifiedId - versioned, always standard path, GetManifestForAsset.GetFullyQualifiedId ln 124
-
-// NOT DONE
-// GetImageId - versioned, use replacements, GetImageInfoJson.GetImageId ln 161
-// GetFullImagePath - versioned, use replacements. ThumbsMiddleware.GetFullImagePath ln 183
-
-/*
- * Have I broken Thumbs handling by having 1 generic setting in parameterStore?
- */

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -85,19 +85,24 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Theory]
-    [InlineData("/iiif-img/2/1/image")]
-    [InlineData("/iiif-img/2/1/image/")]
-    [InlineData("/iiif-img/display-name/1/image")]
-    [InlineData("/iiif-img/display-name/1/image/")]
-    [InlineData("/iiif-img/v2/2/1/image")]
-    [InlineData("/iiif-img/v2/2/1/image/")]
-    [InlineData("/iiif-img/v2/display-name/1/image")]
-    [InlineData("/iiif-img/v2/display-name/1/image/")]
-    public async Task Get_ImageRoot_RedirectsToInfoJson(string path)
+    [InlineData("/iiif-img/2/1/image", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/2/1/image/", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/2/1/image?x=y", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/2/1/image/?x=y", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image/", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image?x=y", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image/?x=y", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image", "/iiif-img/v2/2/1/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image/", "/iiif-img/v2/2/1/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image?x=y", "/iiif-img/v2/2/1/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image/?x=y", "/iiif-img/v2/2/1/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image", "/iiif-img/v2/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image/", "/iiif-img/v2/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image?x=y", "/iiif-img/v2/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image/?x=y", "/iiif-img/v2/display-name/1/image/info.json")]
+    public async Task Get_ImageRoot_RedirectsToInfoJson(string path, string expected)
     {
-        // Arrange
-        var expected = path[^1] == '/' ? $"{path}info.json" : $"{path}/info.json";
-        
         // Act
         var response = await httpClient.GetAsync(path);
 
@@ -109,16 +114,28 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Theory]
     [InlineData("/iiif-img/2/1/image", "/const_value/2/image/info.json")]
     [InlineData("/iiif-img/2/1/image/", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/2/1/image?x=y", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/2/1/image/?x=y", "/const_value/2/image/info.json")]
     [InlineData("/iiif-img/display-name/1/image", "/const_value/display-name/image/info.json")]
     [InlineData("/iiif-img/display-name/1/image/", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image?x=y", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/display-name/1/image/?x=y", "/const_value/display-name/image/info.json")]
     [InlineData("/iiif-img/v2/2/1/image", "/const_value/v2/2/image/info.json")]
     [InlineData("/iiif-img/v2/2/1/image/", "/const_value/v2/2/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image?x=y", "/const_value/v2/2/image/info.json")]
+    [InlineData("/iiif-img/v2/2/1/image/?x=y", "/const_value/v2/2/image/info.json")]
     [InlineData("/iiif-img/v3/2/1/image", "/const_value/2/image/info.json")]
     [InlineData("/iiif-img/v3/2/1/image/", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image?x=y", "/const_value/2/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image/?x=y", "/const_value/2/image/info.json")]
     [InlineData("/iiif-img/v2/display-name/1/image", "/const_value/v2/display-name/image/info.json")]
     [InlineData("/iiif-img/v2/display-name/1/image/", "/const_value/v2/display-name/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image?x=y", "/const_value/v2/display-name/image/info.json")]
+    [InlineData("/iiif-img/v2/display-name/1/image/?x=y", "/const_value/v2/display-name/image/info.json")]
     [InlineData("/iiif-img/v3/display-name/1/image", "/const_value/display-name/image/info.json")]
     [InlineData("/iiif-img/v3/display-name/1/image/", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image?x=y", "/const_value/display-name/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image/?x=y", "/const_value/display-name/image/info.json")]
     public async Task Get_ImageRoot_RedirectsToInfoJson_CustomPathValues(string path, string expected)
     {
         // Act
@@ -133,9 +150,13 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     
     [Theory]
     [InlineData("/iiif-img/v3/2/1/image", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image?x=y", "/iiif-img/2/1/image/info.json")]
     [InlineData("/iiif-img/v3/2/1/image/", "/iiif-img/2/1/image/info.json")]
+    [InlineData("/iiif-img/v3/2/1/image/?x=y", "/iiif-img/2/1/image/info.json")]
     [InlineData("/iiif-img/v3/display-name/1/image", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image?x=y", "/iiif-img/display-name/1/image/info.json")]
     [InlineData("/iiif-img/v3/display-name/1/image/", "/iiif-img/display-name/1/image/info.json")]
+    [InlineData("/iiif-img/v3/display-name/1/image/?x=y", "/iiif-img/display-name/1/image/info.json")]
     public async Task Get_ImageRoot_RedirectsToCanonicalInfoJson_IfRequestingCanonicalVersion(string path, string expected)
     {
         // Act

--- a/src/protagonist/Thumbs.Tests/Integration/InfoJsonTests.cs
+++ b/src/protagonist/Thumbs.Tests/Integration/InfoJsonTests.cs
@@ -32,16 +32,22 @@ public class InfoJsonTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
     [Theory]
     [InlineData("/thumbs/99/1/image", "http://localhost/thumbs/99/1/image/info.json")]
+    [InlineData("/thumbs/99/1/image?x=y", "http://localhost/thumbs/99/1/image/info.json")]
     [InlineData("/thumbs/99/1/image/", "http://localhost/thumbs/99/1/image/info.json")]
     [InlineData("/thumbs/test/1/image", "http://localhost/thumbs/test/1/image/info.json")]
+    [InlineData("/thumbs/test/1/image?x=y", "http://localhost/thumbs/test/1/image/info.json")]
     [InlineData("/thumbs/test/1/image/", "http://localhost/thumbs/test/1/image/info.json")]
     [InlineData("/thumbs/v2/99/1/image", "http://localhost/thumbs/v2/99/1/image/info.json")]
+    [InlineData("/thumbs/v2/99/1/image?x=y", "http://localhost/thumbs/v2/99/1/image/info.json")]
     [InlineData("/thumbs/v2/99/1/image/", "http://localhost/thumbs/v2/99/1/image/info.json")]
     [InlineData("/thumbs/v2/test/1/image", "http://localhost/thumbs/v2/test/1/image/info.json")]
+    [InlineData("/thumbs/v2/test/1/image?x=y", "http://localhost/thumbs/v2/test/1/image/info.json")]
     [InlineData("/thumbs/v2/test/1/image/", "http://localhost/thumbs/v2/test/1/image/info.json")]
     [InlineData("/thumbs/v3/99/1/image", "http://localhost/thumbs/99/1/image/info.json")] // Canonical version goes to canonical url
+    [InlineData("/thumbs/v3/99/1/image?x=y", "http://localhost/thumbs/99/1/image/info.json")]
     [InlineData("/thumbs/v3/99/1/image/", "http://localhost/thumbs/99/1/image/info.json")]
     [InlineData("/thumbs/v3/test/1/image", "http://localhost/thumbs/test/1/image/info.json")]
+    [InlineData("/thumbs/v3/test/1/image?x=y", "http://localhost/thumbs/test/1/image/info.json")]
     [InlineData("/thumbs/v3/test/1/image/", "http://localhost/thumbs/test/1/image/info.json")]
     public async Task Get_ImageRoot_RedirectsToInfoJson(string path, string expected)
     {

--- a/src/protagonist/Thumbs/ThumbsMiddleware.cs
+++ b/src/protagonist/Thumbs/ThumbsMiddleware.cs
@@ -191,7 +191,7 @@ public class ThumbsMiddleware
             baseRequest.VersionPathValue = null;
         }
         
-        return pathGenerator.GetFullPathForRequest(baseRequest);
+        return pathGenerator.GetFullPathForRequest(baseRequest, includeQueryParams: false);
     }
 
     private bool IsCanonical(Version requestedVersion)


### PR DESCRIPTION
Fixes #514

Modified `AssetDeliveryPathParser` to remove query string params. This wasn't causing the issue seen but could result in other bugs in the future.

Modified `HttpRequest.GetDisplayUrl()` extension method to optionally exclude querystring. Left the default to include querystring as this prevents changing existing usage. `GetBaseUrl()` can now call this as the behaviour can be replicated with new parameter.

`ThumbsMiddleware` calls `IAssetPathGenerator` to construct info.json path so added `bool includeQueryParams` to call here, which is passed to above `GetDisplayUrl()`. This is used when constructing both default paths and paths that differ based on `x-forward-host` header. 

Removed unused `GetFullPathForRequest` method from `IAssetPathGenerator` - this allowed constructing paths using non-default templates but usage has been removed in previous commits.