### PR TITLE
Do not include query params on info.json id prop

### DIFF
--- a/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Requests/GetImageInfoJson.cs
@@ -165,7 +165,7 @@ public class GetImageInfoJsonHandler : IRequestHandler<GetImageInfoJson, Descrip
         
         // We want the image id only, without "/info.json"
         baseRequest.AssetPath = request.AssetRequest.AssetId;
-        return assetPathGenerator.GetFullPathForRequest(baseRequest);
+        return assetPathGenerator.GetFullPathForRequest(baseRequest, includeQueryParams: false);
     }
 
     private void SetServiceIdProperties(AssetId assetId, List<IService>? services)


### PR DESCRIPTION
Issue encountered where requests for `https://dlcs.example/iiif-img/1/1/foo/info.json?query=param` would result in info.json having `"id" : "https://dlcs.example/iiif-img/1/1/foo?query=param"`.

This fix updates `GetImageInfoJson` handler to exclude query params so resulting id for above would be `"id" : "https://dlcs.example/iiif-img/1/1/foo"`.