### PR TITLE
Delete asset returns DeleteEntityResult

### DIFF
--- a/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
@@ -44,15 +44,18 @@ public class ApiAssetRepositoryTests
             .AddInMemoryCollection(new[]
                 { new KeyValuePair<string, string>("ConnectionStrings:PostgreSQLConnection", dbFixture.ConnectionString) })
             .Build();
-        var dapperAssetRepository = new DapperAssetRepository(
-            config,
-            new MockCachingService(),
-            Options.Create(new CacheSettings()),
-            new NullLogger<DapperAssetRepository>()
-        );
+        
         var entityCounterRepo = new EntityCounterRepository(dbContext);
 
-        sut = new ApiAssetRepository(dbContext, dapperAssetRepository, entityCounterRepo);
+        var assetRepository = new AssetRepository(
+            dbContext,
+            new MockCachingService(),
+            entityCounterRepo,
+            Options.Create(new CacheSettings()),
+            new NullLogger<AssetRepository>()
+        );
+
+        sut = new ApiAssetRepository(dbContext, assetRepository, entityCounterRepo);
 
         dbFixture.CleanUp();
     }

--- a/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
+++ b/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
@@ -1,4 +1,3 @@
-using DLCS.Core;
 using DLCS.Core.Types;
 using DLCS.Model;
 using DLCS.Model.Assets;
@@ -34,7 +33,7 @@ public class ApiAssetRepository : IApiAssetRepository
 
     public Task<ImageLocation?> GetImageLocation(AssetId assetId) => assetRepository.GetImageLocation(assetId);
     
-    public Task<ResultStatus<DeleteResult>> DeleteAsset(AssetId assetId) => assetRepository.DeleteAsset(assetId);
+    public Task<DeleteEntityResult<Asset>> DeleteAsset(AssetId assetId) => assetRepository.DeleteAsset(assetId);
     
     /// <summary>
     /// Save changes to Asset, incrementing EntityCounters if required.

--- a/src/protagonist/API/Features/Image/Requests/DeleteAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/DeleteAsset.cs
@@ -43,12 +43,11 @@ public class DeleteAssetHandler : IRequestHandler<DeleteAsset, DeleteResult>
     public async Task<DeleteResult> Handle(DeleteAsset request, CancellationToken cancellationToken)
     {
         logger.LogDebug("Deleting asset {AssetId}", request.AssetId);
-        var assetFromDatabase = await assetRepository.GetAsset(request.AssetId);
         var deleteResult = await assetRepository.DeleteAsset(request.AssetId);
 
-        if (!deleteResult.Success)
+        if (deleteResult.Result != DeleteResult.Deleted)
         {
-            return deleteResult.Value;
+            return deleteResult.Result;
         }
 
         try
@@ -56,7 +55,7 @@ public class DeleteAssetHandler : IRequestHandler<DeleteAsset, DeleteResult>
             var customerPathElement = await customerPathRepository.GetCustomerPathElement(request.AssetId.Customer.ToString());
             logger.LogDebug("Sending delete asset notification for {AssetId}", request.AssetId);
             await assetNotificationSender.SendAssetModifiedNotification(ChangeType.Delete,
-                assetFromDatabase, null, customerPathElement);
+                deleteResult.DeletedEntity, null, customerPathElement);
         }
         catch (Exception ex)
         {

--- a/src/protagonist/DLCS.Model.Tests/DeleteEntityResultTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/DeleteEntityResultTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using DLCS.Core;
+using DLCS.Model.Assets;
+using FluentAssertions;
+using Xunit;
+
+namespace DLCS.Model.Tests;
+
+public class DeleteEntityResultTests
+{
+    [Fact]
+    public void Ctor_Throws_IfDeletedStatus_WithNullEntity()
+    {
+        // Act
+        Action action = () => new DeleteEntityResult<Asset>(DeleteResult.Deleted);
+
+        // Assert
+        action.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("Deleted Asset entity must be provided if status is 'Deleted'");
+    }
+    
+    [Theory]
+    [InlineData(DeleteResult.Conflict)]
+    [InlineData(DeleteResult.Error)]
+    [InlineData(DeleteResult.NotFound)]
+    public void Ctor_AllowsNullEntity_ForAllOtherStatus(DeleteResult result)
+    {
+        // Act
+        var deleteResult = new DeleteEntityResult<Asset>(result);
+
+        // Assert
+        deleteResult.Result.Should().Be(result);
+        deleteResult.DeletedEntity.Should().BeNull();
+    }
+}

--- a/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
@@ -12,5 +12,5 @@ public interface IAssetRepository
 
     public Task<ImageLocation?> GetImageLocation(AssetId assetId);
 
-    public Task<ResultStatus<DeleteResult>> DeleteAsset(AssetId assetId);
+    public Task<DeleteEntityResult<Asset>> DeleteAsset(AssetId assetId);
 }

--- a/src/protagonist/DLCS.Model/DeleteEntityResult.cs
+++ b/src/protagonist/DLCS.Model/DeleteEntityResult.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using DLCS.Core;
+
+namespace DLCS.Model;
+
+/// <summary>
+/// Represents the result of a delete operation
+/// </summary>
+/// <typeparam name="T">Type of entity deleted</typeparam>
+public class DeleteEntityResult<T>
+    where T : class
+{
+    /// <summary>
+    /// Deleted entity - only available if delete was successful
+    /// </summary>
+    public T? DeletedEntity { get; }
+    
+    /// <summary>
+    /// The overall result of the attempted delete operation
+    /// </summary>
+    public DeleteResult Result { get; }
+
+    public DeleteEntityResult(DeleteResult deleteResult, T? deletedEntity = default)
+    {
+        if (deleteResult == DeleteResult.Deleted && deletedEntity is null)
+        {
+            throw new InvalidOperationException(
+                $"Deleted {typeof(T).Name} entity must be provided if status is 'Deleted'");
+        }
+        
+        Result = deleteResult;
+        DeletedEntity = deletedEntity;
+    }
+}

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepositoryCachingBase.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using DLCS.Core;
 using DLCS.Core.Caching;
 using DLCS.Core.Types;
+using DLCS.Model;
 using DLCS.Model.Assets;
 using LazyCache;
 using Microsoft.Extensions.Logging;
@@ -33,7 +34,7 @@ public abstract class AssetRepositoryCachingBase : IAssetRepository
 
     public abstract Task<ImageLocation?> GetImageLocation(AssetId assetId);
 
-    public Task<ResultStatus<DeleteResult>> DeleteAsset(AssetId assetId)
+    public Task<DeleteEntityResult<Asset>> DeleteAsset(AssetId assetId)
     {
         AppCache.Remove(GetCacheKey(assetId));
         
@@ -45,7 +46,7 @@ public abstract class AssetRepositoryCachingBase : IAssetRepository
     /// <summary>
     /// Delete asset from database
     /// </summary>
-    protected abstract Task<ResultStatus<DeleteResult>> DeleteAssetFromDatabase(AssetId assetId);
+    protected abstract Task<DeleteEntityResult<Asset>> DeleteAssetFromDatabase(AssetId assetId);
     
     /// <summary>
     /// Find asset in DB and materialise to <see cref="Asset"/> object

--- a/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
-using DLCS.Core;
 using DLCS.Core.Caching;
 using DLCS.Core.Types;
+using DLCS.Model;
 using DLCS.Model.Assets;
 using LazyCache;
 using Microsoft.Extensions.Configuration;
@@ -29,11 +29,9 @@ public class DapperAssetRepository : AssetRepositoryCachingBase, IDapperConfigRe
     
     public override async Task<ImageLocation?> GetImageLocation(AssetId assetId) 
         => await this.QuerySingleOrDefaultAsync<ImageLocation>(ImageLocationSql, new {Id = assetId.ToString()});
-    
-    protected override Task<ResultStatus<DeleteResult>> DeleteAssetFromDatabase(AssetId assetId)
-    {
-        throw new NotImplementedException();
-    }
+
+    protected override Task<DeleteEntityResult<Asset>> DeleteAssetFromDatabase(AssetId assetId)
+        => throw new NotImplementedException("Deleting assets via Dapper is not supported");
 
     protected override async Task<Asset?> GetAssetFromDatabase(AssetId assetId)
     {


### PR DESCRIPTION
`DeleteEntityResult<T>` is a new construct that contains a `DeleteResult` enum and deleted asset.

This allows us to conduct post-deletion operations (e.g. raise notification) with values that have been removed from database.