### PR TITLE
Set w + h on NQ image body

### DIFF
--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -77,6 +77,8 @@ public class IIIFCanvasFactory
                             Id = GetFullQualifiedImagePath(i, customerPathElement,
                                 thumbnailSizes.MaxDerivativeSize, false),
                             Format = "image/jpeg",
+                            Width = thumbnailSizes.MaxDerivativeSize.Width,
+                            Height = thumbnailSizes.MaxDerivativeSize.Height,
                             Service = GetImageServices(i, customerPathElement)
                         }
                     }.AsListOf<IAnnotation>()
@@ -128,8 +130,8 @@ public class IIIFCanvasFactory
                     {
                         Id = GetFullQualifiedImagePath(i, customerPathElement,
                             thumbnailSizes.MaxDerivativeSize, false),
-                        Width = i.Width,
-                        Height = i.Height,
+                        Width = thumbnailSizes.MaxDerivativeSize.Width,
+                        Height = thumbnailSizes.MaxDerivativeSize.Height,
                         Service = GetImageServices(i, customerPathElement)
                     }
                 }.AsList()


### PR DESCRIPTION
Resolves #518

Largest available thumbnail size is now output on canvas for images.

V2 was outputting full Image size, V3 was outputting no size at this level.