### PR TITLE
update to priority queue to allow family or delivery channel to not be set

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -943,7 +943,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
         await dbContext.SaveChangesAsync();
 
-        // a batch of 3 images - 1 with Family, 1 with DC and 1 with both
+        // a batch of 4 images - 1 with Family, 1 with DC, 1 with both, and 1 without
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
     ""@type"": ""Collection"",
@@ -969,6 +969,12 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
           ""family"": ""I"",
           ""space"": 2,
           ""mediaType"": ""image/tiff""
+        },
+        {
+          ""id"": ""four"",
+          ""origin"": ""https://example.org/foo.tiff"",
+          ""space"": 2,
+          ""mediaType"": ""image/tiff""
         }
     ]
 }";
@@ -991,7 +997,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Hydra batch received
         var hydraBatch = await response.ReadAsHydraResponseAsync<DLCS.HydraModel.Batch>();
         hydraBatch.Completed.Should().Be(0);
-        hydraBatch.Count.Should().Be(3);
+        hydraBatch.Count.Should().Be(4);
         var batchId = hydraBatch.GetLastPathElementAsInt()!.Value;
         
         // Db batch exists (unnecessary?)
@@ -1000,7 +1006,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Images exist with Batch set + File marked as complete
         var images = dbContext.Images.Where(i => i.Customer == customerId && i.Space == 2).ToList();
-        images.Count.Should().Be(3);
+        images.Count.Should().Be(4);
         images.Should().AllSatisfy(a =>
         {
             a.Finished.Should().BeNull();
@@ -1014,14 +1020,15 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Customer Storage incremented
         var storage = await dbContext.CustomerStorages.SingleAsync(q => q.Customer == customerId && q.Space == 0);
-        storage.NumberOfStoredImages.Should().Be(3);
+        storage.NumberOfStoredImages.Should().Be(4);
 
         // Items queued for processing
         A.CallTo(() =>
             EngineClient.AsynchronousIngestBatch(
-                A<IReadOnlyCollection<IngestAssetRequest>>.That.Matches(i => i.Count == 3), true,
+                A<IReadOnlyCollection<IngestAssetRequest>>.That.Matches(i => i.Count == 4), true,
                 A<CancellationToken>._)).MustHaveHappened();
     }
+    
     
     [Fact]
     public async Task Post_TestBatch_404_IfBatchNotFoundForCustomer()

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -46,8 +46,8 @@ public class AssetProcessor
     /// <param name="requiresReingestPreSave">Optional delegate for modifying asset prior to saving</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <param name="isPriorityQueue">Whether the request is for the priority queue or not</param>
-    public async Task<ProcessAssetResult> Process(Asset asset, bool mustExist, bool alwaysReingest, bool isBatchUpdate,
-        bool isPriorityQueue, Func<Asset, Task>? requiresReingestPreSave = null, 
+    public async Task<ProcessAssetResult> Process(Asset asset, bool mustExist, bool alwaysReingest, bool isBatchUpdate, 
+        Func<Asset, Task>? requiresReingestPreSave = null, 
         CancellationToken cancellationToken = default)
     {
         Asset? existingAsset;
@@ -96,20 +96,6 @@ public class AssetProcessor
             
             var updatedAsset = assetPreparationResult.UpdatedAsset!;
             var requiresEngineNotification = assetPreparationResult.RequiresReingest || alwaysReingest;
-            
-            // TODO - we may need to support non-Image assets here 
-            if (isPriorityQueue)
-            {
-                if (updatedAsset.Family != AssetFamily.Image && 
-                    !updatedAsset.HasDeliveryChannel(AssetDeliveryChannels.Image))
-                {
-                    return new ProcessAssetResult
-                    {
-                        Result = ModifyEntityResult<Asset>.Failure("Priority queue only supports image assets",
-                            WriteResult.FailedValidation)
-                    };
-                }
-            }
 
             if (existingAsset == null)
             {

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -45,8 +45,10 @@ public class AssetProcessor
     /// </param>
     /// <param name="requiresReingestPreSave">Optional delegate for modifying asset prior to saving</param>
     /// <param name="cancellationToken">Current cancellation token</param>
+    /// <param name="isPriorityQueue">Whether the request is for the priority queue or not</param>
     public async Task<ProcessAssetResult> Process(Asset asset, bool mustExist, bool alwaysReingest, bool isBatchUpdate,
-        Func<Asset, Task>? requiresReingestPreSave = null, CancellationToken cancellationToken = default)
+        bool isPriorityQueue, Func<Asset, Task>? requiresReingestPreSave = null, 
+        CancellationToken cancellationToken = default)
     {
         Asset? existingAsset;
         try
@@ -91,9 +93,23 @@ public class AssetProcessor
                         WriteResult.FailedValidation)
                 };
             }
-
+            
             var updatedAsset = assetPreparationResult.UpdatedAsset!;
             var requiresEngineNotification = assetPreparationResult.RequiresReingest || alwaysReingest;
+            
+            // TODO - we may need to support non-Image assets here 
+            if (isPriorityQueue)
+            {
+                if (updatedAsset.Family != AssetFamily.Image && 
+                    !updatedAsset.HasDeliveryChannel(AssetDeliveryChannels.Image))
+                {
+                    return new ProcessAssetResult
+                    {
+                        Result = ModifyEntityResult<Asset>.Failure("Priority queue only supports image assets",
+                            WriteResult.FailedValidation)
+                    };
+                }
+            }
 
             if (existingAsset == null)
             {

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -99,7 +99,6 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
             request.AssetMustExist,
             request.AlwaysReingest,
             false,
-            false,
             async updatedAsset =>
             {
                 if (updatedAsset.Family == AssetFamily.Timebased)

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -99,6 +99,7 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
             request.AssetMustExist,
             request.AlwaysReingest,
             false,
+            false,
             async updatedAsset =>
             {
                 if (updatedAsset.Family == AssetFamily.Timebased)

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -55,17 +55,6 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
     public async Task<ModifyEntityResult<Batch>> Handle(CreateBatchOfImages request,
         CancellationToken cancellationToken)
     {
-        // TODO - we may need to support non-Image assets here 
-        if (request.IsPriority)
-        {
-            if (request.Assets.Any(a =>
-                    a.Family != AssetFamily.Image && !a.HasDeliveryChannel(AssetDeliveryChannels.Image)))
-            {
-                return ModifyEntityResult<Batch>.Failure("Priority queue only supports image assets",
-                    WriteResult.FailedValidation);
-            }
-        }
-        
         var (exists, missing) = await DoAllSpacesExist(request.CustomerId, request.Assets, cancellationToken);
         if (!exists)
         {
@@ -91,7 +80,8 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
             {
                 logger.LogDebug("Processing asset {AssetId}", asset.Id);
                 var processAssetResult =
-                    await assetProcessor.Process(asset, false, true, true, cancellationToken: cancellationToken);
+                    await assetProcessor.Process(asset, false, true, true, 
+                        request.IsPriority, cancellationToken: cancellationToken);
                 if (!processAssetResult.IsSuccess)
                 {
                     logger.LogDebug("Processing asset {AssetId} failed, aborting batch. Error: '{Error}'", asset.Id,

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -55,6 +55,18 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
     public async Task<ModifyEntityResult<Batch>> Handle(CreateBatchOfImages request,
         CancellationToken cancellationToken)
     {
+        // TODO - we may need to support non-Image assets here 
+        if (request.IsPriority)
+        {
+            if (request.Assets.Any(a =>
+                    a.Family != AssetFamily.Image && !a.HasDeliveryChannel(AssetDeliveryChannels.Image) &&
+                    !MIMEHelper.IsImage(a.MediaType)))
+            {
+                return ModifyEntityResult<Batch>.Failure("Priority queue only supports image assets",
+                    WriteResult.FailedValidation);
+            }
+        }
+        
         var (exists, missing) = await DoAllSpacesExist(request.CustomerId, request.Assets, cancellationToken);
         if (!exists)
         {
@@ -80,8 +92,8 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
             {
                 logger.LogDebug("Processing asset {AssetId}", asset.Id);
                 var processAssetResult =
-                    await assetProcessor.Process(asset, false, true, true, 
-                        request.IsPriority, cancellationToken: cancellationToken);
+                    await assetProcessor.Process(asset, false, true, true,
+                        cancellationToken: cancellationToken);
                 if (!processAssetResult.IsSuccess)
                 {
                     logger.LogDebug("Processing asset {AssetId} failed, aborting batch. Error: '{Error}'", asset.Id,


### PR DESCRIPTION
Resolves #657

This pull request updates the priority queue so that it can handle not having a `family` or `deliveryChannel` set, which brings it inline with `batch POST` .  This works by checking the `MIMEtype` in addition to the other 2 properties.