### PR TITLE
Allow storage objects to be read via the API

### DIFF
--- a/src/protagonist/API.Tests/Integration/StorageTests.cs
+++ b/src/protagonist/API.Tests/Integration/StorageTests.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using API.Tests.Integration.Infrastructure;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Spaces;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using Test.Helpers.Integration;
+using Test.Helpers.Integration.Infrastructure;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
+public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly HttpClient httpClient;
+    private readonly DlcsContext dlcsContext;
+
+    public StorageTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        dlcsContext = dbFixture.DbContext;
+        httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task Get_CustomerStorage_200()
+    {
+        // Arrange
+        const int customerId = 90;
+        
+        var path = $"customers/{customerId}/storage";
+        var customerStorage = new CustomerStorage()
+        {
+            StoragePolicy = "default",
+            Customer = customerId,
+            NumberOfStoredImages = 5,
+            TotalSizeOfStoredImages = 8863407,
+            TotalSizeOfThumbnails = 1029624,
+            Space = 0,
+        };
+        
+        await dlcsContext.CustomerStorages.AddAsync(customerStorage);
+        await dlcsContext.SaveChangesAsync();
+        
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Fact]
+    public async Task Get_SpaceStorage_200()
+    {
+        // Arrange
+        const int customerId = 91;
+        const int spaceId = 1;
+        var path = $"customers/{customerId}/spaces/{spaceId}/storage";
+        
+        var space = new Space()
+        {
+            Id = spaceId,
+            Name = "test-space",
+            Customer = customerId,
+            Created = DateTime.MinValue.ToUniversalTime()
+          
+        };
+        var spaceStorage = new CustomerStorage()
+        {
+            StoragePolicy = "default",
+            Customer = customerId,
+            NumberOfStoredImages = 5,
+            TotalSizeOfStoredImages = 8863407,
+            TotalSizeOfThumbnails = 1029624,
+            Space = spaceId,
+        };
+        
+        await dlcsContext.Spaces.AddAsync(space);
+        await dlcsContext.CustomerStorages.AddAsync(spaceStorage);
+        await dlcsContext.SaveChangesAsync();
+        
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Get_ImageStorage_200()
+    {
+        // Arrange
+        const int customerId = 91;
+        const string imageId = "test-image";
+        var path = $"customers/{customerId}/spaces/0/images/{imageId}/storage";
+   
+        var imageStorage = new ImageStorage()
+        {
+            Id = AssetId.FromString($"{customerId}/0/{imageId}"),
+            Customer = customerId,
+            Space = 0,
+            ThumbnailSize = 168104,
+            Size = 2605964,
+            LastChecked = DateTime.MinValue.ToUniversalTime()
+        };
+        
+        await dlcsContext.ImageStorages.AddAsync(imageStorage);
+        await dlcsContext.SaveChangesAsync();
+        
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/src/protagonist/API.Tests/Integration/StorageTests.cs
+++ b/src/protagonist/API.Tests/Integration/StorageTests.cs
@@ -77,14 +77,6 @@ public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const int spaceId = 1;
         
         var path = $"customers/{customerId}/spaces/{spaceId}/storage";
-        var space = new Space()
-        {
-            Id = spaceId,
-            Name = "test-space",
-            Customer = customerId,
-            Created = DateTime.MinValue.ToUniversalTime()
-          
-        };
         var spaceStorage = new CustomerStorage()
         {
             StoragePolicy = "default",
@@ -95,7 +87,6 @@ public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
             Space = spaceId,
         };
         
-        await dlcsContext.Spaces.AddAsync(space);
         await dlcsContext.CustomerStorages.AddAsync(spaceStorage);
         await dlcsContext.SaveChangesAsync();
         

--- a/src/protagonist/API.Tests/Integration/StorageTests.cs
+++ b/src/protagonist/API.Tests/Integration/StorageTests.cs
@@ -55,13 +55,28 @@ public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task Get_SpaceStorage_200()
+    public async Task Get_CustomerStorage_400_IfNotFound()
     {
         // Arrange
         const int customerId = 91;
-        const int spaceId = 1;
-        var path = $"customers/{customerId}/spaces/{spaceId}/storage";
         
+        var path = $"customers/{customerId}/storage";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_SpaceStorage_200()
+    {
+        // Arrange
+        const int customerId = 92;
+        const int spaceId = 1;
+        
+        var path = $"customers/{customerId}/spaces/{spaceId}/storage";
         var space = new Space()
         {
             Id = spaceId,
@@ -90,15 +105,29 @@ public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
+    
+    [Fact]
+    public async Task Get_SpaceStorage_400_IfNotFound()
+    {
+        // Arrange
+        const int customerId = 93;
+        var path = $"customers/{customerId}/spaces/256/storage";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
 
     [Fact]
     public async Task Get_ImageStorage_200()
     {
         // Arrange
-        const int customerId = 91;
+        const int customerId = 94;
         const string imageId = "test-image";
+        
         var path = $"customers/{customerId}/spaces/0/images/{imageId}/storage";
-   
         var imageStorage = new ImageStorage()
         {
             Id = AssetId.FromString($"{customerId}/0/{imageId}"),
@@ -117,5 +146,19 @@ public class StorageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Fact]
+    public async Task Get_ImageStorage_400_IfNotFound()
+    {
+        // Arrange
+        const int customerId = 95;
+        var path = $"customers/{customerId}/spaces/0/images/256/storage";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 }

--- a/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
@@ -12,12 +12,13 @@ public static class CustomerStorageConverter
     {
         var hydraCustomerStorage = new DLCS.HydraModel.CustomerStorage(baseUrl, customerStorage.Customer, customerStorage.Space)
         {
-            StoragePolicy = customerStorage.StoragePolicy,
+            StoragePolicy = $"{baseUrl}/storagePolicies/{customerStorage.StoragePolicy}",
             NumberOfStoredImages = customerStorage.NumberOfStoredImages,
             TotalSizeOfStoredImages = customerStorage.TotalSizeOfStoredImages,
             TotalSizeOfThumbnails = customerStorage.TotalSizeOfThumbnails,
             LastCalculated = customerStorage.LastCalculated
         };
+        
         return hydraCustomerStorage;
     }
 }

--- a/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
@@ -1,0 +1,18 @@
+﻿
+namespace API.Features.Storage.Converters;
+
+public static class CustomerStorageConverter
+{
+    public static DLCS.HydraModel.CustomerStorage ToHydra(this DLCS.Model.Storage.CustomerStorage customerStorage, string baseUrl)
+    {
+        var hydraCustomerStorage = new DLCS.HydraModel.CustomerStorage(baseUrl, customerStorage.Customer, customerStorage.Space)
+        {
+            StoragePolicy = customerStorage.StoragePolicy,
+            NumberOfStoredImages = customerStorage.NumberOfStoredImages,
+            TotalSizeOfStoredImages = customerStorage.TotalSizeOfStoredImages,
+            TotalSizeOfThumbnails = customerStorage.TotalSizeOfThumbnails,
+            LastCalculated = customerStorage.LastCalculated
+        };
+        return hydraCustomerStorage;
+    }
+}

--- a/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/CustomerStorageConverter.cs
@@ -1,8 +1,13 @@
-﻿
-namespace API.Features.Storage.Converters;
+﻿namespace API.Features.Storage.Converters;
 
+/// <summary>
+/// Conversion between API and EF forms of CustomerStorage resource
+/// </summary>
 public static class CustomerStorageConverter
 {
+    /// <summary>
+    /// Convert CustomerStorage entity to API resource
+    /// </summary>
     public static DLCS.HydraModel.CustomerStorage ToHydra(this DLCS.Model.Storage.CustomerStorage customerStorage, string baseUrl)
     {
         var hydraCustomerStorage = new DLCS.HydraModel.CustomerStorage(baseUrl, customerStorage.Customer, customerStorage.Space)

--- a/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
@@ -1,7 +1,13 @@
 ﻿namespace API.Features.Storage.Converters;
 
+/// <summary>
+/// Conversion between API and EF forms of ImageStorage resource
+/// </summary>
 public static class ImageStorageConverter
 {
+    /// <summary>
+    /// Convert ImageStorage entity to API resource
+    /// </summary>
     public static DLCS.HydraModel.ImageStorage ToHydra(this DLCS.Model.Assets.ImageStorage imageStorage, string baseUrl)
     {
         var hydraImageStorage = new DLCS.HydraModel.ImageStorage(baseUrl, imageStorage.Customer,

--- a/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
@@ -13,8 +13,8 @@ public static class ImageStorageConverter
         var hydraImageStorage = new DLCS.HydraModel.ImageStorage(baseUrl, imageStorage.Customer,
             imageStorage.Space, imageStorage.Id.Asset)
         {
-            ThumbnailSize = (int)imageStorage.ThumbnailSize,
-            Size = (int)imageStorage.Size,
+            ThumbnailSize = imageStorage.ThumbnailSize,
+            Size = imageStorage.Size,
             LastChecked = imageStorage.LastChecked,
             CheckingInProgress = imageStorage.CheckingInProgress,
         };

--- a/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
+++ b/src/protagonist/API/Features/Storage/Converters/ImageStorageConverter.cs
@@ -1,0 +1,18 @@
+﻿namespace API.Features.Storage.Converters;
+
+public static class ImageStorageConverter
+{
+    public static DLCS.HydraModel.ImageStorage ToHydra(this DLCS.Model.Assets.ImageStorage imageStorage, string baseUrl)
+    {
+        var hydraImageStorage = new DLCS.HydraModel.ImageStorage(baseUrl, imageStorage.Customer,
+            imageStorage.Space, imageStorage.Id.Asset)
+        {
+            ThumbnailSize = (int)imageStorage.ThumbnailSize,
+            Size = (int)imageStorage.Size,
+            LastChecked = imageStorage.LastChecked,
+            CheckingInProgress = imageStorage.CheckingInProgress,
+        };
+        
+        return hydraImageStorage;
+    }
+}

--- a/src/protagonist/API/Features/Storage/Requests/GetCustomerStorage.cs
+++ b/src/protagonist/API/Features/Storage/Requests/GetCustomerStorage.cs
@@ -19,7 +19,8 @@ public class GetCustomerStorage : IRequest<FetchEntityResult<CustomerStorage>>
 public class GetCustomerStorageHandler : IRequestHandler<GetCustomerStorage, FetchEntityResult<CustomerStorage>>
 {
     private readonly DlcsContext dbContext;
-
+    private const int DefaultStorageId = 0;
+    
     public GetCustomerStorageHandler(DlcsContext dbContext)
     {
         this.dbContext = dbContext;
@@ -28,7 +29,7 @@ public class GetCustomerStorageHandler : IRequestHandler<GetCustomerStorage, Fet
     public async Task<FetchEntityResult<CustomerStorage>> Handle(GetCustomerStorage request, CancellationToken cancellationToken)
     {
         var storage = await dbContext.CustomerStorages.AsNoTracking()
-            .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Space == 0, 
+            .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Space == DefaultStorageId, 
                 cancellationToken: cancellationToken);
         
         return storage == null

--- a/src/protagonist/API/Features/Storage/Requests/GetCustomerStorage.cs
+++ b/src/protagonist/API/Features/Storage/Requests/GetCustomerStorage.cs
@@ -1,0 +1,38 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Storage.Requests;
+
+public class GetCustomerStorage : IRequest<FetchEntityResult<CustomerStorage>>
+{
+    public int CustomerId { get; }
+    
+    public GetCustomerStorage(int customerId)
+    {
+        CustomerId = customerId;
+    }
+}
+
+public class GetCustomerStorageHandler : IRequestHandler<GetCustomerStorage, FetchEntityResult<CustomerStorage>>
+{
+    private readonly DlcsContext dbContext;
+
+    public GetCustomerStorageHandler(DlcsContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public async Task<FetchEntityResult<CustomerStorage>> Handle(GetCustomerStorage request, CancellationToken cancellationToken)
+    {
+        var storage = await dbContext.CustomerStorages.AsNoTracking()
+            .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Space == 0, 
+                cancellationToken: cancellationToken);
+        
+        return storage == null
+            ? FetchEntityResult<CustomerStorage>.NotFound()
+            : FetchEntityResult<CustomerStorage>.Success(storage);
+    }
+}

--- a/src/protagonist/API/Features/Storage/Requests/GetImageStorage.cs
+++ b/src/protagonist/API/Features/Storage/Requests/GetImageStorage.cs
@@ -34,7 +34,7 @@ public class GetImageStorageHandler : IRequestHandler<GetImageStorage, FetchEnti
 
     public async Task<FetchEntityResult<ImageStorage>> Handle(GetImageStorage request, CancellationToken cancellationToken)
     {
-        var assetId = AssetId.FromString($"{request.CustomerId}/{request.SpaceId}/{request.ImageId}");
+        var assetId = new AssetId(request.CustomerId, request.SpaceId, request.ImageId);
         var storage = await dbContext.ImageStorages.AsNoTracking()
             .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Id == assetId,
                 cancellationToken: cancellationToken);

--- a/src/protagonist/API/Features/Storage/Requests/GetImageStorage.cs
+++ b/src/protagonist/API/Features/Storage/Requests/GetImageStorage.cs
@@ -1,0 +1,46 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Storage.Requests;
+
+public class GetImageStorage : IRequest<FetchEntityResult<ImageStorage>>
+{
+    public int CustomerId { get; }
+    
+    public int SpaceId { get; }
+    
+    public string ImageId { get; }
+    
+    public GetImageStorage(int customerId, int spaceId, string imageId)
+    {
+        CustomerId = customerId;
+        SpaceId = spaceId;
+        ImageId = imageId;
+    }
+}
+
+public class GetImageStorageHandler : IRequestHandler<GetImageStorage, FetchEntityResult<ImageStorage>>
+{
+    private readonly DlcsContext dbContext;
+
+    public GetImageStorageHandler(DlcsContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public async Task<FetchEntityResult<ImageStorage>> Handle(GetImageStorage request, CancellationToken cancellationToken)
+    {
+        var assetId = AssetId.FromString($"{request.CustomerId}/{request.SpaceId}/{request.ImageId}");
+        var storage = await dbContext.ImageStorages.AsNoTracking()
+            .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Id == assetId,
+                cancellationToken: cancellationToken);
+        
+        return storage == null
+            ? FetchEntityResult<ImageStorage>.NotFound()
+            : FetchEntityResult<ImageStorage>.Success(storage);
+    }
+}

--- a/src/protagonist/API/Features/Storage/Requests/GetSpaceStorage.cs
+++ b/src/protagonist/API/Features/Storage/Requests/GetSpaceStorage.cs
@@ -1,0 +1,41 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Storage.Requests;
+
+public class GetSpaceStorage : IRequest<FetchEntityResult<CustomerStorage>>
+{
+    public int CustomerId { get; }
+    
+    public int SpaceId { get; }
+    
+    public GetSpaceStorage(int customerId, int spaceId)
+    {
+        CustomerId = customerId;
+        SpaceId = spaceId;
+    }
+}
+
+public class GetSpaceStorageHandler : IRequestHandler<GetSpaceStorage, FetchEntityResult<CustomerStorage>>
+{
+    private readonly DlcsContext dbContext;
+
+    public GetSpaceStorageHandler(DlcsContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+
+    public async Task<FetchEntityResult<CustomerStorage>> Handle(GetSpaceStorage request, CancellationToken cancellationToken)
+    {
+        var storage = await dbContext.CustomerStorages.AsNoTracking()
+            .SingleOrDefaultAsync(s => s.Customer == request.CustomerId && s.Space == request.SpaceId, 
+                cancellationToken: cancellationToken);
+        
+        return storage == null
+            ? FetchEntityResult<CustomerStorage>.NotFound()
+            : FetchEntityResult<CustomerStorage>.Success(storage);
+    }
+}

--- a/src/protagonist/API/Features/Storage/StorageController.cs
+++ b/src/protagonist/API/Features/Storage/StorageController.cs
@@ -27,7 +27,7 @@ public class StorageController : HydraController
     [Route("/customers/{customerId}/spaces/{spaceId}/images/{imageId}/storage")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetSpaceImageStorage(
+    public async Task<IActionResult> GetImageStorage(
         [FromRoute] int customerId,
         [FromRoute] int spaceId,
         [FromRoute] string imageId,

--- a/src/protagonist/API/Features/Storage/StorageController.cs
+++ b/src/protagonist/API/Features/Storage/StorageController.cs
@@ -21,7 +21,7 @@ public class StorageController : HydraController
     }
 
     /// <summary>
-    /// Gets the storage of an image within a customer's space
+    /// Gets the storage object of an image within a customer's space
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/spaces/{spaceId}/images/{imageId}/storage")]
@@ -42,7 +42,7 @@ public class StorageController : HydraController
     }
     
     /// <summary>
-    /// Gets the storage of a customer's space
+    /// Get the storage object of a customer's space
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/spaces/{spaceId}/storage")]
@@ -62,7 +62,7 @@ public class StorageController : HydraController
     }
     
     /// <summary>
-    /// Get the customer's default storage
+    /// Get the customer's default storage object
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/storage")]

--- a/src/protagonist/API/Features/Storage/StorageController.cs
+++ b/src/protagonist/API/Features/Storage/StorageController.cs
@@ -1,0 +1,82 @@
+﻿using API.Features.Storage.Converters;
+using API.Features.Storage.Requests;
+using API.Infrastructure;
+using API.Settings;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Storage;
+
+/// <summary>
+/// DLCS REST API Operations for customer storage objects
+/// </summary>
+public class StorageController : HydraController
+{
+    public StorageController(
+        IMediator mediator,
+        IOptions<ApiSettings> settings) : base(settings.Value, mediator)
+    {
+    }
+
+    /// <summary>
+    /// Gets the storage of an image within a customer's space
+    /// </summary>
+    [HttpGet]
+    [Route("/customers/{customerId}/spaces/{spaceId}/images/{imageId}/storage")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetSpaceImageStorage(
+        [FromRoute] int customerId,
+        [FromRoute] int spaceId,
+        [FromRoute] string imageId,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetImageStorage(customerId, spaceId, imageId);
+        
+        return await HandleFetch(request, 
+            s => s.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Failed to get storage from image",
+            cancellationToken: cancellationToken);
+    }
+    
+    /// <summary>
+    /// Gets the storage of a customer's space
+    /// </summary>
+    [HttpGet]
+    [Route("/customers/{customerId}/spaces/{spaceId}/storage")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetSpaceStorage(
+        [FromRoute] int customerId,
+        [FromRoute] int spaceId,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetSpaceStorage(customerId, spaceId);
+        
+        return await HandleFetch(request, 
+            s => s.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Failed to get storage from space",
+            cancellationToken: cancellationToken);
+    }
+    
+    /// <summary>
+    /// Get the customer's default storage
+    /// </summary>
+    [HttpGet]
+    [Route("/customers/{customerId}/storage")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetCustomerStorage(
+        [FromRoute] int customerId,
+        CancellationToken cancellationToken)
+    {
+        var request = new GetCustomerStorage(customerId);
+        
+        return await HandleFetch(request, 
+            s => s.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Failed to get storage",
+            cancellationToken: cancellationToken);
+    }
+}

--- a/src/protagonist/API/Features/Storage/StorageController.cs
+++ b/src/protagonist/API/Features/Storage/StorageController.cs
@@ -37,7 +37,7 @@ public class StorageController : HydraController
         
         return await HandleFetch(request, 
             s => s.ToHydra(GetUrlRoots().BaseUrl),
-            errorTitle: "Failed to get storage from image",
+            errorTitle: "Failed to get storage for image",
             cancellationToken: cancellationToken);
     }
     
@@ -57,7 +57,7 @@ public class StorageController : HydraController
         
         return await HandleFetch(request, 
             s => s.ToHydra(GetUrlRoots().BaseUrl),
-            errorTitle: "Failed to get storage from space",
+            errorTitle: "Failed to get storage for space",
             cancellationToken: cancellationToken);
     }
     

--- a/src/protagonist/DLCS.HydraModel/ImageStorage.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageStorage.cs
@@ -34,12 +34,12 @@ public class ImageStorage : DlcsResource
     [RdfProperty(Description = "Storage space taken up by this item's thumbnails",
         Range = Names.XmlSchema.NonNegativeInteger, ReadOnly = true, WriteOnly = false)]
     [JsonProperty(Order = 53, PropertyName = "thumbnailSize")]
-    public int ThumbnailSize { get; set; }
+    public long ThumbnailSize { get; set; }
 
     [RdfProperty(Description = "Storage space taken up by the DLCS artifacts for this item",
         Range = Names.XmlSchema.NonNegativeInteger, ReadOnly = true, WriteOnly = false)]
     [JsonProperty(Order = 54, PropertyName = "size")]
-    public int Size { get; set; }
+    public long Size { get; set; }
 
     [RdfProperty(Description = "When these figures were last computed",
         Range = Names.XmlSchema.DateTime, ReadOnly = true, WriteOnly = false)]


### PR DESCRIPTION
Resolves #543

Additions:

- A controller (+ tests) for reading storage objects, with the following endpoints:
  - `/customers/{customer}/spaces/{space}/images/{image}/storage`
  - `/customers/{customer}/spaces/{space}/storage`
  - `/customers/{customer}/storage`
- Classes for converting `CustomerStorage` and `ImageStorage` into their Hydra equivalents
