### PR TITLE
Add 'Test if superseded' button to Batch and Queue pages in Portal

### DIFF
--- a/src/protagonist/API.Client/DlcsClient.cs
+++ b/src/protagonist/API.Client/DlcsClient.cs
@@ -14,6 +14,7 @@ using Hydra.Collections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace API.Client;
@@ -261,6 +262,14 @@ public class DlcsClient : IDlcsClient
         var response = await httpClient.GetAsync(url);
         var batch = await response.ReadAsHydraResponseAsync<Batch>(jsonSerializerSettings);
         return batch;  
+    }
+    
+    public async Task<bool> TestBatch(int batchId)
+    {
+        var url = $"customers/{currentUser.GetCustomerId()}/queue/batches/{batchId}/test";
+        var response = await httpClient.PostAsync(url, null);
+        var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
+        return jObject.SelectToken("success").Value<bool>();
     }
 
     public async Task<HydraCollection<Image>> GetBatchImages(int batchId)

--- a/src/protagonist/API.Client/IDlcsClient.cs
+++ b/src/protagonist/API.Client/IDlcsClient.cs
@@ -28,6 +28,7 @@ public interface IDlcsClient
     Task<HydraCollection<Image>> PatchImages(HydraCollection<Image> images, int spaceId);
     Task<HydraCollection<Batch>> GetBatches(string type, int page, int pageSize);
     Task<Batch> GetBatch(int batchId);
+    Task<bool> TestBatch(int batchId);
     Task<HydraCollection<Image>> GetBatchImages(int batchId);
     Task<CustomerQueue> GetQueue();
 }

--- a/src/protagonist/Portal/Features/Batches/BatchController.cs
+++ b/src/protagonist/Portal/Features/Batches/BatchController.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Portal.Features.Batches.Requests;
+
+namespace Portal.Features.Batches;
+
+[Route("[controller]/[action]")]
+public class BatchController : Controller
+{
+    private readonly IMediator mediator;
+
+    public BatchController(IMediator mediator)
+    {
+        this.mediator = mediator;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Test(int batch)
+    {
+        var response = await mediator.Send(new TestBatch(){ BatchId = batch});
+        return Ok(response);
+    }
+}

--- a/src/protagonist/Portal/Features/Batches/Requests/TestBatch.cs
+++ b/src/protagonist/Portal/Features/Batches/Requests/TestBatch.cs
@@ -1,0 +1,32 @@
+﻿using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Client;
+using DLCS.Core.Settings;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace Portal.Features.Batches.Requests;
+
+public class TestBatch : IRequest<bool>
+{
+    public int BatchId { get; set; }
+}
+
+public class TestBatchHandler : IRequestHandler<TestBatch, bool>
+{
+    private readonly DlcsSettings dlcsSettings;
+    private readonly IDlcsClient dlcsClient;
+
+    public TestBatchHandler(IDlcsClient dlcsClient, ClaimsPrincipal currentUser, IOptions<DlcsSettings> dlcsSettings)
+    {
+        this.dlcsClient = dlcsClient;
+        this.dlcsSettings = dlcsSettings.Value;
+    }
+
+    public async Task<bool> Handle(TestBatch request, CancellationToken cancellationToken)
+    {
+        var response = await dlcsClient.TestBatch(request.BatchId);
+        return response;
+    }
+}

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -8,7 +8,7 @@
     var batchId = Model.Batch.Id.GetLastPathElement();
     var percentComplete = Math.Round(Model.Batch.Count > 0 ? (double)Model.Batch.Completed / (double)Model.Batch.Count * 100.0 : 1.0);
     var progressPct = Model.Batch.Finished.HasValue ? 100 : percentComplete;
-    ViewData["Title"] = $"Batch {batchId} - {Model.Batch.Count} image{(Model.Batch.Count > 1 || Model.Batch.Count == 0 ? "s" : null)}";
+    ViewData["Title"] = $"Batch {batchId} - {Model.Batch.Count} image{(Model.Batch.Count == 1 ? null : "s")}";
 }
 
 <div class="card w-100">

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -8,7 +8,7 @@
     var batchId = Model.Batch.Id.GetLastPathElement();
     var percentComplete = Math.Round(Model.Batch.Count > 0 ? (double)Model.Batch.Completed / (double)Model.Batch.Count * 100.0 : 1.0);
     var progressPct = Model.Batch.Finished.HasValue ? 100 : percentComplete;
-    ViewData["Title"] = $"Batch {batchId} - {Model.Batch.Count} images";
+    ViewData["Title"] = $"Batch {batchId} - {Model.Batch.Count} image{(Model.Batch.Count > 1 || Model.Batch.Count == 0 ? "s" : null)}";
 }
 
 <div class="card w-100">
@@ -23,15 +23,15 @@
             </div>
         }
         <div class="row mb-2">
-            <div class="col-sm">
+            <div class="col">
                 Completion: @percentComplete% (@Model.Batch.Completed/@Model.Batch.Count)
             </div>
-            <div class="col-sm">
+            <div class="col">
                 <div class="progress h-100">
                     <div class="progress-bar bg-success" role="progressbar" style="width: @progressPct%;" aria-valuenow="@progressPct" aria-valuemin="0" aria-valuemax="100">@progressPct%</div>
                 </div>
             </div>
-            <div class="col-sm">
+            <div class="col">
                 @if (Model.Batch.Finished > DateTime.MinValue)
                 {
                     <span class="badge bg-success float-end">Finished</span>
@@ -53,6 +53,15 @@
         @if (Model.Batch.Finished != null)
         {
             <span>Completed: @Model.Batch.Finished</span>
+        }
+        else
+        {
+            <hr/>
+            <div class="row mb-1">
+                <div class="col">
+                    <div id="test-button" class="btn btn-sm btn-warning" onclick="TestBatch()">Test if superseded</div>
+                </div>
+            </div>
         }
     </div>
 </div>
@@ -82,7 +91,7 @@
                     {
                         <div class="card m-auto">
                             <div class="card-body">
-                                  <i class="text-secondary" data-feather="film"></i>
+                                <i class="text-secondary" data-feather="film"></i>
                             </div>
                         </div>                           
                     }
@@ -114,3 +123,58 @@
         }
     </div>
 </div>
+<div class="modal fade" id="superseded-status-modal" tabindex="-1" aria-labelledby="supersededStatusLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-md">
+        <div class="modal-content">
+            <div id="success" hidden>
+                <div class="modal-header border-0">
+                     <h5 class="modal-title">Superseded</h5>
+                 </div>
+                 <div class="modal-body">
+                     Batch has been superseded and marked.
+                 </div>
+            </div>
+            <div id="fail" hidden>
+                  <div class="modal-header border-0">
+                       <h5 class="modal-title">Not superseded</h5>
+                   </div>
+                   <div class="modal-body">
+                       Batch does not appear to have been superseded. There may be some other kind of issue with one of the images it contains.
+                   </div>
+              </div>
+            <div class="modal-footer border-0 py-1">
+                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    function TestBatch() {
+        $.ajax({
+            type: 'POST',
+            url: '@Url.Action("Test", "Batch", new { batch = batchId })',
+            success: function (data, status) { 
+               let testBtn = $('#test-button')
+               let testSuccessMsg = $('#superseded-status-modal #success');
+               let testFailMsg = $('#superseded-status-modal #fail')
+                 
+                if (data === true) {
+                    testBtn.text("Superseded");
+                    testBtn.removeClass('btn-warning');
+                    testBtn.addClass('btn-info');
+                    testFailMsg.attr("hidden", true);
+                    testSuccessMsg.attr("hidden", false);
+                } 
+                else {
+                    testBtn.text("Just tested");
+                    testBtn.removeClass('btn-warning');
+                    testBtn.addClass('btn-light');
+                    testFailMsg.attr("hidden", false);
+                    testSuccessMsg.attr("hidden", true);
+                }
+                $('#superseded-status-modal').modal('show'); 
+            }    
+        });
+    }
+</script>

--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -149,32 +149,35 @@
     </div>
 </div>
 
-<script>
-    function TestBatch() {
-        $.ajax({
-            type: 'POST',
-            url: '@Url.Action("Test", "Batch", new { batch = batchId })',
-            success: function (data, status) { 
-               let testBtn = $('#test-button')
-               let testSuccessMsg = $('#superseded-status-modal #success');
-               let testFailMsg = $('#superseded-status-modal #fail')
-                 
-                if (data === true) {
-                    testBtn.text("Superseded");
-                    testBtn.removeClass('btn-warning');
-                    testBtn.addClass('btn-info');
-                    testFailMsg.attr("hidden", true);
-                    testSuccessMsg.attr("hidden", false);
-                } 
-                else {
-                    testBtn.text("Just tested");
-                    testBtn.removeClass('btn-warning');
-                    testBtn.addClass('btn-light');
-                    testFailMsg.attr("hidden", false);
-                    testSuccessMsg.attr("hidden", true);
-                }
-                $('#superseded-status-modal').modal('show'); 
-            }    
-        });
-    }
-</script>
+@section Scripts 
+{
+    <script>
+        function TestBatch() {
+            $.ajax({
+                type: 'POST',
+                url: '@Url.Action("Test", "Batch", new { batch = batchId })',
+                success: function (data, status) { 
+                   let testBtn = $('#test-button');
+                   let testSuccessMsg = $('#superseded-status-modal #success');
+                   let testFailMsg = $('#superseded-status-modal #fail');
+                     
+                    if (data === true) {
+                        testBtn.text("Superseded");
+                        testBtn.removeClass('btn-warning');
+                        testBtn.addClass('btn-info');
+                        testFailMsg.attr("hidden", true);
+                        testSuccessMsg.attr("hidden", false);
+                    } 
+                    else {
+                        testBtn.text("Just tested");
+                        testBtn.removeClass('btn-warning');
+                        testBtn.addClass('btn-light');
+                        testFailMsg.attr("hidden", false);
+                        testSuccessMsg.attr("hidden", true);
+                    }
+                    $('#superseded-status-modal').modal('show'); 
+                }    
+            });
+        }
+    </script>
+}

--- a/src/protagonist/Portal/Pages/Images/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Images/Index.cshtml
@@ -208,7 +208,6 @@
     </div>
 </div>
 
-
 @section Scripts
 {
     <script>         

--- a/src/protagonist/Portal/Pages/Queue/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Index.cshtml
@@ -57,7 +57,7 @@
                         }
                         else
                         {
-                            <span>Processing</span>
+                            <div data-batch="@batchId" class="btn btn-sm btn-warning test-button">Test if superseded</div>
                         }
 
                         @if (batch.Finished > DateTime.MinValue)
@@ -89,3 +89,32 @@ else
     </div>
 }
 @await Component.InvokeAsync("Pager", new { values = Model.PagerValues })
+
+@section Scripts 
+{
+    <script>
+         $('.test-button').click(function() {
+            let batchId = $(this).data('batch');
+            let button = this;
+            $.ajax({
+                type: 'POST',
+                url: '@Url.Action("Test", "Batch")',
+                data: { 
+                    batch: batchId
+                },
+                success: function (data, status) { 
+                    if (data === true) {
+                        $(button).text('Superseded');
+                        $(button).removeClass('btn-warning');
+                        $(button).addClass('btn-primary');
+                    } 
+                    else {
+                        $(button).text('Not superseded');
+                        $(button).removeClass('btn-warning');
+                        $(button).addClass('btn-light');
+                    }
+                }    
+            });
+        });
+    </script>
+}

--- a/src/protagonist/Portal/Pages/Users/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Users/Index.cshtml
@@ -76,7 +76,8 @@
     </div>
 </div>
 
-@section Scripts {
+@section Scripts 
+{
     <script type="text/javascript">
         
         function deleteUser(evt){            


### PR DESCRIPTION
Resolves https://github.com/dlcs/private-protagonist/issues/119

This PR adds the ability to test if a batch has been superseded in the queue and individual batch viewers, as seen in the previous version in the portal:

![image](https://github.com/dlcs/protagonist/assets/95353889/859e5037-d954-4e7c-9751-cb7dcc67c5fe)
![image](https://github.com/dlcs/protagonist/assets/95353889/92518b4a-90e4-4192-9ed5-55445698cf5e)

