### PR TITLE
Configure CleanupHandler to use `AddSystemsManager`

### DIFF
--- a/src/protagonist/CleanupHandler/Program.cs
+++ b/src/protagonist/CleanupHandler/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CleanupHandler.Infrastructure;
+using DLCS.AWS.SSM;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -40,5 +41,9 @@ public class Program
             .UseSerilog((hostingContext, loggerConfiguration)
                 => loggerConfiguration
                     .ReadFrom.Configuration(hostingContext.Configuration)
-            );
+            )
+            .ConfigureAppConfiguration((context, builder) =>
+            {
+                builder.AddSystemsManager(context);
+            });
 }


### PR DESCRIPTION
Resolves https://github.com/dlcs/protagonist/issues/643

This PR configures CleanupHandler to use AWS parameters from `AddSystemsManager` when running in a production environment.