### PR TITLE
Change Portal time format to `yyyy-MM-dd hh:mm:ss`

### DIFF
--- a/src/protagonist/Portal/Pages/Batches/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Batches/Index.cshtml
@@ -52,7 +52,7 @@
         </div>
         @if (Model.Batch.Finished != null)
         {
-            <span>Completed: @Model.Batch.Finished</span>
+            <span>Completed: @Model.Batch.Finished.Value.ToString("yyyy-MM-dd hh:mm:ss")</span>
         }
         else
         {

--- a/src/protagonist/Portal/Pages/Images/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Images/Index.cshtml
@@ -30,7 +30,7 @@
                     <tbody>
                         <tr>
                             <td>Created</td>
-                            <td>@Model.Image.Created</td>
+                            <td>@Model.Image.Created.Value.ToString("yyyy-MM-dd hh:mm:ss")</td>
                         </tr>
                         <tr>
                             <td>Batch</td>

--- a/src/protagonist/Portal/Pages/Queue/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Index.cshtml
@@ -53,7 +53,7 @@
                     <td>
                         @if (Model.QueueType == QueueType.Recent)
                         {
-                            <span>Completed: @batch.Finished</span>
+                            <span>Completed: @batch.Finished.Value.ToString("yyyy-MM-dd hh:mm:ss")</span>
                         }
                         else
                         {

--- a/src/protagonist/Portal/Pages/Spaces/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Spaces/Index.cshtml
@@ -51,7 +51,7 @@
         <tr>
             <th scope="row">@space.SpaceId</th>
             <td><a asp-page="/Spaces/Details" asp-route-id="@space.SpaceId">@space.Name</a></td>
-            <td>@space.Created</td>
+            <td>@space.Created.ToString("yyyy-MM-dd hh:mm:ss")</td>
         </tr>
     }
     </tbody>

--- a/src/protagonist/Portal/Pages/Users/Index.cshtml
+++ b/src/protagonist/Portal/Pages/Users/Index.cshtml
@@ -60,7 +60,7 @@
                 {
                     <tr>
                         <td>@m.Email</td>
-                        <td>@m.Created</td>
+                        <td>@m.Created.Value.ToString("yyyy-MM-dd hh:mm:ss")</td>
                         <td>@m.Enabled</td>
                         <td>
                             <a asp-controller="User" asp-action="Delete" asp-route-id="@m.Id"


### PR DESCRIPTION
This PR changes the time format used in the portal to `yyyy-MM-dd hh:mm:ss`, like the previous version:

![image](https://github.com/dlcs/protagonist/assets/95353889/f6683ffe-ef65-4d5a-a760-ba06d744f14d)
