### PR TITLE
Allow batches to be viewed individually in Portal

### DIFF
--- a/src/protagonist/API.Client/DlcsClient.cs
+++ b/src/protagonist/API.Client/DlcsClient.cs
@@ -255,6 +255,22 @@ public class DlcsClient : IDlcsClient
         return batches; 
     }
 
+    public async Task<Batch> GetBatch(int batchId)
+    {
+        var url = $"customers/{currentUser.GetCustomerId()}/queue/batches/{batchId}";
+        var response = await httpClient.GetAsync(url);
+        var batch = await response.ReadAsHydraResponseAsync<Batch>(jsonSerializerSettings);
+        return batch;  
+    }
+
+    public async Task<HydraCollection<Image>> GetBatchImages(int batchId)
+    {
+        var url = $"customers/{currentUser.GetCustomerId()}/queue/batches/{batchId}/images";
+        var response = await httpClient.GetAsync(url);
+        var batchImages = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>(jsonSerializerSettings);
+        return batchImages;      
+    }
+
     public async Task<CustomerQueue> GetQueue()
     {
         var url = $"customers/{currentUser.GetCustomerId()}/queue";

--- a/src/protagonist/API.Client/IDlcsClient.cs
+++ b/src/protagonist/API.Client/IDlcsClient.cs
@@ -27,5 +27,7 @@ public interface IDlcsClient
     Task<Image> PatchImage(Image image, int spaceId, string imageId);
     Task<HydraCollection<Image>> PatchImages(HydraCollection<Image> images, int spaceId);
     Task<HydraCollection<Batch>> GetBatches(string type, int page, int pageSize);
+    Task<Batch> GetBatch(int batchId);
+    Task<HydraCollection<Image>> GetBatchImages(int batchId);
     Task<CustomerQueue> GetQueue();
 }

--- a/src/protagonist/Portal/Features/Batches/Requests/GetBatch.cs
+++ b/src/protagonist/Portal/Features/Batches/Requests/GetBatch.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using API.Client;
 using DLCS.Core.Settings;
 using DLCS.HydraModel;
+using DLCS.Web.Auth;
 using Hydra.Collections;
 using MediatR;
 using Microsoft.Extensions.Options;
@@ -28,13 +30,13 @@ public class GetBatchHandler : IRequestHandler<GetBatch, GetBatchResult>
 {
     private readonly DlcsSettings dlcsSettings;
     private readonly IDlcsClient dlcsClient;
-    private readonly HttpClient httpClient;
+    private readonly string customerId;
     
-    public GetBatchHandler(IDlcsClient dlcsClient, HttpClient httpClient, IOptions<DlcsSettings> dlcsSettings)
+    public GetBatchHandler(IDlcsClient dlcsClient, ClaimsPrincipal currentUser, IOptions<DlcsSettings> dlcsSettings)
     {
         this.dlcsClient = dlcsClient;
-        this.httpClient = httpClient;
         this.dlcsSettings = dlcsSettings.Value;
+        customerId = (currentUser.GetCustomerId() ?? -1).ToString();
     }
 
     public async Task<GetBatchResult> Handle(GetBatch request, CancellationToken cancellationToken)
@@ -46,7 +48,7 @@ public class GetBatchHandler : IRequestHandler<GetBatch, GetBatchResult>
         foreach (var image in images.Members)
         {
             var thumbnailSrc = new Uri(dlcsSettings.ResourceRoot, 
-                $"thumbs/27/{image.Space}/{image.ModelId}/full/full/0/default.jpg").ToString();
+                $"thumbs/{customerId}/{image.Space}/{image.ModelId}/full/full/0/default.jpg").ToString();
             thumbnails.Add(image.ModelId, thumbnailSrc);
         }
         

--- a/src/protagonist/Portal/Features/Batches/Requests/GetBatch.cs
+++ b/src/protagonist/Portal/Features/Batches/Requests/GetBatch.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Client;
+using DLCS.Core.Settings;
+using DLCS.HydraModel;
+using Hydra.Collections;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Portal.Features.Batches.Requests;
+
+public class GetBatch : IRequest<GetBatchResult>
+{
+    public int BatchId { get; set; }
+}
+
+public class GetBatchResult
+{
+    public Batch Batch { get; set; }
+    public HydraCollection<Image> Images { get; set; }
+    public Dictionary<string, string> Thumbnails { get; set; }
+}
+
+public class GetBatchHandler : IRequestHandler<GetBatch, GetBatchResult>
+{
+    private readonly DlcsSettings dlcsSettings;
+    private readonly IDlcsClient dlcsClient;
+    private readonly HttpClient httpClient;
+    
+    public GetBatchHandler(IDlcsClient dlcsClient, HttpClient httpClient, IOptions<DlcsSettings> dlcsSettings)
+    {
+        this.dlcsClient = dlcsClient;
+        this.httpClient = httpClient;
+        this.dlcsSettings = dlcsSettings.Value;
+    }
+
+    public async Task<GetBatchResult> Handle(GetBatch request, CancellationToken cancellationToken)
+    {
+        var batch = await dlcsClient.GetBatch(request.BatchId);
+        var images = await dlcsClient.GetBatchImages(request.BatchId);
+        var thumbnails = new Dictionary<string, string>();
+        
+        foreach (var image in images.Members)
+        {
+            var thumbnailSrc = new Uri(dlcsSettings.ResourceRoot, 
+                $"thumbs/27/{image.Space}/{image.ModelId}/full/full/0/default.jpg").ToString();
+            thumbnails.Add(image.ModelId, thumbnailSrc);
+        }
+        
+        return new GetBatchResult() {
+            Batch = batch,
+            Images = images,
+            Thumbnails = thumbnails
+        };
+    }
+}

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@page "{batch}"
 @using Hydra
 @using DLCS.Model.Assets
+@using AssetFamily = DLCS.HydraModel.AssetFamily
 @model Portal.Pages.Batches.Index
 
 @{
@@ -17,7 +18,7 @@
             <div class="row px-2">
                 <div class="alert alert-danger" role="alert">
                     <i class="me-2" data-feather="alert-circle"></i><strong>Error!</strong>
-                    This batch contains @Model.Batch.Errors image@(Model.Batch.Errors > 1 ? "s" : null) that could not be processed
+                    This batch contains @Model.Batch.Errors image@(Model.Batch.Errors > 1 ? "s" : null) with errors
                 </div>
             </div>
         }
@@ -76,6 +77,30 @@
                                 <div class="spinner-border text-muted m-auto"></div>
                             </div>
                         </div>   
+                    }
+                    else if (image.Family == AssetFamily.Timebased)
+                    {
+                        <div class="card m-auto">
+                            <div class="card-body">
+                                  <i class="text-secondary" data-feather="film"></i>
+                            </div>
+                        </div>                           
+                    }
+                    else if (image.Family == AssetFamily.File)
+                    {
+                        <div class="card m-auto">
+                            <div class="card-body">
+                                <i class="text-secondary" data-feather="save"></i>
+                            </div>
+                        </div>                           
+                    }
+                    else if (image.Roles.Any())
+                    {
+                        <div class="card m-auto">
+                            <div class="card-body">
+                                <i class="text-secondary" data-feather="lock"></i>
+                            </div>
+                        </div>  
                     }
                     else
                     {

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -60,7 +60,7 @@
         @foreach (var image in Model.Images.Members)
         {
             <div class="p-4 d-flex flex-column" style="width:20%; min-width: 128px;">
-                <a href="/images/@image.Space/@image.ModelId" class="flex-grow-1 align-items-center d-flex mb-1">
+                <a asp-page="/Images/Index" asp-route-space="@image.Space" asp-route-image="@image.ModelId" class="flex-grow-1 align-items-center d-flex mb-1">
                     @if (!string.IsNullOrEmpty(image.Error) || !Model.Thumbnails.ContainsKey(image.ModelId))
                     {
                         <div class="card m-auto">

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -49,16 +49,19 @@
                 }
             </div>
         </div>
-        Completed: @Model.Batch.Finished
+        @if (Model.Batch.Finished != null)
+        {
+            <span>Completed: @Model.Batch.Finished</span>
+        }
     </div>
 </div>
 <div class="row m-1 justify-content-center">
     <div class="row">
         @foreach (var image in Model.Images.Members)
         {
-            <div class="p-4 d-flex flex-column" style="width:20%">
+            <div class="p-4 d-flex flex-column" style="width:20%; min-width: 128px;">
                 <a href="/images/@image.Space/@image.ModelId" class="flex-grow-1 align-items-center d-flex mb-1">
-                    @if (!string.IsNullOrEmpty(image.Error))
+                    @if (!string.IsNullOrEmpty(image.Error) || !Model.Thumbnails.ContainsKey(image.ModelId))
                     {
                         <div class="card m-auto">
                             <div class="card-body">
@@ -66,7 +69,7 @@
                             </div>
                         </div>
                     }
-                    else if (image.Ingesting.Value)
+                    else if (image.Ingesting == true)
                     {
                         <div class="card m-auto">
                             <div class="card-body">

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -1,0 +1,55 @@
+﻿@page "{batch}"
+@using Hydra
+@using DLCS.Model.Assets
+@model Portal.Pages.Batches.Index
+
+@{
+    var batchId = Model.Batch.Id.GetLastPathElement();
+    var percentComplete = Math.Round(Model.Batch.Count > 0 ? (double)Model.Batch.Completed / (double)Model.Batch.Count * 100.0 : 1.0);
+    var progressPct = Model.Batch.Finished.HasValue ? 100 : percentComplete;
+    ViewData["Title"] = $"Batch {batchId} - {Model.Batch.Count} images";
+}
+
+<div class="card w-100">
+    <div class="card-body">
+        <div class="row mb-2">
+            <div class="col-sm">
+                Completion: @percentComplete% (@Model.Batch.Completed/@Model.Batch.Count)
+            </div>
+            <div class="col-sm">
+                <div class="progress h-100">
+                    <div class="progress-bar bg-success" role="progressbar" style="width: @progressPct%;" aria-valuenow="@progressPct" aria-valuemin="0" aria-valuemax="100">@progressPct%</div>
+                </div>
+            </div>
+            <div class="col-sm">
+                @if (Model.Batch.Finished > DateTime.MinValue)
+                {
+                    <span class="badge bg-success float-end">Finished</span>
+                }
+                else if (Model.Batch.Completed == 0)
+                {
+                    <span class="badge bg-primary float-end">Waiting</span>
+                }
+                else if (Model.Batch.Errors == 0)
+                {
+                    <span class="badge bg-warning float-end">In progress</span>
+                }
+                else
+                {
+                    <span class="badge bg-danger float-end">Errors</span>
+                }
+            </div>
+        </div>
+        Completed: @Model.Batch.Finished
+    </div>
+</div>
+<div class="row m-1">
+    @foreach(var image in Model.Images.Members)
+    {
+        <div class="p-4" style="width:20%">
+            <a href="/images/@image.Space/@image.ModelId">
+                <img src="@Model.Thumbnails[image.ModelId]" class="img-thumbnail rounded mx-auto d-block" style="max-height:256px;"/>
+            </a>
+        </div>
+    }
+</div>

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -12,6 +12,15 @@
 
 <div class="card w-100">
     <div class="card-body">
+        @if (Model.Batch.Errors > 0)
+        {
+            <div class="row px-2">
+                <div class="alert alert-danger" role="alert">
+                    <i class="me-2" data-feather="alert-circle"></i><strong>Error!</strong>
+                    This batch contains @Model.Batch.Errors image@(Model.Batch.Errors > 1 ? "s" : null) that could not be processed
+                </div>
+            </div>
+        }
         <div class="row mb-2">
             <div class="col-sm">
                 Completion: @percentComplete% (@Model.Batch.Completed/@Model.Batch.Count)
@@ -43,13 +52,37 @@
         Completed: @Model.Batch.Finished
     </div>
 </div>
-<div class="row m-1">
-    @foreach(var image in Model.Images.Members)
-    {
-        <div class="p-4" style="width:20%">
-            <a href="/images/@image.Space/@image.ModelId">
-                <img src="@Model.Thumbnails[image.ModelId]" class="img-thumbnail rounded mx-auto d-block" style="max-height:256px;"/>
-            </a>
-        </div>
-    }
+<div class="row m-1 justify-content-center">
+    <div class="row">
+        @foreach (var image in Model.Images.Members)
+        {
+            <div class="p-4 d-flex flex-column" style="width:20%">
+                <a href="/images/@image.Space/@image.ModelId" class="flex-grow-1 align-items-center d-flex mb-1">
+                    @if (!string.IsNullOrEmpty(image.Error))
+                    {
+                        <div class="card m-auto">
+                            <div class="card-body">
+                                <i class="text-secondary" data-feather="alert-triangle"></i>
+                            </div>
+                        </div>
+                    }
+                    else if (image.Ingesting.Value)
+                    {
+                        <div class="card m-auto">
+                            <div class="card-body">
+                                <div class="spinner-border text-muted m-auto"></div>
+                            </div>
+                        </div>   
+                    }
+                    else
+                    {
+                        <img src="@Model.Thumbnails[image.ModelId]" class="img-thumbnail rounded mx-auto d-block"/>  
+                    }
+                </a>
+                <small class="d-inline-block text-truncate text-muted text-center w-100">
+                    @Model.GetImageReference(image)
+                </small>
+            </div>
+        }
+    </div>
 </div>

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
@@ -16,7 +16,6 @@ namespace Portal.Pages.Batches;
 public class Index : PageModel
 {
     private readonly IMediator mediator;
-    private const int ImageReferenceMaxLength = 32;
     public Batch Batch { get; set; }
     public HydraCollection<Image> Images { get; set; }
     public Dictionary<string, string> Thumbnails { get; set; }
@@ -37,14 +36,6 @@ public class Index : PageModel
     
     public string GetImageReference(Image image)
     {
-        var reference = string.Format("{0}/{1}/{2}/{3}/{4}/{5}",
-            image.String1 ?? string.Empty,
-            image.String2 ?? string.Empty,
-            image.String3 ?? string.Empty,
-            image.Number1,
-            image.Number2,
-            image.Number3);
-        
-        return reference;
+        return $"{image.String1}/{image.String2}/{image.String3}/{image.Number1}/{image.Number2}/{image.Number3}";
     }
 }

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using DLCS.Core;
+using DLCS.HydraModel;
+using Hydra.Collections;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Portal.Features.Batches.Requests;
+using Portal.Features.Spaces.Requests;
+
+
+namespace Portal.Pages.Batches;
+
+[BindProperties]
+public class Index : PageModel
+{
+    private readonly IMediator mediator;
+    public Batch Batch { get; set; }
+    public HydraCollection<Image> Images { get; set; }
+    public Dictionary<string, string> Thumbnails { get; set; }
+    
+    public Index(IMediator mediator)
+    {
+        this.mediator = mediator;
+    }
+    
+    public async Task<IActionResult> OnGetAsync(int batch)
+    {
+        var batchResult = await mediator.Send(new GetBatch{ BatchId = batch });
+        Batch = batchResult.Batch;
+        Images = batchResult.Images;
+        Thumbnails = batchResult.Thumbnails;
+        return Page();
+    }
+}

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml.cs
@@ -16,6 +16,7 @@ namespace Portal.Pages.Batches;
 public class Index : PageModel
 {
     private readonly IMediator mediator;
+    private const int ImageReferenceMaxLength = 32;
     public Batch Batch { get; set; }
     public HydraCollection<Image> Images { get; set; }
     public Dictionary<string, string> Thumbnails { get; set; }
@@ -32,5 +33,18 @@ public class Index : PageModel
         Images = batchResult.Images;
         Thumbnails = batchResult.Thumbnails;
         return Page();
+    }
+    
+    public string GetImageReference(Image image)
+    {
+        var reference = string.Format("{0}/{1}/{2}/{3}/{4}/{5}",
+            image.String1 ?? string.Empty,
+            image.String2 ?? string.Empty,
+            image.String3 ?? string.Empty,
+            image.Number1,
+            image.Number2,
+            image.Number3);
+        
+        return reference;
     }
 }

--- a/src/protagonist/Portal/Pages/Images/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Images/Index.cshtml
@@ -1,5 +1,6 @@
 @page "{space}/{image}"
 @using DLCS.Core.Strings
+@using Hydra
 @model Portal.Pages.Images.Index
 
 @{
@@ -33,7 +34,13 @@
                         </tr>
                         <tr>
                             <td>Batch</td>
-                            <td>@Model.Image.Batch</td>
+                            <td>
+                                @if (!string.IsNullOrEmpty(Model.Image.Batch))
+                                {
+                                    var batchId = Model.Image.Batch.GetLastPathElement();
+                                    <a asp-page="/Batches/Index" asp-route-batch="@batchId">@batchId</a>
+                                }
+                            </td>
                         </tr>
                         <tr>
                             <td>Origin</td>

--- a/src/protagonist/Portal/Pages/Queue/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Index.cshtml
@@ -34,7 +34,7 @@
             </tr>
         </thead>
         <tbody>
-            @foreach (var batch in Model.Batches.Members.OrderByDescending(batch => batch.Id))
+            @foreach (var batch in Model.Batches.Members)
             {
                 var batchId = batch.Id.GetLastPathElement();
                 var percentComplete = Math.Round(batch.Count > 0 ? (double)batch.Completed / (double)batch.Count * 100.0 : 1.0);

--- a/src/protagonist/Portal/Pages/Queue/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Index.cshtml
@@ -36,11 +36,12 @@
         <tbody>
             @foreach (var batch in Model.Batches.Members.OrderByDescending(batch => batch.Id))
             {
+                var batchId = @batch.Id.GetLastPathElement();
                 var percentComplete = Math.Round(batch.Count > 0 ? (double)batch.Completed / (double)batch.Count * 100.0 : 1.0);
                 var progressPct = batch.Finished.HasValue ? 100 : percentComplete;
 
                 <tr>
-                    <td>@batch.Id.GetLastPathElement()</td>
+                    <td><a href="/batches/@batchId">@batchId</a></td>
                     <td>
                         @percentComplete% (@batch.Completed/@batch.Count)
                     </td>

--- a/src/protagonist/Portal/Pages/Queue/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Index.cshtml
@@ -36,12 +36,12 @@
         <tbody>
             @foreach (var batch in Model.Batches.Members.OrderByDescending(batch => batch.Id))
             {
-                var batchId = @batch.Id.GetLastPathElement();
+                var batchId = batch.Id.GetLastPathElement();
                 var percentComplete = Math.Round(batch.Count > 0 ? (double)batch.Completed / (double)batch.Count * 100.0 : 1.0);
                 var progressPct = batch.Finished.HasValue ? 100 : percentComplete;
 
                 <tr>
-                    <td><a href="/batches/@batchId">@batchId</a></td>
+                    <td><a asp-page="/Batches/Index" asp-route-batch="@batchId">@batchId</a></td>
                     <td>
                         @percentComplete% (@batch.Completed/@batch.Count)
                     </td>


### PR DESCRIPTION
Resolves https://github.com/dlcs/private-protagonist/issues/118

This PR adds a page for viewing individual batches in Portal:

![image](https://github.com/dlcs/protagonist/assets/95353889/7f85e025-71fc-4694-8c75-10ab7ba6c188)
