### PR TITLE
Use Fluent for customer validation, disallow customer names starting with "v<n>"

### DIFF
--- a/src/protagonist/API.Tests/Customers/CustomerValidationTests.cs
+++ b/src/protagonist/API.Tests/Customers/CustomerValidationTests.cs
@@ -1,13 +1,18 @@
-using API.Features.Customer.Requests;
 using API.Features.Customer.Validation;
 using DLCS.HydraModel;
-using FluentAssertions;
-using Xunit;
+using FluentValidation.TestHelper;
 
 namespace API.Tests.Customers;
 
 public class CustomerValidationTests
 {
+    private readonly HydraCustomerValidator sut;
+    
+    public CustomerValidationTests()
+    {
+        sut = new HydraCustomerValidator();
+    }
+    
     private Customer GetValidNewCustomer()
     {
         return new Customer
@@ -16,14 +21,15 @@ public class CustomerValidationTests
             DisplayName = "My test customer"
         };
     }
+    
     [Fact]
     public void NewCustomer_RequiresOnly_Names()
     {
         var customer = GetValidNewCustomer();
         
-        var errors = HydraCustomerValidator.GetNewHydraCustomerErrors(customer);
+        var result = sut.TestValidate(customer);
 
-        errors.Length.Should().Be(0);
+        result.ShouldNotHaveAnyValidationErrors();
     }
     
     [Fact]
@@ -31,11 +37,10 @@ public class CustomerValidationTests
     {
         var customer = new Customer();
         
-        var errors = HydraCustomerValidator.GetNewHydraCustomerErrors(customer);
+        var result = sut.TestValidate(customer);
 
-        errors.Length.Should().BeGreaterThan(0);
+        result.ShouldHaveAnyValidationError();
     }
-    
     
     [Fact]
     public void NewCustomer_CannotBe_Admin()
@@ -43,11 +48,10 @@ public class CustomerValidationTests
         var customer = GetValidNewCustomer();
         customer.Administrator = true;
         
-        var errors = HydraCustomerValidator.GetNewHydraCustomerErrors(customer);
+        var result = sut.TestValidate(customer);
 
-        errors.Length.Should().BeGreaterThan(0);
+        result.ShouldHaveAnyValidationError();
     }
-   
     
     [Fact]
     public void NewCustomer_CannotHaveName_Admin()
@@ -55,8 +59,8 @@ public class CustomerValidationTests
         var customer = GetValidNewCustomer();
         customer.Name = "Admin";
         
-        var errors = HydraCustomerValidator.GetNewHydraCustomerErrors(customer);
+        var result = sut.TestValidate(customer);
 
-        errors.Length.Should().BeGreaterThan(0);
+        result.ShouldHaveAnyValidationError();
     }
 }

--- a/src/protagonist/API.Tests/Customers/CustomerValidationTests.cs
+++ b/src/protagonist/API.Tests/Customers/CustomerValidationTests.cs
@@ -63,4 +63,15 @@ public class CustomerValidationTests
 
         result.ShouldHaveAnyValidationError();
     }
+    
+    [Fact]
+    public void NewCustomer_CannotHaveName_Version()
+    {
+        var customer = GetValidNewCustomer();
+        customer.Name = "v2-customer";
+        
+        var result = sut.TestValidate(customer);
+
+        result.ShouldHaveAnyValidationError();
+    }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerTests.cs
@@ -166,6 +166,42 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
+    
+    [Fact] 
+    public async Task CreateNewCustomer_Returns400_IfNameStartsWithVersion()
+    {
+        // Tests HydraCustomerValidator:StartsWithVersion
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""v2"",
+  ""displayName"": ""TestUser""
+}";
+        
+        // act
+        var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsAdmin().PostAsync("/customers", content);
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact] 
+    public async Task CreateNewCustomer_Returns400_IfNameReserved()
+    {
+        // Tests HydraCustomerValidator:IsReservedWord
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""Admin"",
+  ""displayName"": ""TestUser""
+}";
+        
+        // act
+        var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsAdmin().PostAsync("/customers", content);
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 
     [Fact]
     public async Task Non_Admin_Cant_Create_Customer()

--- a/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
@@ -1,53 +1,43 @@
-using System.Collections.Generic;
 using DLCS.Core.Strings;
+using FluentValidation;
 
-namespace API.Features.Customer.Validation;
+namespace API.Features.Customer.Validation; 
 
 /// <summary>
 /// Performs basic checks on a new POSTed or PUT Hydra Customer.
 /// Does not perform data integrity/constraint checks.
 /// </summary>
-public static class HydraCustomerValidator
+public class HydraCustomerValidator : AbstractValidator<DLCS.HydraModel.Customer>
 {
-    /// <summary>
-    /// Validates a customer is ready to be passed to the Customer repository
-    /// </summary>
-    /// <param name="newCustomer">The new Hydra Customer</param>
-    /// <returns>A list of string error messages</returns>
-    public static string[] GetNewHydraCustomerErrors(DLCS.HydraModel.Customer newCustomer)
+    public HydraCustomerValidator()
     {
-        var errorList = new List<string>();
-        if (newCustomer.ModelId > 0)
-        {
-            errorList.Add($"DLCS must allocate customer id, but id {newCustomer.ModelId} was supplied.");
-        }
-
-        if (string.IsNullOrEmpty(newCustomer.Name))
-        {
-            errorList.Add($"A new customer must have a name (url part).");
-        }
-            
-        if (string.IsNullOrEmpty(newCustomer.DisplayName))
-        {
-            errorList.Add($"A new customer must have a Display name (label).");
-        }
-            
-        if (newCustomer.Administrator == true)
-        {
-            errorList.Add($"You can't attempt to create an Administrator customer.");
-        }
-
-        if (newCustomer.Keys.HasText())
-        {
-            errorList.Add( $"You can't supply API Keys at customer creation time.");
-        }
+        RuleFor(c => c.ModelId).Empty()
+            .WithMessage(c => $"DLCS must allocate customer id, but id {c.ModelId} was supplied.");
         
-        if (Enum.GetNames(typeof(DLCS.HydraModel.Customer.ReservedNames)).Any(n =>
-                String.Equals(n, newCustomer.Name, StringComparison.CurrentCultureIgnoreCase)))
-        {
-            errorList.Add($"Name field [{newCustomer.Name}] cannot be a reserved word.");
-        }
-
-        return errorList.ToArray();
+        RuleFor(c => c.Name)
+            .NotEmpty()
+            .WithMessage("A new customer must have a name (url part).");
+        
+        RuleFor(c => c.DisplayName)
+            .NotEmpty()
+            .WithMessage("A new customer must have a Display name (label)..");
+        
+        RuleFor(c => c.Administrator)
+            .NotEqual(true)
+            .WithMessage("You can't attempt to create an Administrator customer.");
+        
+        RuleFor(c => c.Keys.HasText())
+            .Equal(false)
+            .WithMessage("You can't supply API Keys at customer creation time.");
+        
+        RuleFor(c => c.Name)
+            .Must(name => !IsReservedWord(name))
+            .WithMessage(c=> $"Name field [{c.Name}] cannot be a reserved word.");
+    }
+    
+    private bool IsReservedWord(string? customerName)
+    {
+        return Enum.GetNames(typeof(DLCS.HydraModel.Customer.ReservedNames)).Any(n =>
+            String.Equals(n, customerName, StringComparison.CurrentCultureIgnoreCase));
     }
 }

--- a/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
@@ -20,7 +20,7 @@ public class HydraCustomerValidator : AbstractValidator<DLCS.HydraModel.Customer
         
         RuleFor(c => c.DisplayName)
             .NotEmpty()
-            .WithMessage("A new customer must have a Display name (label)..");
+            .WithMessage("A new customer must have a Display name (label).");
         
         RuleFor(c => c.Administrator)
             .NotEqual(true)

--- a/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/HydraCustomerValidator.cs
@@ -39,7 +39,7 @@ public class HydraCustomerValidator : AbstractValidator<DLCS.HydraModel.Customer
         RuleFor(c => c.Name)
             .Must(name => !StartsWithVersion(name!))
             .When(c => !string.IsNullOrEmpty(c.Name))
-            .WithMessage(c=> $"Name field [{c.Name}] cannot start with a version slug");
+            .WithMessage(c=> $"Name field [{c.Name}] cannot start with a version slug.");
     }
     
     private bool IsReservedWord(string customerName)


### PR DESCRIPTION
Related to #204

Modified `HydraCustomerValidator` to use FluentValidator

Added a validation rule to `HydraCustomerValidator` that disallows names that begin with version slugs ("v1","v2-user", etc)

Added `NewCustomer_CannotHaveName_Version()` unit test to `CustomerValidationTests` and `CreateNewCustomer_Returns400_IfNameStartsWithVersion()` integration test to `CustomerTests` to test this functionality

Also added a `CreateNewCustomer_Returns400_IfNameReserved()` integration test to `CustomerTests` to test that reserved names such as "admin" are also disallowed