### PR TITLE
Calculate Family from mediaType if family and dc not provided

### DIFF
--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -257,6 +257,23 @@ public class AssetPreparerTests
     }
     
     [Theory]
+    [InlineData("image/jpeg", AssetFamily.Image)]
+    [InlineData("video/mp4", AssetFamily.Timebased)]
+    [InlineData("audio/mp4", AssetFamily.Timebased)]
+    [InlineData("text/plain", AssetFamily.File)]
+    public void PrepareAssetForUpsert_SetsAssetFamily_FromMediaType_IfFamilyAndDeliveryChannelNotSet(string mediaType, AssetFamily expected)
+    {
+        // Arrange
+        var updateAsset = new Asset { Origin = "required", MediaType = mediaType };
+
+        // Act
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+
+        // Assert
+        result.UpdatedAsset.Family.Should().Be(expected);
+    }
+    
+    [Theory]
     [InlineData("file", AssetFamily.Timebased, AssetFamily.File)]
     [InlineData("file,iiif-img", AssetFamily.Timebased, AssetFamily.Image)]
     [InlineData("iiif-img", AssetFamily.Timebased, AssetFamily.Image)]

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Core.Strings;
+using Microsoft.Extensions.Logging;
 
 namespace DLCS.Model.Assets;
 
@@ -288,6 +289,23 @@ public static class AssetPreparer
         if (workingAsset.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
         {
             workingAsset.Family = AssetFamily.Timebased;
+            return;
+        }
+
+        if (workingAsset.Family == null)
+        {
+            if (MIMEHelper.IsImage(workingAsset.MediaType))
+            {
+                workingAsset.Family = AssetFamily.Image;
+            }
+            else if (MIMEHelper.IsAudio(workingAsset.MediaType) || MIMEHelper.IsVideo(workingAsset.MediaType))
+            {
+                workingAsset.Family = AssetFamily.Timebased;
+            }
+            else
+            {
+                workingAsset.Family = AssetFamily.File;
+            }
         }
     }
 


### PR DESCRIPTION
This change re-adds support for minimal payload of (this was supported prior to introduction of `deliveryChannels`):

```json
{
  "origin": "https://example.org/my-asset.tiff",
  "mediaType": "image/tiff"
}
```

Without this change the above would result in a 500/`Nullable object must have a value` as we need `Asset.Family` to calculate ingest defaults for policies etc.

Logic in `AssetPreparer` as this is used by single item ingest + batch ingest. Will only be called if neither `deliveryChannels` nor `family` provided. Logic is:

* `images/*` = `AssetFamily.Image`
* `audio/*` = `AssetFamily.Timebased`
* `video/*` = `AssetFamily.Timebased`
* `<else>` = `AssetFamily.File`

We may want to make this configurable in the future but this will allow the same behaviour as deliverator.