### PR TITLE
Allow Base64 encoded images to be ingested via PUT

### DIFF
--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -17,7 +17,8 @@ public static class LegacyModeConverter
     /// </summary>
     /// <param name="image">The image to convert</param>
     /// <returns>A converted image</returns>
-    public static Image VerifyAndConvertToModernFormat(Image image)
+    public static T VerifyAndConvertToModernFormat<T>(T image)
+        where T : Image
     {
         if (image.MediaType.IsNullOrEmpty())
         {

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -61,7 +61,7 @@ public class ImageController : HydraController
     ///
     /// Image + File assets are ingested synchronously. Timebased assets are ingested asynchronously.
     ///
-    /// "File" property should be base64 encoded image, if included. Only "I" family assets are accepted.
+    /// "File" property should be base64 encoded image, if included.
     /// </summary>
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>
@@ -212,7 +212,7 @@ public class ImageController : HydraController
     }
 
     /// <summary>
-    /// <para>Ingest specified file bytes to DLCS. Only "I" family assets are accepted.
+    /// <para>Ingest specified file bytes to DLCS.
     /// "File" property should be base64 encoded image.</para>
     /// <para>This route is now deprecated. <see cref="PutImage"/> should be used instead.</para>
     /// </summary>

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -230,7 +230,7 @@ public class ImageController : HydraController
         CancellationToken cancellationToken)
     {
         logger.LogWarning(
-            "Warning: A deprecated route (POST /spaces/{Space}/images/{Image}) was called by customer {Customer}",
+            "Warning: POST /customers/{CustomerId}/spaces/{SpaceId}/images/{ImageId} was called. This route is deprecated.",
             spaceId, imageId, customerId);
         
         var validationResult = await validator.ValidateAsync(hydraAsset, cancellationToken);

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -60,11 +60,13 @@ public class ImageController : HydraController
     /// PUT requests always trigger reingesting of asset - in general batch processing should be preferred.
     ///
     /// Image + File assets are ingested synchronously. Timebased assets are ingested asynchronously.
+    ///
+    /// "File" property should be base64 encoded image, if included. Only "I" family assets are accepted.
     /// </summary>
     /// <param name="hydraAsset">The body of the request contains the Asset in Hydra JSON-LD form (Image class)</param>
     /// <returns>The created or updated Hydra Image object for the Asset</returns>
     /// <remarks>
-    /// Sample request:
+    /// Sample requests:
     ///
     ///     PUT: /customers/1/spaces/1/images/my-image
     ///     {
@@ -73,6 +75,13 @@ public class ImageController : HydraController
     ///         "origin": "https://example.text/.../image.jpeg",
     ///         "mediaType": "image/jpeg",
     ///         "string1": "my-metadata"
+    ///     }
+    ///
+    ///     PUT: /customers/1/spaces/1/images/my-image
+    ///     {
+    ///         "@type":"Image",
+    ///         "family": "I",
+    ///         "file": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAM...."
     ///     }
     /// </remarks>
     [ProducesResponseType((int)HttpStatusCode.OK, Type = typeof(DLCS.HydraModel.Image))]
@@ -83,6 +92,7 @@ public class ImageController : HydraController
     [ProducesResponseType((int)HttpStatusCode.InsufficientStorage, Type = typeof(ProblemDetails))]
     [ProducesResponseType((int)HttpStatusCode.NotImplemented, Type = typeof(ProblemDetails))]
     [ProducesResponseType((int)HttpStatusCode.InternalServerError, Type = typeof(ProblemDetails))]
+    [RequestFormLimits(MultipartBodyLengthLimit = 100_000_000, ValueLengthLimit = 100_000_000)]
     [HttpPut]
     public async Task<IActionResult> PutImage(
         [FromRoute] int customerId,
@@ -204,8 +214,9 @@ public class ImageController : HydraController
     }
 
     /// <summary>
-    /// Ingest specified file bytes to DLCS. Only "I" family assets are accepted.
-    /// "File" property should be base64 encoded image. 
+    /// <para>Ingest specified file bytes to DLCS. Only "I" family assets are accepted.
+    /// "File" property should be base64 encoded image.</para>
+    /// <para>This route is now deprecated. <see cref="PutImage"/> should be used instead.</para>
     /// </summary>
     /// <remarks>
     /// Sample request:

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -231,15 +231,9 @@ public class ImageController : HydraController
     {
         logger.LogWarning(
             "Warning: POST /customers/{CustomerId}/spaces/{SpaceId}/images/{ImageId} was called. This route is deprecated.",
-            spaceId, imageId, customerId);
+            customerId, spaceId, imageId);
         
-        var validationResult = await validator.ValidateAsync(hydraAsset, cancellationToken);
-        if (!validationResult.IsValid)
-        {
-            return this.ValidationFailed(validationResult);
-        }
-        
-        return await PutOrPatchAssetWithFileBytes(customerId, spaceId, imageId, hydraAsset, cancellationToken);
+        return await PutImage(customerId, spaceId, imageId, hydraAsset, validator, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
Resolves #338

This PR changes the `PutImage` route in `ImageController` to support the `File` field for directly ingesting image bytes, it also includes a test for verifying this functionality.

`PostImageWithFileBytes` is now deprecated and re-routes requests to `PutImage`.

