### PR TITLE
Getting retrieve space by name to cache correctly

### DIFF
--- a/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
+++ b/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
@@ -11,17 +11,7 @@ public interface ISpaceRepository
     Task<Space?> GetSpace(int customerId, int spaceId, CancellationToken cancellationToken);
     
     Task<Space?> GetSpace(int customerId, int spaceId, bool noCache, CancellationToken cancellationToken);
-    
-    /// <summary>
-    /// Retrieves a space by name
-    /// </summary>
-    /// <param name="customerId">The customer to retrieve a space from</param>
-    /// <param name="name">The name of the space</param>
-    /// <param name="noCache">Whether the value should be cached</param>
-    /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>A space, or null if it can't be found</returns>
-    Task<Space?> GetSpace(int customerId, string name,  bool noCache, CancellationToken cancellationToken);
-    
+
     /// <summary>
     /// Retrieves a space by name
     /// </summary>

--- a/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
+++ b/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
@@ -12,6 +12,23 @@ public interface ISpaceRepository
     
     Task<Space?> GetSpace(int customerId, int spaceId, bool noCache, CancellationToken cancellationToken);
     
+    /// <summary>
+    /// Retrieves a space by name
+    /// </summary>
+    /// <param name="customerId">The customer to retrieve a space from</param>
+    /// <param name="name">The name of the space</param>
+    /// <param name="noCache">Whether the value should be cached</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>A space, or null if it can't be found</returns>
+    Task<Space?> GetSpace(int customerId, string name,  bool noCache, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Retrieves a space by name
+    /// </summary>
+    /// <param name="customerId">The customer to retrieve a space from</param>
+    /// <param name="name">The name of the space</param>
+    /// <param name="cancellationToken">The cancellation token</param>
+    /// <returns>A space, or null if it can't be found</returns>
     Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken);
 
     Task<Space> CreateSpace(int customer, string name, string? imageBucket, string[]? tags, string[]? roles,

--- a/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
@@ -1,12 +1,14 @@
 ﻿using System.Threading;
 using DLCS.Core;
 using DLCS.Core.Caching;
+using DLCS.Core.Types;
 using DLCS.Model;
 using DLCS.Repository.Spaces;
 using FakeItEasy;
-using LazyCache;
+using LazyCache.Mocks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Test.Helpers.Integration;
 
 namespace DLCS.Repository.Tests.Spaces;
 
@@ -14,25 +16,58 @@ namespace DLCS.Repository.Tests.Spaces;
 [Collection(DatabaseCollection.CollectionName)]
 public class SpaceRepositoryTests
 {
+    private readonly DlcsContext dbContext;
     private readonly SpaceRepository sut;
-    public SpaceRepositoryTests()
+    private readonly MockCachingService appCache;
+    
+    public SpaceRepositoryTests(DlcsDatabaseFixture dbFixture)
     {
-        var dbContext = A.Fake<DlcsContext>();
+        dbContext = dbFixture.DbContext;
         var cacheOptions = A.Fake<IOptions<CacheSettings>>();
-        var appCache = A.Fake<IAppCache>();
+        appCache = new MockCachingService();
         var entityCounterRepository = A.Fake<IEntityCounterRepository>();
 
 
-        sut = new SpaceRepository(dbContext, cacheOptions, appCache, new NullLogger<SpaceRepository>(), entityCounterRepository);
+        sut = new SpaceRepository(dbFixture.DbContext, Options.Create(new CacheSettings()), appCache, new NullLogger<SpaceRepository>(), entityCounterRepository);
+
+        dbFixture.CleanUp();
+        dbContext.Images.AddTestAsset(AssetId.FromString("99/1/1"), ref1: "foobar");
+        dbContext.SaveChanges();
     }
     
     [Fact]
     public async Task DeleteSpace_ReturnsError_WhenCalledWithIncorrectDatabaseSetup()
     {
+        var sutTwo = new SpaceRepository(A.Fake<DlcsContext>(), 
+            Options.Create(new CacheSettings()), appCache, new NullLogger<SpaceRepository>(), 
+            A.Fake<IEntityCounterRepository>());
+        
         // Arrange and Act
-        var deleteResult = await sut.DeleteSpace(1, 1, new CancellationToken());
+        var deleteResult = await sutTwo.DeleteSpace(1, 1, new CancellationToken());
         
         // Assert
         deleteResult.Value.Should().Be(DeleteResult.Error);
+    }
+    
+    [Fact]
+    public async Task GetSpace_ReturnsSpace_WhenCalled()
+    {
+        // Arrange and Act
+        var getResult = await sut.GetSpace(99, 1, new CancellationToken());
+
+        // Assert
+        getResult.Customer.Should().Be(99);
+        getResult.Name.Should().Be("space-1");
+    }
+    
+    [Fact]
+    public async Task GetSpaceWithName_ReturnsSpace_WhenCalled()
+    {
+        // Arrange and Act
+        var getResult = await sut.GetSpace(99, "space-1", new CancellationToken());
+
+        // Assert
+        getResult.Customer.Should().Be(99);
+        getResult.Id.Should().Be(1);
     }
 }

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -68,13 +68,7 @@ public class SpaceRepository : ISpaceRepository
     
     public async Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken)
     {
-        return await GetSpace(customerId, name, false, cancellationToken);
-    }
-    
-    public async Task<Space?> GetSpace(int customerId, string name, bool noCache, CancellationToken cancellationToken)
-    {
-        var space = await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: noCache);
-        return space;
+        return await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: false);
     }
 
     public async Task<Space> CreateSpace(int customer, string name, string? imageBucket, 
@@ -121,7 +115,9 @@ public class SpaceRepository : ISpaceRepository
         CancellationToken cancellationToken, string? name = null,
         bool withApproximateImageCount = false, bool noCache = false)
     {
-        var key = $"space:{customerId}/{name ?? spaceId.ToString()}";
+        var cacheId = name != null ? $"name:{name}" : $"id:{spaceId}";
+        
+        var key = $"space:{cacheId}";
         if (noCache)
         {
             appCache.Remove(key);

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -68,7 +68,12 @@ public class SpaceRepository : ISpaceRepository
     
     public async Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken)
     {
-        var space = await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache:true);
+        return await GetSpace(customerId, name, false, cancellationToken);
+    }
+    
+    public async Task<Space?> GetSpace(int customerId, string name, bool noCache, CancellationToken cancellationToken)
+    {
+        var space = await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: noCache);
         return space;
     }
 
@@ -116,7 +121,7 @@ public class SpaceRepository : ISpaceRepository
         CancellationToken cancellationToken, string? name = null,
         bool withApproximateImageCount = false, bool noCache = false)
     {
-        var key = $"space:{customerId}/{spaceId}";
+        var key = $"space:{customerId}/{name ?? spaceId.ToString()}";
         if (noCache)
         {
             appCache.Remove(key);
@@ -127,7 +132,7 @@ public class SpaceRepository : ISpaceRepository
             Space? space;
             if (name != null)
             {
-                space = await dlcsContext.Spaces
+                space = await dlcsContext.Spaces.AsNoTracking()
                     .Where(s => s.Customer == customerId)
                     .SingleOrDefaultAsync(s => s.Name == name, cancellationToken: cancellationToken);
             }


### PR DESCRIPTION
Resolves #598 

This fix updates the `GetSpace` by name method to cache with a key like `space:{customer id}/{name of space}`, in similarity to the `GetSpace` by id method 