### PR TITLE
Removing ability to set a public ACL from the timebased delivery channel

### DIFF
--- a/src/protagonist/DLCS.AWS/S3/IBucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/IBucketWriter.cs
@@ -19,13 +19,12 @@ public interface IBucketWriter
     /// <param name="source">Bucket where object is currently stored.</param>
     /// <param name="destination">Target bucket where object is to be stored.</param>
     /// <param name="verifySize">Function to verify objectSize prior to copying. Not copied if false returned.</param>
-    /// <param name="destIsPublic">If true the copied object is given public access rights</param>
     /// <param name="contentType">ContentType to set on uploaded object</param>
     /// <param name="token">Cancellation token</param>
     /// <returns>ResultStatus signifying success or failure alongside ContentSize</returns>
     /// <remarks>See https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingLLNetMPUapi.html </remarks>
     public Task<LargeObjectCopyResult> CopyLargeObject(ObjectInBucket source, ObjectInBucket destination,
-        Func<long, Task<bool>>? verifySize = null, bool destIsPublic = false, string? contentType = null, 
+        Func<long, Task<bool>>? verifySize = null, string? contentType = null, 
         CancellationToken token = default);
 
     /// <summary>

--- a/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
@@ -58,7 +58,7 @@ public class AssetToS3Tests
         var context = new IngestionContext(asset);
 
         A.CallTo(() => bucketWriter.CopyLargeObject(A<ObjectInBucket>._, A<ObjectInBucket>._,
-                A<Func<long, Task<bool>>>._, false, A<string?>._, A<CancellationToken>._))
+                A<Func<long, Task<bool>>>._, A<string?>._, A<CancellationToken>._))
             .Returns(new LargeObjectCopyResult(LargeObjectStatus.Success, 100));
 
         var ct = new CancellationToken();
@@ -70,7 +70,7 @@ public class AssetToS3Tests
         A.CallTo(() => bucketWriter.CopyLargeObject(
                 A<ObjectInBucket>.That.Matches(o => o.ToString() == "origin:::large_file.mov"),
                 A<ObjectInBucket>.That.Matches(o => o.ToString() == "fantasy:::test-key"),
-                A<Func<long, Task<bool>>>._, false, A<string?>._, ct))
+                A<Func<long, Task<bool>>>._, A<string?>._, ct))
             .MustHaveHappened();
     }
 
@@ -95,7 +95,7 @@ public class AssetToS3Tests
         var context = new IngestionContext(asset);
 
         A.CallTo(() => bucketWriter.CopyLargeObject(A<ObjectInBucket>._, A<ObjectInBucket>._,
-                A<Func<long, Task<bool>>>._, false, A<string?>._, A<CancellationToken>._))
+                A<Func<long, Task<bool>>>._, A<string?>._, A<CancellationToken>._))
             .Returns(new LargeObjectCopyResult(LargeObjectStatus.Success, assetSize));
 
         var expected = new AssetFromOrigin(asset.Id, assetSize, "s3://fantasy/test-key", mediaType);
@@ -128,7 +128,7 @@ public class AssetToS3Tests
         var context = new IngestionContext(asset);
 
         A.CallTo(() => bucketWriter.CopyLargeObject(A<ObjectInBucket>._, A<ObjectInBucket>._,
-                A<Func<long, Task<bool>>>._, false, A<string?>._, A<CancellationToken>._))
+                A<Func<long, Task<bool>>>._, A<string?>._, A<CancellationToken>._))
             .Returns(new LargeObjectCopyResult(LargeObjectStatus.FileTooLarge, assetSize));
 
         var expected = new AssetFromOrigin(asset.Id, assetSize, "s3://fantasy/test-key", mediaType);
@@ -163,7 +163,7 @@ public class AssetToS3Tests
         var context = new IngestionContext(asset);
 
         A.CallTo(() => bucketWriter.CopyLargeObject(A<ObjectInBucket>._, A<ObjectInBucket>._,
-                A<Func<long, Task<bool>>>._, false, A<string?>._, A<CancellationToken>._))
+                A<Func<long, Task<bool>>>._, A<string?>._, A<CancellationToken>._))
             .Returns(new LargeObjectCopyResult(status));
 
         var ct = new CancellationToken();

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Completion/TimebasedIngesterCompletionTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Completion/TimebasedIngesterCompletionTests.cs
@@ -85,7 +85,7 @@ public class TimebasedIngesterCompletionTests
             }
         });
         A.CallTo(() => bucketWriter.CopyLargeObject(A<ObjectInBucket>._, A<ObjectInBucket>._,
-                A<Func<long, Task<bool>>>._, A<bool>._, A<string?>._, A<CancellationToken>._))
+                A<Func<long, Task<bool>>>._, A<string?>._, A<CancellationToken>._))
             .Returns(new LargeObjectCopyResult(status));
         
         // Act

--- a/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
+++ b/src/protagonist/Test.Helpers/Storage/TestBucketWriter.cs
@@ -108,7 +108,7 @@ public class TestBucketWriter : IBucketWriter
     }
 
     public async Task<LargeObjectCopyResult> CopyLargeObject(ObjectInBucket source, ObjectInBucket destination,
-        Func<long, Task<bool>> verifySize = null, bool destIsPublic = false, string? contentType = null,
+        Func<long, Task<bool>> verifySize = null, string? contentType = null,
         CancellationToken token = default)
     {
         Operations[destination.Key] = new BucketObject { Bucket = destination.Bucket, ContentType = contentType };


### PR DESCRIPTION
Resolves #609 

Setting a public ACL is no longer required as requests are now proxied through yarp.  However, there was the possibility of errors when a public ACL is set on an object in a bucket that isn't public.  This PR removes the ability for this to be set from the code