### PR TITLE
Trigger reingest when patching an image's `ThumbnailPolicy`

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
@@ -142,4 +142,15 @@ public class ImageBatchPatchValidatorTests
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor("Members[0].DeliveryChannels");
     }
+    
+    [Fact]
+    public void Member_ThumbnailPolicy_Provided()
+    {
+        var model = new HydraCollection<Image> { Members = new[]
+        {
+            new Image { ThumbnailPolicy = "example-policy" }
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].ThumbnailPolicy");
+    }
 }

--- a/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
@@ -36,6 +36,7 @@ public class ImageBatchPatchValidator : AbstractValidator<HydraCollection<DLCS.H
             members.RuleFor(a => a.ImageOptimisationPolicy).Empty().WithMessage("Image optimisation policies cannot be set in a bulk patching operation");
             members.RuleFor(a => a.MaxUnauthorised).Empty().WithMessage("MaxUnauthorised cannot be set in a bulk patching operation");
             members.RuleFor(a => a.DeliveryChannels).Empty().WithMessage("Delivery channels cannot be set in a bulk patching operation");
+            members.RuleFor(a => a.ThumbnailPolicy).Empty().WithMessage("Thumbnail policy cannot be set in a bulk patching operation");
         });
     }
 }

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -221,6 +221,20 @@ public class AssetPreparerTests
         // Assert
         result.RequiresReingest.Should().BeTrue();
     }
+    
+    [Fact]
+    public void PrepareAssetForUpsert_RequiresReingest_IfThumbnailPolicyChanged()
+    {
+        // Arrange
+        var updateAsset = new Asset { Origin = "https://whatever", ThumbnailPolicy = "new-policy" };
+        var existingAsset = new Asset { Origin = "https://whatever", ThumbnailPolicy = "none" };
+
+        // Act
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+
+        // Assert
+        result.RequiresReingest.Should().BeTrue();
+    }
 
     [Theory]
     [MemberData(nameof(DeliveryChannels))]
@@ -237,7 +251,7 @@ public class AssetPreparerTests
         // Assert
         result.RequiresReingest.Should().BeTrue(reason);
     }
-
+    
     [Theory]
     [InlineData("file", AssetFamily.File)]
     [InlineData("file,iiif-img", AssetFamily.Image)]

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -108,9 +108,7 @@ public static class AssetPreparer
             
             if (updateAsset.ThumbnailPolicy.HasText() && updateAsset.ThumbnailPolicy != existingAsset.ThumbnailPolicy)
             {
-                // requiresReingest = true; NO, because we'll re-create thumbs on demand - "backfill"
-                // However, we can treat a PUT as always triggering reingest, whereas a PATCH does not,
-                // even if they are otherwise equivalent - see CreateOrUpdateImage
+                requiresReingest = true;
             }
 
             if (updateAsset.ImageOptimisationPolicy.HasText() &&

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -250,12 +250,7 @@ public static class AssetPreparer
             {
                 return AssetPreparationResult.Failure("Batch cannot be edited.");
             }
-
-            if (updateAsset.ThumbnailPolicy != null && updateAsset.ThumbnailPolicy != existingAsset.ThumbnailPolicy)
-            {
-                return AssetPreparationResult.Failure("ThumbnailPolicy cannot be edited.");
-            }
-
+            
             if (updateAsset.Family != null && updateAsset.Family != existingAsset.Family)
             {
                 return AssetPreparationResult.Failure("Family cannot be edited.");


### PR DESCRIPTION
Resolves https://github.com/dlcs/protagonist/issues/647

Changes in this PR:

- Thumbnail policies can now be modified in PATCH operations. Doing so will trigger a re-ingest.
- A `RequiresReingest_IfThumbnailPolicyChanged` test has been added to `AssetPreparerTests` to ensure that a re-ingest is triggered whenever the thumbnail policy of an asset is changed during a PATCH
- Thumbnail policy changes are disallowed in bulk asset patching operations