### PR TITLE
Include custom fields, tags, and roles in single item/named query manifests

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -8,6 +9,7 @@ using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
@@ -213,7 +215,86 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         response.Headers.CacheControl.Public.Should().BeTrue();
         response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
     }
+
+    [Fact]
+    public async Task Get_V3ManifestForImage_ReturnsManifest_WithCustomFields()
+    {
+        // Arrange
+        const string defaultLanguage = "none"; 
+        var id = AssetId.FromString($"99/1/{nameof(Get_V3ManifestForImage_ReturnsManifest_WithCustomFields)}");
+        var namedId = $"test/1/{nameof(Get_V3ManifestForImage_ReturnsManifest_WithCustomFields)}";
+        var asset = await dbFixture.DbContext.Images.AddTestAsset(id, 
+            origin: "testorigin",
+            ref1: "string-example-1",
+            ref2: "string-example-2",
+            ref3: "string-example-3",
+            num1: 1,
+            num2: 2,
+            num3: 3);
+        await dbFixture.DbContext.SaveChangesAsync();
         
+        var path = $"iiif-manifest/{namedId}";
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+      
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        var metadata = jsonResponse.SelectToken("items[0].metadata")
+            .ToObject<List<LabelValuePair>>()
+            .ToDictionary(
+                lvp => lvp.Label[defaultLanguage][0],
+                lvp => lvp.Value[defaultLanguage][0]);
+        
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        metadata.Should().NotBeNullOrEmpty();
+        metadata.Should().Contain("String 1", asset.Entity.Reference1);
+        metadata.Should().Contain("String 2", asset.Entity.Reference2);
+        metadata.Should().Contain("String 3", asset.Entity.Reference3);
+        metadata.Should().Contain("Number 1", asset.Entity.NumberReference1.ToString());
+        metadata.Should().Contain("Number 2", asset.Entity.NumberReference2.ToString());
+        metadata.Should().Contain("Number 3", asset.Entity.NumberReference3.ToString());
+    }
+    
+    [Fact]
+    public async Task Get_V2ManifestForImage_ReturnsManifest_WithCustomFields()
+    {
+        // Arrange
+        var id = AssetId.FromString($"99/1/{nameof(Get_V2ManifestForImage_ReturnsManifest_WithCustomFields)}");
+        var namedId = $"test/1/{nameof(Get_V2ManifestForImage_ReturnsManifest_WithCustomFields)}";
+        var asset = await dbFixture.DbContext.Images.AddTestAsset(id, 
+            origin: "testorigin",
+            ref1: "string-example-1",
+            ref2: "string-example-2",
+            ref3: "string-example-3",
+            num1: 1,
+            num2: 2,
+            num3: 3);
+        await dbFixture.DbContext.SaveChangesAsync();
+        
+        var path = $"iiif-manifest/v2/{namedId}";
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+      
+        // Assert
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        var metadata = jsonResponse.SelectToken("sequences[0].canvases[0].metadata")
+            .ToObject<List<IIIF.Presentation.V2.Metadata>>()
+            .ToDictionary(
+                m => m.Label.LanguageValues[0].Value,
+                m => m.Value.LanguageValues[0].Value);
+        
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        metadata.Should().NotBeNullOrEmpty();
+        metadata.Should().Contain("String 1", asset.Entity.Reference1);
+        metadata.Should().Contain("String 2", asset.Entity.Reference2);
+        metadata.Should().Contain("String 3", asset.Entity.Reference3);
+        metadata.Should().Contain("Number 1", asset.Entity.NumberReference1.ToString());
+        metadata.Should().Contain("Number 2", asset.Entity.NumberReference2.ToString());
+        metadata.Should().Contain("Number 3", asset.Entity.NumberReference3.ToString());
+    }
+    
     [Fact]
     public async Task Get_V2ManifestForRestrictedImage_ReturnsManifest_WithoutAuthServices()
     {

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -266,13 +266,16 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Act
         var response = await httpClient.GetAsync(path);
+        var test = response.Content.ReadAsStringAsync();
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var jsonContent = await response.Content.ReadAsStringAsync();
         var jsonResponse = JObject.Parse(jsonContent);
-        jsonContent.Should().NotContain("clickthrough", "auth services are not included in v2 manifests");
+        jsonResponse.SelectTokens("sequences[*].canvases[*].images[*].resource.service")
+            .Select(token => token.ToString())
+            .Should().NotContainMatch("*clickthrough*", "auth services are not included in v2 manifests");
         jsonResponse.SelectToken("sequences[0].canvases").Count().Should().Be(3);
     }
     

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -36,7 +36,8 @@ public class IIIFCanvasFactory
     private readonly IPolicyRepository policyRepository;
     private readonly OrchestratorSettings orchestratorSettings;
     private readonly Dictionary<string, ThumbnailPolicy> thumbnailPolicies = new();
-
+    private const string MetadataLanguage = "none";
+    
     public IIIFCanvasFactory(
         IAssetPathGenerator assetPathGenerator,
         IOptions<OrchestratorSettings> orchestratorSettings,
@@ -69,8 +70,8 @@ public class IIIFCanvasFactory
                 Height = i.Height,
                 Metadata = GetImageMetadata(i)
                     .Select(m => 
-                        new LabelValuePair(new LanguageMap("none", m.Key), 
-                            new LanguageMap("none", m.Value)))
+                        new LabelValuePair(new LanguageMap(MetadataLanguage, m.Key), 
+                            new LanguageMap(MetadataLanguage, m.Value)))
                     .ToList(),
                 Items = new AnnotationPage
                 {
@@ -86,7 +87,7 @@ public class IIIFCanvasFactory
                             Format = "image/jpeg",
                             Width = thumbnailSizes.MaxDerivativeSize.Width,
                             Height = thumbnailSizes.MaxDerivativeSize.Height,
-                            Service = GetImageServices(i, customerPathElement, authProbeServices),
+                            Service = GetImageServices(i, customerPathElement, authProbeServices)
                         }
                     }.AsListOf<IAnnotation>()
                 }.AsList()
@@ -142,7 +143,6 @@ public class IIIFCanvasFactory
                     On = canvasId,
                     Resource = new IIIF2.ImageResource
                     {
-                        
                         Id = GetFullQualifiedImagePath(i, customerPathElement,
                             thumbnailSizes.MaxDerivativeSize, false),
                         Width = thumbnailSizes.MaxDerivativeSize.Width,
@@ -337,6 +337,8 @@ public class IIIFCanvasFactory
             { "Number 1", (asset.NumberReference1 ?? 0).ToString() },
             { "Number 2", (asset.NumberReference2 ?? 0).ToString() },
             { "Number 3", (asset.NumberReference3 ?? 0).ToString() },
+            { "Tags", asset.Tags ?? string.Empty },
+            { "Roles", asset.Roles ?? string.Empty }
         };
     }
     

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -67,6 +67,11 @@ public class IIIFCanvasFactory
                 Label = new LanguageMap("en", $"Canvas {counter}"),
                 Width = i.Width,
                 Height = i.Height,
+                Metadata = GetImageMetadata(i)
+                    .Select(m => 
+                        new LabelValuePair(new LanguageMap("none", m.Key), 
+                            new LanguageMap("none", m.Value)))
+                    .ToList(),
                 Items = new AnnotationPage
                 {
                     Id = $"{canvasId}/page",
@@ -81,7 +86,7 @@ public class IIIFCanvasFactory
                             Format = "image/jpeg",
                             Width = thumbnailSizes.MaxDerivativeSize.Width,
                             Height = thumbnailSizes.MaxDerivativeSize.Height,
-                            Service = GetImageServices(i, customerPathElement, authProbeServices)
+                            Service = GetImageServices(i, customerPathElement, authProbeServices),
                         }
                     }.AsListOf<IAnnotation>()
                 }.AsList()
@@ -124,18 +129,26 @@ public class IIIFCanvasFactory
                 Label = new MetaDataValue($"Canvas {counter}"),
                 Width = i.Width,
                 Height = i.Height,
+                Metadata = GetImageMetadata(i)
+                    .Select(m => new IIIF2.Metadata()
+                    {
+                        Label = new MetaDataValue(m.Key),
+                        Value = new MetaDataValue(m.Value)
+                    })
+                    .ToList(),
                 Images = new ImageAnnotation
                 {
                     Id = string.Concat(fullyQualifiedImageId, "/imageanno/0"),
                     On = canvasId,
                     Resource = new IIIF2.ImageResource
                     {
+                        
                         Id = GetFullQualifiedImagePath(i, customerPathElement,
                             thumbnailSizes.MaxDerivativeSize, false),
                         Width = thumbnailSizes.MaxDerivativeSize.Width,
                         Height = thumbnailSizes.MaxDerivativeSize.Height,
                         Service = GetImageServices(i, customerPathElement, null)
-                    }
+                    },
                 }.AsList()
             };
 
@@ -313,7 +326,20 @@ public class IIIFCanvasFactory
             return authServiceToAdd.AsListOf<IService>();
         }
     }
-
+    
+    private Dictionary<string, string> GetImageMetadata(Asset asset)
+    {
+        return new Dictionary<string, string>()
+        {
+            { "String 1", asset.Reference1 ?? string.Empty },
+            { "String 2", asset.Reference2 ?? string.Empty },
+            { "String 3", asset.Reference3 ?? string.Empty },
+            { "Number 1", (asset.NumberReference1 ?? 0).ToString() },
+            { "Number 2", (asset.NumberReference2 ?? 0).ToString() },
+            { "Number 3", (asset.NumberReference3 ?? 0).ToString() },
+        };
+    }
+    
     /// <summary>
     /// Class containing details of available thumbnail sizes
     /// </summary>


### PR DESCRIPTION
Resolves #698

This PR includes custom fields, as well as roles and tags in asset manifests constructed by `IIIFCanvasFactory`.

Example in Universal Viewer:
![image](https://github.com/dlcs/protagonist/assets/95353889/719796a7-c0f1-483d-addd-f094a7e0291a)

