### PR TITLE
Use Fluent validation in Image Batch PATCH operations

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using API.Features.Image.Validation;
+using API.Settings;
+using DLCS.HydraModel;
+using FluentValidation.TestHelper;
+using Hydra.Collections;
+using Microsoft.Extensions.Options;
+
+namespace API.Tests.Features.Images.Validation;
+
+public class ImageBatchPatchValidatorTests
+{
+    private readonly ImageBatchPatchValidator sut;
+
+    public ImageBatchPatchValidatorTests()
+    {
+        var apiSettings = new ApiSettings { MaxBatchSize = 4 };
+        sut = new ImageBatchPatchValidator(Options.Create(apiSettings));
+    }
+    
+    [Fact]
+    public void Members_Null()
+    {
+        var model = new HydraCollection<Image>();
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members);
+    }
+    
+    [Fact]
+    public void Members_Empty()
+    {
+        var model = new HydraCollection<Image> { Members = Array.Empty<Image>() };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members);
+    }
+
+    [Fact]
+    public void Members_GreaterThanMaxBatchSize()
+    {
+        var model = new HydraCollection<Image>
+        {
+            Members = new[]
+            {
+                new Image { ModelId = "1/2/f" },
+                new Image { ModelId = "1/2/fo" },
+                new Image { ModelId = "1/2/foo" },
+                new Image { ModelId = "1/2/bar" },
+                new Image { ModelId = "1/2/baz" },
+            }
+        };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(r => r.Members)
+            .WithErrorMessage("Maximum assets in single batch is 4");
+    }
+    
+    [Fact]
+    public void Members_EqualMaxBatchSize_Valid()
+    {
+        var model = new HydraCollection<Image>
+        {
+            Members = new[]
+            {
+                new Image { ModelId = "1/2/fo" },
+                new Image { ModelId = "1/2/foo" },
+                new Image { ModelId = "1/2/bar" },
+                new Image { ModelId = "1/2/baz" },
+            }
+        };
+        var result = sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(r => r.Members);
+    }
+
+    [Fact]
+    public void Members_ContainsDuplicateIds()
+    {
+        var model = new HydraCollection<Image>
+        {
+            Members = new[]
+            {
+                new Image { ModelId = "1/2/foo" },
+                new Image { ModelId = "1/2/bar" },
+                new Image { ModelId = "1/2/foo" },
+            }
+        };
+        var result = sut.TestValidate(model);
+        result
+            .ShouldHaveValidationErrorFor(r => r.Members)
+            .WithErrorMessage("Members contains 1 duplicate Id(s): 1/2/foo");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Member_ModelId_NullOrEmpty(string id)
+    {
+        var model = new HydraCollection<Image> { Members = new[] { new Image { ModelId = id } } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].ModelId");
+    }
+    
+    [Fact]
+    public void Member_Origin_Provided()
+    {
+        var model = new HydraCollection<Image> { Members = new[]
+        {
+            new Image { Origin = "https://example.com/images/example-image.jpg" }
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].Origin");
+    }
+    
+    [Fact]
+    public void Member_ImageOptimisationPolicy_Provided()
+    {
+        var model = new HydraCollection<Image> { Members = new[]
+        {
+            new Image { ImageOptimisationPolicy = "example-policy" }
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].ImageOptimisationPolicy");
+    }
+    
+    [Fact]
+    public void Member_MaxUnauthorised_Provided()
+    {
+        var model = new HydraCollection<Image> { Members = new[]
+        {
+            new Image { MaxUnauthorised = 200 }
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].MaxUnauthorised");
+    }
+    
+    [Fact]
+    public void Member_DeliveryChannels_Provided()
+    {
+        var model = new HydraCollection<Image> { Members = new[]
+        {
+            new Image { DeliveryChannels = new []{"iiif-img","thumbs"}}
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].DeliveryChannels");
+    }
+}

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -818,6 +818,31 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         img12.Reference1.Should().Be("Asset 12 patched");
         img12.Reference3.Should().Be("Asset 12 string3 added");
     }
+    
+    [Theory]
+    [InlineData("origin","https://example.com/images/example-image.jpg")]
+    [InlineData("imageOptimisationPolicy","example-policy")]
+    [InlineData("maxUnauthorised","200")]
+    [InlineData("deliveryChannel","[\"iiif-img\",\"thumbs\"]")]
+    public async Task Patch_Images_Returns400_IfReingestRequired(string field, string value)
+    {
+        var hydraCollectionBody = $@"{{
+          ""@type"": ""Collection"",
+          ""member"": [
+           {{
+                ""@type"": ""Image"",
+                ""id"": ""asset-0000"",
+                ""{field}"": ""{value}""
+           }}]
+        }}";
+        
+        // act
+        var content = new StringContent(hydraCollectionBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PatchAsync("/customers/99/spaces/3003/images", content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 
     [Fact]
     public async Task Bulk_Patch_Prevents_Engine_Call()

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -826,6 +826,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [InlineData("deliveryChannel","[\"iiif-img\",\"thumbs\"]")]
     public async Task Patch_Images_Returns400_IfReingestRequired(string field, string value)
     {
+        // arrange
         var hydraCollectionBody = $@"{{
           ""@type"": ""Collection"",
           ""member"": [
@@ -838,12 +839,33 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // act
         var content = new StringContent(hydraCollectionBody, Encoding.UTF8, "application/json");
-        var response = await httpClient.AsCustomer(99).PatchAsync("/customers/99/spaces/3003/images", content);
+        var response = await httpClient.AsCustomer(99).PatchAsync("/customers/99/spaces/1/images", content);
         
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
-
+    
+    [Fact]
+    public async Task Patch_Images_Returns400_IfMemberIdMissing()
+    {
+        // arrange
+        var hydraCollectionBody = $@"{{
+          ""@type"": ""Collection"",
+          ""member"": [
+           {{
+                ""@type"": ""Image"",
+                ""string1"": ""Example""
+           }}]
+        }}";
+        
+        // act
+        var content = new StringContent(hydraCollectionBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PatchAsync("/customers/99/spaces/1/images", content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
     [Fact]
     public async Task Bulk_Patch_Prevents_Engine_Call()
     {

--- a/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
@@ -1,0 +1,41 @@
+﻿using API.Settings;
+using DLCS.Core.Collections;
+using FluentValidation;
+using Hydra.Collections;
+using Microsoft.Extensions.Options;
+
+namespace API.Features.Image.Validation;
+
+/// <summary>
+/// Validator for model sent to PATCH /customers/{customerId}/spaces/{spaceId}/images
+/// </summary>
+public class ImageBatchPatchValidator : AbstractValidator<HydraCollection<DLCS.HydraModel.Image>>
+{
+    public ImageBatchPatchValidator(IOptions<ApiSettings> apiSettings)
+    {
+        RuleFor(c => c.Members)
+            .NotEmpty().WithMessage("Members cannot be empty");
+        
+        RuleFor(c => c.Members)
+            .Must(m => m.IsNullOrEmpty() || m!.Select(a => a.ModelId).Distinct().Count() == m!.Length)
+            .WithMessage((_, mem) =>
+            {
+                var dupes = mem!.Select(a => a.ModelId).GetDuplicates().ToList();
+                return $"Members contains {dupes.Count} duplicate Id(s): {string.Join(",", dupes)}";
+            });
+
+        var maxBatch = apiSettings.Value.MaxBatchSize;
+        RuleFor(c => c.Members)
+            .Must(m => (m?.Length ?? 0) <= maxBatch)
+            .WithMessage($"Maximum assets in single batch is {maxBatch}");
+        
+        RuleForEach(c => c.Members).ChildRules(members =>
+        {
+            members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("All assets require a ModelId");
+            members.RuleFor(a => a.Origin).Empty().WithMessage("Origin cannot be set in a bulk patching operation");
+            members.RuleFor(a => a.ImageOptimisationPolicy).Empty().WithMessage("Image optimisation policies cannot be set in a bulk patching operations");
+            members.RuleFor(a => a.MaxUnauthorised).Empty().WithMessage("MaxUnauthorised cannot be set in a bulk patching operation");
+            members.RuleFor(a => a.DeliveryChannels).Empty().WithMessage("Delivery channels cannot be set in a bulk patching operation");
+        });
+    }
+}

--- a/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
@@ -33,7 +33,7 @@ public class ImageBatchPatchValidator : AbstractValidator<HydraCollection<DLCS.H
         {
             members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("All assets require a ModelId");
             members.RuleFor(a => a.Origin).Empty().WithMessage("Origin cannot be set in a bulk patching operation");
-            members.RuleFor(a => a.ImageOptimisationPolicy).Empty().WithMessage("Image optimisation policies cannot be set in a bulk patching operations");
+            members.RuleFor(a => a.ImageOptimisationPolicy).Empty().WithMessage("Image optimisation policies cannot be set in a bulk patching operation");
             members.RuleFor(a => a.MaxUnauthorised).Empty().WithMessage("MaxUnauthorised cannot be set in a bulk patching operation");
             members.RuleFor(a => a.DeliveryChannels).Empty().WithMessage("Delivery channels cannot be set in a bulk patching operation");
         });


### PR DESCRIPTION
Resolves #472

`ImagesController` now uses a `ImageBatchPatchValidator` class to validate batch PATCH requests.
Additionally, attempting to change the delivery channel of an image via this request now returns a 400 Bad Request error.