### PR TITLE
Small changes for new developers

### DIFF
--- a/compose/docker-compose.engine.yml
+++ b/compose/docker-compose.engine.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  appetiser:
+    image: digirati/appetiser:latest
+    ports:
+      - "5031:80"
+    volumes:
+      - $HOME\Docker\scratch:/scratch
+      - $HOME\.aws:/root/.aws
+    env_file:
+      - .env

--- a/compose/docker-compose.orchestrator.yml
+++ b/compose/docker-compose.orchestrator.yml
@@ -1,0 +1,61 @@
+version: '3'
+
+volumes:
+  dlcs_postgres_data: {}
+  dlcs_postgres_data_backups: {}
+  dlcs_localstack_tmp: {}
+
+services:
+  cantaloupe:
+    image: ghcr.io/dlcs/cantaloupe:5.0.5
+    ports:
+      - "5026:8182"
+    environment:
+      - ENDPOINT_ADMIN_ENABLED=true
+      - ENDPOINT_ADMIN_SECRET=admin
+      - PROCESSOR_SELECTION_STRATEGY=ManualSelectionStrategy
+      - PROCESSOR_MANUALSELECTIONSTRATEGY_JP2=GrokProcessor
+      - MAX_SCALE=0
+    volumes:
+      - $HOME\Docker\scratch:/home/cantaloupe/images/
+
+  special-server:
+    image: ghcr.io/dlcs/cantaloupe:5.0.5
+    ports:
+      - "5126:8182"
+    environment:
+      - ENDPOINT_ADMIN_ENABLED=true
+      - ENDPOINT_ADMIN_SECRET=admin
+      - DELEGATE_SCRIPT_ENABLED=true
+      - SOURCE_STATIC=S3Source
+      - DELEGATE_SCRIPT_PATHNAME=/cantaloupe/delegates.rb
+      - S3SOURCE_LOOKUP_STRATEGY=ScriptLookupStrategy
+      - AWS_ACCESS_KEY_ID=${SS_AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${SS_AWS_SECRET_ACCESS_KEY}
+      - MAX_SCALE=0
+    env_file:
+      - .env
+
+  fireball:
+    image: ghcr.io/dlcs/fireball:03f76e5893ae95ee22c307e2dadec1ab033cdb79
+    ports:
+      - "5030:80"
+    environment:
+      - FIREBALL_DOWNLOAD_POOL_SIZE=100
+      - FIREBALL_WORK_FOLDER=/scratch/fireball
+    volumes:
+      - $HOME\Docker\scratch\fireball:/scratch/fireball
+      - $HOME\.aws:/root/.aws
+    env_file:
+      - .env
+
+  thumbs:
+    build:
+      context: ../src/protagonist
+      dockerfile: ..\..\Dockerfile.Thumbs
+    ports:
+      - "5019:80"
+    env_file:
+      - .env
+    volumes:
+      - $HOME\.aws:/root/.aws

--- a/compose/localstack/seed-resources.sh
+++ b/compose/localstack/seed-resources.sh
@@ -4,7 +4,9 @@
 awslocal s3 mb s3://dlcs-output
 awslocal s3 mb s3://dlcs-thumbs
 awslocal s3 mb s3://dlcs-storage
+awslocal s3 mb s3://dlcs-origin
 awslocal s3 mb s3://dlcs-timebased-in
+awslocal s3 mb s3://dlcs-timebased-out
 
 # create queues
 awslocal sqs create-queue --queue-name dlcs-image

--- a/compose/readme.md
+++ b/compose/readme.md
@@ -13,3 +13,11 @@ _There is a limitation with fireball that it will always write to AWS so PDF gen
 ## `docker-compose.local.yml`
 
 This contains external dependencies for running the dotnet apps locally.
+
+## `docker-compose.engine.yml`
+
+This contains external dependencies for debugging the Engine.
+
+## `docker-compose.orchestrator.yml`
+
+This contains external dependencies for debugging Orchestrator.

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -1,12 +1,24 @@
 {
   "ConnectionStrings": {
-    "PostgreSQLConnection": "<conn-str>"
+    "PostgreSQLConnection": "Server=localhost;Port=5452;Database=postgres;User Id=postgres;Password=dlcs_password;Command Timeout=60;"
   },
   "AWS": {
-    "Profile": "dlcsspinup",
+    "Profile": "default",
     "Region": "eu-west-1",
     "S3": {
-      "OriginBucket": "<storage-origin-bucket>"
+      "OutputBucket": "dlcs-output",
+      "ThumbsBucket": "dlcs-thumbs",
+      "StorageBucket": "dlcs-storage",
+      "OriginBucket": "dlcs-origin",
+      "TimebasedInputBucket": "dlcs-timebased-in",
+      "TimebasedOutputBucket": "dlcs-timebased-out"
+    },
+    "SQS": {
+      "ImageQueueName": "dlcs-image",
+      "PriorityImageQueueName": "dlcs-priority-image",
+      "TimebasedQueueName": "dlcs-timebased",
+      "TranscodeCompleteQueueName": "dlcs-transcode-complete",
+      "FileQueueName": "dlcs-file"
     }
   },
   "DLCS": {
@@ -27,6 +39,6 @@
     }
   },
   "PathBase": "",
-  "Salt": "xxx",
+  "Salt": "********",
   "PageSize": 100
 }

--- a/src/protagonist/Engine/appsettings-Development-Example.json
+++ b/src/protagonist/Engine/appsettings-Development-Example.json
@@ -1,0 +1,47 @@
+{
+  "ConnectionStrings": {
+    "PostgreSQLConnection": "Server=localhost;Port=5452;Database=postgres;User Id=postgres;Password=dlcs_password;Command Timeout=60;"
+  },
+  "S3OriginRegex": "http\\\\:\\\\/\\\\/localhost:4566\\\\/.*",
+  "ImageIngest": {
+    "ScratchRoot": "/scratch",
+    "ImageProcessorRoot": "/scratch/",
+    "SourceTemplate": "{root}{customer}/{space}/{image}",
+    "DestinationTemplate": "{root}{customer}/{space}/{image}/output/",
+    "ThumbsTemplate": "{root}{customer}/{space}/{image}/output/thumbs",
+    "ImageProcessorUrl": "http://localhost:5031",
+    "ImageProcessorDelayMs": 1000,
+    "IncludeRegionInS3Uri": true,
+    "OrchestratorBaseUrl": "https://localhost:5003",
+    "OrchestrateImageAfterIngest": false
+  },
+  "TimebasedIngest": {
+    "PipelineName": "dlcs-pipeline"
+  },
+  "CustomerOverrides": {
+    "4": {
+      "OrchestrateImageAfterIngest": false,
+      "NoStoragePolicyCheck": false
+    }
+  },
+  "DownloadTemplate": "/scratch/engine/{customer}/{space}/{image}",
+  "AWS": {
+    "Profile": "default",
+    "Region": "eu-west-1",
+    "UseLocalStack": false,
+    "S3": {
+      "OutputBucket": "dlcs-output",
+      "ThumbsBucket": "dlcs-thumbs",
+      "StorageBucket": "dlcs-storage",
+      "TimebasedInputBucket": "dlcs-timebased-in",
+      "TimebasedOutputBucket": "dlcs-timebased-out"
+    },
+    "SQS": {
+      "ImageQueueName": "dlcs-image",
+      "PriorityImageQueueName": "dlcs-priority-image",
+      "TimebasedQueueName": "dlcs-timebased",
+      "TranscodeCompleteQueueName": "dlcs-transcode-complete",
+      "FileQueueName": "dlcs-file"
+    }
+  }
+}

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -19,12 +19,6 @@ public class OrchestratorSettings
     public string S3OriginRegex { get; set; }
 
     /// <summary>
-    /// Timeout for critical orchestration path. How long to wait to achieve lock when orchestrating asset.
-    /// If timeout breached, multiple orchestrations can happen for same item.
-    /// </summary>
-    public int CriticalPathTimeoutMs { get; set; } = 10000;
-
-    /// <summary>
     /// Which image-server is handling downstream tile requests
     /// </summary>
     /// <remarks>

--- a/src/protagonist/Orchestrator/appSettings-Development-Example.json
+++ b/src/protagonist/Orchestrator/appSettings-Development-Example.json
@@ -42,10 +42,9 @@
   "RunMigrations": true,
   "S3OriginRegex": "http\\\\:\\\\/\\\\/localhost:4566\\\\/.*",
   "AuthServicesUriTemplate": "https://localhost:5003/auth/{customer}/{behaviour}",
-  "ImageFolderTemplateImageServer": "/nas/{customer}/{space}/{image-dir}/{image}.jp2",
   "ImageFolderTemplateOrchestrator": "/nas/{customer}/{space}/{image-dir}/{image}.jp2",
-  "ApiSalt": "a-secret",
-  "ApiRoot": "TODO",
+  "ApiSalt": "********",
+  "ApiRoot": "http://127.0.0.1:5012",
   "Auth": {
     "CookieDomains": [
       "localhost",
@@ -77,9 +76,9 @@
   },
   "ReverseProxy": {
     "Clusters": {
-      "image_server": {
+      "cantaloupe": {
         "Destinations": {
-          "image_server/one": {
+          "cantaloupe/one": {
             "Address": "http://localhost:5025"
           }
         }
@@ -95,6 +94,13 @@
         "Destinations": {
           "thumbresize/one": {
             "Address": "http://localhost:5019"
+          }
+        }
+      },
+      "specialserver": {
+        "Destinations": {
+          "specialserver_one": {
+            "Address": "http://localhost:5126"
           }
         }
       }

--- a/src/protagonist/Portal/appSettings-Development-Example.json
+++ b/src/protagonist/Portal/appSettings-Development-Example.json
@@ -1,26 +1,6 @@
 {
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console"
-    ],
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      }
-    ],
-    "Properties": {
-      "ApplicationName": "Portal"
-    }
-  },
   "ConnectionStrings": {
-    "PostgreSQLConnection": "<connection-string>"
+    "PostgreSQLConnection": "Server=localhost;Port=5452;Database=postgres;User Id=postgres;Password=dlcs_password;Command Timeout=60;"
   },
   "AWS": {
     "Profile": "default",
@@ -30,7 +10,8 @@
     }
   },
   "Portal": {
-    "loginSalt": "a-salt-value"
+    "loginSalt": "********",
+    "ApiSalt": "********"
   },
   "API": {
     "PageSize": 100

--- a/src/protagonist/Thumbs/appSettings-Development-Example.json
+++ b/src/protagonist/Thumbs/appSettings-Development-Example.json
@@ -1,22 +1,17 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "Microsoft": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
   "Thumbs": {
-    "ThumbsBucket": "thumbs-bucket-name",
     "EnsureNewThumbnailLayout": true,
     "Resize": false
   },  
   "ConnectionStrings": {
-    "PostgreSQLConnection": ""
+    "PostgreSQLConnection": "Server=localhost;Port=5452;Database=postgres;User Id=postgres;Password=dlcs_password;Command Timeout=60;"
   },
   "AWS": {
     "Profile": "default",
-    "Region": "eu-west-1"
+    "Region": "eu-west-1",
+    "S3": {
+      "ThumbsBucket": "dlcs-thumbs"
+    }
   },
   "PathRules": {
     "Default": "/{prefix}/{customer}/{space}/{assetPath}",


### PR DESCRIPTION
Tidy sample appsettings, removing out of date values and using LocalStack queue/bucket names and docker PG connection string.

Add new docker-compose files for local development:
* `docker-compose.engine.yml` - external dependencies for debugging Engine (just appetiser currently).
* `docker-compose.orchestrator.yml` - external dependencies for debugging Orchestrator. These are downstream destinations: special-server, cantaloupe and thumbs and fireball for PDF generation.