### PR TITLE
adding in ability to put/post an image using legacy formats

### DIFF
--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -79,4 +79,19 @@ public class LegacyModeConverterTests
         convertedImage.MaxUnauthorised.Should().Be(-1);
         convertedImage.Family.Should().Be(AssetFamily.Image);
     }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_MaxUnauthorisedUnchanged_WhenRolesSet()
+    {
+        // Arrange
+        var hydraImage = new Image{ Origin = "something.jpg", Roles = new []{ "some role" }};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be("image/jpeg");
+        convertedImage.MaxUnauthorised.Should().Be(null);
+        convertedImage.Family.Should().Be(AssetFamily.Image);
+    }
 }

--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -1,0 +1,82 @@
+﻿using API.Converters;
+using DLCS.HydraModel;
+
+namespace API.Tests.Converters;
+
+public class LegacyModeConverterTests
+{
+    [Fact]
+    public void VerifyAndConvertToModernFormat_ChangesNothing_WithNewFormat()
+    {
+        // Arrange
+        var hydraImage = new Image{ MediaType = "type", MaxUnauthorised = 5, Family = AssetFamily.File};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be(hydraImage.MediaType);
+        convertedImage.MaxUnauthorised.Should().Be(hydraImage.MaxUnauthorised);
+        convertedImage.Family.Should().Be(hydraImage.Family);
+    }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_SetsMediaType_WithNotSet()
+    {
+        // Arrange
+        var hydraImage = new Image{ MaxUnauthorised = 5, Family = AssetFamily.File};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be("dlcs/unknown");
+        convertedImage.MaxUnauthorised.Should().Be(hydraImage.MaxUnauthorised);
+        convertedImage.Family.Should().Be(hydraImage.Family);
+    }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_InferMediaType_WhenOriginSet()
+    {
+        // Arrange
+        var hydraImage = new Image{ Origin = "something.jpg",MaxUnauthorised = 5, Family = AssetFamily.File};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be("image/jpeg");
+        convertedImage.MaxUnauthorised.Should().Be(hydraImage.MaxUnauthorised);
+        convertedImage.Family.Should().Be(hydraImage.Family);
+    }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_SetMaxUnauthorised_WhenSetToOldFormat()
+    {
+        // Arrange
+        var hydraImage = new Image{ Origin = "something.jpg",MaxUnauthorised = 0, Family = AssetFamily.File};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be("image/jpeg");
+        convertedImage.MaxUnauthorised.Should().Be(-1);
+        convertedImage.Family.Should().Be(hydraImage.Family);
+    }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_SetFamily_WhenNotSet()
+    {
+        // Arrange
+        var hydraImage = new Image{ Origin = "something.jpg"};
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.MediaType.Should().Be("image/jpeg");
+        convertedImage.MaxUnauthorised.Should().Be(-1);
+        convertedImage.Family.Should().Be(AssetFamily.Image);
+    }
+}

--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -30,7 +30,7 @@ public class LegacyModeConverterTests
         var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
 
         // Assert
-        convertedImage.MediaType.Should().Be("dlcs/unknown");
+        convertedImage.MediaType.Should().Be("image/unknown");
         convertedImage.MaxUnauthorised.Should().Be(hydraImage.MaxUnauthorised);
         convertedImage.Family.Should().Be(hydraImage.Family);
     }

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -95,6 +95,56 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         asset.ImageOptimisationPolicy.Should().Be("fast-higher");
     }
     
+    [Fact]
+    public async Task Put_NewImageAsset_FailsToCreateAsset_whenMediaTypeAndFamilyNotSet()
+    {
+        var assetId = new AssetId(99, 1, nameof(Put_NewImageAsset_FailsToCreateAsset_whenMediaTypeAndFamilyNotSet));
+        var hydraImageBody = $@"{{
+  ""@type"": ""Image"",
+  ""origin"": ""https://example.org/{assetId.Asset}.tiff""
+}}";
+        A.CallTo(() =>
+                EngineClient.SynchronousIngest(
+                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<CancellationToken>._))
+            .Returns(HttpStatusCode.OK);
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Put_NewImageAsset_CreatesAsset_whenMediaTypeAndFamilyNotSetWithLegacyEnabled()
+    {
+        const int customer = 325665;
+        const int space = 2;
+        var assetId = new AssetId(customer, space, nameof(Put_NewImageAsset_CreatesAsset_whenMediaTypeAndFamilyNotSetWithLegacyEnabled));
+        await dbContext.Customers.AddTestCustomer(customer);
+        await dbContext.Spaces.AddTestSpace(customer, space);
+        await dbContext.SaveChangesAsync();
+        
+        var hydraImageBody = $@"{{
+  ""@type"": ""Image"",
+  ""origin"": ""https://example.org/{assetId.Asset}.tiff""
+}}";
+        A.CallTo(() =>
+                EngineClient.SynchronousIngest(
+                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<CancellationToken>._))
+            .Returns(HttpStatusCode.OK);
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customer).PutAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+    
     [Theory]
     [InlineData("audio/mp3", AssetFamily.Timebased)]
     [InlineData("video/mp4", AssetFamily.Timebased)]

--- a/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
+++ b/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
@@ -51,4 +51,94 @@ public class ApiSettingsTests
         settings.GetCustomerSettings(2).LegacySupport.Should().BeTrue();
         settings.GetCustomerSettings(2).NovelSpaces.Should().Contain("1");
     }
+    
+    [Fact]
+    public void LegacyModeEnabled_LegacySupportEnabledForAllCustomers_byDefault()
+    {
+        // Arrange
+        var settings = new ApiSettings();
+        
+        // Assert
+        settings.LegacyModeEnabled(1,1).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabled_LegacySupportDisabledForAllCustomers_WhenDefaultLegacyDisabled()
+    {
+        // Arrange
+        var settings = new ApiSettings
+        {
+            DefaultLegacySupport = false
+        };
+        
+        // Assert
+        settings.LegacyModeEnabled(1,1).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabled_LegacySupportEnabledForSingleCustomer_WhenDefaultLegacyDisabled()
+    {
+        // Arrange
+        var settings = new ApiSettings
+        {
+            DefaultLegacySupport = false
+        };
+
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = true,
+            NovelSpaces = new List<string>()
+            {
+                "1"
+            }
+        });
+        
+        // Assert
+        settings.LegacyModeEnabled(1, 1).Should().BeFalse();
+        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
+        settings.LegacyModeEnabled(2, 2).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabled_LegacySupportDisabledForSpace_WhenDefaultLegacyEnabled()
+    {
+        // Arrange
+        var settings = new ApiSettings();
+        
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = true,
+            NovelSpaces = new List<string>()
+            {
+                "1"
+            }
+        });
+        
+        settings.CustomerOverrides.Add("3", new CustomerOverrideSettings()
+        {
+            LegacySupport = false
+        });
+        
+        // Assert
+        settings.LegacyModeEnabled(1, 1).Should().BeTrue();
+        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
+        settings.LegacyModeEnabled(2, 2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LegacyModeEnabled_LegacySupportDisabledForCustomer_WhenDefaultLegacyEnabled()
+    {
+        // Arrange
+        var settings = new ApiSettings();
+        
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = false,
+        });
+
+        
+        // Assert
+        settings.LegacyModeEnabled(1, 1).Should().BeTrue();
+        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
+    }
 }

--- a/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
+++ b/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
@@ -6,26 +6,26 @@ namespace API.Tests.Settings;
 public class ApiSettingsTests
 {
     [Fact]
-    public void ApiSettings_LegacySupportEnabledForAllCustomers_byDefault()
+    public void ApiSettings_LegacySupportDisabledForAllCustomers_byDefault()
     {
         // Arrange
         var settings = new ApiSettings();
         
         // Assert
-        settings.GetCustomerSettings(1).LegacySupport.Should().BeTrue();
+        settings.GetCustomerSettings(1).LegacySupport.Should().BeFalse();
     }
     
     [Fact]
-    public void ApiSettings_LegacySupportDisabledForAllCustomers_WhenDefaultLegacyDisabled()
+    public void ApiSettings_LegacySupportEnabledForAllCustomers_WhenDefaultLegacyEnabled()
     {
         // Arrange
         var settings = new ApiSettings
         {
-            DefaultLegacySupport = false
+            DefaultLegacySupport = true
         };
 
         // Assert
-        settings.GetCustomerSettings(1).LegacySupport.Should().BeFalse();
+        settings.GetCustomerSettings(1).LegacySupport.Should().BeTrue();
     }
     
     [Fact]
@@ -53,36 +53,33 @@ public class ApiSettingsTests
     }
     
     [Fact]
-    public void LegacyModeEnabled_LegacySupportEnabledForAllCustomers_byDefault()
+    public void LegacyModeEnabledForSpace_LegacySupportDisabledForAllCustomers_byDefault()
     {
         // Arrange
         var settings = new ApiSettings();
         
         // Assert
-        settings.LegacyModeEnabled(1,1).Should().BeTrue();
+        settings.LegacyModeEnabledForSpace(1,1).Should().BeFalse();
     }
     
     [Fact]
-    public void LegacyModeEnabled_LegacySupportDisabledForAllCustomers_WhenDefaultLegacyDisabled()
+    public void LegacyModeEnabledForSpace_LegacySupportEnabledForAllCustomers_WhenDefaultLegacySupportEnabled()
     {
         // Arrange
-        var settings = new ApiSettings
+        var settings = new ApiSettings()
         {
-            DefaultLegacySupport = false
+            DefaultLegacySupport = true
         };
         
         // Assert
-        settings.LegacyModeEnabled(1,1).Should().BeFalse();
+        settings.LegacyModeEnabledForSpace(1,1).Should().BeTrue();
     }
     
     [Fact]
-    public void LegacyModeEnabled_LegacySupportEnabledForSingleCustomer_WhenDefaultLegacyDisabled()
+    public void LegacyModeEnabledForSpace_LegacySupportEnabledForSingleCustomer_WhenDefaultLegacySupportDisabled()
     {
         // Arrange
-        var settings = new ApiSettings
-        {
-            DefaultLegacySupport = false
-        };
+        var settings = new ApiSettings();
 
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
@@ -94,16 +91,19 @@ public class ApiSettingsTests
         });
         
         // Assert
-        settings.LegacyModeEnabled(1, 1).Should().BeFalse();
-        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
-        settings.LegacyModeEnabled(2, 2).Should().BeTrue();
+        settings.LegacyModeEnabledForSpace(1, 1).Should().BeFalse();
+        settings.LegacyModeEnabledForSpace(2, 1).Should().BeFalse();
+        settings.LegacyModeEnabledForSpace(2, 2).Should().BeTrue();
     }
     
     [Fact]
-    public void LegacyModeEnabled_LegacySupportDisabledForSpace_WhenDefaultLegacyEnabled()
+    public void LegacyModeEnabledForSpace_LegacySupportDisabledForSpace_WhenDefaultLegacyEnabled()
     {
         // Arrange
-        var settings = new ApiSettings();
+        var settings = new ApiSettings()
+        {
+            DefaultLegacySupport = true
+        };
         
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
@@ -120,25 +120,91 @@ public class ApiSettingsTests
         });
         
         // Assert
-        settings.LegacyModeEnabled(1, 1).Should().BeTrue();
-        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
-        settings.LegacyModeEnabled(2, 2).Should().BeTrue();
+        settings.LegacyModeEnabledForSpace(1, 1).Should().BeTrue();
+        settings.LegacyModeEnabledForSpace(2, 1).Should().BeFalse();
+        settings.LegacyModeEnabledForSpace(2, 2).Should().BeTrue();
     }
 
     [Fact]
-    public void LegacyModeEnabled_LegacySupportDisabledForCustomer_WhenDefaultLegacyEnabled()
+    public void LegacyModeEnabledForSpace_LegacySupportDisabledForCustomer_WhenDefaultLegacyEnabled()
+    {
+        // Arrange
+        var settings = new ApiSettings()
+        {
+            DefaultLegacySupport = true
+        };
+        
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = false,
+        });
+        
+        // Assert
+        settings.LegacyModeEnabledForSpace(1, 1).Should().BeTrue();
+        settings.LegacyModeEnabledForSpace(2, 1).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabledForCustomer_LegacySupportDisabledForAllCustomers_byDefault()
+    {
+        // Arrange
+        var settings = new ApiSettings();
+        
+        // Assert
+        settings.LegacyModeEnabledForCustomer(1).Should().BeFalse();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabledForCustomer_LegacySupportDisabledForAllCustomers_WhenDefaultLegacySupportDisabled()
+    {
+        // Arrange
+        var settings = new ApiSettings()
+        {
+            DefaultLegacySupport = true
+        };
+        
+        // Assert
+        settings.LegacyModeEnabledForCustomer(1).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabledForCustomer_LegacySupportEnabledForCustomer_WhenDefaultLegacySupportDisabled()
     {
         // Arrange
         var settings = new ApiSettings();
         
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
-            LegacySupport = false,
+            LegacySupport = true,
+            NovelSpaces = new List<string>()
+            {
+                "1"
+            }
         });
-
         
         // Assert
-        settings.LegacyModeEnabled(1, 1).Should().BeTrue();
-        settings.LegacyModeEnabled(2, 1).Should().BeFalse();
+        settings.LegacyModeEnabledForCustomer(2).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void LegacyModeEnabledForCustomer_LegacySupportDisabledForCustomer_WhenDefaultLegacySupportEnabled()
+    {
+        // Arrange
+        var settings = new ApiSettings()
+        {
+            DefaultLegacySupport = true
+        };
+        
+        settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
+        {
+            LegacySupport = false,
+            NovelSpaces = new List<string>()
+            {
+                "1"
+            }
+        });
+        
+        // Assert
+        settings.LegacyModeEnabledForCustomer(2).Should().BeFalse();
     }
 }

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -29,7 +29,6 @@
   },
   "PageSize": 100,
   "Salt": "this-is-a-salt",
-  "DefaultLegacySupport": false,
   "CustomerOverrides": {
     "15": {
       "LegacySupport": true,

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -28,5 +28,16 @@
     }
   },
   "PageSize": 100,
-  "Salt": "this-is-a-salt"
+  "Salt": "this-is-a-salt",
+  "DefaultLegacySupport": false,
+  "CustomerOverrides": {
+    "15": {
+      "LegacySupport": true,
+      "NovelSpaces": ["1","4"]
+    },
+    "325665": {
+      "LegacySupport": true,
+      "NovelSpaces": ["1","4"]
+    }
+  }
 }

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -9,7 +9,7 @@ namespace API.Converters;
 /// </summary>
 public static class LegacyModeConverter
 {
-    private const string DefaultMediaType = "dlcs/unknown";
+    private const string DefaultMediaType = "image/unknown";
     
     /// <summary>
     /// Converts from legacy format to new format
@@ -18,7 +18,7 @@ public static class LegacyModeConverter
     /// <returns>A converted image</returns>
     public static Image VerifyAndConvertToModernFormat(Image image)
     {
-        if (image.MediaType is null)
+        if (image.MediaType.IsNullOrEmpty())
         {
             var contentType = image.Origin?.Split('.').Last() ?? string.Empty;
             
@@ -30,7 +30,7 @@ public static class LegacyModeConverter
             }
         }
 
-        if (image.MaxUnauthorised is null or 0)
+        if (image.MaxUnauthorised is null or 0 && image.Roles.IsNullOrEmpty())
         {
             image.MaxUnauthorised = -1;
         }

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -1,0 +1,40 @@
+﻿using DLCS.Core;
+using DLCS.Core.Collections;
+using DLCS.HydraModel;
+
+namespace API.Converters;
+
+/// <summary>
+/// Converts legacy image API calls
+/// </summary>
+public static class LegacyModeConverter
+{
+    private const string DefaultMediaType = "dlcs/unknown";
+    
+    /// <summary>
+    /// Converts from legacy format to new format
+    /// </summary>
+    /// <param name="image">The image to convert</param>
+    /// <returns>A converted image</returns>
+    public static Image VerifyAndConvertToModernFormat(Image image)
+    {
+        if (image.MediaType is null)
+        {
+            var contentType = image.Origin?.Split('.').Last() ?? string.Empty;
+            
+            image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ?? DefaultMediaType;
+            
+            if (image.Origin is not null && image.Family is null && image.DeliveryChannels.IsNullOrEmpty())
+            {
+                  image.Family = AssetFamily.Image;
+            }
+        }
+
+        if (image.MaxUnauthorised is null or 0)
+        {
+            image.MaxUnauthorised = -1;
+        }
+
+        return image;
+    }
+}

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -23,13 +23,13 @@ namespace API.Features.Image;
 [ApiController]
 public class ImageController : HydraController
 {
-    private readonly ApiSettings _apiSettings;
+    private readonly ApiSettings apiSettings;
     
     public ImageController(
         IMediator mediator,
         IOptions<ApiSettings> options) : base(options.Value, mediator)
     {
-        _apiSettings = options.Value;
+        apiSettings = options.Value;
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class ImageController : HydraController
         [FromServices] HydraImageValidator validator,
         CancellationToken cancellationToken)
     {
-        if (_apiSettings.LegacyModeEnabled(customerId, spaceId))
+        if (apiSettings.LegacyModeEnabledForSpace(customerId, spaceId))
         {
             hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset);
         }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -23,10 +23,13 @@ namespace API.Features.Image;
 [ApiController]
 public class ImageController : HydraController
 {
+    private readonly ApiSettings _apiSettings;
+    
     public ImageController(
         IMediator mediator,
         IOptions<ApiSettings> options) : base(options.Value, mediator)
     {
+        _apiSettings = options.Value;
     }
 
     /// <summary>
@@ -85,6 +88,11 @@ public class ImageController : HydraController
         [FromServices] HydraImageValidator validator,
         CancellationToken cancellationToken)
     {
+        if (_apiSettings.LegacyModeEnabled(customerId, spaceId))
+        {
+            hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset);
+        }
+        
         var validationResult = await validator.ValidateAsync(hydraAsset, cancellationToken);
         if (!validationResult.IsValid)
         {

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -5,7 +5,6 @@ using API.Features.Image.Validation;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.Core;
-using DLCS.Core.Collections;
 using DLCS.Core.Types;
 using DLCS.HydraModel;
 using Hydra.Model;
@@ -98,6 +97,7 @@ public class ImageController : HydraController
         {
             return this.ValidationFailed(validationResult);
         }
+         
         
         return await PutOrPatchAsset(customerId, spaceId, imageId, hydraAsset, cancellationToken);
     }

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -23,11 +23,11 @@ namespace API.Features.Queues;
 [ApiController]
 public class CustomerQueueController : HydraController
 {
-    private readonly ApiSettings _apiSettings;
+    private readonly ApiSettings apiSettings;
     
     public CustomerQueueController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
     {
-        _apiSettings = settings.Value;
+        apiSettings = settings.Value;
     }
 
     /// <summary>
@@ -95,11 +95,14 @@ public class CustomerQueueController : HydraController
     {
         if (images.Members != null)
         {
-            for (int i = 0; i < images.Members.Length; i++)
+            if (apiSettings.LegacyModeEnabledForCustomer(customerId))
             {
-                if (_apiSettings.LegacyModeEnabled(customerId, images.Members[i].Space))
+                for (int i = 0; i < images.Members.Length; i++)
                 {
-                    images.Members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(images.Members[i]);
+                    if (apiSettings.LegacyModeEnabledForSpace(customerId, images.Members[i].Space))
+                    {
+                        images.Members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(images.Members[i]);
+                    }
                 }
             }
         }

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -23,8 +23,11 @@ namespace API.Features.Queues;
 [ApiController]
 public class CustomerQueueController : HydraController
 {
+    private readonly ApiSettings _apiSettings;
+    
     public CustomerQueueController(IOptions<ApiSettings> settings, IMediator mediator) : base(settings.Value, mediator)
     {
+        _apiSettings = settings.Value;
     }
 
     /// <summary>
@@ -90,6 +93,17 @@ public class CustomerQueueController : HydraController
         [FromServices] QueuePostValidator validator,
         CancellationToken cancellationToken)
     {
+        if (images.Members != null)
+        {
+            for (int i = 0; i < images.Members.Length; i++)
+            {
+                if (_apiSettings.LegacyModeEnabled(customerId, images.Members[i].Space))
+                {
+                    images.Members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(images.Members[i]);
+                }
+            }
+        }
+        
         var validationResult = await validator.ValidateAsync(images, cancellationToken);
         if (!validationResult.IsValid)
         {

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -1,4 +1,5 @@
-﻿using API.Features.Image.Validation;
+﻿using API.Converters;
+using API.Features.Image.Validation;
 using API.Settings;
 using DLCS.Core.Collections;
 using FluentValidation;

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -35,7 +35,7 @@ public class ApiSettings
     /// <summary>
     /// Whether legacy support is enabled by default
     /// </summary>
-    public bool DefaultLegacySupport { get; set; } = true;
+    public bool DefaultLegacySupport { get; set; }
     
     /// <summary>
     /// A collection of customer-specific overrides, keyed by customerId.
@@ -57,13 +57,23 @@ public class ApiSettings
             };
     
     /// <summary>
-    /// Get whether legacy mode is enabled for the 
+    /// Get whether legacy mode is enabled for a particular customer and space
     /// </summary>
     /// <param name="customerId">CustomerId to get settings for.</param>
     /// <param name="spaceId">The space to check if legacy mode is disabled</param>
-    /// <returns>Customer specific overrides, or default if not found.</returns>
-    public bool LegacyModeEnabled(int customerId, int spaceId)
+    /// <returns>Whether legacy mode is enabled or not</returns>
+    public bool LegacyModeEnabledForSpace(int customerId, int spaceId)
         => CustomerOverrides.TryGetValue(Convert.ToString(customerId), out var settings) 
             ? settings.LegacySupport && !settings.NovelSpaces.Contains(spaceId.ToString()) 
+            : DefaultLegacySupport;
+    
+    /// <summary>
+    /// Get whether legacy mode is enabled for a particular customer
+    /// </summary>
+    /// <param name="customerId">CustomerId to get settings for.</param>
+    /// <returns>Whether legacy mode is enabled or not</returns>
+    public bool LegacyModeEnabledForCustomer(int customerId)
+        => CustomerOverrides.TryGetValue(Convert.ToString(customerId), out var settings) 
+            ? settings.LegacySupport 
             : DefaultLegacySupport;
 }

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -55,4 +55,15 @@ public class ApiSettings
             {
                 LegacySupport = DefaultLegacySupport
             };
+    
+    /// <summary>
+    /// Get whether legacy mode is enabled for the 
+    /// </summary>
+    /// <param name="customerId">CustomerId to get settings for.</param>
+    /// <param name="spaceId">The space to check if legacy mode is disabled</param>
+    /// <returns>Customer specific overrides, or default if not found.</returns>
+    public bool LegacyModeEnabled(int customerId, int spaceId)
+        => CustomerOverrides.TryGetValue(Convert.ToString(customerId), out var settings) 
+            ? settings.LegacySupport && !settings.NovelSpaces.Contains(spaceId.ToString()) 
+            : DefaultLegacySupport;
 }

--- a/src/protagonist/API/Settings/CustomerOverrideSettings.cs
+++ b/src/protagonist/API/Settings/CustomerOverrideSettings.cs
@@ -9,8 +9,8 @@ public class CustomerOverrideSettings
     /// <summary>
     /// Whether the customer has legacy support enabled
     /// </summary>
-    public bool LegacySupport { get; init; } = false;
-
+    public bool LegacySupport { get; init; }
+    
     /// <summary>
     /// Spaces which are exempt from legacy support in a customer that has legacy support enabled
     /// </summary>

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -58,6 +58,8 @@ public class Startup
 
         var apiSettings = configuration.Get<ApiSettings>();
         var cacheSettings = cachingSection.Get<CacheSettings>();
+        
+        Log.Information("settings: {@Settings}", apiSettings);
 
         services
             .AddHttpContextAccessor()

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -58,8 +58,6 @@ public class Startup
 
         var apiSettings = configuration.Get<ApiSettings>();
         var cacheSettings = cachingSection.Get<CacheSettings>();
-        
-        Log.Information("settings: {@Settings}", apiSettings);
 
         services
             .AddHttpContextAccessor()

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -173,6 +173,56 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task IngestAsset_Success_ChangesMediaTypeToContentType_WhenCalledWithUnknownImageType()
+    {
+        // Arrange
+        var assetId = AssetId.FromString($"99/1/{nameof(IngestAsset_Success_ChangesMediaTypeToContentType_WhenCalledWithUnknownImageType)}");
+
+        // Note - API will have set this up before handing off
+        var initial = $"{apiStub.Address}/image";
+        var origin = $"{apiStub.Address}/this-will-fail";
+        var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
+            imageOptimisationPolicy: "fast-higher", mediaType: "image/unknown", width: 0, height: 0, duration: 0,
+            deliveryChannels: imageDeliveryChannels);
+        var asset = entity.Entity;
+        asset.InitialOrigin = initial;
+        await dbContext.SaveChangesAsync();
+        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+
+        // Act
+        var jsonContent =
+            new StringContent(JsonSerializer.Serialize(message, settings), Encoding.UTF8, "application/json");
+        var result = await httpClient.PostAsync("asset-ingest", jsonContent);
+
+        // Assert
+        result.Should().BeSuccessful();
+        
+        // S3 assets created
+        BucketWriter.ShouldHaveKey(assetId.ToString()).ForBucket(LocalStackFixture.StorageBucketName);
+        BucketWriter.ShouldHaveKey($"{assetId}/low.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
+        BucketWriter.ShouldHaveKey($"{assetId}/open/200.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
+        BucketWriter.ShouldHaveKey($"{assetId}/open/400.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
+        BucketWriter.ShouldHaveKey($"{assetId}/open/800.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
+        BucketWriter.ShouldHaveKey($"{assetId}/s.json").ForBucket(LocalStackFixture.ThumbsBucketName);
+        
+        // Database records updated
+        var updatedAsset = await dbContext.Images.SingleAsync(a => a.Id == assetId);
+        updatedAsset.Width.Should().Be(500);
+        updatedAsset.Height.Should().Be(1000);
+        updatedAsset.Ingesting.Should().BeFalse();
+        updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+        updatedAsset.MediaType.Should().Be("image/jpeg");
+        updatedAsset.Error.Should().BeEmpty();
+
+        var location = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);
+        location.Nas.Should().BeEmpty();
+        location.S3.Should().Be($"s3://us-east-1/{LocalStackFixture.StorageBucketName}/{assetId}");
+
+        var storage = await dbContext.ImageStorages.SingleAsync(a => a.Id == assetId);
+        storage.Size.Should().BeGreaterThan(0);
+    }
+    
+    [Fact]
     public async Task IngestAsset_Error_ExceedAllowance()
     {
         // Arrange

--- a/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
@@ -67,6 +67,8 @@ public class ImageIngesterWorker : IAssetIngesterWorker, IAssetIngesterPostProce
             ingestionContext.WithAssetFromOrigin(assetOnDisk);
 
             ingestSuccess = await imageProcessor.ProcessImage(ingestionContext);
+
+            ingestionContext.UpdateMediaTypeIfRequired();
         }
         catch (Exception ex)
         {

--- a/src/protagonist/Engine/Ingest/IngestionContext.cs
+++ b/src/protagonist/Engine/Ingest/IngestionContext.cs
@@ -1,4 +1,5 @@
 using DLCS.AWS.S3.Models;
+using DLCS.Core.Collections;
 using DLCS.Core.Guard;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
@@ -57,6 +58,22 @@ public class IngestionContext
         ImageStorage.ThumbnailSize += thumbnailSize ?? 0;
         ImageStorage.LastChecked = DateTime.UtcNow;
         
+        return this;
+    }
+
+    /// <summary>
+    /// Updates the media type if it's been set as something the caller didn't understand
+    /// </summary>
+    /// <returns></returns>
+    public IngestionContext UpdateMediaTypeIfRequired()
+    {
+        if (AssetFromOrigin == null) return this;
+        
+        if (Asset.MediaType == "image/unknown" && !AssetFromOrigin.ContentType.IsNullOrEmpty())
+        {
+            Asset.MediaType = AssetFromOrigin.ContentType;
+        }
+
         return this;
     }
 }


### PR DESCRIPTION
This PR adds in the ability to use protagonist in a similar manner to deliverator via the use of settings.

This is disabled by default using the `DefaultLegacySupport` app setting. Individual customers can also be controlled using the appsettings like the following:

```json
"CustomerOverrides": {
    "2": {
      "LegacySupport": true,
      "NovelSpaces": ["1","2","4"]
    }
```

`NovelSpaces` are to specifically set spaces that are handled in a protagonist manner when legacy support is enabled.  If legacy support is disabled, there is no use to setting `NovelSpaces`