### PR TITLE
Adding ability to disable delivery channels

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -13,7 +13,7 @@ public class HydraImageValidatorTests
 
     public HydraImageValidatorTests()
     {
-        var apiSettings = new ApiSettings();
+        var apiSettings = new ApiSettings() { DeliveryChannelsEnabled = true};
         sut = new HydraImageValidator(Options.Create(apiSettings));
     }
 
@@ -237,16 +237,16 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenDeliveryChannelsDisabled()
     {
-        var apiSettings = new ApiSettings() { DeliveryChannelsDisabled = true};
+        var apiSettings = new ApiSettings();
         var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
-        var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "iif-img" } };
+        var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "iiif-img" } };
         var result = imageValidator.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
     }
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsDisabled()
     {
-        var apiSettings = new ApiSettings() { DeliveryChannelsDisabled = true};
+        var apiSettings = new ApiSettings();
         var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
         var model = new DLCS.HydraModel.Image();
         var result = imageValidator.TestValidate(model);

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using API.Features.Image.Validation;
+using API.Settings;
 using DLCS.Model.Policies;
 using FluentValidation.TestHelper;
+using Microsoft.Extensions.Options;
 
 namespace API.Tests.Features.Images.Validation;
 
@@ -11,7 +13,8 @@ public class HydraImageValidatorTests
 
     public HydraImageValidatorTests()
     {
-        sut = new HydraImageValidator();
+        var apiSettings = new ApiSettings();
+        sut = new HydraImageValidator(Options.Create(apiSettings));
     }
 
     [Theory]
@@ -223,10 +226,30 @@ public class HydraImageValidatorTests
     }
     
     [Fact]
-    public void DeliveryChannel_UnkonwValue()
+    public void DeliveryChannel_UnknownValue()
     {
         var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "foo" } };
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+    }
+    
+        
+    [Fact]
+    public void DeliveryChannel_ValidationError_WhenDeliveryChannelsDisabled()
+    {
+        var apiSettings = new ApiSettings() { DeliveryChannelsDisabled = true};
+        var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
+        var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "iif-img" } };
+        var result = imageValidator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+    }
+    [Fact]
+    public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsDisabled()
+    {
+        var apiSettings = new ApiSettings() { DeliveryChannelsDisabled = true};
+        var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
+        var model = new DLCS.HydraModel.Image();
+        var result = imageValidator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
     }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -42,6 +42,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         dbContext = dbFixture.DbContext;
         httpClient = factory
             .WithConnectionString(dbFixture.ConnectionString)
+            .WithConfigValue("DeliveryChannelsEnabled", "true")
             .WithTestServices(services =>
             {
                 services.AddScoped<IEngineClient>(_ => EngineClient);

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -51,7 +51,6 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         httpClient = factory
             .WithConnectionString(dbFixture.ConnectionString)
             .WithLocalStack(storageFixture.LocalStackFixture)
-            .WithConfigValue("DeliveryChannelsDisabled", "True")
             .WithTestServices(services =>
             {
                 services.AddScoped<IEngineClient>(_ => EngineClient);

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -51,6 +51,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         httpClient = factory
             .WithConnectionString(dbFixture.ConnectionString)
             .WithLocalStack(storageFixture.LocalStackFixture)
+            .WithConfigValue("DeliveryChannelsDisabled", "True")
             .WithTestServices(services =>
             {
                 services.AddScoped<IEngineClient>(_ => EngineClient);
@@ -62,6 +63,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
             {
                 AllowAutoRedirect = false
             });
+        
         dbFixture.CleanUp();
     }
 
@@ -894,6 +896,34 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled()
+    {
+        // Arrange 
+        var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
+
+        var testAsset = await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.Image,
+            ref1: "I am string 1", origin: "https://images.org/image2.tiff");
+        await dbContext.SaveChangesAsync();
+
+        var hydraImageBody = @"{
+  ""@type"": ""Image"",
+  ""string1"": ""I am edited"",
+  ""deliveryChannels"": [
+        ""iiif-img""
+]
+}";                        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PatchAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Delivery channels are disabled");
     }
     
     [Fact]

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -5,6 +5,7 @@ using API.Features.Image.Validation;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.Core;
+using DLCS.Core.Collections;
 using DLCS.Core.Types;
 using DLCS.HydraModel;
 using Hydra.Model;
@@ -135,6 +136,12 @@ public class ImageController : HydraController
         [FromBody] DLCS.HydraModel.Image hydraAsset,
         CancellationToken cancellationToken)
     {
+        if (apiSettings.DeliveryChannelsDisabled && !hydraAsset.DeliveryChannels.IsNullOrEmpty())
+        {
+            var assetId = new AssetId(customerId, spaceId, imageId);
+            return this.HydraProblem("Delivery channels are disabled", assetId.ToString(), 400, "Bad Request");
+        }
+        
         return await PutOrPatchAsset(customerId, spaceId, imageId, hydraAsset, cancellationToken);
     }
 

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -136,7 +136,7 @@ public class ImageController : HydraController
         [FromBody] DLCS.HydraModel.Image hydraAsset,
         CancellationToken cancellationToken)
     {
-        if (apiSettings.DeliveryChannelsDisabled && !hydraAsset.DeliveryChannels.IsNullOrEmpty())
+        if (!apiSettings.DeliveryChannelsEnabled && !hydraAsset.DeliveryChannels.IsNullOrEmpty())
         {
             var assetId = new AssetId(customerId, spaceId, imageId);
             return this.HydraProblem("Delivery channels are disabled", assetId.ToString(), 400, "Bad Request");

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -33,7 +33,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
 
         // Other validation
         RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
-            .When(_ => apiSettings.Value.DeliveryChannelsDisabled)
+            .When(_ => !apiSettings.Value.DeliveryChannelsEnabled)
             .WithMessage("Delivery channels are disabled");
         
         RuleForEach(a => a.DeliveryChannels)

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -1,8 +1,10 @@
-﻿using DLCS.Core;
+﻿using API.Settings;
+using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Model.Policies;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace API.Features.Image.Validation;
 
@@ -11,7 +13,7 @@ namespace API.Features.Image.Validation;
 /// </summary>
 public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
 {
-    public HydraImageValidator()
+    public HydraImageValidator(IOptions<ApiSettings> apiSettings)
     {
         // Required fields
         RuleFor(a => a.MediaType).NotEmpty().WithMessage("Media type must be specified");
@@ -28,8 +30,12 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Batch).Empty().WithMessage("Should not include batch");
         RuleFor(a => a.Finished).Empty().WithMessage("Should not include finished");
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
-        
+
         // Other validation
+        RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
+            .When(_ => apiSettings.Value.DeliveryChannelsDisabled)
+            .WithMessage("Delivery channels are disabled");
+        
         RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -31,7 +31,7 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
             .Must(m => (m?.Length ?? 0) <= maxBatch)
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
 
-        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator());
+        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(apiSettings));
 
         // In addition to above validation, batched updates must have ModelId + Space as this can't be taken from
         // path

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -76,4 +76,9 @@ public class ApiSettings
         => CustomerOverrides.TryGetValue(Convert.ToString(customerId), out var settings) 
             ? settings.LegacySupport 
             : DefaultLegacySupport;
+    
+    /// <summary>
+    /// Whether the delivery channel feature is disabled
+    /// </summary>
+    public bool DeliveryChannelsDisabled { get; set; }
 }

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -78,7 +78,7 @@ public class ApiSettings
             : DefaultLegacySupport;
     
     /// <summary>
-    /// Whether the delivery channel feature is disabled
+    /// Whether the delivery channel feature is enabled
     /// </summary>
-    public bool DeliveryChannelsDisabled { get; set; }
+    public bool DeliveryChannelsEnabled { get; set; }
 }


### PR DESCRIPTION
Resolves #659 

This pull request adds a setting called `DeliveryChannelsDisabled` to the API.  When this property is enabled, if a request is sent with a `DeliveryChannel`, a `400` response will be returned, otherwise the API will work as intended