### PR TITLE
Fix issue where newly created Portal users cannot log in

### DIFF
--- a/src/protagonist/API.Tests/Infrastructure/Validation/ApiSettingsValidatorTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Validation/ApiSettingsValidatorTests.cs
@@ -14,8 +14,8 @@ public class ApiSettingsValidatorTests
     [InlineData(" ")]
     public void Salt_Null(string salt)
     {
-        var settings = new ApiSettings { Salt = salt };
+        var settings = new ApiSettings { ApiSalt = salt };
         var result = sut.TestValidate(settings);
-        result.ShouldHaveValidationErrorFor(a => a.Salt);
+        result.ShouldHaveValidationErrorFor(a => a.ApiSalt);
     }
 }

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -32,7 +32,7 @@
     }
   },
   "PageSize": 100,
-  "Salt": "this-is-a-salt",
+  "ApiSalt": "this-is-a-salt",
   "CustomerOverrides": {
     "15": {
       "LegacySupport": true,

--- a/src/protagonist/API/Auth/ApiKeyGenerator.cs
+++ b/src/protagonist/API/Auth/ApiKeyGenerator.cs
@@ -24,7 +24,7 @@ public class ApiKeyGenerator
     public (string key, string secret) CreateApiKey(Customer customer)
     {
         var apiKey = Guid.NewGuid().ToString();
-        var apiSecret = encryption.GetApiSecret(customer, settings.Salt, apiKey);
+        var apiSecret = encryption.GetApiSecret(customer, settings.ApiSalt, apiKey);
 
         return (apiKey, apiSecret);
     }

--- a/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
@@ -82,7 +82,7 @@ public class CreatePortalUserHandler : IRequestHandler<CreatePortalUser, CreateP
             Customer = request.PortalUser.Customer,
             Email = request.PortalUser.Email,
             Enabled = true,
-            EncryptedPassword = encryption.Encrypt(String.Concat(settings.Salt, request.Password)),
+            EncryptedPassword = encryption.Encrypt(String.Concat(settings.LoginSalt, request.Password)),
             Roles = string.Empty
         };
 

--- a/src/protagonist/API/Features/Customer/Requests/PatchPortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/PatchPortalUser.cs
@@ -66,7 +66,7 @@ public class PatchPortalUserHandler : IRequestHandler<PatchPortalUser, PatchPort
         }
         if (request.Password.HasText())
         {
-            dbUser.EncryptedPassword = encryption.Encrypt(String.Concat(settings.Salt, request.Password));
+            dbUser.EncryptedPassword = encryption.Encrypt(String.Concat(settings.LoginSalt, request.Password));
         }
         
         var i = await dbContext.SaveChangesAsync(cancellationToken);
@@ -84,7 +84,7 @@ public class PatchPortalUserHandler : IRequestHandler<PatchPortalUser, PatchPort
                 }
             };
         }
-
+        
         return new PatchPortalUserResult
         {
             Error = "Unable to Patch portal user."

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -15,7 +15,9 @@ public class ApiSettings
 
     public string PathBase { get; set; }
     
-    public string Salt { get; set; }
+    public string ApiSalt { get; set; }
+    
+    public string LoginSalt { get; set; }
     
     /// <summary>
     /// The default PageSize for endpoints that support paging 

--- a/src/protagonist/API/Settings/Validation/ApiSettingsValidator.cs
+++ b/src/protagonist/API/Settings/Validation/ApiSettingsValidator.cs
@@ -6,6 +6,6 @@ public class ApiSettingsValidator : AbstractValidator<ApiSettings>
 {
     public ApiSettingsValidator()
     {
-        RuleFor(a => a.Salt).NotEmpty();
+        RuleFor(a => a.ApiSalt).NotEmpty();
     }    
 }

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -87,7 +87,7 @@ public class Startup
         services.AddDlcsBasicAuth(options =>
             {
                 options.Realm = "DLCS-API";
-                options.Salt = apiSettings.Salt;
+                options.Salt = apiSettings.ApiSalt;
             });
         
         services.AddCors(options =>


### PR DESCRIPTION
Resolves https://github.com/dlcs/private-protagonist/issues/134

This PR changes the API so that `LoginSalt` is used when creating and patching new users.