### PR TITLE
Add x-asset-id header to single asset requests

### DIFF
--- a/src/protagonist/DLCS.Core/Guard/GuardX.cs
+++ b/src/protagonist/DLCS.Core/Guard/GuardX.cs
@@ -16,7 +16,8 @@ public static class GuardX
     /// <typeparam name="T">Type of argument to check.</typeparam>
     /// <returns>Passed argument, if not null.</returns>
     /// <exception cref="ArgumentNullException">Thrown if provided argument is null.</exception>
-    public static T ThrowIfNull<T>([NotNull] this T argument, string argName)
+    [return: NotNull]
+    public static T ThrowIfNull<T>(this T argument, string argName)
     {
         if (argument == null)
         {

--- a/src/protagonist/DLCS.Web/Response/HttpResponseX.cs
+++ b/src/protagonist/DLCS.Web/Response/HttpResponseX.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using DLCS.Core.Types;
 using Microsoft.AspNetCore.Http;
 
 namespace DLCS.Web.Response;
@@ -45,4 +46,13 @@ public static class HttpResponseX
         const string template = "public, s-maxage={0}, max-age={0}";
         response.Headers.Append("Cache-Control", String.Format(template, seconds));
     }
+
+    /// <summary>
+    /// Set the x-asset-id header to AssetId value
+    /// </summary>
+    public static void SetAssetIdResponseHeader(this HttpResponse response, AssetId assetId)
+    {
+        const string assetIdHeader = "x-asset-id";
+        response.Headers[assetIdHeader] = assetId.ToString();
+    } 
 }

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -138,7 +138,7 @@ public class ImageRequestHandlerTests
         var context = new DefaultHttpContext();
         context.Request.Path = "/iiif-img/2/2/test-image/full/!200,200/0/default.jpg";
         var sut = GetImageRequestHandlerWithMockPathParser();
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage { Channels = deliveryChannel, RequiresAuth = true});
             
         // Act
@@ -157,7 +157,7 @@ public class ImageRequestHandlerTests
 
         var roles = new List<string> { "role" };
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
                 Roles = roles, RequiresAuth = true, Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
@@ -189,7 +189,7 @@ public class ImageRequestHandlerTests
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
@@ -217,7 +217,7 @@ public class ImageRequestHandlerTests
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
@@ -250,7 +250,7 @@ public class ImageRequestHandlerTests
 
         var roles = new List<string> { "role" };
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(new AssetId(2, 2, "test-image")))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
                 Roles = roles, MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
@@ -276,7 +276,7 @@ public class ImageRequestHandlerTests
 
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } }, Height = 1000, Width = 1000,
@@ -302,7 +302,7 @@ public class ImageRequestHandlerTests
 
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
@@ -331,7 +331,7 @@ public class ImageRequestHandlerTests
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
@@ -362,7 +362,7 @@ public class ImageRequestHandlerTests
         var roles = new List<string> { "role" };
         var assetId = new AssetId(2, 2, "test-image");
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
@@ -402,7 +402,7 @@ public class ImageRequestHandlerTests
 
         List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
 
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
@@ -444,7 +444,7 @@ public class ImageRequestHandlerTests
             ? new List<int[]> { new[] { 150, 150 } }
             : new List<int[]>();
 
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
@@ -481,7 +481,7 @@ public class ImageRequestHandlerTests
         var settings = CreateOrchestratorSettings();
         settings.ImageServer = imageServer;
         var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
@@ -512,7 +512,7 @@ public class ImageRequestHandlerTests
         var settings = CreateOrchestratorSettings();
         settings.ImageServer = imageServer;
         var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
@@ -538,7 +538,7 @@ public class ImageRequestHandlerTests
 
         var settings = CreateOrchestratorSettings();
         var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
@@ -575,7 +575,7 @@ public class ImageRequestHandlerTests
 
         List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
 
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
@@ -607,7 +607,7 @@ public class ImageRequestHandlerTests
 
         List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
 
-        A.CallTo(() => assetTracker.GetOrchestrationAsset(assetId))
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "",

--- a/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -163,6 +163,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact(Skip = "'not in dlcs storage' handling removed when switch to Yarp handling")]
@@ -265,6 +266,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -280,6 +282,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -297,6 +300,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -319,6 +323,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -350,6 +355,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Set-Cookie");
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
 
     private static void ConfigureStubbery(OrchestratorFixture orchestratorFixture)

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -166,6 +166,42 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.SeeOther);
         response.Headers.Location.Should().Be(expected);
     }
+    
+    [Fact]
+    public async Task GetInfoJson_Correct_ViaDisplayName()
+    {
+        // Arrange
+        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}");
+        var namedId = $"test/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = sizesJsonContent
+        });
+        await dbFixture.DbContext.SaveChangesAsync();
+        var expectedSizes = new List<Size> { new(800, 800), new(400, 400), new(200, 200) };
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/v2/{namedId}/info.json");
+        
+        // Assert
+        // Verify correct info.json returned
+        var jsonResponse = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService2>();
+        jsonResponse.Id.Should().Be($"http://localhost/iiif-img/v2/{namedId}");
+        jsonResponse.Context.ToString().Should().Be("http://iiif.io/api/image/2/context.json");
+        jsonResponse.Sizes.Should().BeEquivalentTo(expectedSizes);
+
+        // With correct headers/status
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+        response.Content.Headers.ContentType.ToString().Should()
+            .Be("application/json", "application/json unless Accept header specified");
+    }
 
     [Fact]
     public async Task GetInfoJsonV2_Correct_ViaDirectPath_NotInS3()
@@ -195,6 +231,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // With correct headers/status
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -232,6 +269,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // With correct headers/status
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -277,6 +315,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // With correct headers/status
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -325,6 +364,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // With correct headers/status
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -366,6 +406,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // With correct headers/status
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -398,6 +439,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["@id"].ToString().Should().Be("http://localhost/iiif-img/99/1/GetInfoJsonV2_Correct_ViaConneg");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/image/2/context.json");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -449,6 +491,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse.Sizes.Should().BeEquivalentTo(expectedSizes);
         
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
@@ -480,6 +523,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["id"].ToString().Should().Be("http://localhost/iiif-img/99/1/GetInfoJsonV3_Correct_ViaConneg");
         jsonResponse["@context"].ToString().Should().Be("http://iiif.io/api/image/3/context.json");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
@@ -507,6 +551,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["id"].ToString().Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_OpenImage_Correct");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
     }
@@ -658,6 +703,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         infoJson.Id.Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_RestrictedImage_Correct");
         infoJson.Service.Single().Id.Should().Be("http://localhost/auth/99/test-service");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
@@ -710,6 +756,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             .Be($"http://my-proxy.com/const_value/99/{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}");
         infoJson.Service.Single().Id.Should().Be("http://my-proxy.com/auth/test-service");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
@@ -740,6 +787,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         infoJson.Id.Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_RestrictedImage_NoRole_HasNoService");
         infoJson.Service.Should().BeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
@@ -770,6 +818,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
         jsonResponse["services"].Should().BeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
@@ -799,6 +848,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
     }
@@ -829,6 +879,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
     }
@@ -864,6 +915,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
     }
@@ -901,6 +953,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["id"].ToString().Should().Be($"http://localhost/iiif-img/{id}");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeFalse();
         response.Headers.CacheControl.Private.Should().BeTrue();
         

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1029,6 +1029,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]
@@ -1050,6 +1051,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]
@@ -1076,6 +1078,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]
@@ -1112,6 +1115,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         proxyResponse.Uri.ToString().Should().StartWith("http://image-server/iiif");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Set-Cookie");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]
@@ -1148,6 +1152,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Set-Cookie");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1174,6 +1179,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
 
     [Fact]
@@ -1200,6 +1206,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1226,6 +1233,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1252,6 +1260,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1279,6 +1288,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.ToString().Should().StartWith("http://special-server/iiif");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1307,6 +1317,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1353,6 +1364,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.Headers.CacheControl.SharedMaxAge.Should().Be(TimeSpan.FromDays(28));
         response.Headers.CacheControl.MaxAge.Should().Be(TimeSpan.FromDays(28));
         response.Headers.Should().ContainKey("x-test-key").WhoseValue.Should().BeEquivalentTo("foo bar");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]
@@ -1385,6 +1397,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.Headers.CacheControl.SharedMaxAge.Should().Be(TimeSpan.FromDays(28));
         response.Headers.CacheControl.MaxAge.Should().Be(TimeSpan.FromDays(28));
         response.Headers.Should().ContainKey("x-test-key").WhoseValue.Should().BeEquivalentTo("foo bar");
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1413,6 +1426,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -1441,6 +1455,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Theory]

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -149,6 +149,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             .Should().StartWith($"http://my-proxy.com/thumbs/{id}/full");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
     }
@@ -173,6 +174,33 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+    }
+    
+    [Fact]
+    public async Task Get_ManifestForImage_ReturnsManifest_ByName()
+    {
+        // Arrange
+        var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest_ByName)}");
+        var namedId = $"test/1/{nameof(Get_ManifestForImage_ReturnsManifest_ByName)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin");
+        await dbFixture.DbContext.SaveChangesAsync();
+            
+        var path = $"iiif-manifest/v2/{namedId}";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/iiif-manifest/v2/{namedId}");
+        jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail.@id").Value<string>()
+            .Should().StartWith($"http://localhost/thumbs/{id}/full");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
     }
@@ -198,6 +226,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             .Should().StartWith($"http://localhost/thumbs/{id}/full");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
     }
@@ -220,6 +249,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
@@ -243,6 +273,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
@@ -269,6 +300,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
@@ -292,6 +324,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
@@ -315,6 +348,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Vary.Should().Contain("Accept");
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());

--- a/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -146,6 +146,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -162,6 +163,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -182,6 +184,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -206,6 +209,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -230,6 +234,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -253,6 +258,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -272,6 +278,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
 
     [Fact]
@@ -301,6 +308,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         proxyResponse.Uri.Should().Be(expectedPath);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -325,6 +333,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
     
     [Fact]
@@ -348,5 +357,6 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
     }
 }

--- a/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
@@ -53,7 +53,7 @@ public class FileRequestHandler
             return new StatusCodeResult(statusCode ?? HttpStatusCode.InternalServerError);
         }
         
-        var orchestrationAsset = await assetRequestProcessor.GetAsset(assetRequest);
+        var orchestrationAsset = await assetRequestProcessor.GetAsset<OrchestrationAsset>(httpContext, assetRequest);
         if (orchestrationAsset == null)
         {
             logger.LogDebug("Request for {Path} asset not found", httpContext.Request.Path);

--- a/src/protagonist/Orchestrator/Features/Images/ImageController.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageController.cs
@@ -136,12 +136,6 @@ public class ImageController : IIIFAssetControllerBase
         return await RenderInfoJson(requestedVersion.Value, noOrchestrate, cancellationToken);
     }
 
-    private StatusCodeResult RedirectToInfoJson()
-    {
-        var location = HttpContext.Request.Path.Add("/info.json");
-        return this.SeeAlsoResult(location);
-    }
-
     private Task<IActionResult> RenderInfoJson(Version imageApiVersion, bool noOrchestrate,
         CancellationToken cancellationToken)
     {

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -71,8 +71,8 @@ public class ImageRequestHandler
             return new StatusCodeResult(statusCode ?? HttpStatusCode.InternalServerError);
         }
         
-        var orchestrationAsset = await assetRequestProcessor.GetAsset(assetRequest);
-        if (orchestrationAsset is not OrchestrationImage orchestrationImage)
+        var orchestrationImage = await assetRequestProcessor.GetAsset<OrchestrationImage>(httpContext, assetRequest);
+        if (orchestrationImage == null)
         {
             logger.LogDebug("Request for {Path}: asset not found", httpContext.Request.Path);
             return new StatusCodeResult(HttpStatusCode.NotFound);

--- a/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
@@ -53,8 +53,7 @@ public class TimeBasedRequestHandler
             return new StatusCodeResult(statusCode ?? HttpStatusCode.InternalServerError);
         }
 
-        // If "HEAD" then add CORS - is this required here?
-        var orchestrationAsset = await assetRequestProcessor.GetAsset(assetRequest);
+        var orchestrationAsset = await assetRequestProcessor.GetAsset<OrchestrationAsset>(httpContext, assetRequest);
         if (orchestrationAsset == null)
         {
             logger.LogDebug("Request for {Path} asset not found", httpContext.Request.Path);

--- a/src/protagonist/Orchestrator/Infrastructure/Mediatr/IAssetRequest.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Mediatr/IAssetRequest.cs
@@ -13,14 +13,6 @@ public interface IAssetRequest
 }
 
 /// <summary>
-/// Marker interface for any File asset requests
-/// </summary>
-public interface IFileRequest : IAssetRequest
-{
-    FileAssetDeliveryRequest AssetRequest { set; }
-}
-
-/// <summary>
 /// Marker interface for any Image asset requests
 /// </summary>
 public interface IImageRequest : IAssetRequest

--- a/src/protagonist/Thumbs.Tests/Integration/ImageRequestTests.cs
+++ b/src/protagonist/Thumbs.Tests/Integration/ImageRequestTests.cs
@@ -44,6 +44,7 @@ public class ImageRequestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
         responseObject["message"].ToString().Should().Be($"Requested format '{format}' not supported, use 'jpg'");
         responseObject["statusCode"].ToString().Should().Be("400");
@@ -62,6 +63,7 @@ public class ImageRequestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
         responseObject["message"].ToString().Should()
             .Be($"Requested quality '{quality}' not supported, use 'default' or 'color'");
@@ -81,6 +83,7 @@ public class ImageRequestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         var responseObject = JsonNode.Parse(await response.Content.ReadAsStringAsync());
         responseObject["message"].ToString().Should()
             .Be($"Requested rotation value not supported, use '0'");

--- a/src/protagonist/Thumbs.Tests/Integration/InfoJsonTests.cs
+++ b/src/protagonist/Thumbs.Tests/Integration/InfoJsonTests.cs
@@ -85,6 +85,7 @@ public class InfoJsonTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["height"].ToString().Should().Be("800");
         jsonResponse["width"].ToString().Should().Be("800");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -119,6 +120,7 @@ public class InfoJsonTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["height"].ToString().Should().Be("800");
         jsonResponse["width"].ToString().Should().Be("800");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should()
@@ -146,6 +148,7 @@ public class InfoJsonTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.Location.Should().Be(expected);
     }
 
@@ -177,6 +180,7 @@ public class InfoJsonTests : IClassFixture<ProtagonistAppFactory<Startup>>
         jsonResponse["height"].ToString().Should().Be("800");
         jsonResponse["width"].ToString().Should().Be("800");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);

--- a/src/protagonist/Thumbs/ThumbsMiddleware.cs
+++ b/src/protagonist/Thumbs/ThumbsMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
+using DLCS.Core.Guard;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 using DLCS.Web.IIIF;
@@ -48,7 +49,9 @@ public class ThumbsMiddleware
     {
         try
         {
-            var thumbnailRequest = await parser.Parse<ImageAssetDeliveryRequest>(context.Request.Path.Value);
+            var pathValue = context.Request.Path.Value.ThrowIfNullOrEmpty(nameof(context.Request.Path.Value));
+            var thumbnailRequest = await parser.Parse<ImageAssetDeliveryRequest>(pathValue);
+            context.Response.SetAssetIdResponseHeader(thumbnailRequest.GetAssetId());
             if (thumbnailRequest.IIIFImageRequest.IsBase)
             {
                 await RedirectToInfoJson(context, thumbnailRequest);


### PR DESCRIPTION
Resolves #583 

Add `x-asset-id` header to all endpoints that deal with single-asset requests. Most of the diff is tests, main points of change are:

* `AssetRequestProcessor` - this is a helper with common helpers used by `/file/`, `/iiif-img/` and `/iiif-av/` (ie Yarp requests). The helper to get cached `OrchestrationAsset` will set `x-asset-id` if found.
* `AssetRequestParsingBehavior` - a mediatr behaviour used to parse requests for `/iiif-img/*/info.json` and `/iiif-manifest/`. If asset request is parsed correctly `x-asset-id` is set.
  * Deleted `IFileRequest : IAssetRequest` as part of this as it's no longer used, File serving goes via Yarp.
* `ThumbsMiddleware` - used by all `/thumbs/` requests

> [!NOTE]
> On some occasions a 400/404 will have the header cached but that felt okay as those may be cached for a very short duration.