### PR TITLE
Add special-server as a dependency to orchestrator health checks

### DIFF
--- a/src/protagonist/Orchestrator/Infrastructure/EndpointRouteBuilderX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/EndpointRouteBuilderX.cs
@@ -19,6 +19,11 @@ public static class EndpointRouteBuilderX
             AllowCachingResponses = false,
             Predicate = registration => registration.Name == "Image Server",
         });
+        endpoints.MapHealthChecks("/health/specialserver", new HealthCheckOptions
+        {
+            AllowCachingResponses = false,
+            Predicate = registration => registration.Name == "Special Server",
+        });
         endpoints.MapHealthChecks("/health/detail", new HealthCheckOptions
         {
             AllowCachingResponses = false,

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -131,8 +131,9 @@ public static class ServiceCollectionX
             .AddHealthChecks()
             .AddNpgSql(configuration.GetPostgresSqlConnection(), name: "Database")
             .AddProxyDestination(ProxyDestination.ImageServer, "Image Server")
+            .AddProxyDestination(ProxyDestination.SpecialServer, "Special Server")
             .AddProxyDestination(ProxyDestination.Thumbs, "Thumbs", tags: tagsList);
-            
+
         if (proxy.CanResizeThumbs)
         {
             healthChecksBuilder.AddProxyDestination(ProxyDestination.ResizeThumbs, "ThumbsResize", tags: tagsList);


### PR DESCRIPTION
Related to #504 

Added a proxy destination for `ProxyDestination.SpecialServer` in `ServiceCollectionX:ConfigureHealthChecks`

Added special-server to the list of health checks in `EndpointRouteBuilderX:MapConfiguredHealthChecks`
