### PR TITLE
Bugfix - Remove items when /deleteImages called

### DIFF
--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
@@ -1,0 +1,55 @@
+﻿using API.Infrastructure.Messaging;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+
+namespace API.Tests.Infrastructure.Messaging;
+
+public class AssetModificationRecordTests
+{
+    [Fact]
+    public void Delete_SetsCorrectFields()
+    {
+        // Arrange
+        var asset = new Asset { Id = new AssetId(1, 2, "foo") };
+        
+        // Act
+        var notification = AssetModificationRecord.Delete(asset);
+        
+        // Assert
+        notification.ChangeType.Should().Be(ChangeType.Delete);
+        notification.Before.Should().Be(asset);
+        notification.After.Should().BeNull();
+    }
+    
+    [Fact]
+    public void Create_SetsCorrectFields()
+    {
+        // Arrange
+        var asset = new Asset { Id = new AssetId(1, 2, "foo") };
+        
+        // Act
+        var notification = AssetModificationRecord.Create(asset);
+        
+        // Assert
+        notification.ChangeType.Should().Be(ChangeType.Create);
+        notification.After.Should().Be(asset);
+        notification.Before.Should().BeNull();
+    }
+    
+    [Fact]
+    public void Update_SetsCorrectFields()
+    {
+        // Arrange
+        var before = new Asset { Id = new AssetId(1, 2, "foo") };
+        var after = new Asset { Id = new AssetId(1, 2, "foo"), MaxUnauthorised = 10 };
+        
+        // Act
+        var notification = AssetModificationRecord.Update(before, after);
+        
+        // Assert
+        notification.ChangeType.Should().Be(ChangeType.Update);
+        notification.Before.Should().Be(before);
+        notification.After.Should().Be(after);
+    }
+}

--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using API.Infrastructure.Messaging;
+using DLCS.AWS.SNS;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+using DLCS.Model.PathElements;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace API.Tests.Infrastructure.Messaging;
+
+public class AssetNotificationSenderTests
+{
+    private readonly ITopicPublisher topicPublisher;
+    private readonly IPathCustomerRepository customerPathRepository;
+    private readonly AssetNotificationSender sut;
+
+    public AssetNotificationSenderTests()
+    {
+        topicPublisher = A.Fake<ITopicPublisher>();
+        customerPathRepository = A.Fake<IPathCustomerRepository>();
+
+        sut = new AssetNotificationSender(topicPublisher, customerPathRepository,
+            new NullLogger<AssetNotificationSender>());
+    }
+
+    [Fact]
+    public async Task SendAssetModifiedMessage_Single_Noop_IfUpdate()
+    {
+        // Arrange
+        var assetModifiedRecord =
+            AssetModificationRecord.Update(new Asset(new AssetId(1, 2, "foo")), new Asset(new AssetId(1, 2, "bar")));
+
+        // Act
+        await sut.SendAssetModifiedMessage(assetModifiedRecord, CancellationToken.None);
+        
+        // Assert
+        A.CallTo(() =>
+            topicPublisher.PublishToAssetModifiedTopic(A<IReadOnlyList<AssetModifiedNotification>>._,
+                A<CancellationToken>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task SendAssetModifiedMessage_Single_Noop_IfCreate()
+    {
+        // Arrange
+        var assetModifiedRecord = AssetModificationRecord.Create(new Asset(new AssetId(1, 2, "foo")));
+
+        // Act
+        await sut.SendAssetModifiedMessage(assetModifiedRecord, CancellationToken.None);
+        
+        // Assert
+        A.CallTo(() =>
+            topicPublisher.PublishToAssetModifiedTopic(A<IReadOnlyList<AssetModifiedNotification>>._,
+                A<CancellationToken>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task SendAssetModifiedMessage_Single_SendsNotification_IfDelete()
+    {
+        // Arrange
+        var assetModifiedRecord = AssetModificationRecord.Delete(new Asset(new AssetId(1, 2, "foo")));
+        const string customerName = "uno";
+        A.CallTo(() => customerPathRepository.GetCustomerPathElement("1"))
+            .Returns(new CustomerPathElement(1, customerName));
+
+        // Act
+        await sut.SendAssetModifiedMessage(assetModifiedRecord, CancellationToken.None);
+        
+        // Assert
+        A.CallTo(() =>
+            topicPublisher.PublishToAssetModifiedTopic(
+                A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
+                    n.Single().ChangeType == ChangeType.Delete && n.Single().MessageContents.Contains(customerName)),
+                A<CancellationToken>._)).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task SendAssetModifiedMessage_Multiple_SendsNotification_IfDelete()
+    {
+        // Arrange
+        var assetModifiedRecord = AssetModificationRecord.Delete(new Asset(new AssetId(1, 2, "foo")));
+        var assetModifiedRecord2 = AssetModificationRecord.Delete(new Asset(new AssetId(1, 2, "bar")));
+        var updates = new List<AssetModificationRecord> { assetModifiedRecord, assetModifiedRecord2 };
+        const string customerName = "uno";
+        A.CallTo(() => customerPathRepository.GetCustomerPathElement("1"))
+            .Returns(new CustomerPathElement(1, customerName));
+
+        // Act
+        await sut.SendAssetModifiedMessage(updates, CancellationToken.None);
+        
+        // Assert
+        A.CallTo(() =>
+            topicPublisher.PublishToAssetModifiedTopic(
+                A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
+                    n.Count == 2 && n.All(m =>
+                        m.ChangeType == ChangeType.Delete && m.MessageContents.Contains(customerName))),
+                A<CancellationToken>._)).MustHaveHappened();
+    }
+}

--- a/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -173,9 +174,10 @@ public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Post_DeleteImages_200_WithMatches()
     {
         // Arrange
-        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/deleteImages_1"));
-        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/deleteImages_2"));
-        await dbContext.Images.AddTestAsset(AssetId.FromString("99/2/deleteImages_3"), space: 2);
+        var reference = nameof(Post_DeleteImages_200_WithMatches);
+        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/deleteImages_1"), ref1: reference);
+        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/deleteImages_2"), ref1: reference);
+        await dbContext.Images.AddTestAsset(AssetId.FromString("99/2/deleteImages_3"), space: 2, ref1: reference);
         await dbContext.SaveChangesAsync();
         
         const string newCustomerJson = @"{
@@ -192,5 +194,6 @@ public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
+        dbContext.Images.Count(i => i.Reference1 == reference).Should().Be(0);
     }
 }

--- a/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
@@ -29,18 +29,18 @@ public class DeleteMultipleImagesById : IRequest<int>
 public class DeleteMultipleImagesByIdHandler : IRequestHandler<DeleteMultipleImagesById, int>
 {
     private readonly DlcsContext dlcsContext;
-    private readonly IAssetNotificationSender assetNotificationSender;
+    private readonly IIngestNotificationSender ingestNotificationSender;
     private readonly ILogger<DeleteMultipleImagesByIdHandler> logger;
     private readonly IPathCustomerRepository customerPathRepository;
 
     public DeleteMultipleImagesByIdHandler(
         DlcsContext dlcsContext,
-        IAssetNotificationSender assetNotificationSender,
+        IIngestNotificationSender ingestNotificationSender,
         IPathCustomerRepository customerPathRepository,
         ILogger<DeleteMultipleImagesByIdHandler> logger)
     {
         this.dlcsContext = dlcsContext;
-        this.assetNotificationSender = assetNotificationSender;
+        this.ingestNotificationSender = ingestNotificationSender;
         this.customerPathRepository = customerPathRepository;
         this.logger = logger;
     }
@@ -67,7 +67,7 @@ public class DeleteMultipleImagesByIdHandler : IRequestHandler<DeleteMultipleIma
     {
         foreach (var asset in assets)
         {
-            await assetNotificationSender.SendAssetModifiedNotification(ChangeType.Delete, asset, null, customerPathElement);
+            await ingestNotificationSender.SendAssetModifiedNotification(ChangeType.Delete, asset, null, customerPathElement);
         }
     }
 }

--- a/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/DeleteMultipleImagesById.cs
@@ -1,12 +1,9 @@
 ﻿using System.Collections.Generic;
 using API.Features.Customer.Validation;
-using DLCS.Core.Types;
+using API.Infrastructure.Messaging;
 using DLCS.Model.Assets;
-using DLCS.Model.Messaging;
-using DLCS.Model.PathElements;
 using DLCS.Repository;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace API.Features.Customer.Requests;
@@ -29,45 +26,58 @@ public class DeleteMultipleImagesById : IRequest<int>
 public class DeleteMultipleImagesByIdHandler : IRequestHandler<DeleteMultipleImagesById, int>
 {
     private readonly DlcsContext dlcsContext;
-    private readonly IIngestNotificationSender ingestNotificationSender;
+    private readonly IAssetNotificationSender assetNotificationSender;
     private readonly ILogger<DeleteMultipleImagesByIdHandler> logger;
-    private readonly IPathCustomerRepository customerPathRepository;
 
     public DeleteMultipleImagesByIdHandler(
         DlcsContext dlcsContext,
-        IIngestNotificationSender ingestNotificationSender,
-        IPathCustomerRepository customerPathRepository,
+        IAssetNotificationSender assetNotificationSender,
         ILogger<DeleteMultipleImagesByIdHandler> logger)
     {
         this.dlcsContext = dlcsContext;
-        this.ingestNotificationSender = ingestNotificationSender;
-        this.customerPathRepository = customerPathRepository;
+        this.assetNotificationSender = assetNotificationSender;
         this.logger = logger;
     }
 
     public async Task<int> Handle(DeleteMultipleImagesById request, CancellationToken cancellationToken)
     {
+        var assetsFromDatabase = GetRequestedAssetsFromDatabase(request);
+        if (assetsFromDatabase.Count == 0) return 0;
+
+        var rowCount = await DeleteAssetsFromDb(assetsFromDatabase, cancellationToken);
+        logger.LogInformation("Deleted {DeletedRows} assets from a requested {RequestedRows}", rowCount,
+            request.AssetIds.Count);
+        
+        await RaiseModifiedNotifications(assetsFromDatabase, cancellationToken);
+        return assetsFromDatabase.Count;
+    }
+    
+    private List<Asset> GetRequestedAssetsFromDatabase(DeleteMultipleImagesById request)
+    {
         var assetIds = ImageIdListValidation.ValidateRequest(request.AssetIds, request.CustomerId);
         var assetsFromDatabase = dlcsContext.Images
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id)).ToList();
-        dlcsContext.Images.RemoveRange(assetsFromDatabase);
-
-        logger.LogInformation("Deleted {DeletedRows} assets from a requested {RequestedRows}", assetsFromDatabase.Count,
-            request.AssetIds.Count);
-
-        if (assetsFromDatabase.Count == 0) return 0;
-        
-        var customerPathElement = await customerPathRepository.GetCustomerPathElement(request.CustomerId.ToString());
-        await RaiseModifiedNotifications(assetsFromDatabase, customerPathElement);
-
-        return assetsFromDatabase.Count;
+        return assetsFromDatabase;
     }
 
-    private async Task RaiseModifiedNotifications(List<Asset> assets, CustomerPathElement customerPathElement)
+    private async Task<int> DeleteAssetsFromDb(List<Asset> assetsFromDatabase, CancellationToken cancellationToken)
     {
-        foreach (var asset in assets)
+        try
         {
-            await ingestNotificationSender.SendAssetModifiedNotification(ChangeType.Delete, asset, null, customerPathElement);
+            dlcsContext.Images.RemoveRange(assetsFromDatabase);
+            var rowCount = await dlcsContext.SaveChangesAsync(cancellationToken);
+            return rowCount;
         }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting assets from database");
+            return 0;
+        }
+    }
+
+    private async Task RaiseModifiedNotifications(List<Asset> assets, CancellationToken cancellationToken)
+    {
+        var changeSet = assets.Select(AssetModificationRecord.Delete).ToList();
+        await assetNotificationSender.SendAssetModifiedMessage(changeSet, cancellationToken);
     }
 }

--- a/src/protagonist/API/Features/Image/Requests/DeleteAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/DeleteAsset.cs
@@ -23,18 +23,18 @@ public class DeleteAsset : IRequest<DeleteResult>
 
 public class DeleteAssetHandler : IRequestHandler<DeleteAsset, DeleteResult>
 {
-    private readonly IAssetNotificationSender assetNotificationSender;
+    private readonly IIngestNotificationSender ingestNotificationSender;
     private readonly IAssetRepository assetRepository;
     private readonly ILogger<DeleteAssetHandler> logger;
     private readonly IPathCustomerRepository customerPathRepository;
 
     public DeleteAssetHandler(
-        IAssetNotificationSender assetNotificationSender,
+        IIngestNotificationSender ingestNotificationSender,
         IAssetRepository assetRepository,
         IPathCustomerRepository customerPathRepository,
         ILogger<DeleteAssetHandler> logger)
     {
-        this.assetNotificationSender = assetNotificationSender;
+        this.ingestNotificationSender = ingestNotificationSender;
         this.assetRepository = assetRepository;
         this.customerPathRepository = customerPathRepository;
         this.logger = logger;
@@ -54,7 +54,7 @@ public class DeleteAssetHandler : IRequestHandler<DeleteAsset, DeleteResult>
         {
             var customerPathElement = await customerPathRepository.GetCustomerPathElement(request.AssetId.Customer.ToString());
             logger.LogDebug("Sending delete asset notification for {AssetId}", request.AssetId);
-            await assetNotificationSender.SendAssetModifiedNotification(ChangeType.Delete,
+            await ingestNotificationSender.SendAssetModifiedNotification(ChangeType.Delete,
                 deleteResult.DeletedEntity, null, customerPathElement);
         }
         catch (Exception ex)

--- a/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
@@ -25,16 +25,16 @@ public class ReingestAsset : IRequest<ModifyEntityResult<Asset>>
 
 public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityResult<Asset>>
 {
-    private readonly IAssetNotificationSender assetNotificationSender;
+    private readonly IIngestNotificationSender ingestNotificationSender;
     private readonly IApiAssetRepository assetRepository;
     private readonly ILogger<ReingestAssetHandler> logger;
 
     public ReingestAssetHandler(
-        IAssetNotificationSender assetNotificationSender,
+        IIngestNotificationSender ingestNotificationSender,
         IApiAssetRepository assetRepository,
         ILogger<ReingestAssetHandler> logger)
     {
-        this.assetNotificationSender = assetNotificationSender;
+        this.ingestNotificationSender = ingestNotificationSender;
         this.assetRepository = assetRepository;
         this.logger = logger;
     }
@@ -48,8 +48,8 @@ public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityR
         
         var asset = await MarkAssetAsIngesting(cancellationToken, existingAsset!);
         
-        await assetNotificationSender.SendAssetModifiedNotification(ChangeType.Update, existingAsset, asset);
-        var statusCode = await assetNotificationSender.SendImmediateIngestAssetRequest(asset, false, cancellationToken);
+        await ingestNotificationSender.SendAssetModifiedNotification(ChangeType.Update, existingAsset, asset);
+        var statusCode = await ingestNotificationSender.SendImmediateIngestAssetRequest(asset, false, cancellationToken);
         
         if (statusCode.IsSuccess())
         {

--- a/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using API.Features.Assets;
+using API.Infrastructure.Messaging;
 using API.Infrastructure.Requests;
 using DLCS.Core;
 using DLCS.Core.Types;
@@ -26,15 +27,18 @@ public class ReingestAsset : IRequest<ModifyEntityResult<Asset>>
 public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityResult<Asset>>
 {
     private readonly IIngestNotificationSender ingestNotificationSender;
+    private readonly IAssetNotificationSender assetNotificationSender;
     private readonly IApiAssetRepository assetRepository;
     private readonly ILogger<ReingestAssetHandler> logger;
 
     public ReingestAssetHandler(
         IIngestNotificationSender ingestNotificationSender,
+        IAssetNotificationSender assetNotificationSender,
         IApiAssetRepository assetRepository,
         ILogger<ReingestAssetHandler> logger)
     {
         this.ingestNotificationSender = ingestNotificationSender;
+        this.assetNotificationSender = assetNotificationSender;
         this.assetRepository = assetRepository;
         this.logger = logger;
     }
@@ -47,8 +51,9 @@ public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityR
         if (validationException != null) return validationException;
         
         var asset = await MarkAssetAsIngesting(cancellationToken, existingAsset!);
-        
-        await ingestNotificationSender.SendAssetModifiedNotification(ChangeType.Update, existingAsset, asset);
+
+        await assetNotificationSender.SendAssetModifiedMessage(AssetModificationRecord.Update(existingAsset!, asset),
+            cancellationToken);
         var statusCode = await ingestNotificationSender.SendImmediateIngestAssetRequest(asset, false, cancellationToken);
         
         if (statusCode.IsSuccess())

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -35,20 +35,20 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
     private readonly DlcsContext dlcsContext;
     private readonly IBatchRepository batchRepository;
     private readonly AssetProcessor assetProcessor;
-    private readonly IAssetNotificationSender assetNotificationSender;
+    private readonly IIngestNotificationSender ingestNotificationSender;
     private readonly ILogger<CreateBatchOfImagesHandler> logger;
 
     public CreateBatchOfImagesHandler(
         DlcsContext dlcsContext,
         IBatchRepository batchRepository,
         AssetProcessor assetProcessor,
-        IAssetNotificationSender assetNotificationSender,
+        IIngestNotificationSender ingestNotificationSender,
         ILogger<CreateBatchOfImagesHandler> logger)
     {
         this.dlcsContext = dlcsContext;
         this.batchRepository = batchRepository;
         this.assetProcessor = assetProcessor;
-        this.assetNotificationSender = assetNotificationSender;
+        this.ingestNotificationSender = ingestNotificationSender;
         this.logger = logger;
     }
 
@@ -148,7 +148,7 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         {
             // Raise notifications
             logger.LogDebug("Batch {BatchId} created - sending engine notifications", batch.Id);
-            await assetNotificationSender.SendIngestAssetsRequest(assetNotificationList, request.IsPriority,
+            await ingestNotificationSender.SendIngestAssetsRequest(assetNotificationList, request.IsPriority,
                 cancellationToken);
         }
         

--- a/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
@@ -1,0 +1,31 @@
+﻿using DLCS.Core.Guard;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+
+namespace API.Infrastructure.Messaging;
+
+/// <summary>
+/// Represents a change to a single asset - the relevant status before/after change and the change type
+/// </summary>
+public class AssetModificationRecord
+{
+    public ChangeType ChangeType { get; }
+    public Asset? Before { get; }
+    public Asset? After { get; }
+
+    private AssetModificationRecord(ChangeType changeType, Asset? before, Asset? after)
+    {
+        ChangeType = changeType;
+        Before = before;
+        After = after;
+    }
+
+    public static AssetModificationRecord Delete(Asset before) 
+        => new(ChangeType.Delete, before.ThrowIfNull(nameof(before)), null);
+    
+    public static AssetModificationRecord Update(Asset before, Asset after)
+        => new(ChangeType.Update, before.ThrowIfNull(nameof(before)), after.ThrowIfNull(nameof(after)));
+
+    public static AssetModificationRecord Create(Asset after) 
+        => new(ChangeType.Create, null, after.ThrowIfNull(nameof(after)));
+}

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using DLCS.AWS.SNS;
+using DLCS.Core.Collections;
+using DLCS.Core.Strings;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+using DLCS.Model.PathElements;
+using Microsoft.Extensions.Logging;
+
+namespace API.Infrastructure.Messaging;
+
+/// <summary>
+/// Class that handles raising notifications for modifications made to assets (Create/Update/Delete)
+/// </summary>
+public class AssetNotificationSender : IAssetNotificationSender
+{
+    private readonly ILogger<AssetNotificationSender> logger;
+    private readonly ITopicPublisher topicPublisher;
+    private readonly IPathCustomerRepository customerPathRepository;
+    private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
+
+    private readonly Dictionary<int, CustomerPathElement> customerPathElements = new();
+
+    public AssetNotificationSender(
+        ITopicPublisher topicPublisher,
+        IPathCustomerRepository customerPathRepository,
+        ILogger<AssetNotificationSender> logger)
+    {
+        this.logger = logger;
+        this.topicPublisher = topicPublisher;
+        this.customerPathRepository = customerPathRepository;
+    }
+
+    public Task SendAssetModifiedMessage(AssetModificationRecord notification,
+        CancellationToken cancellationToken = default)
+        => SendAssetModifiedMessage(notification.AsList(), cancellationToken);
+
+    public async Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications,
+        CancellationToken cancellationToken = default)
+    {
+        // Iterate through AssetModifiedMessage objects and build list(s) of changes
+        var changes = new Dictionary<ChangeType, List<string>>()
+        {
+            [ChangeType.Create] = new(),
+            [ChangeType.Update] = new(),
+            [ChangeType.Delete] = new(),
+        };
+        
+        foreach (var notification in notifications)
+        {
+            var serialisedNotification = await GetSerialisedNotification(notification);
+            if (serialisedNotification.HasText())
+            {
+                changes[notification.ChangeType].Add(serialisedNotification);
+            }
+        }
+
+        // Send notifications generated in above method
+        await SendCleanupAssetRequest(changes[ChangeType.Delete], cancellationToken);
+    }
+
+    private async Task<string?> GetSerialisedNotification(AssetModificationRecord notification)
+    {
+        if (notification.ChangeType == ChangeType.Delete)
+        {
+            logger.LogDebug("Message Bus: Asset Deleted: {AssetId}", notification.Before!.Id);
+            return await GetSerialisedCleanupAssetNotification(notification.Before!);
+        }
+        
+        if (notification.ChangeType == ChangeType.Create)
+        {
+            logger.LogDebug("Message Bus: Asset Created: {AssetId}", notification.After!.Id);
+        }
+        else if (notification.ChangeType == ChangeType.Update)
+        {
+            logger.LogDebug("Message Bus: Asset Modified: {AssetId}", notification.Before?.Id);
+        }
+        return null; 
+    }
+    
+    private async Task<string> GetSerialisedCleanupAssetNotification(Asset assetToCleanup)
+    {
+        var customerPathElement = await GetCustomerPathElement(assetToCleanup.Customer);
+        
+        var request = new CleanupAssetNotificationRequest
+        {
+            Asset = assetToCleanup,
+            CustomerPathElement = customerPathElement
+        };
+
+        return JsonSerializer.Serialize(request, settings);
+    }
+    
+    private async Task<CustomerPathElement> GetCustomerPathElement(int customer)
+    {
+        if (customerPathElements.TryGetValue(customer, out var prefetchedCustomer)) return prefetchedCustomer;
+        
+        var customerPathElement = await customerPathRepository.GetCustomerPathElement(customer.ToString());
+        customerPathElements[customer] = customerPathElement;
+        return customerPathElement;
+    }
+    
+    private async Task<bool> SendCleanupAssetRequest(IList<string> change, CancellationToken cancellationToken)
+    {
+        if (change.IsNullOrEmpty()) return true;
+
+        var toSend = change.Select(n => new AssetModifiedNotification(n, ChangeType.Delete)).ToList();
+
+        return await topicPublisher.PublishToAssetModifiedTopic(toSend, cancellationToken);
+    }
+}

--- a/src/protagonist/API/Infrastructure/Messaging/IAssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/IAssetNotificationSender.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace API.Infrastructure.Messaging;
+
+public interface IAssetNotificationSender
+{
+    /// <summary>
+    /// Broadcast a change to the status of an Asset, for any subscribers.
+    /// </summary>
+    Task SendAssetModifiedMessage(AssetModificationRecord notification,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Broadcast a change to the status of multiple Assets, for any subscribers.
+    /// </summary>
+    Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications,
+        CancellationToken cancellationToken = default);
+}

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -3,6 +3,7 @@ using API.Auth;
 using API.Features.Image.Ingest;
 using API.Features.OriginStrategies.Credentials;
 using API.Infrastructure;
+using API.Infrastructure.Messaging;
 using API.Infrastructure.Validation;
 using API.Settings;
 using DLCS.Core.Caching;
@@ -70,6 +71,7 @@ public class Startup
             .AddCaching(cacheSettings)
             .AddDataAccess(configuration)
             .AddScoped<IIngestNotificationSender, IngestNotificationSender>()
+            .AddSingleton<IAssetNotificationSender, AssetNotificationSender>()
             .AddScoped<AssetProcessor>()
             .AddTransient<TimingHandler>()
             .AddValidatorsFromAssemblyContaining<Startup>()

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -69,7 +69,7 @@ public class Startup
             .AddTransient<ClaimsPrincipal>(s => s.GetRequiredService<IHttpContextAccessor>().HttpContext.User)
             .AddCaching(cacheSettings)
             .AddDataAccess(configuration)
-            .AddScoped<IAssetNotificationSender, AssetNotificationSender>()
+            .AddScoped<IIngestNotificationSender, IngestNotificationSender>()
             .AddScoped<AssetProcessor>()
             .AddTransient<TimingHandler>()
             .AddValidatorsFromAssemblyContaining<Startup>()

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using Amazon.SimpleNotificationService;
+﻿using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using DLCS.AWS.Settings;
 using DLCS.AWS.SNS;
@@ -25,20 +24,6 @@ public class TopicPublisherTests
         });
 
         sut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
-    }
-
-    [Fact]
-    public async Task PublishToAssetModifiedTopic_SuccessfullyPublishesToTopic()
-    {
-        // Act
-        await sut.PublishToAssetModifiedTopic("message", ChangeType.Delete);
-
-        // Assert
-        A.CallTo(() =>
-            snsClient.PublishAsync(
-                A<PublishRequest>.That.Matches(r =>
-                    r.Message == "message" && r.MessageAttributes["messageType"].StringValue == "Delete"),
-                A<CancellationToken>._)).MustHaveHappened();
     }
     
     [Fact]
@@ -109,35 +94,5 @@ public class TopicPublisherTests
                                                              "Delete") &&
                                                          b.PublishBatchRequestEntries.Count == 5),
                 A<CancellationToken>._)).MustHaveHappened();
-    }
-    
-    [Fact]
-    public async Task PublishToAssetModifiedTopic_ReturnsTrue_IfPublishSuccess()
-    {
-        // Arrange
-        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
-            .Returns(new PublishResponse { HttpStatusCode = HttpStatusCode.OK });
-        
-        // Act
-        var published = await sut.PublishToAssetModifiedTopic("message", ChangeType.Delete);
-
-        // Assert
-        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustHaveHappened();
-        published.Should().BeTrue();
-    }
-    
-    [Fact]
-    public async Task PublishToAssetModifiedTopic_ReturnsFalse_IfPublishFailse()
-    {
-        // Arrange
-        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
-            .Returns(new PublishResponse { HttpStatusCode = HttpStatusCode.BadRequest });
-        
-        // Act
-        var published = await sut.PublishToAssetModifiedTopic("message", ChangeType.Delete);
-
-        // Assert
-        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustHaveHappened();
-        published.Should().BeFalse();
     }
 }

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -5,7 +5,7 @@ namespace DLCS.AWS.SNS;
 public interface ITopicPublisher
 {
     /// <summary>
-    /// Asynchronously publishes a message to a Asset Modified SNS topic
+    /// Asynchronously publishes a message to an Asset Modified SNS topic
     /// </summary>
     /// <param name="messages">A collection of notifications to send</param>
     /// <param name="cancellationToken">Current cancellation token</param>

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -7,15 +7,6 @@ public interface ITopicPublisher
     /// <summary>
     /// Asynchronously publishes a message to a Asset Modified SNS topic
     /// </summary>
-    /// <param name="messageContents">The contents of the message</param>
-    /// <param name="changeType">The type of change that has happened</param>
-    /// <param name="cancellationToken">Current cancellation token</param>
-    public Task<bool> PublishToAssetModifiedTopic(string messageContents, ChangeType changeType,
-        CancellationToken cancellationToken);
-
-    /// <summary>
-    /// Asynchronously publishes a message to a Asset Modified SNS topic
-    /// </summary>
     /// <param name="messages">A collection of notifications to send</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Boolean representing the overall success/failure status of all requests</returns>

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -5,12 +5,25 @@ namespace DLCS.AWS.SNS;
 public interface ITopicPublisher
 {
     /// <summary>
-    /// Asynchronously publishes a message to an SNS topic
+    /// Asynchronously publishes a message to a Asset Modified SNS topic
     /// </summary>
     /// <param name="messageContents">The contents of the message</param>
     /// <param name="changeType">The type of change that has happened</param>
-    /// <param name="cancellationToken">A cancellation token</param>
-    /// ///
+    /// <param name="cancellationToken">Current cancellation token</param>
     public Task<bool> PublishToAssetModifiedTopic(string messageContents, ChangeType changeType,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Asynchronously publishes a message to a Asset Modified SNS topic
+    /// </summary>
+    /// <param name="messages">A collection of notifications to send</param>
+    /// <param name="cancellationToken">Current cancellation token</param>
+    /// <returns>Boolean representing the overall success/failure status of all requests</returns>
+    public Task<bool> PublishToAssetModifiedTopic(IReadOnlyList<AssetModifiedNotification> messages,
+        CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// Represents the contents + type of change for Asset modified notification
+/// </summary>
+public record AssetModifiedNotification(string MessageContents, ChangeType ChangeType);

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -41,7 +41,7 @@ public class TopicPublisher : ITopicPublisher
         var batchNumber = 0;
         foreach (var chunk in messages.Chunk(maxSnsBatchSize))
         {
-            var success = await PublishBatchResponse(chunk, batchIdPrefix, batchNumber++, cancellationToken);
+            var success = await PublishBatch(chunk, batchIdPrefix, batchNumber++, cancellationToken);
             if (allBatchSuccess) allBatchSuccess = success;
         }
         
@@ -72,7 +72,7 @@ public class TopicPublisher : ITopicPublisher
         }
     }
 
-    private async Task<bool> PublishBatchResponse(AssetModifiedNotification[] chunk, Guid batchIdPrefix, int batchNumber,
+    private async Task<bool> PublishBatch(AssetModifiedNotification[] chunk, Guid batchIdPrefix, int batchNumber,
         CancellationToken cancellationToken)
     {
         try

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -34,7 +34,7 @@ public class TopicPublisher : ITopicPublisher
         }
 
         const int maxSnsBatchSize = 10;
-        var allBatchSuccess = false;
+        var allBatchSuccess = true;
         var batchIdPrefix = Guid.NewGuid();
         logger.LogDebug("Publishing SNS batch {BatchPrefix} containing {ItemCount} items", batchIdPrefix,
             messages.Count);

--- a/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Model.Assets;
-using DLCS.Model.PathElements;
 
 namespace DLCS.Model.Messaging;
 
@@ -23,6 +21,7 @@ public interface IIngestNotificationSender
     /// </summary>
     /// <param name="assets">List of assets to ingest</param>
     /// <param name="isPriority">If true then assets are added to ingest queue</param>
+    /// <param name="cancellationToken">Current cancellationToken</param>
     Task<int> SendIngestAssetsRequest(IReadOnlyList<Asset> assets, bool isPriority,
         CancellationToken cancellationToken = default);
 
@@ -30,13 +29,7 @@ public interface IIngestNotificationSender
     /// Send an asset for immediate processing; the call blocks until complete.
     /// </summary>
     /// <param name="derivativesOnly">If true, only derivatives (e.g. thumbs) will be created</param>
+    /// <param name="cancellationToken">Current cancellationToken</param>
     Task<HttpStatusCode> SendImmediateIngestAssetRequest(Asset assetToIngest, bool derivativesOnly,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Broadcast a change to the status of an Asset, for any subscribers.
-    /// </summary>
-    [Obsolete("Use IAssetNotificationSender instead")]
-    Task SendAssetModifiedNotification(ChangeType changeType, Asset? before, Asset? after,
-        CustomerPathElement? customerPathElement = null);
 }

--- a/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
@@ -35,6 +36,7 @@ public interface IIngestNotificationSender
     /// <summary>
     /// Broadcast a change to the status of an Asset, for any subscribers.
     /// </summary>
+    [Obsolete("Use IAssetNotificationSender instead")]
     Task SendAssetModifiedNotification(ChangeType changeType, Asset? before, Asset? after,
         CustomerPathElement? customerPathElement = null);
 }

--- a/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IIngestNotificationSender.cs
@@ -10,7 +10,7 @@ namespace DLCS.Model.Messaging;
 /// <summary>
 /// Interface for transmitting notifications related to <see cref="Asset"/> 
 /// </summary>
-public interface IAssetNotificationSender
+public interface IIngestNotificationSender
 {
     /// <summary>
     /// Enqueue a message that an asset needs to be ingested.

--- a/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
@@ -17,18 +17,18 @@ using Newtonsoft.Json.Serialization;
 
 namespace DLCS.Repository.Messaging;
 
-public class AssetNotificationSender : IAssetNotificationSender
+public class IngestNotificationSender : IIngestNotificationSender
 {
-    private readonly ILogger<AssetNotificationSender> logger;
+    private readonly ILogger<IngestNotificationSender> logger;
     private readonly IEngineClient engineClient;
     private readonly ICustomerQueueRepository customerQueueRepository;
     private readonly ITopicPublisher topicPublisher;
     private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
 
-    public AssetNotificationSender(
+    public IngestNotificationSender(
         IEngineClient engineClient,
         ICustomerQueueRepository customerQueueRepository,
-        ILogger<AssetNotificationSender> logger,
+        ILogger<IngestNotificationSender> logger,
         ITopicPublisher topicPublisher)
     {
         this.engineClient = engineClient;

--- a/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
@@ -2,14 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.AWS.SNS;
 using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
-using DLCS.Model.PathElements;
 using DLCS.Model.Processing;
 using Microsoft.Extensions.Logging;
 
@@ -20,19 +17,15 @@ public class IngestNotificationSender : IIngestNotificationSender
     private readonly ILogger<IngestNotificationSender> logger;
     private readonly IEngineClient engineClient;
     private readonly ICustomerQueueRepository customerQueueRepository;
-    private readonly ITopicPublisher topicPublisher;
-    private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
 
     public IngestNotificationSender(
         IEngineClient engineClient,
         ICustomerQueueRepository customerQueueRepository,
-        ILogger<IngestNotificationSender> logger,
-        ITopicPublisher topicPublisher)
+        ILogger<IngestNotificationSender> logger)
     {
         this.engineClient = engineClient;
         this.logger = logger;
         this.customerQueueRepository = customerQueueRepository;
-        this.topicPublisher = topicPublisher;
     }
     
     public async Task<bool> SendIngestAssetRequest(Asset assetToIngest, CancellationToken cancellationToken = default)
@@ -87,47 +80,5 @@ public class IngestNotificationSender : IIngestNotificationSender
         var ingestAssetRequest = new IngestAssetRequest(assetToIngest, DateTime.UtcNow);
         var statusCode = await engineClient.SynchronousIngest(ingestAssetRequest, derivativesOnly, cancellationToken);
         return statusCode;
-    }
-
-    private async Task<bool> SendCleanupAssetRequest(Asset assetToCleanup, CustomerPathElement customerPathElement, CancellationToken cancellationToken = default)
-    {
-        var request = new CleanupAssetNotificationRequest()
-        {
-            Asset = assetToCleanup,
-            CustomerPathElement = customerPathElement
-        };
-        
-        return await topicPublisher.PublishToAssetModifiedTopic(JsonSerializer.Serialize(request, settings), ChangeType.Delete, cancellationToken);
-    }
-
-    public async Task SendAssetModifiedNotification(ChangeType changeType, Asset? before, Asset? after, CustomerPathElement? customerPathElement)
-    {
-        /*
-         * TODO - this should probably have a bulk implementation, assuming it handles bulk enqueuing of messages
-         * it's more efficient to do in batches rather than 1 at a time (like engine client)
-         */
-        switch (changeType)
-        {
-            case ChangeType.Create when before != null:
-                throw new ArgumentException("Asset Creation cannot have a before asset", nameof(before));
-            case ChangeType.Create when after == null:
-                throw new ArgumentException("Asset Creation must have an after asset", nameof(after));
-            case ChangeType.Update when before == null:
-                throw new ArgumentException("Asset Update must have a before asset", nameof(before));
-            case ChangeType.Update when after == null:
-                throw new ArgumentException("Asset Update must have an after asset", nameof(after));
-            case ChangeType.Delete when before == null:
-                throw new ArgumentException("Asset Delete must have a before asset", nameof(before));
-            case ChangeType.Delete when after != null:
-                throw new ArgumentException("Asset Delete cannot have an after asset", nameof(after));
-            case ChangeType.Delete when customerPathElement == null:
-                throw new ArgumentException("Asset Delete must have a customer path element", nameof(after));
-            case ChangeType.Delete:
-                await SendCleanupAssetRequest(before, customerPathElement);
-                break;
-            default:
-                logger.LogDebug("Message Bus: Asset Modified: {AssetId}", after?.Id ?? before.Id);
-                break;
-        }
     }
 }

--- a/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
@@ -12,8 +12,6 @@ using DLCS.Model.Messaging;
 using DLCS.Model.PathElements;
 using DLCS.Model.Processing;
 using Microsoft.Extensions.Logging;
-//using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace DLCS.Repository.Messaging;
 


### PR DESCRIPTION
Fixes #656

As detailed in the original ticket there was a bug where `.SaveChanges()` wasn't called when bulk deleting images via `/deleteImages` endpoint. This is the main reason for this fix but while making the change I implemented batch raising of SNS notifications as some bulk deletion may be quite large and raising batch SNS notifications is much more efficient.

Summary of changes:
* Renamed existing `AssetNotificationSender` -> `IngestNotificationSender`. The latter now only has methods for raising ingest notifications to the Engine.
* Introduced a new `AssetNotificationSender` class, in API project, to handle raising notifications resulting from `Asset` status changes.
* Moved `SendAssetModifiedNotification()` from `IngestNotificationSender` to new `AssetNotificationSender` class. Simplified the signature to `SendAssetModifiedMessage(AssetModificationRecord notification)` because:
  * `AssetModificationRecord` contains before/after `Asset` properties and `ChangeType`. Used static creation methods to remove complex validation logic from original `SendAssetModifiedMessage` method.
  * `CustomerPathElement` is no longer passed in, it's only used for Delete notifications and is purely to allow the notification to be handled by downstream recipient so felt cleaner to be a messaging/notification concern than having caller look it up.
* Added overload of `SendAssetModifiedNotification` that takes a collection of `AssetModificationRecord` classes.
* Updated `TopicPublisher` to take a list of `AssetModifiedNotification` records, these contain serialised message and `ChangeType`. Method will now either publish a single topic, or publish topics in batches.

Note that the new `AssetNotificationSender` class only raises notifications for Deletes but I left in plumbing for Create + Update so that these can be utilised later.