### PR TITLE
Adding ability to restrict allowed characters in an asset id and allowing `(` and `)`

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
+++ b/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
@@ -22,12 +22,12 @@ public class AssetProcessorTest
 
     public AssetProcessorTest()
     {
-        var dlcsSettings = new DlcsSettings();
+        var apiSettings = new ApiSettings();
         storageRepository = A.Fake<IStorageRepository>();
         policyRepository = A.Fake<IPolicyRepository>();
         assetRepository = A.Fake<IApiAssetRepository>();
 
-        sut = new AssetProcessor(assetRepository, storageRepository, policyRepository, Options.Create(dlcsSettings));
+        sut = new AssetProcessor(assetRepository, storageRepository, policyRepository, Options.Create(apiSettings));
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
+++ b/src/protagonist/API.Tests/Features/Images/Ingest/AssetProcessorTest.cs
@@ -10,6 +10,7 @@ using DLCS.Model.Policies;
 using DLCS.Model.Storage;
 using FakeItEasy;
 using Microsoft.Extensions.Options;
+using Test.Helpers.Settings;
 
 namespace API.Tests.Features.Images.Ingest;
 
@@ -26,8 +27,10 @@ public class AssetProcessorTest
         storageRepository = A.Fake<IStorageRepository>();
         policyRepository = A.Fake<IPolicyRepository>();
         assetRepository = A.Fake<IApiAssetRepository>();
+        
+        var optionsMonitor = OptionsHelpers.GetOptionsMonitor(apiSettings);
 
-        sut = new AssetProcessor(assetRepository, storageRepository, policyRepository, Options.Create(apiSettings));
+        sut = new AssetProcessor(assetRepository, storageRepository, policyRepository, optionsMonitor);
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -282,7 +282,7 @@ public class HydraImageValidatorTests
     }
     
     [Fact]
-    public void Id_HasNoValidationErrors_WhenCalledWithStrictAssetIdDisabled ()
+    public void Id_HasNoValidationErrors_WhenCalledWithStrictAssetIdDisabled()
     {
         var model = new DLCS.HydraModel.Image
         {
@@ -295,6 +295,31 @@ public class HydraImageValidatorTests
         {
             DeliveryChannelsEnabled = true, 
             RestrictedAssetIdCharacters = "\\ ", 
+            DisableStrictAssetIdChecks = true
+        };
+        var validator = new HydraImageValidator(Options.Create(apiSettings));
+        
+        var result = validator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.ModelId);
+    }
+    
+    [Theory]
+    [InlineData("some id")]
+    [InlineData("some\\id")]
+    [InlineData("someId")]
+    public void Id_HasNoValidationErrors_WhenCalledWithEmptyStrictAssetIdCharacters(string id)
+    {
+        var model = new DLCS.HydraModel.Image
+        {
+            ModelId = id,
+            MediaType = "image/jpeg",
+            ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
+        };
+        
+        var apiSettings = new ApiSettings()
+        {
+            DeliveryChannelsEnabled = true, 
+            RestrictedAssetIdCharacters = "", 
             DisableStrictAssetIdChecks = true
         };
         var validator = new HydraImageValidator(Options.Create(apiSettings));

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -13,7 +13,7 @@ public class HydraImageValidatorTests
 
     public HydraImageValidatorTests()
     {
-        var apiSettings = new ApiSettings() { DeliveryChannelsEnabled = true, RestrictedAssetIdCharacters = "\\ "};
+        var apiSettings = new ApiSettings() { DeliveryChannelsEnabled = true, RestrictedAssetIdCharacterString = "\\ "};
         sut = new HydraImageValidator(Options.Create(apiSettings));
     }
 
@@ -251,57 +251,5 @@ public class HydraImageValidatorTests
         var model = new DLCS.HydraModel.Image();
         var result = imageValidator.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
-    }
-    
-    [Theory]
-    [InlineData("some id")]
-    [InlineData("some\\id")]
-    public void Id_HasValidationErrors_WhenCalledWithRestrictedCharacters(string id)
-    {
-        var model = new DLCS.HydraModel.Image
-        {
-            ModelId = id,
-            MediaType = "image/jpeg",
-            ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
-        };
-        var result = sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor(a => a.ModelId);
-    }
-    
-    [Fact]
-    public void Id_HasNoValidationErrors_WhenCalledWithoutRestrictedCharacters()
-    {
-        var model = new DLCS.HydraModel.Image
-        {
-            ModelId = "someId",
-            MediaType = "image/jpeg",
-            ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
-        };
-        var result = sut.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.ModelId);
-    }
-
-    [Theory]
-    [InlineData("some id")]
-    [InlineData("some\\id")]
-    [InlineData("someId")]
-    public void Id_HasNoValidationErrors_WhenCalledWithEmptyStrictAssetIdCharacters(string id)
-    {
-        var model = new DLCS.HydraModel.Image
-        {
-            ModelId = id,
-            MediaType = "image/jpeg",
-            ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
-        };
-        
-        var apiSettings = new ApiSettings()
-        {
-            DeliveryChannelsEnabled = true, 
-            RestrictedAssetIdCharacters = ""
-        };
-        var validator = new HydraImageValidator(Options.Create(apiSettings));
-        
-        var result = validator.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.ModelId);
     }
 }

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -320,7 +320,7 @@ public class HydraImageValidatorTests
         {
             DeliveryChannelsEnabled = true, 
             RestrictedAssetIdCharacters = "", 
-            DisableStrictAssetIdChecks = true
+            DisableStrictAssetIdChecks = false
         };
         var validator = new HydraImageValidator(Options.Create(apiSettings));
         

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -280,29 +280,7 @@ public class HydraImageValidatorTests
         var result = sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.ModelId);
     }
-    
-    [Fact]
-    public void Id_HasNoValidationErrors_WhenCalledWithStrictAssetIdDisabled()
-    {
-        var model = new DLCS.HydraModel.Image
-        {
-            ModelId = "some Id",
-            MediaType = "image/jpeg",
-            ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
-        };
-        
-        var apiSettings = new ApiSettings()
-        {
-            DeliveryChannelsEnabled = true, 
-            RestrictedAssetIdCharacters = "\\ ", 
-            DisableStrictAssetIdChecks = true
-        };
-        var validator = new HydraImageValidator(Options.Create(apiSettings));
-        
-        var result = validator.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.ModelId);
-    }
-    
+
     [Theory]
     [InlineData("some id")]
     [InlineData("some\\id")]
@@ -319,8 +297,7 @@ public class HydraImageValidatorTests
         var apiSettings = new ApiSettings()
         {
             DeliveryChannelsEnabled = true, 
-            RestrictedAssetIdCharacters = "", 
-            DisableStrictAssetIdChecks = false
+            RestrictedAssetIdCharacters = ""
         };
         var validator = new HydraImageValidator(Options.Create(apiSettings));
         

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -43,6 +43,5 @@
       "NovelSpaces": ["1","4"]
     }
   },
-  "RestrictedAssetIdCharacters": "\\ ",
-  "DisableStrictAssetIdChecks": false
+  "RestrictedAssetIdCharacters": "\\ "
 }

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -43,5 +43,5 @@
       "NovelSpaces": ["1","4"]
     }
   },
-  "RestrictedAssetIdCharacters": "\\ "
+  "RestrictedAssetIdCharacterString": "\\ "
 }

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -42,5 +42,7 @@
       "LegacySupport": true,
       "NovelSpaces": ["1","4"]
     }
-  }
+  },
+  "RestrictedAssetIdCharacters": "\\ ",
+  "DisableStrictAssetIdChecks": false
 }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -99,9 +99,12 @@ public class ImageController : HydraController
         {
             hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset);
         }
-        
-        hydraAsset.ModelId = imageId;
 
+        if (hydraAsset.ModelId == null)
+        {
+            hydraAsset.ModelId = imageId;
+        }
+        
         var validationResult = await validator.ValidateAsync(hydraAsset, cancellationToken);
         if (!validationResult.IsValid)
         {

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -66,7 +66,7 @@ public class ImageController : HydraController
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>
     /// <remarks>
-    /// Sample requests:
+    /// Sample request:
     ///
     ///     PUT: /customers/1/spaces/1/images/my-image
     ///     {
@@ -75,13 +75,6 @@ public class ImageController : HydraController
     ///         "origin": "https://example.text/.../image.jpeg",
     ///         "mediaType": "image/jpeg",
     ///         "string1": "my-metadata"
-    ///     }
-    ///
-    ///     PUT: /customers/1/spaces/1/images/my-image
-    ///     {
-    ///         "@type":"Image",
-    ///         "family": "I",
-    ///         "file": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAM...."
     ///     }
     /// </remarks>
     [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))]
@@ -107,6 +100,8 @@ public class ImageController : HydraController
             hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset);
         }
         
+        hydraAsset.ModelId = imageId;
+
         var validationResult = await validator.ValidateAsync(hydraAsset, cancellationToken);
         if (!validationResult.IsValid)
         {
@@ -212,9 +207,8 @@ public class ImageController : HydraController
     }
 
     /// <summary>
-    /// <para>Ingest specified file bytes to DLCS.
-    /// "File" property should be base64 encoded image.</para>
-    /// <para>This route is now deprecated. <see cref="PutImage"/> should be used instead.</para>
+    /// Ingest specified file bytes to DLCS. Only "I" family assets are accepted.
+    /// "File" property should be base64 encoded image. 
     /// </summary>
     /// <remarks>
     /// Sample request:
@@ -242,7 +236,8 @@ public class ImageController : HydraController
             "Warning: POST /customers/{CustomerId}/spaces/{SpaceId}/images/{ImageId} was called. This route is deprecated.",
             customerId, spaceId, imageId);
         
-        return await PutImage(customerId, spaceId, imageId, hydraAsset, validator, cancellationToken);
+
+        return await PutOrPatchAsset(customerId, spaceId, imageId, hydraAsset, cancellationToken);
     }
 
     /// <summary>

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -235,6 +235,7 @@ public class ImageController : HydraController
         [FromServices] HydraImageValidator validator,
         CancellationToken cancellationToken)
     {
+
         logger.LogWarning(
             "Warning: POST /customers/{CustomerId}/spaces/{SpaceId}/images/{ImageId} was called. This route is deprecated.",
             customerId, spaceId, imageId);

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -241,7 +241,7 @@ public class ImageController : HydraController
             customerId, spaceId, imageId);
         
 
-        return await PutOrPatchAsset(customerId, spaceId, imageId, hydraAsset, cancellationToken);
+        return await PutImage(customerId, spaceId, imageId, hydraAsset, validator, cancellationToken);
     }
 
     /// <summary>

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -27,12 +27,12 @@ public class AssetProcessor
         IApiAssetRepository assetRepository,
         IStorageRepository storageRepository,
         IPolicyRepository policyRepository,
-        IOptions<ApiSettings> apiSettings)
+        IOptionsMonitor<ApiSettings> apiSettings)
     {
         this.assetRepository = assetRepository;
         this.storageRepository = storageRepository;
         this.policyRepository = policyRepository;
-        this.settings = apiSettings.Value;
+        settings = apiSettings.CurrentValue;
     }
 
     /// <summary>

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using API.Features.Assets;
 using API.Infrastructure.Requests;
+using API.Settings;
 using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Core.Settings;
@@ -20,18 +21,18 @@ public class AssetProcessor
     private readonly IPolicyRepository policyRepository;
     private readonly IApiAssetRepository assetRepository;
     private readonly IStorageRepository storageRepository;
-    private readonly DlcsSettings settings;
+    private readonly ApiSettings settings;
     
     public AssetProcessor(
         IApiAssetRepository assetRepository,
         IStorageRepository storageRepository,
         IPolicyRepository policyRepository,
-        IOptions<DlcsSettings> dlcsSettings)
+        IOptions<ApiSettings> apiSettings)
     {
         this.assetRepository = assetRepository;
         this.storageRepository = storageRepository;
         this.policyRepository = policyRepository;
-        this.settings = dlcsSettings.Value;
+        this.settings = apiSettings.Value;
     }
 
     /// <summary>
@@ -94,7 +95,7 @@ public class AssetProcessor
             }
 
             var assetPreparationResult =
-                AssetPreparer.PrepareAssetForUpsert(existingAsset, asset, false, isBatchUpdate);
+                AssetPreparer.PrepareAssetForUpsert(existingAsset, asset, false, isBatchUpdate, settings.RestrictedAssetIdCharacters);
 
             if (!assetPreparationResult.Success)
             {
@@ -110,7 +111,7 @@ public class AssetProcessor
 
             if (existingAsset == null)
             {
-                var preset = settings.IngestDefaults.GetPresets((char)updatedAsset.Family!,
+                var preset = settings.DLCS.IngestDefaults.GetPresets((char)updatedAsset.Family!,
                     updatedAsset.MediaType ?? string.Empty);
                 var deliveryChannelChanged = SetDeliveryChannel(updatedAsset, preset);
                 if (deliveryChannelChanged)

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -35,7 +35,14 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
             .When(_ => !apiSettings.Value.DeliveryChannelsEnabled)
             .WithMessage("Delivery channels are disabled");
-        
+
+        if (!apiSettings.Value.DisableStrictAssetIdChecks)
+        {
+            RuleFor(a => a.ModelId).Must(id => id.IndexOfAny(apiSettings.Value.RestrictedAssetIdCharacters.ToCharArray()) == -1)
+                .When(asset => !asset.ModelId.IsNullOrEmpty())
+                .WithMessage("Asset id contains a restricted character");
+        }
+
         RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -35,15 +35,12 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
             .When(_ => !apiSettings.Value.DeliveryChannelsEnabled)
             .WithMessage("Delivery channels are disabled");
+        
+        RuleFor(a => a.ModelId).Must(id => id.IndexOfAny(apiSettings.Value.RestrictedAssetIdCharacters.ToCharArray()) == -1)
+            .When(asset => !asset.ModelId.IsNullOrEmpty())
+            .WithMessage("Asset id contains a restricted character");
 
-        if (!apiSettings.Value.DisableStrictAssetIdChecks)
-        {
-            RuleFor(a => a.ModelId).Must(id => id.IndexOfAny(apiSettings.Value.RestrictedAssetIdCharacters.ToCharArray()) == -1)
-                .When(asset => !asset.ModelId.IsNullOrEmpty())
-                .WithMessage("Asset id contains a restricted character");
-        }
-
-        RuleForEach(a => a.DeliveryChannels)
+            RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
     }

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -38,7 +38,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         
         RuleFor(a => a.ModelId).Must(id => id.IndexOfAny(apiSettings.Value.RestrictedAssetIdCharacters.ToCharArray()) == -1)
             .When(asset => !asset.ModelId.IsNullOrEmpty())
-            .WithMessage("Asset id contains a restricted character");
+            .WithMessage($"Asset id contains at least one of the following restricted characters - {apiSettings.Value.RestrictedAssetIdCharacters}");
 
             RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -35,12 +35,8 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
             .When(_ => !apiSettings.Value.DeliveryChannelsEnabled)
             .WithMessage("Delivery channels are disabled");
-        
-        RuleFor(a => a.ModelId).Must(id => id.IndexOfAny(apiSettings.Value.RestrictedAssetIdCharacters.ToCharArray()) == -1)
-            .When(asset => !asset.ModelId.IsNullOrEmpty())
-            .WithMessage($"Asset id contains at least one of the following restricted characters - {apiSettings.Value.RestrictedAssetIdCharacters}");
 
-            RuleForEach(a => a.DeliveryChannels)
+        RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
     }

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -89,7 +89,7 @@ public class ApiSettings
     /// <summary>
     /// Characters that are not allowed in an asset id
     /// </summary>
-    public char[]? RestrictedAssetIdCharacters => 
+    public char[] RestrictedAssetIdCharacters => 
         restrictedAssetIdCharacters.Length != 0 ? restrictedAssetIdCharacters 
             : RestrictedAssetIdCharacterString.ToCharArray();
 

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -83,11 +83,6 @@ public class ApiSettings
     /// Whether the delivery channel feature is enabled
     /// </summary>
     public bool DeliveryChannelsEnabled { get; set; }
-    
-    /// <summary>
-    /// Whether strict checks on the asset id are disabled
-    /// </summary>
-    public bool DisableStrictAssetIdChecks { get; set; }
 
     /// <summary>
     /// Characters that are not allowed in an asset id

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -83,4 +83,14 @@ public class ApiSettings
     /// Whether the delivery channel feature is enabled
     /// </summary>
     public bool DeliveryChannelsEnabled { get; set; }
+    
+    /// <summary>
+    /// Whether strict checks on the asset id are disabled
+    /// </summary>
+    public bool DisableStrictAssetIdChecks { get; set; }
+
+    /// <summary>
+    /// Characters that are not allowed in an asset id
+    /// </summary>
+    public string RestrictedAssetIdCharacters { get; set; } = "";
 }

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -7,6 +7,7 @@ namespace API.Settings;
 public class ApiSettings
 {
     private char[] restrictedAssetIdCharacters = Array.Empty<char>();
+    private string restrictedAssetIdCharacterString = "";
     
     /// <summary>
     /// The base URI of DLCS to hand-off requests to.
@@ -89,9 +90,18 @@ public class ApiSettings
     /// <summary>
     /// Characters that are not allowed in an asset id
     /// </summary>
-    public char[] RestrictedAssetIdCharacters => 
-        restrictedAssetIdCharacters.Length != 0 ? restrictedAssetIdCharacters 
-            : RestrictedAssetIdCharacterString.ToCharArray();
+    public char[] RestrictedAssetIdCharacters => restrictedAssetIdCharacters;
 
-    public string RestrictedAssetIdCharacterString { get; set; } = "";
+    /// <summary>
+    /// A string of characters not allowed in an asset id
+    /// </summary>
+    public string RestrictedAssetIdCharacterString
+    {
+        get => restrictedAssetIdCharacterString;
+        set
+        {
+            restrictedAssetIdCharacterString = value;
+            restrictedAssetIdCharacters = restrictedAssetIdCharacterString.ToCharArray();
+        }
+    }
 }

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -6,6 +6,8 @@ namespace API.Settings;
 
 public class ApiSettings
 {
+    private char[] restrictedAssetIdCharacters = Array.Empty<char>();
+    
     /// <summary>
     /// The base URI of DLCS to hand-off requests to.
     /// </summary>
@@ -87,5 +89,9 @@ public class ApiSettings
     /// <summary>
     /// Characters that are not allowed in an asset id
     /// </summary>
-    public string RestrictedAssetIdCharacters { get; set; } = "";
+    public char[]? RestrictedAssetIdCharacters => 
+        restrictedAssetIdCharacters.Length != 0 ? restrictedAssetIdCharacters 
+            : RestrictedAssetIdCharacterString.ToCharArray();
+
+    public string RestrictedAssetIdCharacterString { get; set; } = "";
 }

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -55,5 +55,6 @@
       "LegacySupport": true,
       "NovelSpaces": [15]
     }
-  }
+  },
+  "RestrictedAssetIdCharacters": "\\ "
 }

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -8,6 +8,8 @@ namespace DLCS.Model.Tests.Assets;
 
 public class AssetPreparerTests
 {
+    private readonly char[] restrictedCharacters = Array.Empty<char>();
+    
     [Fact]
     public void PrepareAssetForUpsert_NotSuccessful_IfExistingAssetIsNotForDelivery()
     {
@@ -15,7 +17,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { NotForDelivery = true };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, new Asset(), false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, new Asset(), false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -28,7 +30,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Finished = DateTime.Now };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -41,7 +43,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Error = "change" };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -60,7 +62,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { MediaType = mediaType, DeliveryChannels = dc.Split(","), Duration = 99 };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -77,7 +79,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { MediaType = mediaType, DeliveryChannels = new[] { "file" }, Duration = 99 };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeTrue();
@@ -99,7 +101,7 @@ public class AssetPreparerTests
         };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -117,7 +119,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { DeliveryChannels = dc.Split(","), MediaType = mediaType, Width = 99 };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeTrue();
@@ -139,7 +141,7 @@ public class AssetPreparerTests
         };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -157,7 +159,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { DeliveryChannels = dc.Split(","), MediaType = mediaType, Height = 99 };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeTrue();
@@ -170,7 +172,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Origin = "https://whatever" };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.RequiresReingest.Should().BeTrue();
@@ -185,7 +187,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Origin = origin };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.Success.Should().BeFalse();
@@ -202,7 +204,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Origin = "foo", Batch = 24 };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, isBatchUpdate);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, isBatchUpdate, restrictedCharacters);
         
         // Assert
         result.Success.Should().Be(expectedSuccess);
@@ -216,7 +218,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Origin = "https://wherever" };
         
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
         // Assert
         result.RequiresReingest.Should().BeTrue();
@@ -230,7 +232,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Origin = "https://whatever", ThumbnailPolicy = "none" };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.RequiresReingest.Should().BeTrue();
@@ -246,7 +248,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Origin = "https://whatever", DeliveryChannels = existing };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.RequiresReingest.Should().BeTrue(reason);
@@ -264,7 +266,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(",") };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.UpdatedAsset.Family.Should().Be(expected);
@@ -281,7 +283,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Origin = "required", MediaType = mediaType };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.UpdatedAsset.Family.Should().Be(expected);
@@ -299,7 +301,7 @@ public class AssetPreparerTests
         var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(","), Family = current};
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.UpdatedAsset.Family.Should().Be(expected);
@@ -319,7 +321,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Family = current, DeliveryChannels = new[] { "fake" } };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.UpdatedAsset.Family.Should().Be(expected);
@@ -335,7 +337,7 @@ public class AssetPreparerTests
         var existingAsset = new Asset { Origin = "https://whatever", DeliveryChannels = existing };
 
         // Act
-        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false);
+        var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
 
         // Assert
         result.RequiresReingest.Should().BeFalse();

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using FluentAssertions;
 using Xunit;
@@ -27,7 +28,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_NotSuccessful_IfChangeFinished_AndAllowNonApiUpdatesFalse()
     {
         // Arrange
-        var updateAsset = new Asset { Finished = DateTime.Now };
+        var updateAsset = new Asset { Finished = DateTime.Now, Id = new AssetId(1, 1, "100")  };
         
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -40,7 +41,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_NotSuccessful_IfChangeError_AndAllowNonApiUpdatesFalse()
     {
         // Arrange
-        var updateAsset = new Asset { Error = "change" };
+        var updateAsset = new Asset { Error = "change", Id = new AssetId(1, 1, "100") };
         
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -169,7 +170,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_RequiresReingestTrue_IfExistingAssetNull()
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "https://whatever" };
+        var updateAsset = new Asset { Origin = "https://whatever", Id = new AssetId(1, 1, "100")  };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -184,7 +185,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_NotSuccessful_IfRequiresReingest_ButNoOrigin(string origin)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = origin };
+        var updateAsset = new Asset { Origin = origin, Id = new AssetId(1, 1, "100")  };
         
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -263,7 +264,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_SetsAssetFamilyIfNotSet(string dc, AssetFamily expected)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(",") };
+        var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(","), Id = new AssetId(1, 1, "100")  };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -280,7 +281,7 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_SetsAssetFamily_FromMediaType_IfFamilyAndDeliveryChannelNotSet(string mediaType, AssetFamily expected)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "required", MediaType = mediaType };
+        var updateAsset = new Asset { Origin = "required", MediaType = mediaType, Id = new AssetId(1, 1, "100")  };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -298,7 +299,12 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_ChangesAssetFamilyIfSet_New(string dc, AssetFamily current, AssetFamily expected)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(","), Family = current};
+        var updateAsset = new Asset { 
+            Origin = "required", 
+            DeliveryChannels = dc.Split(","), 
+            Family = current, 
+            Id = new AssetId(1, 1, "100")
+        };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
@@ -80,7 +80,7 @@ public class AppetiserClientTests
     }
     
     [Fact]
-    public async Task ProcessImage_UpdatesContextBasedOnImageIdWithBrackets()
+    public async Task ProcessImage_ChangesFileSavedLocationBasedOnImageIdWithBrackets()
     {
         // Arrange
         httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.InternalServerError));

--- a/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToDiskTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToDiskTests.cs
@@ -7,9 +7,11 @@ using DLCS.Repository.Strategy.DependencyInjection;
 using DLCS.Repository.Strategy.Utils;
 using Engine.Ingest;
 using Engine.Ingest.Persistence;
+using Engine.Settings;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
 using Test.Helpers;
+using Test.Helpers.Settings;
 
 namespace Engine.Tests.Ingest.Persistence;
 
@@ -28,10 +30,25 @@ public class AssetToDiskTests
         // For unit-test only s3ambient will be mocked
         customerOriginStrategy = A.Fake<IOriginStrategy>();
         OriginStrategyResolver resolver = _ => customerOriginStrategy;
+
+        var engineSettings = new EngineSettings()
+        {
+            ImageIngest = new ImageIngestSettings()
+            {
+                OpenBracketReplacement = "_",
+                CloseBracketReplacement = "_"
+            }
+        };
+        var optionsMonitor = OptionsHelpers.GetOptionsMonitor(engineSettings);
+        
         
         var originFetched = new OriginFetcher(null, resolver);
 
-        sut = new AssetToDisk(originFetched, customerStorageRepository, fileSaver, new NullLogger<AssetToDisk>());
+        sut = new AssetToDisk(originFetched, 
+            customerStorageRepository, 
+            fileSaver,   
+            optionsMonitor, 
+            new NullLogger<AssetToDisk>());
     }
 
     [Theory]

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -193,7 +193,7 @@ public class AppetiserClient : IImageProcessor
         UpdateImageDimensions(context.Asset, responseModel);
 
         // Process output: upload derivative/original to DLCS storage if required and set Location + Storage on context 
-        await ProcessOriginImage(context, processorFlags, modifiedAssetId);
+        await ProcessOriginImage(context, processorFlags);
 
         // Create new thumbnails + update Storage on context
         await CreateNewThumbs(context, responseModel, modifiedAssetId);
@@ -205,7 +205,7 @@ public class AppetiserClient : IImageProcessor
         asset.Width = responseModel.Width;
     }
 
-    private async Task ProcessOriginImage(IngestionContext context, ImageProcessorFlags processorFlags, AssetId modifiedAssetId)
+    private async Task ProcessOriginImage(IngestionContext context, ImageProcessorFlags processorFlags)
     {
         var asset = context.Asset;
         var imageIngestSettings = engineSettings.ImageIngest!;
@@ -230,7 +230,7 @@ public class AppetiserClient : IImageProcessor
         RegionalisedObjectInBucket targetStorageLocation;
         if (processorFlags.OriginIsImageServerReady)
         {
-            targetStorageLocation = storageKeyGenerator.GetStoredOriginalLocation(modifiedAssetId);
+            targetStorageLocation = storageKeyGenerator.GetStoredOriginalLocation(context.AssetId);
             if (context.StoredObjects.ContainsKey(targetStorageLocation))
             {
                 // Target is image-server ready and should be stored in DLCS but it has already been copied (as part of  
@@ -244,8 +244,8 @@ public class AppetiserClient : IImageProcessor
         else
         {
             // Location for derivative
-            targetStorageLocation = storageKeyGenerator.GetStorageLocation(modifiedAssetId);
-            logger.LogDebug("Asset {AssetId} derivative will be stored in DLCS storage", modifiedAssetId);
+            targetStorageLocation = storageKeyGenerator.GetStorageLocation(context.AssetId);
+            logger.LogDebug("Asset {AssetId} derivative will be stored in DLCS storage", context.AssetId);
         }
 
         var imageServerFile = processorFlags.ImageServerFilePath;

--- a/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/Appetiser/AppetiserClient.cs
@@ -266,10 +266,9 @@ public class AppetiserClient : IImageProcessor
         SetAssetLocation(targetStorageLocation);
     }
 
-    private async Task CreateNewThumbs(IngestionContext context, AppetiserResponseModel responseModel, 
-        AssetId modifiedAssetId)
+    private async Task CreateNewThumbs(IngestionContext context, AppetiserResponseModel responseModel, AssetId modifiedAssetId)
     {
-        SetThumbsOnDiskLocation(context, responseModel, modifiedAssetId);
+        SetThumbsOnDiskLocation(responseModel, modifiedAssetId);
 
         await thumbCreator.CreateNewThumbs(context.Asset, responseModel.Thumbs.ToList());
 
@@ -277,8 +276,7 @@ public class AppetiserClient : IImageProcessor
         context.WithStorage(thumbnailSize: thumbSize);
     }
 
-    private void SetThumbsOnDiskLocation(IngestionContext context, AppetiserResponseModel responseModel, 
-        AssetId modifiedAssetId)
+    private void SetThumbsOnDiskLocation(AppetiserResponseModel responseModel, AssetId modifiedAssetId)
     {
         // Update the location of all thumbs to be full path on disk, relative to orchestrator
         var partialTemplate = TemplatedFolders.GenerateFolderTemplate(engineSettings.ImageIngest.ThumbsTemplate,

--- a/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.Model.Assets;
+﻿using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Templates;
 using Engine.Settings;
 
@@ -15,7 +16,9 @@ internal static class ImageIngestionHelpers
         var root = imageIngest.GetRoot();
             
         // source is the main folder for storing downloaded image
-        var assetId = asset.Id;
+        var assetId = new AssetId(asset.Id.Customer, asset.Id.Space,
+            asset.Id.Asset.Replace("(", imageIngest.OpenBracketReplacement)
+                .Replace(")", imageIngest.CloseBracketReplacement));;
         var source = TemplatedFolders.GenerateFolderTemplate(imageIngest.SourceTemplate, assetId, root: root);
         return source;
     }

--- a/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
@@ -18,7 +18,7 @@ internal static class ImageIngestionHelpers
         // source is the main folder for storing downloaded image
         var assetId = new AssetId(asset.Id.Customer, asset.Id.Space,
             asset.Id.Asset.Replace("(", imageIngest.OpenBracketReplacement)
-                .Replace(")", imageIngest.CloseBracketReplacement));;
+                .Replace(")", imageIngest.CloseBracketReplacement));
         var source = TemplatedFolders.GenerateFolderTemplate(imageIngest.SourceTemplate, assetId, root: root);
         return source;
     }

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
@@ -90,8 +90,8 @@ public class AssetToDisk : AssetMoverBase, IAssetToDisk
     {
         TrySetContentTypeForBinary(originResponse, asset);
         var extension = GetFileExtension(originResponse);
-        
-        var targetPath = $"{Path.Join(destinationTemplate, asset.Id.Asset)}.{extension}";
+
+        var targetPath = $"{Path.Join(destinationTemplate, asset.Id.Asset.Replace('(', '_').Replace(')', '_'))}.{extension}";
 
         var received = await fileSaver.SaveResponseToDisk(asset.Id, originResponse, targetPath,
             cancellationToken);

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
@@ -7,6 +7,8 @@ using DLCS.Model.Customers;
 using DLCS.Model.Storage;
 using DLCS.Repository.Strategy;
 using DLCS.Repository.Strategy.Utils;
+using Engine.Settings;
+using Microsoft.Extensions.Options;
 
 namespace Engine.Ingest.Persistence;
 
@@ -33,17 +35,20 @@ public class AssetToDisk : AssetMoverBase, IAssetToDisk
 {
     private readonly OriginFetcher originFetcher;
     private readonly IFileSaver fileSaver;
+    private readonly EngineSettings engineSettings;
     private readonly ILogger<AssetToDisk> logger;
 
     public AssetToDisk(
         OriginFetcher originFetcher,
         IStorageRepository storageRepository,
         IFileSaver fileSaver,
+        IOptionsMonitor<EngineSettings> engineOptions,
         ILogger<AssetToDisk> logger) : base(storageRepository)
     {
         this.originFetcher = originFetcher;
         this.fileSaver = fileSaver;
         this.logger = logger;
+        this.engineSettings = engineOptions.CurrentValue;
     }
     
     /// <summary>
@@ -91,7 +96,11 @@ public class AssetToDisk : AssetMoverBase, IAssetToDisk
         TrySetContentTypeForBinary(originResponse, asset);
         var extension = GetFileExtension(originResponse);
 
-        var targetPath = $"{Path.Join(destinationTemplate, asset.Id.Asset.Replace('(', '_').Replace(')', '_'))}.{extension}";
+        var path = Path.Join(destinationTemplate,
+            asset.Id.Asset.Replace("(", engineSettings.ImageIngest.OpenBracketReplacement)
+                .Replace(")", engineSettings.ImageIngest.CloseBracketReplacement));
+
+        var targetPath = $"{path}.{extension}";
 
         var received = await fileSaver.SaveResponseToDisk(asset.Id, originResponse, targetPath,
             cancellationToken);

--- a/src/protagonist/Engine/Settings/EngineSettings.cs
+++ b/src/protagonist/Engine/Settings/EngineSettings.cs
@@ -95,6 +95,17 @@ public class ImageIngestSettings
     public bool OrchestrateImageAfterIngest { get; set; }
 
     /// <summary>
+    /// The character to use when replacing an open bracket character
+    /// </summary>
+    public string OpenBracketReplacement { get; set; } = "_";
+    
+    /// <summary>
+    /// The character to use when replacing a closing bracket character
+    /// </summary>
+    public string CloseBracketReplacement { get; set; } = "_";
+    
+
+    /// <summary>
     /// Get the root folder, if forImageProcessor will ensure that it is compatible with needs of image-processor
     /// sidecar.
     /// </summary>


### PR DESCRIPTION
Resolves #340 
Resolves #323

This pull request adds in the ability to restrict the characters allowed in an asset id.  It does this by adding a set of 2 new settings:

```
"RestrictedAssetIdCharacters": "\\ "
"DisableStrictAssetIdChecks": true
```

`RestrictedAssetIdCharacters` is a series of characters that are not allowed within an asset id

`DisableStrictAssetIdChecks`  sets whether the check for strict asset ids is disabled.  As such, this check is *enabled* by default

Additionally, this pull request enables `(` and `)` characters to be used in the image id which would previously cause appetiser to fail.  It manages this by replacing these characters with an alternative.  By default this is an underscore, but can be set to a specific string via settings to be able to reduce the possibility of collisions