### PR TITLE
initial commit for adding the flag

### DIFF
--- a/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
+++ b/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using API.Settings;
+
+namespace API.Tests.Settings;
+
+public class ApiSettingsTests
+{
+    [Fact]
+    public void ApiSettings_LegacySupportEnabledForAllCustomers_byDefault()
+    {
+        // Arrange
+        var settings = new ApiSettings();
+        
+        // Assert
+        settings.GetCustomerSettings(1).LegacySupport.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void ApiSettings_LegacySupportDisabledForAllCustomers_WhenDefaultLegacyDisabled()
+    {
+        // Arrange
+        var settings = new ApiSettings
+        {
+            DefaultLegacySupport = false
+        };
+
+        // Assert
+        settings.GetCustomerSettings(1).LegacySupport.Should().BeFalse();
+    }
+    
+    [Fact]
+    public void ApiSettings_LegacySupportEnabledForSingleCustomer_WhenDefaultLegacyDisabled()
+    {
+        // Arrange
+        var settings = new ApiSettings
+        {
+            DefaultLegacySupport = false
+        };
+
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = true,
+            NovelSpaces = new List<string>()
+            {
+                "1"
+            }
+        });
+        
+        // Assert
+        settings.GetCustomerSettings(1).LegacySupport.Should().BeFalse();
+        settings.GetCustomerSettings(2).LegacySupport.Should().BeTrue();
+        settings.GetCustomerSettings(2).NovelSpaces.Should().Contain("1");
+    }
+}

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.AWS.Settings;
+﻿using System.Collections.Generic;
+using DLCS.AWS.Settings;
 using DLCS.Core.Settings;
 
 namespace API.Settings;
@@ -30,4 +31,28 @@ public class ApiSettings
     /// The maximum number of images that can be POSTed in a single batch
     /// </summary>
     public int MaxImageListSize { get; set; } = 500;
+
+    /// <summary>
+    /// Whether legacy support is enabled by default
+    /// </summary>
+    public bool DefaultLegacySupport { get; set; } = true;
+    
+    /// <summary>
+    /// A collection of customer-specific overrides, keyed by customerId.
+    /// </summary> 
+    // ReSharper disable once CollectionNeverUpdated.Global
+    public Dictionary<string, CustomerOverrideSettings> CustomerOverrides { get; set; } = new();
+
+    /// <summary>
+    /// Get CustomerSpecificSettings, if found. 
+    /// </summary>
+    /// <param name="customerId">CustomerId to get settings for.</param>
+    /// <returns>Customer specific overrides, or default if not found.</returns>
+    public CustomerOverrideSettings GetCustomerSettings(int customerId)
+        => CustomerOverrides.TryGetValue(customerId.ToString(), out var settings)
+            ? settings
+            : new CustomerOverrideSettings
+            {
+                LegacySupport = DefaultLegacySupport
+            };
 }

--- a/src/protagonist/API/Settings/CustomerOverrideSettings.cs
+++ b/src/protagonist/API/Settings/CustomerOverrideSettings.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace API.Settings;
+
+public class CustomerOverrideSettings
+{
+    public static readonly CustomerOverrideSettings Empty = new();
+    
+    /// <summary>
+    /// Whether the customer has legacy support enabled
+    /// </summary>
+    public bool LegacySupport { get; init; } = false;
+
+    /// <summary>
+    /// Spaces which are exempt from legacy support in a customer that has legacy support enabled
+    /// </summary>
+    public List<string> NovelSpaces { get; init; } = new();
+}

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -58,7 +58,7 @@ public class Startup
 
         var apiSettings = configuration.Get<ApiSettings>();
         var cacheSettings = cachingSection.Get<CacheSettings>();
-        
+
         services
             .AddHttpContextAccessor()
             .AddSingleton<ApiKeyGenerator>()

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -40,5 +40,16 @@
   },
   "PathBase": "",
   "Salt": "********",
-  "PageSize": 100
+  "PageSize": 100,
+  "DefaultLegacySupport": true,
+  "CustomerOverrides": {
+    "2": {
+      "LegacySupport": true,
+      "NovelSpaces": [1,2,4]
+    },
+    "7": {
+      "LegacySupport": true,
+      "NovelSpaces": [15]
+    }
+  }
 }


### PR DESCRIPTION
resolves https://github.com/dlcs/private-protagonist/issues/70

Adds a custom flag to reenable legacy support to appesttings.

These flags are set like this:

```
{
    "DefaultLegacySupport": true, // default if not defined here
    "CustomerOverrides": {
        "2": {
            "LegacySupport": true, // whether to enable legacy suport
            "NovelSpaces": [1] // if legacy support is enabled, this setting disables legacy support on these spaces
        },
        "4": {
            "LegacySupport": false
        }
    }
}
```

Currently, setting these flags won't do anything, the logic that takes advantage of this will be completed under #463 