### PR TITLE
Return correct `@id` value in `GET /imageOptimisationPolicies`

### DIFF
--- a/src/protagonist/DLCS.HydraModel/ImageOptimisationPolicy.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageOptimisationPolicy.cs
@@ -26,7 +26,7 @@ public class ImageOptimisationPolicy : DlcsResource
         string technicalDetails, bool global, int? customerId)
     {
         ModelId = imageOptimisationPolicyId;
-        if (customerId.HasValue)
+        if (customerId.HasValue && !global)
         {
             Init(baseUrl, true, customerId, imageOptimisationPolicyId);
         }


### PR DESCRIPTION
Fixes #525

This changes the `ImageOptimisationPolicy` Hydra model so that global polices do not contain the customer's ID in the `@id` path.