### PR TITLE
Creating a flag that disables cache invalidation

### DIFF
--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -64,7 +64,13 @@ public class AssetDeletedHandler : IMessageHandler
         DeleteFromNas(request.Asset.Id);
         await DeleteFromOriginBucket(request.Asset.Id);
 
-        return await InvalidateContentDeliveryNetwork(request.Asset);
+        if (!handlerSettings.DisableCacheInvalidation)
+        {
+            return await InvalidateContentDeliveryNetwork(request.Asset);
+        }
+
+        logger.LogDebug("Cache invalidation disabled");
+        return true;
     }
 
     private async Task DeleteFromOriginBucket(AssetId assetId)

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -13,4 +13,9 @@ public class CleanupHandlerSettings
     /// AWS config
     /// </summary>
     public AWSSettings AWS { get; set; }
+    
+    /// <summary>
+    /// Used to disable cache invalidation
+    /// </summary>
+    public bool DisableCacheInvalidation { get; set; }
 }


### PR DESCRIPTION
Resolves #676 

This PR adds a setting called `DisableCacheInvalidation` which is used to stop the cleanup handler from creating invalidations