### PR TITLE
Add space-specific mode to the Portal CSV uploader

### DIFF
--- a/src/protagonist/Portal/Features/Batches/CsvUploadController.cs
+++ b/src/protagonist/Portal/Features/Batches/CsvUploadController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using API.Client;
 using MediatR;
@@ -13,18 +12,16 @@ namespace Portal.Features.Batches;
 public class CsvUploadController : Controller
 {
     private readonly IMediator mediator;
-    private readonly IDlcsClient dlcsClient;
 
-    public CsvUploadController(IMediator mediator, IDlcsClient dlcsClient)
+    public CsvUploadController(IMediator mediator)
     {
         this.mediator = mediator;
-        this.dlcsClient = dlcsClient;
     }
 
     [HttpPost]
-    public async Task<IActionResult> Upload(List<IFormFile> file)
+    public async Task<IActionResult> Upload(List<IFormFile> file, int? space)
     {
-        var request = await mediator.Send(new IngestFromCsv(){ File = file[0]});
+        var request = await mediator.Send(new IngestFromCsv(){ SpaceId = space, File = file[0]});
         
         if (!request.IsSuccess)
         {

--- a/src/protagonist/Portal/Pages/Queue/Upload.cshtml
+++ b/src/protagonist/Portal/Pages/Queue/Upload.cshtml
@@ -1,8 +1,8 @@
 ﻿@page
-@model Portal.Pages.Queue.IndexModel;
+@model Portal.Pages.Queue.UploadModel;
 
 @{
-    ViewData["Title"] = "Upload";
+    ViewData["Title"] = Model.SpaceId.HasValue ? $"Upload into Space {Model.SpaceId.Value}" : "Upload";
 }
 
 @section header
@@ -20,8 +20,9 @@
     </ul>
 </div>
 <div class="my-2">
-    <form action="@Url.Action("Upload", "CsvUpload")" class="dropzone" id="dropzoneForm"></form>
+    <form action="@Url.Action("Upload", "CsvUpload", new { space = Model.SpaceId })" class="dropzone" id="dropzoneForm"></form>
 </div>
+
 @section Scripts
 {
     <script src="https://cdn.jsdelivr.net/npm/dropzone@5.9.2/dist/dropzone.min.js"></script>

--- a/src/protagonist/Portal/Pages/Queue/Upload.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Queue/Upload.cshtml.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Portal.Pages.Queue;
+
+public class UploadModel : PageModel
+{
+    public int? SpaceId;
+    
+    public void OnGetAsync(
+        [FromQuery] int? space)
+    {
+        SpaceId = space;
+    }
+}

--- a/src/protagonist/Portal/Pages/Spaces/Details.cshtml
+++ b/src/protagonist/Portal/Pages/Spaces/Details.cshtml
@@ -15,7 +15,6 @@
     </div>
 }
 
-
 @section header
 {
     <link href="https://cdn.jsdelivr.net/npm/dropzone@5.9.2/dist/min/dropzone.min.css" rel="stylesheet" />
@@ -27,6 +26,10 @@
       class="dropzone"
       id="dropzoneForm">
 </form>
+
+<div class="my-2">
+    <a asp-page="/queue/upload" asp-route-space="@Model.SpaceId">Upload as CSV</a>
+</div>
 
 <form method="post" asp-page-handler="Convert" id="manifestForm">
     <input type="hidden" value="@Model.SpaceId" name="spaceId">


### PR DESCRIPTION
Resolves https://github.com/dlcs/private-protagonist/issues/109

This PR allows CSV files to be uploaded from within a space.
Rows that don't contain the appropriate space ID will cause the file to be rejected.
![image](https://github.com/dlcs/protagonist/assets/95353889/f96f4ce1-ca8f-469a-8a42-b723c688bd66)
