### PR TITLE
validate customer storage allowance before ingestion

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
+++ b/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using API.Features.Assets;
+using API.Features.Image.Ingest;
+using API.Settings;
+using DLCS.Core.Settings;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Policies;
+using DLCS.Model.Storage;
+using FakeItEasy;
+using Microsoft.Extensions.Options;
+
+namespace API.Tests.Features.Images.Ingest;
+
+public class AssetProcessorTest
+{
+    private readonly AssetProcessor sut;
+    private readonly IPolicyRepository policyRepository;
+    private readonly IApiAssetRepository assetRepository;
+    private readonly IStorageRepository storageRepository;
+
+    public AssetProcessorTest()
+    {
+        var dlcsSettings = new DlcsSettings();
+        storageRepository = A.Fake<IStorageRepository>();
+        policyRepository = A.Fake<IPolicyRepository>();
+        assetRepository = A.Fake<IApiAssetRepository>();
+
+        sut = new AssetProcessor(assetRepository, storageRepository, policyRepository, Options.Create(dlcsSettings));
+    }
+    
+    [Fact]
+    public async Task Process_ChecksForMaximumNumberOfImages_Exceeded()
+    {
+        // Arrange
+        A.CallTo(() => assetRepository.GetAsset(A<AssetId>._, A<bool>._)).Returns<Asset?>(null);
+
+        A.CallTo(() => storageRepository.GetStorageMetrics(A<int>._, A<CancellationToken>._))
+            .Returns(new AssetStorageMetric
+            {
+                Policy = new StoragePolicy{MaximumTotalSizeOfStoredImages = 1000, MaximumNumberOfStoredImages = 0},
+                CustomerStorage = new CustomerStorage{ TotalSizeOfStoredImages = 10}
+            });
+
+        var asset = new Asset();
+        
+        // Act
+        var result = await sut.Process(asset, false, false, false);
+        
+        // Assert
+        result.Result.IsSuccess.Should().BeFalse();
+        result.Result.Error.Should().Be("This operation will fall outside of your storage policy for number of images: maximum is 0");
+    }
+    
+    [Fact]
+    public async Task Process_ChecksForTotalImageSize_Exceeded()
+    {
+        // Arrange
+        A.CallTo(() => assetRepository.GetAsset(A<AssetId>._, A<bool>._)).Returns<Asset?>(null);
+
+        A.CallTo(() => storageRepository.GetStorageMetrics(A<int>._, A<CancellationToken>._))
+            .Returns(new AssetStorageMetric
+            {
+                Policy = new StoragePolicy{MaximumTotalSizeOfStoredImages = -1, MaximumNumberOfStoredImages = 10},
+                CustomerStorage = new CustomerStorage{ TotalSizeOfStoredImages = 10}
+            });
+
+        var asset = new Asset();
+        
+        // Act
+        var result = await sut.Process(asset, false, false, false);
+        
+        // Assert
+        result.Result.IsSuccess.Should().BeFalse();
+        result.Result.Error.Should().Be("The total size of stored images has exceeded your allowance: maximum is -1");
+    }
+}

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -78,6 +78,17 @@ public class AssetProcessor
                         )
                     };
                 }
+                
+                if (!counts.CanStoreAssetSize(0,0))
+                {
+                    return new ProcessAssetResult
+                    {
+                        Result = ModifyEntityResult<Asset>.Failure(
+                            $"The total size of stored images has exceeded your allowance: maximum is {counts.MaximumTotalSizeOfStoredImages}",
+                            WriteResult.StorageLimitExceeded
+                        )
+                    };
+                }
 
                 counts.CustomerStorage.NumberOfStoredImages++;
             }

--- a/src/protagonist/Engine.Tests/Ingest/Workers/TimebasedIngesterWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Workers/TimebasedIngesterWorkerTests.cs
@@ -73,25 +73,6 @@ public class TimebasedIngesterWorkerTests
                 A<CustomerOriginStrategy>._, A<CancellationToken>._))
             .MustHaveHappened();
     }
-    
-    [Fact]
-    public async Task Ingest_ReturnsStorageLimitExceeded_IfFileSizeTooLarge()
-    {
-        // Arrange
-        var asset = new Asset(AssetId.FromString("2/1/shallow"));
-        var assetFromOrigin = new AssetFromOrigin(asset.Id, 13, "/target/location", "application/json");
-        assetFromOrigin.FileTooLarge();
-        A.CallTo(() =>
-            assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, A<CustomerOriginStrategy>._,
-                A<CancellationToken>._))
-            .Returns(assetFromOrigin);
-
-        // Act
-        var result = await sut.Ingest(new IngestionContext(asset), new CustomerOriginStrategy());
-
-        // Assert
-        result.Should().Be(IngestResultStatus.StorageLimitExceeded);
-    }
 
     [Fact]
     public async Task Ingest_SetsSizeValue_InMetadata_IfOriginLocationInIngestionContext()

--- a/src/protagonist/Engine/Ingest/AppSettingsAssetIngestorSizeCheck.cs
+++ b/src/protagonist/Engine/Ingest/AppSettingsAssetIngestorSizeCheck.cs
@@ -1,4 +1,5 @@
 ﻿using DLCS.Model.Assets;
+using Engine.Ingest.Models;
 using Engine.Ingest.Persistence;
 using Engine.Settings;
 using Microsoft.Extensions.Options;
@@ -26,7 +27,7 @@ public abstract class AssetIngestorSizeCheckBase : IAssetIngestorSizeCheck
     {
         if (assetFromOrigin.FileExceedsAllowance)
         {
-            asset.Error = "StoragePolicy size limit exceeded";
+            asset.Error = IngestErrors.StoragePolicyExceeded;
             return true;
         }
 

--- a/src/protagonist/Engine/Ingest/Models/IngestErrors.cs
+++ b/src/protagonist/Engine/Ingest/Models/IngestErrors.cs
@@ -1,0 +1,9 @@
+﻿namespace Engine.Ingest.Models;
+
+public static class IngestErrors
+{
+    /// <summary>
+    /// Error message related to the storage policy limit being exceeded
+    /// </summary>
+    public static string StoragePolicyExceeded => "StoragePolicy size limit exceeded";
+}

--- a/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
@@ -46,11 +46,6 @@ public class TimebasedIngesterWorker : IAssetIngesterWorker
                 customerOriginStrategy, cancellationToken);
             ingestionContext.WithAssetFromOrigin(assetInBucket);
 
-            if (assetIngestorSizeCheck.DoesAssetFromOriginExceedAllowance(assetInBucket, asset))
-            {
-                return IngestResultStatus.StorageLimitExceeded;
-            }
-            
             var jobMetadata = GetJobMetadata(ingestionContext);
             var success =
                 await mediaTranscoder.InitiateTranscodeOperation(ingestionContext, jobMetadata, cancellationToken);


### PR DESCRIPTION
Resolves #353 

This PR contains updates to check there is free storage in the bucket prior to ingestion, and removes a check on the origin for size limits
