### PR TITLE
`ThumbnailCalculator` bugfixes

### DIFF
--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -320,4 +320,25 @@ public class ThumbnailCalculatorTests
         result.Ideal.Width.Should().Be(250);
         result.Ideal.Height.Should().Be(450);
     }
+    
+    [Fact]
+    public void GetCandidates_ReturnsCorrectIdealSize_IfLargerThanAvailableSizes()
+    {
+        var imageRequest = new ImageRequest
+        {
+            Size = new SizeParameter
+            {
+                Width = 802,
+                Height = 401,
+                Confined = true,
+            }
+        };
+        
+        // Act
+        var result = (ResizableSize)ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, true);
+        
+        result.KnownSize.Should().BeFalse();
+        result.Ideal.Width.Should().Be(802);
+        result.Ideal.Height.Should().Be(401);
+    }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -13,7 +13,8 @@ public class ThumbnailCalculatorTests
 {
     private readonly List<Size> landscapeSizes;
     private readonly List<Size> portraitSizes;
-
+    private readonly List<Size> squareSizes;
+    
     public ThumbnailCalculatorTests()
     {
         portraitSizes = new List<Size>
@@ -28,6 +29,12 @@ public class ThumbnailCalculatorTests
             new(800, 400),
             new(400, 200),
             new(200, 100),
+        };
+        
+        squareSizes = new List<Size>()
+        {
+            new Size(200, 200),
+            new Size(500, 500)
         };
     }
     
@@ -337,8 +344,29 @@ public class ThumbnailCalculatorTests
         // Act
         var result = (ResizableSize)ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, true);
         
+        // Assert
         result.KnownSize.Should().BeFalse();
         result.Ideal.Width.Should().Be(802);
         result.Ideal.Height.Should().Be(401);
+    }
+
+    [Fact]
+    public void GetCandidates_ReturnsCorrectLongestEdge_IfSquare()
+    {
+        var imageRequest = new ImageRequest
+        {
+            Size = new SizeParameter
+            {
+                Width = 200,
+                Height = 500,
+                Confined = true,
+            }
+        };
+        
+        // Act
+        var result = (ResizableSize)ThumbnailCalculator.GetCandidate(squareSizes, imageRequest, true);
+        
+        // Assert
+        result.LongestEdge.Should().Be(200);
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -291,7 +291,7 @@ public class ThumbnailCalculatorTests
         };
         
         // Act
-        var result = (ResizableSize)ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, true);
+        var result = (ResizableSize)ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, true);
         
         // Assert
         result.KnownSize.Should().BeFalse();

--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -331,6 +331,7 @@ public class ThumbnailCalculatorTests
     [Fact]
     public void GetCandidates_ReturnsCorrectIdealSize_IfLargerThanAvailableSizes()
     {
+        // Arrange
         var imageRequest = new ImageRequest
         {
             Size = new SizeParameter
@@ -353,6 +354,7 @@ public class ThumbnailCalculatorTests
     [Fact]
     public void GetCandidates_ReturnsCorrectLongestEdge_IfSquare()
     {
+        // Arrange
         var imageRequest = new ImageRequest
         {
             Size = new SizeParameter
@@ -368,5 +370,47 @@ public class ThumbnailCalculatorTests
         
         // Assert
         result.LongestEdge.Should().Be(200);
+    }
+
+    [Fact]
+    public void GetCandidates_SelectsCorrectShortestEdge_IfConfined_ForLandscapeImage()
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+        {
+            Size = new SizeParameter
+            {
+                Width = 800,
+                Height = 350,
+                Confined = true,
+            }
+        };
+        
+        //Act
+        var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, false);
+        
+        //Assert
+        result.LongestEdge.Should().NotBe(800);
+    }
+    
+    [Fact]
+    public void GetCandidates_SelectsCorrectShortestEdge_IfConfined_ForPortraitImage()
+    {
+        // Arrange
+        var imageRequest = new ImageRequest
+        {
+            Size = new SizeParameter
+            {
+                Width = 350,
+                Height = 800,
+                Confined = true,
+            }
+        };
+        
+        //Act
+        var result = ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, false);
+        
+        //Assert
+        result.LongestEdge.Should().NotBe(800);
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/ThumbnailCalculatorTests.cs
@@ -373,7 +373,7 @@ public class ThumbnailCalculatorTests
     }
 
     [Fact]
-    public void GetCandidates_SelectsCorrectShortestEdge_IfConfined_ForLandscapeImage()
+    public void GetCandidates_ReturnsEmptyLongestEdge_IfConfined_ForLandscapeImage_IfSmallDimensionTooSmall()
     {
         // Arrange
         var imageRequest = new ImageRequest
@@ -390,11 +390,12 @@ public class ThumbnailCalculatorTests
         var result = ThumbnailCalculator.GetCandidate(landscapeSizes, imageRequest, false);
         
         //Assert
-        result.LongestEdge.Should().NotBe(800);
+        result.KnownSize.Should().BeFalse();
+        result.LongestEdge.Should().BeNull();
     }
     
     [Fact]
-    public void GetCandidates_SelectsCorrectShortestEdge_IfConfined_ForPortraitImage()
+    public void GetCandidates_ReturnsEmptyLongestEdge_IfConfined_ForPortraitImage_IfSmallDimensionTooSmall()
     {
         // Arrange
         var imageRequest = new ImageRequest
@@ -411,6 +412,7 @@ public class ThumbnailCalculatorTests
         var result = ThumbnailCalculator.GetCandidate(portraitSizes, imageRequest, false);
         
         //Assert
-        result.LongestEdge.Should().NotBe(800);
+        result.KnownSize.Should().BeFalse();
+        result.LongestEdge.Should().BeNull();
     }
 }

--- a/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -25,11 +25,21 @@ public static class ThumbnailCalculator
 
     private static SizeCandidate GetLongestEdge(List<Size> sizes, ImageRequest imageRequest)
     {
-        // get the longest dimension of the requested size
-        var max = Math.Max(imageRequest.Size.Width ?? 0, imageRequest.Size.Height ?? 0);
-        
         if (imageRequest.Size.Width > 0 && imageRequest.Size.Height > 0)
         {
+            // get the longest dimension of the requested size
+            var max = Math.Max(imageRequest.Size.Width ?? 0, imageRequest.Size.Height ?? 0);
+            var foundExactSize = sizes.Exists(s => 
+                s.Height == imageRequest.Size.Height &&
+                s.Width == imageRequest.Size.Width);
+
+            // We found a size that matches the request exactly, so we'll go with that
+            if (foundExactSize)
+            {
+                return new SizeCandidate(max);
+            }
+            
+            // If the image is confined, are there any sizes that fit?
             if (imageRequest.Size.Confined)
             {
                 // Pick the first thumbnail size as a reference for shape
@@ -52,16 +62,14 @@ public static class ThumbnailCalculator
                         break;
                 }
                 
-                if (confinedSizeFound) return new SizeCandidate(max);
+                if (confinedSizeFound)
+                {
+                    return new SizeCandidate(max);
+                }
             }
             
-            var foundExactSize = sizes.Exists(s => 
-                s.Height == imageRequest.Size.Height &&
-                s.Width == imageRequest.Size.Width);
-        
-            return foundExactSize ?
-                new SizeCandidate(max) :
-                new SizeCandidate();
+            // Otherwise, resize
+            return new SizeCandidate();
         }
         
         if (imageRequest.Size.Max)

--- a/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -25,13 +25,43 @@ public static class ThumbnailCalculator
 
     private static SizeCandidate GetLongestEdge(List<Size> sizes, ImageRequest imageRequest)
     {
+        // get the longest dimension of the requested size
+        var max = Math.Max(imageRequest.Size.Width ?? 0, imageRequest.Size.Height ?? 0);
+        
         if (imageRequest.Size.Width > 0 && imageRequest.Size.Height > 0)
         {
-            // We don't actually need to check imageRequest.Size.Confined (!w,h) because same logic applies...
-            var max = Math.Max(imageRequest.Size.Width ?? 0, imageRequest.Size.Height ?? 0);
-            return sizes.Select(s => s.MaxDimension).Contains(max)
-                ? new SizeCandidate(max)
-                : new SizeCandidate();
+            if (imageRequest.Size.Confined)
+            {
+                // Pick the first thumbnail size as a reference for shape
+                var shape = sizes.First().GetShape();
+                var confinedSizeFound = false;
+
+                switch (shape)
+                {
+                    // If this is a landscape image, max should match its width
+                    case ImageShape.Landscape:
+                        confinedSizeFound = sizes.Exists(s => s.Width == max && imageRequest.Size.Height >= s.Height);
+                        break;
+                    // For portrait images, max should match its height
+                    case ImageShape.Portrait:
+                        confinedSizeFound = sizes.Exists(s => s.Height == max && imageRequest.Size.Width >= s.Width);
+                        break;
+                    // Lastly, for square images, max should match both dimensions
+                    case ImageShape.Square:
+                        confinedSizeFound = sizes.Exists(s => s.Height == max && s.Width == max);
+                        break;
+                }
+                
+                if (confinedSizeFound) return new SizeCandidate(max);
+            }
+            
+            var foundExactSize = sizes.Exists(s => 
+                s.Height == imageRequest.Size.Height &&
+                s.Width == imageRequest.Size.Width);
+        
+            return foundExactSize ?
+                new SizeCandidate(max) :
+                new SizeCandidate();
         }
         
         if (imageRequest.Size.Max)
@@ -73,6 +103,7 @@ public static class ThumbnailCalculator
         // TODO - handle there being none "open"?
         
         var sizeCandidate = GetLongestEdge(sizes, imageRequest);
+        
         if (sizeCandidate.KnownSize)
         {
             // We have found a matching size, use that.

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -275,7 +275,7 @@ public class ImageRequestHandlerTests
     {
         // Arrange
         var context = new DefaultHttpContext();
-        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
+        context.Request.Path = "/iiif-img/2/2/test-image/full/!150,150/0/default.jpg";
 
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
@@ -293,7 +293,7 @@ public class ImageRequestHandlerTests
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
+        result.Path.Should().Be("thumbs/2/2/test-image/full/!150,150/0/default.jpg");
     }
 
     [Fact]
@@ -301,7 +301,7 @@ public class ImageRequestHandlerTests
     {
         // Arrange
         var context = new DefaultHttpContext();
-        context.Request.Path = "/iiif-img/2/2/test-image/full/!100,150/0/default.jpg";
+        context.Request.Path = "/iiif-img/2/2/test-image/full/!150,150/0/default.jpg";
 
         A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
         var assetId = new AssetId(2, 2, "test-image");
@@ -318,7 +318,7 @@ public class ImageRequestHandlerTests
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!100,150/0/default.jpg");
+        result.Path.Should().Be("thumbs/2/2/test-image/full/!150,150/0/default.jpg");
     }
     
     [Theory]


### PR DESCRIPTION
Resolves https://github.com/dlcs/protagonist/issues/642

This PR fixes a bug with `ThumbnailCalculator` that caused it to serve the wrong pre-generated thumbnail candidate. 

It also fixes the `ProxiesToThumbs` tests in `ImageRequestHandlerTests`, which have been broken by this change. They previously expected a request asking for a confined size of 100x150 to cause Orchestrator to return an image from the thumbnail server, but as the stored thumbnail is 150x150 it received an image from the special server instead.