### PR TITLE
Allow filtering by space when querying batch images

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -483,12 +483,14 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var idRoot = $"99/1/{nameof(Get_BatchImages_200_IfImagesFound_SupportsQuery)}";
-        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}1"), batch: 4004, num1: 10);
-        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}2"), batch: 4004, num1: 9);
-        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}3"), batch: 4004, num1: 10);
+        var altSpaceRoot = $"99/2/{nameof(Get_BatchImages_200_IfImagesFound_SupportsQuery)}";
+        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}1"), batch: 4004, num1: 10, space: 1);
+        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}2"), batch: 4004, num1: 9, space: 1);
+        await dbContext.Images.AddTestAsset(AssetId.FromString($"{idRoot}3"), batch: 4004, num1: 10, space: 1);
+        await dbContext.Images.AddTestAsset(AssetId.FromString($"{altSpaceRoot}1"), batch: 4004, num1: 10, space: 2);
         await dbContext.SaveChangesAsync();
         
-        var q = @"{""number1"":10}";
+        var q = @"{""number1"":10,""space"":1}";
         var path = "customers/99/queue/batches/4004/images?q=" + q;
 
         // Act

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -50,7 +50,7 @@ public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
-                .ApplyAssetFilter(request.AssetFilter),
+                .ApplyAssetFilter(request.AssetFilter, true),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);
 


### PR DESCRIPTION
`AssetQueryX.ApplyAssetFilter()` takes a boolean signifying whether filtering on space is allowed. By default it is `false` as the assumption is that most paths contain a space (so already filtering on a space) but images in batches can be in different spaces so allow filtering there.