### PR TITLE
Refresh customer cache on API key creation

### DIFF
--- a/src/protagonist/API.Tests/Integration/PolicyTests.cs
+++ b/src/protagonist/API.Tests/Integration/PolicyTests.cs
@@ -79,7 +79,7 @@ public class PolicyTests : IClassFixture<ProtagonistAppFactory<Startup>>
         {
             Customer = customerId,
             Id = "customer-specific-policy-example",
-            Name = "Customer Specific Policy",
+            Name = "Global Policy",
             TechnicalDetails = new[] { "Nothing yet" },
             Global = false
         };

--- a/src/protagonist/API/Features/Customer/Requests/CreateApiKey.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateApiKey.cs
@@ -1,6 +1,7 @@
 using API.Auth;
 using DLCS.Core.Collections;
 using DLCS.Repository;
+using LazyCache;
 using MediatR;
 
 namespace API.Features.Customer.Requests;
@@ -19,13 +20,16 @@ public class CreateApiKeyHandler : IRequestHandler<CreateApiKey, CreateApiKeyRes
 {
     private readonly DlcsContext dbContext;
     private readonly ApiKeyGenerator apiKeyGenerator;
+    private readonly IAppCache appCache;
     
     public CreateApiKeyHandler(
         DlcsContext dbContext,
-        ApiKeyGenerator apiKeyGenerator)
+        ApiKeyGenerator apiKeyGenerator,
+        IAppCache appCache)
     {
         this.dbContext = dbContext;
         this.apiKeyGenerator = apiKeyGenerator;
+        this.appCache = appCache;
     }
     
     public async Task<CreateApiKeyResult> Handle(CreateApiKey request, CancellationToken cancellationToken)
@@ -36,16 +40,17 @@ public class CreateApiKeyHandler : IRequestHandler<CreateApiKey, CreateApiKeyRes
         {
             return CreateApiKeyResult.Fail("Insufficient data to create key");
         }
-
+        
         var (apiKey, apiSecret) = apiKeyGenerator.CreateApiKey(customer);
         
         customer.Keys = StringArrays.EnsureString(customer.Keys, apiKey);
         var i = await dbContext.SaveChangesAsync(cancellationToken);
         if (i == 1)
         {
+            appCache.Remove($"cust:{request.CustomerId}");
             return CreateApiKeyResult.Success(apiKey, apiSecret);
         }
-
+        
         return CreateApiKeyResult.Fail("Unable to save new ApiKey");
     }
 }

--- a/src/protagonist/API/Features/Customer/Requests/CreateApiKey.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateApiKey.cs
@@ -47,7 +47,7 @@ public class CreateApiKeyHandler : IRequestHandler<CreateApiKey, CreateApiKeyRes
         var i = await dbContext.SaveChangesAsync(cancellationToken);
         if (i == 1)
         {
-            appCache.Remove($"cust:{request.CustomerId}");
+            appCache.Remove(CacheKeys.Customer(request.CustomerId));
             return CreateApiKeyResult.Success(apiKey, apiSecret);
         }
         

--- a/src/protagonist/DLCS.Repository/CacheKeys.cs
+++ b/src/protagonist/DLCS.Repository/CacheKeys.cs
@@ -1,0 +1,9 @@
+﻿namespace DLCS.Repository;
+
+/// <summary>
+/// Class for managing commonly used cache keys
+/// </summary>
+public static class CacheKeys
+{
+    public static string Customer(int customerId) => $"cust:{customerId}";
+}

--- a/src/protagonist/DLCS.Repository/Customers/DapperCustomerRepository.cs
+++ b/src/protagonist/DLCS.Repository/Customers/DapperCustomerRepository.cs
@@ -77,7 +77,7 @@ public class DapperCustomerRepository : IDapperConfigRepository, ICustomerReposi
 
     private Task<Customer> GetCustomerInternal(int customerId)
     {
-        var key = $"cust:{customerId}";
+        var key = CacheKeys.Customer(customerId);
         return appCache.GetOrAddAsync(key, async entry =>
         {
             const string sql = CustomerSelect + @" WHERE ""Id""=@Id;";


### PR DESCRIPTION
Fixes #388

`CreateApiKey` clears the user's cache after generating an API key.