### PR TITLE
Orchestrator verifies Auth2 access

### DIFF
--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -76,7 +76,7 @@ public class Startup
             .ConfigureMediatR()
             .AddNamedQueriesCore()
             .AddAws(configuration, webHostEnvironment)
-            .AddHeaderPropagation()
+            .AddCorrelationIdHeaderPropagation()
             .ConfigureSwagger();
         
         services.AddHttpClient<IEngineClient, EngineClient>()

--- a/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
+++ b/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
@@ -72,7 +72,7 @@ public static class ApplicationBuilderX
     /// Propagate x-correlation-id header to any downstream calls.
     /// NOTE: This will be added to ALL httpClient requests.
     /// </summary>
-    public static IServiceCollection AddHeaderPropagation(this IServiceCollection services)
+    public static IServiceCollection AddCorrelationIdHeaderPropagation(this IServiceCollection services)
     {
         services.AddSingleton<IHttpMessageHandlerBuilderFilter, HeaderPropagationMessageHandlerBuilderFilter>();
         return services;

--- a/src/protagonist/Engine/Startup.cs
+++ b/src/protagonist/Engine/Startup.cs
@@ -30,7 +30,7 @@ public class Startup
             .AddAssetIngestion(configuration.Get<EngineSettings>())
             .AddDataAccess(configuration)
             .AddCaching(cachingSection.Get<CacheSettings>())
-            .AddHeaderPropagation()
+            .AddCorrelationIdHeaderPropagation()
             .ConfigureHealthChecks();
 
         services.AddControllers();

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Types;
 using DLCS.Model.Assets.CustomHeaders;
@@ -162,8 +163,8 @@ public class ImageRequestHandlerTests
             {
                 Roles = roles, RequiresAuth = true, Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
             });
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie))
-            .Returns(AssetAccessResult.Unauthorized);
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).Returns(AssetAccessResult.Unauthorized);
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
@@ -204,7 +205,8 @@ public class ImageRequestHandlerTests
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
         result.HasPath.Should().BeTrue();
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).MustNotHaveHappened();
     }
     
     [Fact]
@@ -232,7 +234,8 @@ public class ImageRequestHandlerTests
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
         result.HasPath.Should().BeTrue();
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).MustNotHaveHappened();
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).MustNotHaveHappened();
     }
 
     [Theory]
@@ -256,8 +259,8 @@ public class ImageRequestHandlerTests
                 Roles = roles, MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie))
-            .Returns(AssetAccessResult.Unauthorized);
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).Returns(AssetAccessResult.Unauthorized);
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
@@ -338,7 +341,8 @@ public class ImageRequestHandlerTests
                 RequiresAuth = true, Height = 1000, Width = 1000, MaxUnauthorised = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = true
             });
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).Returns(accessResult);
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).Returns(accessResult);
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
@@ -369,7 +373,8 @@ public class ImageRequestHandlerTests
                 RequiresAuth = true, Height = 1000, Width = 1000, MaxUnauthorised = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = false
             });
-        A.CallTo(() => accessValidator.TryValidate(2, roles, AuthMechanism.Cookie)).Returns(accessResult);
+        A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
+            AuthMechanism.Cookie, CancellationToken.None)).Returns(accessResult);
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act

--- a/src/protagonist/Orchestrator/Features/Auth/AuthController.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/AuthController.cs
@@ -151,7 +151,7 @@ public class AuthController : IIIFAssetControllerBase
         [FromRoute] string image,
         CancellationToken cancellationToken = default)
         => GenerateIIIFDescriptionResource(
-            () => new ProbeService(customer, space, image), cacheTtl: 30, cancellationToken: cancellationToken);
+            () => new ProbeService(customer, space, image), cacheTtl: 0, cancellationToken: cancellationToken);
 
     private HttpStatusCode GetStatusCodeForAccessTokenError(AccessTokenErrorConditions conditions)
         => conditions switch

--- a/src/protagonist/Orchestrator/Features/Auth/AuthCookieManager.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/AuthCookieManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
 using DLCS.Repository.Auth;
+using DLCS.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using Orchestrator.Settings;
@@ -51,9 +52,18 @@ public class AuthCookieManager
     public string? GetCookieValueForCustomer(int customer)
     {
         var cookieKey = GetAuthCookieKey(authSettings.CookieNameFormat, customer);
-        return httpContextAccessor.HttpContext.Request.Cookies.TryGetValue(cookieKey, out var cookieValue)
+        return httpContextAccessor.SafeHttpContext().Request.Cookies.TryGetValue(cookieKey, out var cookieValue)
             ? cookieValue
             : null;
+    }
+
+    /// <summary>
+    /// Check if Cookie for Auth2 exists for current customer
+    /// </summary>
+    public bool HasAuth2CookieForCustomer(int customer)
+    {
+        var cookieKey = GetAuthCookieKey(authSettings.Auth2CookieNameFormat, customer);
+        return httpContextAccessor.SafeHttpContext().Request.Cookies.ContainsKey(cookieKey);
     }
 
     /// <summary>

--- a/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Files/FileRequestHandler.cs
@@ -107,7 +107,7 @@ public class FileRequestHandler
         logger.LogDebug("Authenticating request for {Method} {Path} via {Mechanism}", httpRequest.Method,
             httpRequest.Path, authMechanism);
         var authResult =
-            await assetAccessValidator.TryValidate(assetRequest.Customer.Id, asset.Roles, authMechanism);
+            await assetAccessValidator.TryValidate(assetRequest.GetAssetId(), asset.Roles, authMechanism);
 
         return authResult is AssetAccessResult.Open or AssetAccessResult.Authorized;
     }

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -184,9 +184,8 @@ public class ImageRequestHandler
         // IAssetAccessValidator is in container with a Lifetime.Scope
         using var scope = scopeFactory.CreateScope();
         var assetAccessValidator = scope.ServiceProvider.GetRequiredService<IAssetAccessValidator>();
-        var authResult =
-            await assetAccessValidator.TryValidate(assetRequest.Customer.Id,
-                orchestrationImage.Roles, AuthMechanism.Cookie);
+        var authResult = await assetAccessValidator.TryValidate(assetRequest.GetAssetId(), orchestrationImage.Roles,
+            AuthMechanism.Cookie);
 
         return authResult == AssetAccessResult.Unauthorized;
     }

--- a/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
@@ -115,7 +115,7 @@ public class GetImageInfoJsonHandler : IRequestHandler<GetImageInfoJson, Descrip
         }
 
         var accessResult =
-            await accessValidator.TryValidate(assetId.Customer, asset.Roles, AuthMechanism.BearerToken);
+            await accessValidator.TryValidate(assetId, asset.Roles, AuthMechanism.BearerToken, cancellationToken);
         await orchestrationTask;
         return accessResult == AssetAccessResult.Authorized
             ? DescriptionResourceResponse.Restricted(infoJson)

--- a/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
@@ -107,7 +107,7 @@ public class TimeBasedRequestHandler
         logger.LogDebug("Authenticating request for {Method} {Path} via {Mechanism}", httpRequest.Method,
             httpRequest.Path, authMechanism);
         var authResult =
-            await assetAccessValidator.TryValidate(assetRequest.Customer.Id, asset.Roles, authMechanism);
+            await assetAccessValidator.TryValidate(assetRequest.GetAssetId(), asset.Roles, authMechanism);
 
         return authResult is AssetAccessResult.Open or AssetAccessResult.Authorized;
     }

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
@@ -1,171 +1,62 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core.Collections;
-using DLCS.Core.Guard;
-using DLCS.Repository.Auth;
-using DLCS.Web;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
+using DLCS.Core.Strings;
+using DLCS.Core.Types;
+using Microsoft.Extensions.Logging;
 using Orchestrator.Features.Auth;
 
 namespace Orchestrator.Infrastructure.Auth;
 
-public interface IAssetAccessValidator
-{
-    /// <summary>
-    /// Validate whether current request has access to the specified roles for customer.
-    /// This will try to validate request using specified <see cref="AuthMechanism"/>
-    /// </summary>
-    /// <param name="customer">Current customer</param>
-    /// <param name="roles">Roles associated with Asset</param>
-    /// <param name="mechanism">Which mechanism to use to authorize user</param>
-    /// <returns><see cref="AssetAccessResult"/> enum representing result of validation</returns>
-    Task<AssetAccessResult> TryValidate(int customer, IEnumerable<string> roles, AuthMechanism mechanism);
-}
-
 /// <summary>
-/// Contains logic to validate passed BearerTokens and Cookies with a request for an asset.
-/// Setting status code and cookies depending on result of verification.
+/// Unified access validator that can check access via Auth v0/1 (ie Orchestrator managed) or Auth v2 (external
+/// services). This may result in multiple checks being made
 /// </summary>
 public class AssetAccessValidator : IAssetAccessValidator
 {
-    private readonly ISessionAuthService sessionAuthService;
-    private readonly AccessChecker accessChecker;
+    private readonly Auth1AccessValidator auth1AccessValidator;
+    private readonly Auth2AccessValidator auth2AccessValidator;
     private readonly AuthCookieManager authCookieManager;
-    private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly ILogger<AssetAccessValidator> logger;
 
     public AssetAccessValidator(
-        ISessionAuthService sessionAuthService,
-        AccessChecker accessChecker,
+        Auth1AccessValidator auth1AccessValidator, 
+        Auth2AccessValidator auth2AccessValidator,
         AuthCookieManager authCookieManager,
-        IHttpContextAccessor httpContextAccessor)
+        ILogger<AssetAccessValidator> logger)
     {
-        this.sessionAuthService = sessionAuthService;
-        this.accessChecker = accessChecker;
+        this.auth1AccessValidator = auth1AccessValidator;
+        this.auth2AccessValidator = auth2AccessValidator;
         this.authCookieManager = authCookieManager;
-        this.httpContextAccessor = httpContextAccessor;
+        this.logger = logger;
     }
 
-    public Task<AssetAccessResult> TryValidate(int customer, IEnumerable<string> roles, AuthMechanism mechanism)
-        => mechanism switch
-        {
-            AuthMechanism.All => TryValidateAll(customer, roles),
-            AuthMechanism.Cookie => TryValidateCookie(customer, roles),
-            AuthMechanism.BearerToken => TryValidateBearerToken(customer, roles),
-            _ => throw new ArgumentOutOfRangeException(nameof(mechanism), mechanism, null)
-        };
-    
-    private async Task<AssetAccessResult> TryValidateAll(int customer, IEnumerable<string> roles)
+    public async Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism, CancellationToken cancellationToken = default)
     {
-        var enumeratedRoles = roles.ToList();
-        var validateCookieResult = await TryValidateCookie(customer, enumeratedRoles);
-        if (validateCookieResult is AssetAccessResult.Open or AssetAccessResult.Authorized)
+        if (HasAuth1Cookie(assetId.Customer))
         {
-            return validateCookieResult;
-        }
-
-        return await TryValidateBearerToken(customer, enumeratedRoles);
-    }
-    
-    private Task<AssetAccessResult> TryValidateBearerToken(int customer, IEnumerable<string> roles)
-        => ValidateAccess(customer, roles, () =>
-        {
-            var httpContext = httpContextAccessor.SafeHttpContext();
-
-            var bearerToken = GetBearerToken(httpContext.Request);
-            return string.IsNullOrEmpty(bearerToken)
-                ? Task.FromResult<AuthToken?>(null)
-                : sessionAuthService.GetAuthTokenForBearerId(customer, bearerToken);
-        }, false);
-
-    private Task<AssetAccessResult> TryValidateCookie(int customer, IEnumerable<string> roles)
-        => ValidateAccess(customer, roles, () =>
-        {
-            var cookieId = GetCookieId(customer);
-            return string.IsNullOrEmpty(cookieId)
-                ? Task.FromResult<AuthToken?>(null)
-                : sessionAuthService.GetAuthTokenForCookieId(customer, cookieId);
-        }, true);
-
-    private async Task<AssetAccessResult> ValidateAccess(int customer, IEnumerable<string> roles,
-        Func<Task<AuthToken?>> getAuthToken, bool setCookieInResponse)
-    {
-        var assetRoles = roles.ToList();
-        var authToken = await getAuthToken();
-        
-        if (authToken?.SessionUser == null)
-        {
-            // Authtoken token not found, or expired
-            return AssetAccessResult.Unauthorized;
-        }
-        
-        // Validate current user has access for roles for requested asset
-        var canAccess = await accessChecker.CanSessionUserAccessRoles(authToken.SessionUser, customer, assetRoles);
-        if (canAccess)
-        {
-            if (setCookieInResponse)
+            var auth1Status = await auth1AccessValidator.TryValidate(assetId, roles, mechanism, cancellationToken);
+            if (auth1Status == AssetAccessResult.Authorized)
             {
-                authCookieManager.SetCookieInResponse(authToken);
+                logger.LogTrace("{AssetId} can be viewed via Auth1", assetId);
+                return auth1Status;
             }
-
-            return AssetAccessResult.Authorized;
         }
-        
+
+        if (HasAuth2Cookie(assetId.Customer))
+        {
+            var auth2Status = await auth2AccessValidator.TryValidate(assetId, roles, mechanism, cancellationToken);
+            if (auth2Status == AssetAccessResult.Authorized)
+            {
+                logger.LogTrace("{AssetId} can be viewed via Auth2", assetId);
+                return auth2Status;
+            }
+        }
+
         return AssetAccessResult.Unauthorized;
     }
 
-    private string? GetCookieId(int customer)
-    {
-        var cookieValue = authCookieManager.GetCookieValueForCustomer(customer);
-        return string.IsNullOrEmpty(cookieValue) ? null : authCookieManager.GetCookieIdFromValue(cookieValue);
-    }
+    private bool HasAuth1Cookie(int customer) => authCookieManager.GetCookieValueForCustomer(customer).HasText();
+    private bool HasAuth2Cookie(int customer) => authCookieManager.HasAuth2CookieForCustomer(customer);
 
-    private string? GetBearerToken(HttpRequest httpRequest)
-        => httpRequest.Headers.TryGetValue(HeaderNames.Authorization, out var authHeader)
-            ? authHeader.ToString()?[7..] // everything after "Bearer "
-            : null;
-}
-
-/// <summary>
-/// Enum representing various results for attempting to access an asset.
-/// </summary>
-public enum AssetAccessResult
-{
-    /// <summary>
-    /// Asset is open
-    /// </summary>
-    Open,
-    
-    /// <summary>
-    /// Asset is restricted and current user does not have appropriate access
-    /// </summary>
-    Unauthorized,
-    
-    /// <summary>
-    /// Asset is restricted and current user has access
-    /// </summary>
-    Authorized
-}
-
-/// <summary>
-/// Enum representing different mechanisms for authorising users
-/// </summary>
-public enum AuthMechanism
-{
-    /// <summary>
-    /// Auth user by cookie provided with request
-    /// </summary>
-    Cookie,
-    
-    /// <summary>
-    /// Auth user by bearer token provided with request
-    /// </summary>
-    BearerToken,
-    
-    /// <summary>
-    /// Try all possible methods of validation
-    /// </summary>
-    All
 }

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
@@ -3,6 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Strings;
 using DLCS.Core.Types;
+using DLCS.Web;
+using DLCS.Web.Auth;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Orchestrator.Features.Auth;
 
@@ -17,23 +20,26 @@ public class AssetAccessValidator : IAssetAccessValidator
     private readonly Auth1AccessValidator auth1AccessValidator;
     private readonly Auth2AccessValidator auth2AccessValidator;
     private readonly AuthCookieManager authCookieManager;
+    private readonly IHttpContextAccessor httpContextAccessor;
     private readonly ILogger<AssetAccessValidator> logger;
 
     public AssetAccessValidator(
         Auth1AccessValidator auth1AccessValidator, 
         Auth2AccessValidator auth2AccessValidator,
         AuthCookieManager authCookieManager,
+        IHttpContextAccessor httpContextAccessor,
         ILogger<AssetAccessValidator> logger)
     {
         this.auth1AccessValidator = auth1AccessValidator;
         this.auth2AccessValidator = auth2AccessValidator;
         this.authCookieManager = authCookieManager;
+        this.httpContextAccessor = httpContextAccessor;
         this.logger = logger;
     }
 
     public async Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism, CancellationToken cancellationToken = default)
     {
-        if (HasAuth1Cookie(assetId.Customer))
+        if (ShouldAttemptAuth1(assetId.Customer, mechanism))
         {
             var auth1Status = await auth1AccessValidator.TryValidate(assetId, roles, mechanism, cancellationToken);
             if (auth1Status == AssetAccessResult.Authorized)
@@ -58,5 +64,19 @@ public class AssetAccessValidator : IAssetAccessValidator
 
     private bool HasAuth1Cookie(int customer) => authCookieManager.GetCookieValueForCustomer(customer).HasText();
     private bool HasAuth2Cookie(int customer) => authCookieManager.HasAuth2CookieForCustomer(customer);
+
+    private bool ShouldAttemptAuth1(int customer, AuthMechanism mechanism)
+    {
+        if (mechanism is AuthMechanism.All or AuthMechanism.Cookie)
+        {
+            if (HasAuth1Cookie(customer)) return true;
+        }
+
+        return mechanism is AuthMechanism.All or AuthMechanism.BearerToken && HasBearerToken();
+    }
+    
+    private bool HasBearerToken()
+        => httpContextAccessor.SafeHttpContext().Request
+            .GetAuthHeaderValue(AuthenticationHeaderUtils.BearerTokenScheme) != null;
 
 }

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
@@ -80,3 +80,45 @@ public class AssetAccessValidator : IAssetAccessValidator
             .GetAuthHeaderValue(AuthenticationHeaderUtils.BearerTokenScheme) != null;
 
 }
+
+/// <summary>
+/// Enum representing various results for attempting to access an asset.
+/// </summary>
+public enum AssetAccessResult
+{
+    /// <summary>
+    /// Asset is open
+    /// </summary>
+    Open,
+    
+    /// <summary>
+    /// Asset is restricted and current user does not have appropriate access
+    /// </summary>
+    Unauthorized,
+    
+    /// <summary>
+    /// Asset is restricted and current user has access
+    /// </summary>
+    Authorized
+}
+
+/// <summary>
+/// Enum representing different mechanisms for authorising users
+/// </summary>
+public enum AuthMechanism
+{
+    /// <summary>
+    /// Auth user by cookie provided with request
+    /// </summary>
+    Cookie,
+    
+    /// <summary>
+    /// Auth user by bearer token provided with request
+    /// </summary>
+    BearerToken,
+    
+    /// <summary>
+    /// Try all possible methods of validation
+    /// </summary>
+    All
+}

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using DLCS.Core.Types;
 using DLCS.Repository.Auth;
 using DLCS.Web;
+using DLCS.Web.Auth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using Orchestrator.Features.Auth;
@@ -61,7 +62,8 @@ public class Auth1AccessValidator : IAssetAccessValidator
         {
             var httpContext = httpContextAccessor.SafeHttpContext();
 
-            var bearerToken = GetBearerToken(httpContext.Request);
+            var bearerTokenHeader = httpContext.Request.GetAuthHeaderValue(AuthenticationHeaderUtils.BearerTokenScheme);
+            var bearerToken = bearerTokenHeader?.Parameter;
             return string.IsNullOrEmpty(bearerToken)
                 ? Task.FromResult<AuthToken?>(null)
                 : sessionAuthService.GetAuthTokenForBearerId(customer, bearerToken);
@@ -108,11 +110,6 @@ public class Auth1AccessValidator : IAssetAccessValidator
         var cookieValue = authCookieManager.GetCookieValueForCustomer(customer);
         return string.IsNullOrEmpty(cookieValue) ? null : authCookieManager.GetCookieIdFromValue(cookieValue);
     }
-
-    private string? GetBearerToken(HttpRequest httpRequest)
-        => httpRequest.Headers.TryGetValue(HeaderNames.Authorization, out var authHeader)
-            ? authHeader.ToString()?[7..] // everything after "Bearer "
-            : null;
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
@@ -85,7 +85,7 @@ public class Auth1AccessValidator : IAssetAccessValidator
         
         if (authToken?.SessionUser == null)
         {
-            // Authtoken token not found, or expired
+            // SessionUser for BearerToken/Cookie not found, or expired
             return AssetAccessResult.Unauthorized;
         }
         

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
@@ -8,7 +8,6 @@ using DLCS.Repository.Auth;
 using DLCS.Web;
 using DLCS.Web.Auth;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 using Orchestrator.Features.Auth;
 
 namespace Orchestrator.Infrastructure.Auth;
@@ -110,46 +109,4 @@ public class Auth1AccessValidator : IAssetAccessValidator
         var cookieValue = authCookieManager.GetCookieValueForCustomer(customer);
         return string.IsNullOrEmpty(cookieValue) ? null : authCookieManager.GetCookieIdFromValue(cookieValue);
     }
-}
-
-/// <summary>
-/// Enum representing various results for attempting to access an asset.
-/// </summary>
-public enum AssetAccessResult
-{
-    /// <summary>
-    /// Asset is open
-    /// </summary>
-    Open,
-    
-    /// <summary>
-    /// Asset is restricted and current user does not have appropriate access
-    /// </summary>
-    Unauthorized,
-    
-    /// <summary>
-    /// Asset is restricted and current user has access
-    /// </summary>
-    Authorized
-}
-
-/// <summary>
-/// Enum representing different mechanisms for authorising users
-/// </summary>
-public enum AuthMechanism
-{
-    /// <summary>
-    /// Auth user by cookie provided with request
-    /// </summary>
-    Cookie,
-    
-    /// <summary>
-    /// Auth user by bearer token provided with request
-    /// </summary>
-    BearerToken,
-    
-    /// <summary>
-    /// Try all possible methods of validation
-    /// </summary>
-    All
 }

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core.Types;
+using DLCS.Repository.Auth;
+using DLCS.Web;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+using Orchestrator.Features.Auth;
+
+namespace Orchestrator.Infrastructure.Auth;
+
+/// <summary>
+/// Contains logic to validate passed BearerTokens and Cookies with a request for an asset.
+/// Setting status code and cookies depending on result of verification.
+/// </summary>
+public class Auth1AccessValidator : IAssetAccessValidator
+{
+    private readonly ISessionAuthService sessionAuthService;
+    private readonly AccessChecker accessChecker;
+    private readonly AuthCookieManager authCookieManager;
+    private readonly IHttpContextAccessor httpContextAccessor;
+
+    public Auth1AccessValidator(
+        ISessionAuthService sessionAuthService,
+        AccessChecker accessChecker,
+        AuthCookieManager authCookieManager,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        this.sessionAuthService = sessionAuthService;
+        this.accessChecker = accessChecker;
+        this.authCookieManager = authCookieManager;
+        this.httpContextAccessor = httpContextAccessor;
+    }
+
+    public Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+        CancellationToken cancellationToken = default) => mechanism switch
+    {
+        AuthMechanism.All => TryValidateAll(assetId.Customer, roles),
+        AuthMechanism.Cookie => TryValidateCookie(assetId.Customer, roles),
+        AuthMechanism.BearerToken => TryValidateBearerToken(assetId.Customer, roles),
+        _ => throw new ArgumentOutOfRangeException(nameof(mechanism), mechanism, null)
+    };
+
+    private async Task<AssetAccessResult> TryValidateAll(int customer, IEnumerable<string> roles)
+    {
+        var enumeratedRoles = roles.ToList();
+        var validateCookieResult = await TryValidateCookie(customer, enumeratedRoles);
+        if (validateCookieResult is AssetAccessResult.Open or AssetAccessResult.Authorized)
+        {
+            return validateCookieResult;
+        }
+
+        return await TryValidateBearerToken(customer, enumeratedRoles);
+    }
+    
+    private Task<AssetAccessResult> TryValidateBearerToken(int customer, IEnumerable<string> roles)
+        => ValidateAccess(customer, roles, () =>
+        {
+            var httpContext = httpContextAccessor.SafeHttpContext();
+
+            var bearerToken = GetBearerToken(httpContext.Request);
+            return string.IsNullOrEmpty(bearerToken)
+                ? Task.FromResult<AuthToken?>(null)
+                : sessionAuthService.GetAuthTokenForBearerId(customer, bearerToken);
+        }, false);
+
+    private Task<AssetAccessResult> TryValidateCookie(int customer, IEnumerable<string> roles)
+        => ValidateAccess(customer, roles, () =>
+        {
+            var cookieId = GetCookieId(customer);
+            return string.IsNullOrEmpty(cookieId)
+                ? Task.FromResult<AuthToken?>(null)
+                : sessionAuthService.GetAuthTokenForCookieId(customer, cookieId);
+        }, true);
+
+    private async Task<AssetAccessResult> ValidateAccess(int customer, IEnumerable<string> roles,
+        Func<Task<AuthToken?>> getAuthToken, bool setCookieInResponse)
+    {
+        var assetRoles = roles.ToList();
+        var authToken = await getAuthToken();
+        
+        if (authToken?.SessionUser == null)
+        {
+            // Authtoken token not found, or expired
+            return AssetAccessResult.Unauthorized;
+        }
+        
+        // Validate current user has access for roles for requested asset
+        var canAccess = await accessChecker.CanSessionUserAccessRoles(authToken.SessionUser, customer, assetRoles);
+        if (canAccess)
+        {
+            if (setCookieInResponse)
+            {
+                authCookieManager.SetCookieInResponse(authToken);
+            }
+
+            return AssetAccessResult.Authorized;
+        }
+        
+        return AssetAccessResult.Unauthorized;
+    }
+
+    private string? GetCookieId(int customer)
+    {
+        var cookieValue = authCookieManager.GetCookieValueForCustomer(customer);
+        return string.IsNullOrEmpty(cookieValue) ? null : authCookieManager.GetCookieIdFromValue(cookieValue);
+    }
+
+    private string? GetBearerToken(HttpRequest httpRequest)
+        => httpRequest.Headers.TryGetValue(HeaderNames.Authorization, out var authHeader)
+            ? authHeader.ToString()?[7..] // everything after "Bearer "
+            : null;
+}
+
+/// <summary>
+/// Enum representing various results for attempting to access an asset.
+/// </summary>
+public enum AssetAccessResult
+{
+    /// <summary>
+    /// Asset is open
+    /// </summary>
+    Open,
+    
+    /// <summary>
+    /// Asset is restricted and current user does not have appropriate access
+    /// </summary>
+    Unauthorized,
+    
+    /// <summary>
+    /// Asset is restricted and current user has access
+    /// </summary>
+    Authorized
+}
+
+/// <summary>
+/// Enum representing different mechanisms for authorising users
+/// </summary>
+public enum AuthMechanism
+{
+    /// <summary>
+    /// Auth user by cookie provided with request
+    /// </summary>
+    Cookie,
+    
+    /// <summary>
+    /// Auth user by bearer token provided with request
+    /// </summary>
+    BearerToken,
+    
+    /// <summary>
+    /// Try all possible methods of validation
+    /// </summary>
+    All
+}

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth2AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth2AccessValidator.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core.Types;
+using Orchestrator.Infrastructure.Auth.V2;
+
+namespace Orchestrator.Infrastructure.Auth;
+
+/// <summary>
+/// <see cref="IAssetAccessValidator"/> that uses external service to validate access via IIIF Auth v2
+/// </summary>
+public class Auth2AccessValidator : IAssetAccessValidator
+{
+    private readonly IIIFAuth2Client iiifAuth2Client;
+
+    public Auth2AccessValidator(IIIFAuth2Client iiifAuth2Client)
+    {
+        this.iiifAuth2Client = iiifAuth2Client;
+    }
+    
+    public async Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+        CancellationToken cancellationToken = default)
+    {
+        // NOTE(DG) - caller of this has checked appropriate cookie exists
+        if (mechanism == AuthMechanism.BearerToken) return AssetAccessResult.Unauthorized;
+
+        var canAccess = await iiifAuth2Client.VerifyAccess(assetId, roles, cancellationToken);
+
+        return canAccess ? AssetAccessResult.Authorized : AssetAccessResult.Unauthorized;
+    }
+}

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/IAssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/IAssetAccessValidator.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core.Types;
+
+namespace Orchestrator.Infrastructure.Auth;
+
+public interface IAssetAccessValidator
+{
+    /// <summary>
+    /// Validate whether current request has access to the specified roles for customer.
+    /// This will try to validate request using specified <see cref="AuthMechanism"/>
+    /// </summary>
+    /// <param name="assetId">Current assetId</param>
+    /// <param name="roles">Roles associated with Asset</param>
+    /// <param name="mechanism">Which mechanism to use to authorize user</param>
+    /// <returns><see cref="AssetAccessResult"/> enum representing result of validation</returns>
+    Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+        CancellationToken cancellationToken = default);
+}

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/V2/IIIFAuth2Client.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/V2/IIIFAuth2Client.cs
@@ -67,6 +67,21 @@ public class IIIFAuth2Client : IIIIFAuthBuilder
         }
     }
 
+    public async Task<bool> VerifyAccess(AssetId assetId, List<string> roles, CancellationToken cancellationToken)
+    {
+        var path = $"verifyaccess/{assetId}?roles={GetRolesString(roles)}";
+        try
+        {
+            var response = await httpClient.GetAsync(path, cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error verifying access for {AssetId}", assetId);
+            return false;
+        }   
+    }
+
     private static string GetRolesString(IList<string> roles)
         => roles.Count == 1 ? roles[0] : string.Join(",", roles);
 }

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
@@ -136,10 +136,21 @@ public class StoredNamedQueryManager
 
     private async Task<bool> CanUserViewItem(StoredParsedNamedQuery parsedNamedQuery, ControlFile controlFile)
     {
-        var mockAssetId = new AssetId(parsedNamedQuery.Customer, -1, "named-query");
+        var mockAssetId = GetMockAssetId(parsedNamedQuery);
         var access = await assetAccessValidator.TryValidate(mockAssetId, controlFile.Roles ?? new List<string>(),
             AuthMechanism.Cookie);
         return access is AssetAccessResult.Open or AssetAccessResult.Authorized;
+    }
+
+    /// <summary>
+    /// Validation relies on AssetId but for NQs we don't have that, we only have a CustomerId. This is enough to
+    /// perform validation so use dummy space + asset to generate AssetId 
+    /// </summary>
+    private static AssetId GetMockAssetId(StoredParsedNamedQuery parsedNamedQuery)
+    {
+        const int placeholderSpace = -1;
+        const string placeholderAsset = "_namedquery_";
+        return new AssetId(parsedNamedQuery.Customer, placeholderSpace, placeholderAsset);
     }
 }
 

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
@@ -1,8 +1,10 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
 using DLCS.Core.Guard;
+using DLCS.Core.Types;
 using DLCS.Model.Assets.NamedQueries;
 using DLCS.Repository.NamedQueries;
 using DLCS.Repository.NamedQueries.Models;
@@ -134,9 +136,9 @@ public class StoredNamedQueryManager
 
     private async Task<bool> CanUserViewItem(StoredParsedNamedQuery parsedNamedQuery, ControlFile controlFile)
     {
-        var access =
-            await assetAccessValidator.TryValidate(parsedNamedQuery.Customer, controlFile.Roles,
-                AuthMechanism.Cookie);
+        var mockAssetId = new AssetId(parsedNamedQuery.Customer, -1, "named-query");
+        var access = await assetAccessValidator.TryValidate(mockAssetId, controlFile.Roles ?? new List<string>(),
+            AuthMechanism.Cookie);
         return access is AssetAccessResult.Open or AssetAccessResult.Authorized;
     }
 }

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -133,7 +133,7 @@ public static class ServiceCollectionX
             .AddScoped<IRoleProviderService, HttpAwareRoleProviderService>()
             .AddScoped<IAuthPathGenerator, ConfigDrivenAuthPathGenerator>()
             .AddScoped<IIIIFAuthBuilder>(provider => provider.GetRequiredService<IIIFAuth2Client>())
-            .AddHeaderPropagation(options => options.Headers.Add( "Cookie"))
+            .AddHeaderPropagation(options => options.Headers.Add("Cookie"))
             .AddHttpClient<IIIFAuth2Client>(client =>
             {
                 client.DefaultRequestHeaders.WithRequestedBy();

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -131,12 +131,14 @@ public static class ServiceCollectionX
             .AddScoped<IRoleProviderService, HttpAwareRoleProviderService>()
             .AddScoped<IAuthPathGenerator, ConfigDrivenAuthPathGenerator>()
             .AddScoped<IIIIFAuthBuilder>(provider => provider.GetRequiredService<IIIFAuth2Client>())
+            .AddHeaderPropagation(options => options.Headers.Add( "Cookie"))
             .AddHttpClient<IIIFAuth2Client>(client =>
             {
                 client.DefaultRequestHeaders.WithRequestedBy();
                 client.BaseAddress = orchestratorSettings.Auth.Auth2ServiceRoot;
                 client.Timeout = TimeSpan.FromSeconds(orchestratorSettings.Auth.AuthTimeoutSecs);
             })
+            .AddHeaderPropagation()
             .AddHttpMessageHandler<TimingHandler>();
         return services;
     }

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -127,6 +127,8 @@ public static class ServiceCollectionX
             .AddScoped<AccessChecker>()
             .AddScoped<ISessionAuthService, SessionAuthService>()
             .AddScoped<AuthCookieManager>()
+            .AddScoped<Auth2AccessValidator>()
+            .AddScoped<Auth1AccessValidator>()
             .AddScoped<IAssetAccessValidator, AssetAccessValidator>()
             .AddScoped<IRoleProviderService, HttpAwareRoleProviderService>()
             .AddScoped<IAuthPathGenerator, ConfigDrivenAuthPathGenerator>()

--- a/src/protagonist/Orchestrator/Orchestrator.csproj
+++ b/src/protagonist/Orchestrator/Orchestrator.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="MediatR" Version="10.0.1" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.21" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.5" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -172,6 +172,11 @@ public class AuthSettings
     public string CookieNameFormat { get; set; } = "dlcs-token-{0}";
 
     /// <summary>
+    /// Format of authToken for IIIF Auth v2. {0} is replaced with customer id
+    /// </summary>
+    public string Auth2CookieNameFormat { get; set; } = "dlcs-auth2-{0}";
+
+    /// <summary>
     /// A list of domains to set on auth cookie.
     /// </summary>
     public List<string> CookieDomains { get; set; } = new();

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -84,7 +84,7 @@ public class Startup
             .AddApiClient(orchestratorSettings)
             .ConfigureHealthChecks(proxySection, configuration)
             .AddAws(configuration, webHostEnvironment)
-            .AddHeaderPropagation()
+            .AddCorrelationIdHeaderPropagation()
             .AddInfoJsonClient()
             .AddIIIFAuth(orchestratorSettings)
             .HandlePathTemplates();
@@ -142,6 +142,7 @@ public class Startup
             .UseForwardedHeaders()
             .UseRouting()
             .UseOptions()
+            .UseHeaderPropagation()
             .UseSerilogRequestLogging(opts =>
             {
                 opts.GetLevel = LogHelper.ExcludeHealthChecks;


### PR DESCRIPTION
Resolves #549 

Extended Orchestrator to call `iiif-auth-v2` internal verify-access endpoint when checking if a user can view a resource.

High level steps:
* Updated `IAssetAccessValidator` to take `AssetId` rather than just `int customer`.
* Renamed current `AssetAccessValidator` -> `Auth1AccessValidator` (uses DLCS own tables to verify access)
* Introduced new service, `Auth2AccessValidator` (uses iiif-auth-v2 to answer _"can user view this?"_)
  * Added `"Cookie"` header propogation to `IIIFAuth2Client` to pass along provided cookie.
* Refactored `AssetAccessValidator` to check which of the above services should be called. Prefers `Auth1` as it avoids an external call.

Updated all callers of `IAssetAccessValidator` to pass `AssetId`. The exception where this doesn't work is when verifying access to NamedQueries. In this instance a mock asset identifier is generated (`/{customer}/-1/named-query`).

Renamed custom `AddHeaderPropagation` method to `AddCorrelationIdHeaderPropagation` to avoid naming collision.