### PR TITLE
Ignore case when checking for existing user e-mail addresses in Portal

### DIFF
--- a/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
@@ -57,9 +57,11 @@ public class CreatePortalUserHandler : IRequestHandler<CreatePortalUser, CreateP
             return new CreatePortalUserResult { Error = "Email address is invalid" };
         }
 
-        var userWithEmail = await dbContext.Users.SingleOrDefaultAsync(
-            u => u.Email == request.PortalUser.Email, cancellationToken: cancellationToken);
-        if (userWithEmail != null)
+        // get all locally for more string comparison support
+        var allUsers = await dbContext.Users.ToListAsync(cancellationToken);
+        var userWithEmail = allUsers.Any(user => user.Email.Equals(request.PortalUser.Email, 
+            StringComparison.InvariantCultureIgnoreCase));
+        if (userWithEmail)
         {
             return new CreatePortalUserResult { Conflict = true, Error = "Email address already in use." };
         }

--- a/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreatePortalUser.cs
@@ -56,11 +56,9 @@ public class CreatePortalUserHandler : IRequestHandler<CreatePortalUser, CreateP
         {
             return new CreatePortalUserResult { Error = "Email address is invalid" };
         }
-
-        // get all locally for more string comparison support
-        var allUsers = await dbContext.Users.ToListAsync(cancellationToken);
-        var userWithEmail = allUsers.Any(user => user.Email.Equals(request.PortalUser.Email, 
-            StringComparison.InvariantCultureIgnoreCase));
+        
+        var userWithEmail = await dbContext.Users.AnyAsync(
+            user => user.Email.ToLower() == request.PortalUser.Email.ToLower(), cancellationToken);
         if (userWithEmail)
         {
             return new CreatePortalUserResult { Conflict = true, Error = "Email address already in use." };

--- a/src/protagonist/Portal/Features/Admin/Requests/CreateSignupLink.cs
+++ b/src/protagonist/Portal/Features/Admin/Requests/CreateSignupLink.cs
@@ -43,7 +43,7 @@ public class CreateSignupLinkHandler : IRequestHandler<CreateSignupLink, SignupL
             {
                 Id = KeyGenerator.GetUniqueKey(24),
                 Created = DateTime.UtcNow,
-                Expires = request.Expires,
+                Expires = request.Expires.ToUniversalTime(),
                 Note = request.Note
             };
             dbContext.SignupLinks.Add(newLink);

--- a/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml
+++ b/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml
@@ -43,26 +43,26 @@
                     <label asp-for="Input.DisplayName">Display name</label>
                     <input asp-for="Input.DisplayName" class="form-control" aria-describedby="displayNameHelp">
                     <span asp-validation-for="Input.DisplayName" class="text-danger"></span>
-                    <small id="displayNameHelp" class="form-text text-muted">For example, your organisation name. Used internally by the DLCS for admin and reporting.</small>
+                    <div id="displayNameHelp" class="form-text text-muted">For example, your organisation name. Used internally by the DLCS for admin and reporting.</div>
                 </div>
                 <div class="form-group">
                     <label asp-for="Input.Slug">URL name</label>
                     <input asp-for="Input.Slug" class="form-control" aria-describedby="slugHelp" placeholder="my-org">
                     <span asp-validation-for="Input.Slug" class="text-danger"></span>
-                    <small id="slugHelp" class="form-text text-muted">
+                    <div id="slugHelp" class="form-text text-muted">
                         Your IIIF Image URLs will include this as part of the address.
                         For example, dlcs.io/iiif-img/<b>my-org</b>/3/my-deep-zoom-image.
-                    </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label asp-for="Input.Email">Email address</label>
                     <input asp-for="Input.Email" class="form-control">
                     <span asp-validation-for="Input.Email" class="text-danger" aria-describedby="emailHelp"></span>
-                    <small id="emailHelp" class="form-text text-muted">
+                    <div id="emailHelp" class="form-text text-muted">
                         Filling out this form creates the <i>account</i> above,
                         and also creates one user for logging into the portal. You can create more portal users for your account later. You will also
                         be able to create API Keys for developing applications that use the DLCS.
-                    </small>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label asp-for="Input.Password"></label>

--- a/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml.cs
@@ -97,9 +97,7 @@ public class SignupModel : PageModel
 
     private async Task<bool> EmailInUse(string inputEmail)
     {
-        // get all locally for more string comparison support
-        var allUsers = await dbContext.Users.ToListAsync();
-        return allUsers.Any(user => user.Email.Equals(inputEmail, StringComparison.InvariantCultureIgnoreCase));
+        return await dbContext.Users.AnyAsync(user => user.Email.ToLower() == inputEmail.ToLower());
     }
     
     private async Task<bool> CustomerNameInUse(string inputDisplayName)

--- a/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Account/SignupFromLink.cshtml.cs
@@ -97,7 +97,9 @@ public class SignupModel : PageModel
 
     private async Task<bool> EmailInUse(string inputEmail)
     {
-        return await dbContext.Users.AnyAsync(user => user.Email == inputEmail);
+        // get all locally for more string comparison support
+        var allUsers = await dbContext.Users.ToListAsync();
+        return allUsers.Any(user => user.Email.Equals(inputEmail, StringComparison.InvariantCultureIgnoreCase));
     }
     
     private async Task<bool> CustomerNameInUse(string inputDisplayName)

--- a/src/protagonist/Portal/Pages/Admin/Signups.cshtml
+++ b/src/protagonist/Portal/Pages/Admin/Signups.cshtml
@@ -10,7 +10,7 @@
     var linkId = TempData["new-signup-id"] as string;
     <div class="alert alert-success">
         <p>New signup link for <strong>@linkId</strong> created.</p>
-        <p><a asp-page="/account/signupfromlink" asp-route-id="@linkId"
+        <p><a asp-page="/account/signupfromlink" asp-route-signupCode="@linkId"
               class="btn btn-secondary btn-sm copylink">Copy link to clipboard <span data-feather="copy"></span></a></p>
     </div>
 }


### PR DESCRIPTION
Resolves https://github.com/dlcs/private-protagonist/issues/120

Changes in this PR:

- Case-insensitive string comparison is now used when verifying that a prospective user's e-mail address isn't already in use
- The expiry date for signup links is now converted to UTC upon creation to fit current DB rules
- The "copy link to clipboard" button that appears after creating a new signup link now copies over the correct URL
- Hints in the signup form now display correctly whenever validation fails (previously, they would display to the right of the validation messages rather than below)