### PR TITLE
adding ability to set model id from the @id property

### DIFF
--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -99,7 +99,7 @@ public class LegacyModeConverterTests
     public void VerifyAndConvertToModernFormat_ModelIdSet_WhenNoModelId()
     {
         // Arrange
-        var hydraImage = new Image{ Id = "https://test/someId" };
+        var hydraImage = new Image{ Id = "https://test/someId", MediaType = "something"};
         
         // Act
         var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);

--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -94,4 +94,17 @@ public class LegacyModeConverterTests
         convertedImage.MaxUnauthorised.Should().Be(null);
         convertedImage.Family.Should().Be(AssetFamily.Image);
     }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_ModelIdSet_WhenNoModelId()
+    {
+        // Arrange
+        var hydraImage = new Image{ Id = "https://test/someId" };
+        
+        // Act
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+
+        // Assert
+        convertedImage.ModelId.Should().Be("someId");
+    }
 }

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -1,6 +1,7 @@
 ﻿using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.HydraModel;
+using Hydra;
 
 namespace API.Converters;
 
@@ -27,6 +28,11 @@ public static class LegacyModeConverter
             if (image.Origin is not null && image.Family is null && image.DeliveryChannels.IsNullOrEmpty())
             {
                   image.Family = AssetFamily.Image;
+            }
+
+            if (image.ModelId is null && image.Id is not null)
+            {
+                image.ModelId = image.Id.GetLastPathElement();
             }
         }
 

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -29,11 +29,11 @@ public static class LegacyModeConverter
             {
                   image.Family = AssetFamily.Image;
             }
-
-            if (image.ModelId is null && image.Id is not null)
-            {
-                image.ModelId = image.Id.GetLastPathElement();
-            }
+        }
+        
+        if (image.ModelId is null && image.Id is not null)
+        {
+            image.ModelId = image.Id.GetLastPathElement();
         }
 
         if (image.MaxUnauthorised is null or 0 && image.Roles.IsNullOrEmpty())


### PR DESCRIPTION
Resolves #654

when creating a batch of images, using the `@id` property field makes the API return a `500` error.  When running in deliverator mode, this is incorrect and should allow a user to create a batch using this property to set the id.  

Ultimately, this issue is caused by the `LegacyModeConverter` defaulting a `ModelId` when one isn't supplied. However, a later check also checks that the `@id` field is equivalent to the `ModelId` field and throws an error if it doesn't match.  This fix makes the `LegacyModeConverter` take into account the `@id` field when defaulting the `ModelId` field