### PR TITLE
Remove output bucket deletion from cleanupHandler

### DIFF
--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Nodes;
-using CleanupHandler.Infrastructure;
+﻿using CleanupHandler.Infrastructure;
 using DLCS.AWS.Cloudfront;
 using DLCS.AWS.S3;
 using DLCS.AWS.SQS;
@@ -65,7 +63,6 @@ public class AssetDeletedHandler : IMessageHandler
         await DeleteTileOptimised(request.Asset.Id);
         DeleteFromNas(request.Asset.Id);
         await DeleteFromOriginBucket(request.Asset.Id);
-        await DeleteFromOutputBucket(request.Asset.Id);
 
         return await InvalidateContentDeliveryNetwork(request.Asset);
     }
@@ -80,19 +77,6 @@ public class AssetDeletedHandler : IMessageHandler
 
         var storageKey = storageKeyGenerator.GetOriginRoot(assetId);
         logger.LogInformation("Deleting OriginBucket key from {StorageKey} for {AssetId}", storageKey, assetId);
-        await bucketWriter.DeleteFolder(storageKey);
-    }
-    
-    private async Task DeleteFromOutputBucket(AssetId assetId)
-    {
-        if (string.IsNullOrEmpty(handlerSettings.AWS.S3.OutputBucket))
-        {
-            logger.LogDebug("No OutputBucket configured - output folder will not be deleted. {AssetId}", assetId);
-            return;
-        }
-
-        var storageKey = storageKeyGenerator.GetOutputRoot(assetId);
-        logger.LogInformation("Deleting OutputBucket key from {StorageKey} for {AssetId}", storageKey, assetId);
         await bucketWriter.DeleteFolder(storageKey);
     }
 

--- a/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
@@ -38,7 +38,6 @@ public class AssetDeletedHandlerTests
                 {
                     StorageBucket = LocalStackFixture.StorageBucketName,
                     ThumbsBucket = LocalStackFixture.ThumbsBucketName,
-                    OutputBucket = LocalStackFixture.OutputBucketName,
                     OriginBucket = LocalStackFixture.OriginBucketName
                 }
             },
@@ -126,12 +125,6 @@ public class AssetDeletedHandlerTests
             bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
                 a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
     }
     
     [Fact]
@@ -169,12 +162,6 @@ public class AssetDeletedHandlerTests
             bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
                 a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
     }
     
     [Fact]
@@ -211,12 +198,6 @@ public class AssetDeletedHandlerTests
         A.CallTo(() =>
             bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
                 a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
     }
     
@@ -256,12 +237,6 @@ public class AssetDeletedHandlerTests
             bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
                 a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
             ))).MustHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
     }
     
     [Fact]
@@ -300,56 +275,6 @@ public class AssetDeletedHandlerTests
             bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
                 a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
             ))).MustNotHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
-    }
-    
-    [Fact]
-    public async Task Handle_DoesNotDeleteOutput_IfSettingEmpty()
-    {
-        // Arrange
-        const string assetId = "1/99/foo";
-        var queueMessage = CreateMinimalQueueMessage();
-        handlerSettings.AWS.S3.OriginBucket = "";
-
-        // Act
-        var sut = GetSut();
-        var response = await sut.HandleMessage(queueMessage);
-        
-        // Assert
-        response.Should().BeTrue();
-        
-        // File deleted from local disk
-        fakeFileSystem.DeletedFiles.Should().ContainSingle(s => s == "/nas/1/99/foo/foo.jp2");
-        
-        // Thumbs deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.ThumbsBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
-        
-        
-        // storage not deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.StorageBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
-        
-        // origin deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OriginBucketName && a.Key == $"{assetId}/"
-            ))).MustNotHaveHappened();
-        
-        // output deleted
-        A.CallTo(() =>
-            bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(a =>
-                a.Bucket == LocalStackFixture.OutputBucketName && a.Key == $"{assetId}/"
-            ))).MustHaveHappened();
     }
 
     [Fact]

--- a/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
@@ -160,11 +160,4 @@ public interface IStorageKeyGenerator
     /// <param name="assetId">asset id the request is for</param>
     /// <returns><see cref="ObjectInBucket"/> for specified asset's metadata file</returns>
     ObjectInBucket GetOriginRoot(AssetId assetId);
-
-    /// <summary>
-    /// Get <see cref="ObjectInBucket"/> root location for the output bucket
-    /// </summary>
-    /// <param name="assetId">asset id the request is for</param>
-    /// <returns><see cref="ObjectInBucket"/> for specified asset's metadata file</returns>
-    ObjectInBucket GetOutputRoot(AssetId assetId);
 }

--- a/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
@@ -185,10 +185,4 @@ public class S3StorageKeyGenerator : IStorageKeyGenerator
         var key = GetStorageKey(assetId);
         return new ObjectInBucket(s3Options.OriginBucket, $"{key}/");
     }
-
-    public ObjectInBucket GetOutputRoot(AssetId assetId)
-    {
-        var key = GetStorageKey(assetId);
-        return new ObjectInBucket(s3Options.OutputBucket, $"{key}/");
-    }
 }


### PR DESCRIPTION
Fixes #576 

Remove deletion of 'output' bucket (which stores NQ projections like Zip and PDF). These follow a different key structure than other buckets as they don't store asset-specific keys as the outputs contain multiple assets.