### PR TITLE
checking for image location to allow deletion of assets without an image location

### DIFF
--- a/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
@@ -293,7 +293,7 @@ public class ApiAssetRepositoryTests
         var result = await sut.DeleteAsset(assetId);
         
         // Assert
-        result.Result.Should().Be(DeleteResult.NotFound);
+        result.Result.Should().Be(DeleteResult.Deleted);
     }
     
     [Fact]

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -50,9 +50,13 @@ public class AssetRepository : AssetRepositoryCachingBase
             dlcsContext.Images.Remove(asset);
 
             // And related ImageLocation
-            var imageLocation = new ImageLocation { Id = assetId };
-            dlcsContext.ImageLocations.Attach(imageLocation);
-            dlcsContext.ImageLocations.Remove(imageLocation);
+            var imageLocation = await dlcsContext.ImageLocations.FindAsync(assetId);
+
+            if (imageLocation != null)
+            {
+                dlcsContext.ImageLocations.Remove(imageLocation);
+            }
+
             var customer = assetId.Customer;
             var space = assetId.Space;
             

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -98,28 +98,6 @@ public class AssetRepository : AssetRepositoryCachingBase
             await entityCounterRepository.Decrement(0, KnownEntityCounters.CustomerImages, customer.ToString());
             return new DeleteEntityResult<Asset>(DeleteResult.Deleted, asset);
         }
-        catch (DbUpdateConcurrencyException dbEx)
-        {
-            bool notFound = true;
-            foreach (var entry in dbEx.Entries)
-            {
-                var databaseValues = await entry.GetDatabaseValuesAsync();
-                if (databaseValues != null)
-                {
-                    notFound = false;
-                }
-            }
-
-            if (notFound)
-            {
-                return new DeleteEntityResult<Asset>(DeleteResult.NotFound);
-            }
-            else
-            {
-                Logger.LogError(dbEx, "Concurrency exception deleting Asset {AssetId}", assetId);
-                return new DeleteEntityResult<Asset>(DeleteResult.Error);
-            }
-        }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error deleting asset {AssetId}", assetId);


### PR DESCRIPTION
Resolves #636

This pull request updates checks found in the `AssetRepository` class to include checking that the asset exists in the image location table.  The reason for this is that file assets don't contain an `imageLocation` record, causing the check to error out and a `404` to be returned to the user.   