### PR TITLE
Add PUT endpoint to Spaces API

### DIFF
--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -351,7 +351,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var apiSpace = await response.ReadAsHydraResponseAsync<Space>();
         
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
         
         apiSpace.Should().NotBeNull();
         apiSpace.ModelId.Should().Be(spaceId);

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -379,6 +379,60 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         putSpace.Name.Should().Be("Put Space After");
     }
     
+    [Fact]
+    public async Task Put_Space_Prevents_Name_Conflict()
+    {
+        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Prevents_Name_Conflict");
+        await dbContext.Spaces.AddTestSpace(customerId.Value, 1, "Put Space Name 1");
+        await dbContext.Spaces.AddTestSpace(customerId.Value, 2, "Put Space Name 2");
+        await dbContext.SaveChangesAsync();
+        
+        const string putJson = @"{
+            ""@type"": ""Space"",
+            ""name"": ""Put Space Name 2""
+            }";
+        var putContent = new StringContent(putJson, Encoding.UTF8, "application/json");
+        var putUrl = $"/customers/{customerId}/spaces/1";
+        var putResponse = await httpClient.AsCustomer(customerId.Value).PutAsync(putUrl, putContent);
+        putResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+    
+    [Fact]
+    public async Task Put_Space_Leaves_Omitted_Fields_Intact()
+    {
+        // arrange
+        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Leaves_Omitted_Fields_Intact");
+        
+        const string newSpaceJson = @"{
+          ""@type"": ""Space"",
+          ""name"": ""Put Complex Space"",
+          ""defaultRoles"": [""role1"", ""role2""],
+          ""defaultTags"": [""tag1"", ""tag2""],
+          ""maxUnauthorised"": 400
+        }";
+        const string putJson = @"{
+          ""@type"": ""Space"",
+          ""name"": ""Put Complex Space After""
+        }";
+        
+        // act
+        var content = new StringContent(newSpaceJson, Encoding.UTF8, "application/json");
+        var postUrl = $"/customers/{customerId}/spaces";
+        var response = await httpClient.AsCustomer(customerId.Value).PostAsync(postUrl, content);
+        var apiSpace = await response.ReadAsHydraResponseAsync<Space>();
+        
+        // assert
+        var putContent = new StringContent(putJson, Encoding.UTF8, "application/json");
+        var putResponse = await httpClient.AsCustomer(customerId.Value).PutAsync(apiSpace.Id, putContent);
+        var putSpace = await putResponse.ReadAsHydraResponseAsync<Space>();
+
+        putSpace.Name.Should().Be("Put Complex Space After");
+        putSpace.DefaultRoles.Should().BeEquivalentTo("role1", "role2");
+        putSpace.DefaultTags.Should().BeEquivalentTo("tag1", "tag2");
+        putSpace.MaxUnauthorised.Should().Be(400);
+    }
+    
+    
     private async Task<int?> EnsureCustomerForSpaceTests(string customerName = "space-test-customer")
     {
         var spaceTestCustomer = await dbContext.Customers.SingleOrDefaultAsync(c => c.Name == customerName);

--- a/src/protagonist/API/Features/Space/Requests/CreateSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/CreateSpace.cs
@@ -12,7 +12,7 @@ public class CreateSpace : IRequest<DLCS.Model.Spaces.Space>
 {
     public string Name { get; }
     public int Customer { get; }
-    public string? ImageBucket { get; set; } = string.Empty;
+    public string? ImageBucket { get; set; }
     public string[]? Tags { get; set; }
     public string[]? Roles { get; set; }
     public int? MaxUnauthorised { get; set; }
@@ -44,7 +44,9 @@ public class CreateSpaceHandler : IRequestHandler<CreateSpace, DLCS.Model.Spaces
        
         var existing = await spaceRepository.GetSpace(request.Customer, request.Name, cancellationToken);
         if (existing != null)
+        {
             throw new BadRequestException("A space with this name already exists.");
+        }
         
         var newSpace = await spaceRepository.CreateSpace(
             request.Customer, request.Name, request.ImageBucket, 
@@ -58,6 +60,8 @@ public class CreateSpaceHandler : IRequestHandler<CreateSpace, DLCS.Model.Spaces
     {
         var customer = await customerRepository.GetCustomer(request.Customer);
         if (customer == null)
+        { 
             throw new BadRequestException("Space must be created for an existing Customer.");
+        }
     }
 }

--- a/src/protagonist/API/Features/Space/Requests/CreateSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/CreateSpace.cs
@@ -41,12 +41,11 @@ public class CreateSpaceHandler : IRequestHandler<CreateSpace, DLCS.Model.Spaces
     public async Task<DLCS.Model.Spaces.Space> Handle(CreateSpace request, CancellationToken cancellationToken)
     {
         await ValidateRequest(request);
+       
         var existing = await spaceRepository.GetSpace(request.Customer, request.Name, cancellationToken);
         if (existing != null)
-        {
             throw new BadRequestException("A space with this name already exists.");
-        }
-
+        
         var newSpace = await spaceRepository.CreateSpace(
             request.Customer, request.Name, request.ImageBucket, 
             request.Tags, request.Roles, request.MaxUnauthorised,
@@ -59,8 +58,6 @@ public class CreateSpaceHandler : IRequestHandler<CreateSpace, DLCS.Model.Spaces
     {
         var customer = await customerRepository.GetCustomer(request.Customer);
         if (customer == null)
-        {
             throw new BadRequestException("Space must be created for an existing Customer.");
-        }
     }
 }

--- a/src/protagonist/API/Features/Space/Requests/GetSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpace.cs
@@ -1,3 +1,4 @@
+using API.Infrastructure.Requests;
 using DLCS.Model.Spaces;
 using MediatR;
 
@@ -6,7 +7,7 @@ namespace API.Features.Space.Requests;
 /// <summary>
 /// Get details of specified space for customer
 /// </summary>
-public class GetSpace : IRequest<DLCS.Model.Spaces.Space?>
+public class GetSpace : IRequest<FetchEntityResult<DLCS.Model.Spaces.Space>>
 {
     public GetSpace(int customerId, int spaceId)
     {
@@ -18,7 +19,7 @@ public class GetSpace : IRequest<DLCS.Model.Spaces.Space?>
     public int SpaceId { get; }
 }
 
-public class GetSpaceHandler : IRequestHandler<GetSpace, DLCS.Model.Spaces.Space?>
+public class GetSpaceHandler : IRequestHandler<GetSpace, FetchEntityResult<DLCS.Model.Spaces.Space>>
 {
     private readonly ISpaceRepository spaceRepository;
 
@@ -27,10 +28,12 @@ public class GetSpaceHandler : IRequestHandler<GetSpace, DLCS.Model.Spaces.Space
         this.spaceRepository = spaceRepository;
     }
     
-    public async Task<DLCS.Model.Spaces.Space?> Handle(GetSpace request, CancellationToken cancellationToken)
+    public async Task<FetchEntityResult<DLCS.Model.Spaces.Space>> Handle(GetSpace request, CancellationToken cancellationToken)
     {
         var space = await spaceRepository.GetSpace(
             request.CustomerId, request.SpaceId, noCache: true, cancellationToken: cancellationToken);
-        return space;
+        return space == null
+            ? FetchEntityResult<DLCS.Model.Spaces.Space>.NotFound()
+            : FetchEntityResult<DLCS.Model.Spaces.Space>.Success(space);
     }
 }

--- a/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
@@ -1,4 +1,7 @@
 using System.Collections.Generic;
+using System.Net;
+using API.Infrastructure.Requests;
+using DLCS.Core;
 using DLCS.Core.Strings;
 using DLCS.Model.Spaces;
 using MediatR;
@@ -8,7 +11,7 @@ namespace API.Features.Space.Requests;
 /// <summary>
 /// Make a partial updated to an existing space
 /// </summary>
-public class PatchSpace : IRequest<PatchSpaceResult>
+public class PatchSpace : IRequest<ModifyEntityResult<DLCS.Model.Spaces.Space>>
 {
     public int CustomerId { get; set; }
     public int SpaceId { get; set; }
@@ -18,14 +21,7 @@ public class PatchSpace : IRequest<PatchSpaceResult>
     public int? MaxUnauthorised { get; set; }
 }
 
-public class PatchSpaceResult
-{
-    public DLCS.Model.Spaces.Space? Space { get; set; }
-    public List<string> ErrorMessages { get; } = new();
-    public bool Conflict { get; set; }
-}
-
-public class PatchSpaceHandler : IRequestHandler<PatchSpace, PatchSpaceResult>
+public class PatchSpaceHandler : IRequestHandler<PatchSpace, ModifyEntityResult<DLCS.Model.Spaces.Space>>
 {
     private readonly ISpaceRepository spaceRepository;
 
@@ -34,26 +30,26 @@ public class PatchSpaceHandler : IRequestHandler<PatchSpace, PatchSpaceResult>
         this.spaceRepository = spaceRepository;
     }
     
-    public async Task<PatchSpaceResult> Handle(PatchSpace request, CancellationToken cancellationToken)
+    public async Task<ModifyEntityResult<DLCS.Model.Spaces.Space>> Handle(PatchSpace request, CancellationToken cancellationToken)
     {
-        var result = new PatchSpaceResult();
+        var sameIdSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
+        if (sameIdSpace == null)
+            return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure($"Couldn't find a space with the id {request.SpaceId}", WriteResult.NotFound);
+   
         if (request.Name.HasText())
         {
-            var existing = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
-            if (existing != null && existing.Id != request.SpaceId)
-            {
-                result.Conflict = true;
-                result.ErrorMessages.Add($"The space name '{request.Name}' is already taken.");
-                return result;
-            }     
+            var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
+            if (sameNameSpace != null && sameNameSpace.Id != request.SpaceId)
+                return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure($"The space name '{request.Name}' is already taken.", WriteResult.Conflict);
         }
+        
         // The request customer and space override any values for these that may
         // (or more likely, may not) have been sent on the incoming Space to be patched.
         var patchedSpace = await spaceRepository.PatchSpace(
             request.CustomerId, request.SpaceId, request.Name,
             request.MaxUnauthorised, request.Tags, request.Roles,
             cancellationToken);
-        result.Space = patchedSpace;
-        return result;
+        
+        return ModifyEntityResult<DLCS.Model.Spaces.Space>.Success(patchedSpace);
     }
 }

--- a/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PatchSpace.cs
@@ -34,13 +34,17 @@ public class PatchSpaceHandler : IRequestHandler<PatchSpace, ModifyEntityResult<
     {
         var sameIdSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
         if (sameIdSpace == null)
+        {
             return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure($"Couldn't find a space with the id {request.SpaceId}", WriteResult.NotFound);
-   
+        }
+          
         if (request.Name.HasText())
         {
             var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
             if (sameNameSpace != null && sameNameSpace.Id != request.SpaceId)
+            {
                 return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure($"The space name '{request.Name}' is already taken.", WriteResult.Conflict);
+            }
         }
         
         // The request customer and space override any values for these that may

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using API.Infrastructure.Requests;
+using DLCS.Core;
 using DLCS.Core.Strings;
 using DLCS.Model.Spaces;
 using MediatR;
@@ -8,7 +10,7 @@ namespace API.Features.Space.Requests;
 /// <summary>
 /// Create or update an existing space
 /// </summary>
-public class PutSpace : IRequest<PutSpaceResult>
+public class PutSpace : IRequest<ModifyEntityResult<DLCS.Model.Spaces.Space>>
 {
     public int CustomerId { get; set; }
     public int SpaceId { get; set; }
@@ -19,14 +21,7 @@ public class PutSpace : IRequest<PutSpaceResult>
     public int? MaxUnauthorised { get; set; }
 }
 
-public class PutSpaceResult
-{
-    public DLCS.Model.Spaces.Space? Space { get; set; }
-    public List<string> ErrorMessages { get; } = new();
-    public bool Conflict { get; set; }
-}
-
-public class PutSpaceHandler : IRequestHandler<PutSpace, PutSpaceResult>
+public class PutSpaceHandler : IRequestHandler<PutSpace, ModifyEntityResult<DLCS.Model.Spaces.Space>>
 {
     private readonly ISpaceRepository spaceRepository;
 
@@ -35,32 +30,26 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, PutSpaceResult>
         this.spaceRepository = spaceRepository;
     }
     
-    public async Task<PutSpaceResult> Handle(PutSpace request, CancellationToken cancellationToken)
+    public async Task<ModifyEntityResult<DLCS.Model.Spaces.Space>> Handle(PutSpace request, CancellationToken cancellationToken)
     {
-        var result = new PutSpaceResult();
-        
         var sameIdSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
         if (sameIdSpace == null && !request.Name.HasText())
+            return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure("A name is required when creating a new space.",
+                WriteResult.FailedValidation);
+
+        if (request.Name.HasText())
         {
-            result.ErrorMessages.Add("A name is required when creating a new space.");
-            return result;
+            var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
+            if (sameNameSpace != null && sameNameSpace.Id != request.SpaceId)
+                return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure($"The space name '{request.Name}' is already taken.",
+                    WriteResult.Conflict);
         }
         
-        var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
-        if (sameNameSpace != null && sameNameSpace.Id != request.SpaceId)
-        {
-            result.Conflict = true;
-            result.ErrorMessages.Add($"The space name '{request.Name}' is already taken.");
-            return result;
-        }     
-        
-        var putSpace = await spaceRepository.PutSpace(
+        var putSpaceResult = await spaceRepository.PutSpace(
             request.CustomerId, request.SpaceId, request.Name, request.ImageBucket,
             request.MaxUnauthorised, request.Tags, request.Roles,
             cancellationToken);
-        
-        result.Space = putSpace;
-        
-        return result;
+       
+        return ModifyEntityResult<DLCS.Model.Spaces.Space>.Success(putSpaceResult);
     }
 }

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -47,7 +47,7 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, PutSpaceResult>
         }
         
         var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
-        if (sameNameSpace != null)
+        if (sameNameSpace != null && sameNameSpace.Id != request.SpaceId)
         {
             result.Conflict = true;
             result.ErrorMessages.Add($"The space name '{request.Name}' is already taken.");

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -38,15 +38,16 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, PutSpaceResult>
     public async Task<PutSpaceResult> Handle(PutSpace request, CancellationToken cancellationToken)
     {
         var result = new PutSpaceResult();
-        var existingSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
-
-        if (existingSpace == null && !request.Name.HasText())
+        
+        var sameIdSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
+        if (sameIdSpace == null && !request.Name.HasText())
         {
             result.ErrorMessages.Add("A name is required when creating a new space.");
             return result;
         }
         
-        if (existingSpace != null && existingSpace.Id != request.SpaceId)
+        var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
+        if (sameNameSpace != null)
         {
             result.Conflict = true;
             result.ErrorMessages.Add($"The space name '{request.Name}' is already taken.");

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -1,0 +1,65 @@
+﻿using System.Collections.Generic;
+using DLCS.Core.Strings;
+using DLCS.Model.Spaces;
+using MediatR;
+
+namespace API.Features.Space.Requests;
+
+/// <summary>
+/// Create or update an existing space
+/// </summary>
+public class PutSpace : IRequest<PutSpaceResult>
+{
+    public int CustomerId { get; set; }
+    public int SpaceId { get; set; }
+    public string? Name { get; set; }
+    public string? ImageBucket { get; set; } = string.Empty;
+    public string[]? Tags { get; set; }
+    public string[]? Roles { get; set; }
+    public int? MaxUnauthorised { get; set; }
+}
+
+public class PutSpaceResult
+{
+    public DLCS.Model.Spaces.Space? Space { get; set; }
+    public List<string> ErrorMessages { get; } = new();
+    public bool Conflict { get; set; }
+}
+
+public class PutSpaceHandler : IRequestHandler<PutSpace, PutSpaceResult>
+{
+    private readonly ISpaceRepository spaceRepository;
+
+    public PutSpaceHandler(ISpaceRepository spaceRepository)
+    {
+        this.spaceRepository = spaceRepository;
+    }
+    
+    public async Task<PutSpaceResult> Handle(PutSpace request, CancellationToken cancellationToken)
+    {
+        var result = new PutSpaceResult();
+        var existingSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
+
+        if (existingSpace == null && !request.Name.HasText())
+        {
+            result.ErrorMessages.Add("A name is required when creating a new space.");
+            return result;
+        }
+        
+        if (existingSpace != null && existingSpace.Id != request.SpaceId)
+        {
+            result.Conflict = true;
+            result.ErrorMessages.Add($"The space name '{request.Name}' is already taken.");
+            return result;
+        }     
+        
+        var putSpace = await spaceRepository.PutSpace(
+            request.CustomerId, request.SpaceId, request.Name, request.ImageBucket,
+            request.MaxUnauthorised, request.Tags, request.Roles,
+            cancellationToken);
+        
+        result.Space = putSpace;
+        
+        return result;
+    }
+}

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -15,7 +15,7 @@ public class PutSpace : IRequest<ModifyEntityResult<DLCS.Model.Spaces.Space>>
     public int CustomerId { get; set; }
     public int SpaceId { get; set; }
     public string? Name { get; set; }
-    public string? ImageBucket { get; set; } = string.Empty;
+    public string? ImageBucket { get; set; }
     public string[]? Tags { get; set; }
     public string[]? Roles { get; set; }
     public int? MaxUnauthorised { get; set; }
@@ -34,9 +34,11 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, ModifyEntityResult<DLCS
     {
         var sameIdSpace = await spaceRepository.GetSpace(request.CustomerId, request.SpaceId, cancellationToken);
         if (sameIdSpace == null && !request.Name.HasText())
+        {
             return ModifyEntityResult<DLCS.Model.Spaces.Space>.Failure("A name is required when creating a new space.",
-                WriteResult.FailedValidation);
-
+                WriteResult.FailedValidation);            
+        }
+        
         if (request.Name.HasText())
         {
             var sameNameSpace = await spaceRepository.GetSpace(request.CustomerId, request.Name, cancellationToken);
@@ -49,7 +51,9 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, ModifyEntityResult<DLCS
             request.CustomerId, request.SpaceId, request.Name, request.ImageBucket,
             request.MaxUnauthorised, request.Tags, request.Roles,
             cancellationToken);
-       
-        return ModifyEntityResult<DLCS.Model.Spaces.Space>.Success(putSpaceResult);
+        
+        var result = sameIdSpace == null ? WriteResult.Created : WriteResult.Updated;
+        
+        return ModifyEntityResult<DLCS.Model.Spaces.Space>.Success(putSpaceResult, result);
     }
 }

--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -85,11 +85,15 @@ public class SpaceController : HydraController
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(space.Name))
+        {
             return this.HydraProblem("A space must have a name.", null, 400, "Invalid Space");
-        
+        }
+
         if (customerId <= 0)
+        {
             return this.HydraProblem("Space must be created for an existing Customer.", null, 400, "Invalid Space");
-        
+        }
+         
         logger.LogDebug("API will create space {SpaceName} for {CustomerId}", space.Name, customerId);
 
         var command = new CreateSpace(customerId, space.Name)
@@ -103,11 +107,13 @@ public class SpaceController : HydraController
         {
             var newDbSpace = await Mediator.Send(command, cancellationToken);
             var newApiSpace = newDbSpace.ToHydra(GetUrlRoots().BaseUrl);
-            
+
             if (!newApiSpace.Id.HasText())
+            {
                 return this.HydraProblem("New space not assigned an ID", 
                     null, 500, "Bad Request");
-            
+            }
+
             return this.HydraCreated(newApiSpace);
         }
         catch (BadRequestException badRequestException)
@@ -154,12 +160,12 @@ public class SpaceController : HydraController
     }
 
     /// <summary>
-    /// Patch a space within this customer. DLCS assigns identity.
+    /// Make a partial update of an existing space
     /// </summary>
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST: /customers/1/spaces
+    ///     PATCH: /customers/1/spaces/1
     ///     {
     ///         "@type":"Space",
     ///         "name":"foo"

--- a/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
+++ b/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
@@ -22,6 +22,9 @@ public interface ISpaceRepository
 
     Task<Space> PatchSpace(int customerId, int spaceId, string? name, int? maxUnauthorised, string[]? tags,
         string[]? roles, CancellationToken cancellationToken);
+    
+    Task<Space> PutSpace(int customerId, int spaceId, string? name, string? imageBucket, int? maxUnauthorised, string[]? tags,
+        string[]? roles, CancellationToken cancellationToken);
 
     Task<ResultMessage<DeleteResult>> DeleteSpace(int customerId, int spaceId, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -209,7 +209,7 @@ public class SpaceRepository : ISpaceRepository
         
         await dlcsContext.SaveChangesAsync(cancellationToken);
 
-        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken);
+        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache: true);
         return retrievedSpace;
     }
 
@@ -236,28 +236,27 @@ public class SpaceRepository : ISpaceRepository
                 existingSpace.MaxUnauthorised = (int)maxUnauthorised;
             
             await dlcsContext.SaveChangesAsync(cancellationToken);
-            
-            var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken);
-            
-            return retrievedSpace;
         }
-     
-        var space = new Space
+        else
         {
-            Customer = customerId,
-            Id = spaceId,
-            Name = name,
-            Created = DateTime.UtcNow,
-            ImageBucket = imageBucket,
-            Tags = tags ?? Array.Empty<string>(),
-            Roles = roles ?? Array.Empty<string>(),
-            MaxUnauthorised = maxUnauthorised ?? -1
-        };
+            var space = new Space
+            {
+                Customer = customerId,
+                Id = spaceId,
+                Name = name,
+                Created = DateTime.UtcNow,
+                ImageBucket = imageBucket,
+                Tags = tags ?? Array.Empty<string>(),
+                Roles = roles ?? Array.Empty<string>(),
+                MaxUnauthorised = maxUnauthorised ?? -1
+            };
         
-        await dlcsContext.Spaces.AddAsync(space, cancellationToken);
-        await entityCounterRepository.Create(customerId, KnownEntityCounters.SpaceImages, space.Id.ToString());
+            await dlcsContext.Spaces.AddAsync(space, cancellationToken);
+            await entityCounterRepository.Create(customerId, KnownEntityCounters.SpaceImages, space.Id.ToString()); 
+        }
         
-        return space;
+        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache:true);
+        return retrievedSpace;
     }
     
     public async Task<ResultMessage<DeleteResult>> DeleteSpace(int customerId, int spaceId, CancellationToken cancellationToken)

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -232,7 +232,7 @@ public class SpaceRepository : ISpaceRepository
             if (roles != null)
                 existingSpace.Roles = roles;
 
-            if (maxUnauthorised != null)
+            if (maxUnauthorised.HasValue)
                 existingSpace.MaxUnauthorised = (int)maxUnauthorised;
         }
         else

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -234,8 +234,6 @@ public class SpaceRepository : ISpaceRepository
 
             if (maxUnauthorised.HasValue)
                 existingSpace.MaxUnauthorised = (int)maxUnauthorised;
-            
-            await dlcsContext.SaveChangesAsync(cancellationToken);
         }
         else
         {
@@ -254,6 +252,8 @@ public class SpaceRepository : ISpaceRepository
             await dlcsContext.Spaces.AddAsync(space, cancellationToken);
             await entityCounterRepository.Create(customerId, KnownEntityCounters.SpaceImages, space.Id.ToString()); 
         }
+        
+        await dlcsContext.SaveChangesAsync(cancellationToken);
         
         var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache:true);
         return retrievedSpace;

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -221,6 +221,7 @@ public class SpaceRepository : ISpaceRepository
         var existingSpace = await dlcsContext.Spaces.SingleOrDefaultAsync(s =>
             s.Customer == customerId && s.Id == spaceId, cancellationToken: cancellationToken);
 
+        Space retrievedSpace;
         if (existingSpace != null)
         {
             if (name.HasText() && name != existingSpace.Name)
@@ -234,6 +235,8 @@ public class SpaceRepository : ISpaceRepository
 
             if (maxUnauthorised.HasValue)
                 existingSpace.MaxUnauthorised = (int)maxUnauthorised;
+            
+            retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken);
         }
         else
         {
@@ -251,10 +254,11 @@ public class SpaceRepository : ISpaceRepository
             
             await dlcsContext.Spaces.AddAsync(space, cancellationToken);
             await entityCounterRepository.Create(customerId, KnownEntityCounters.SpaceImages, space.Id.ToString());
+
+            retrievedSpace = space;
         }
-        await dlcsContext.SaveChangesAsync(cancellationToken);
         
-        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken);
+        await dlcsContext.SaveChangesAsync(cancellationToken);
         
         return retrievedSpace;
     }

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.CloudFront.Model;
 using DLCS.Core;
 using DLCS.Core.Caching;
 using DLCS.Core.Strings;
@@ -22,6 +23,8 @@ public class SpaceRepository : ISpaceRepository
     private readonly CacheSettings cacheSettings;
     private readonly IAppCache appCache;
     private ILogger<SpaceRepository> logger;
+    
+    private const int DefaultMaxUnauthorised = -1;
 
     public SpaceRepository(
         DlcsContext dlcsContext,
@@ -80,10 +83,10 @@ public class SpaceRepository : ISpaceRepository
             Id = newModelId,
             Name = name,
             Created = DateTime.UtcNow,
-            ImageBucket = imageBucket,
+            ImageBucket = imageBucket ?? string.Empty,
             Tags = tags ?? Array.Empty<string>(),
             Roles = roles ?? Array.Empty<string>(),
-            MaxUnauthorised = maxUnauthorised ?? -1
+            MaxUnauthorised = maxUnauthorised ?? DefaultMaxUnauthorised 
         };
 
         await dlcsContext.Spaces.AddAsync(space, cancellationToken);
@@ -224,16 +227,24 @@ public class SpaceRepository : ISpaceRepository
         if (existingSpace != null)
         {
             if (name.HasText() && name != existingSpace.Name)
+            {
                 existingSpace.Name = name;
+            }
 
             if (tags != null)
+            {
                 existingSpace.Tags = tags;
+            }
 
             if (roles != null)
+            {
                 existingSpace.Roles = roles;
+            }
 
             if (maxUnauthorised.HasValue)
+            {
                 existingSpace.MaxUnauthorised = (int)maxUnauthorised;
+            }
         }
         else
         {
@@ -243,10 +254,10 @@ public class SpaceRepository : ISpaceRepository
                 Id = spaceId,
                 Name = name,
                 Created = DateTime.UtcNow,
-                ImageBucket = imageBucket,
+                ImageBucket = imageBucket ?? string.Empty,
                 Tags = tags ?? Array.Empty<string>(),
                 Roles = roles ?? Array.Empty<string>(),
-                MaxUnauthorised = maxUnauthorised ?? -1
+                MaxUnauthorised = maxUnauthorised ?? DefaultMaxUnauthorised 
             };
         
             await dlcsContext.Spaces.AddAsync(space, cancellationToken);

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -60,6 +60,7 @@ public class DlcsDatabaseFixture : IAsyncLifetime
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"SessionUsers\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"AuthTokens\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"Batches\"");
+        DbContext.Database.ExecuteSqlRaw("DELETE FROM \"Queues\"");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'space' AND \"Customer\" != 99");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'space-images' AND \"Customer\" != 99");
         DbContext.Database.ExecuteSqlRaw("DELETE FROM \"EntityCounters\" WHERE \"Type\" = 'customer-images' AND \"Scope\" != '99'");


### PR DESCRIPTION
Resolves #562 

Additions:
- `PUT` endpoint for `SpaceController.cs` + tests
- `PutSpace` request that can create and update an existing space

Changes:
- `DlcsDatabaseFixture.CleanUp()` now includes queues when clearing old test data
- `GetSpace` and `PatchSpace` have been rewritten to use the the `FetchEntityResult` and `ModifyEntityResult` helper classes, respectively

Notes:
- It might be worth reviewing how `CreateSpace` and `GetPageOfSpaces` are implemented and possibly update them so that they match current DLCS practices, e.g

  - Both `CreateSpace` and `GetPageOfSpaces` validate the calling user before performing the request, but this behaviour isn't seen in other requests
https://github.com/dlcs/protagonist/blob/47bfbf0455d1a60fa76b119758751ef39b320315/src/protagonist/API/Features/Space/Requests/CreateSpace.cs#L57 https://github.com/dlcs/protagonist/blob/39abf53f6cf369caba4501ca79d81c5769736fca/src/protagonist/API/Features/Space/Requests/GetPageOfSpaces.cs#L45
  - The `CreateSpace` route in `SpaceController` has a check that ensures that the created space has been assigned an ID. Is this still necessary?
https://github.com/dlcs/protagonist/blob/39abf53f6cf369caba4501ca79d81c5769736fca/src/protagonist/API/Features/Space/SpaceController.cs#L103