### PR TITLE
Accept `wcDeliveryChannels` as an alias for `DeliveryChannels` in `HydraModel.Image`

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -571,6 +571,34 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_New_Asset_Ignores_DeliveryChannels()
+    {
+        var assetId = new AssetId(99, 1, nameof(Put_New_Asset_Ignores_DeliveryChannels));
+        var hydraImageBody = $@"{{
+          ""@type"": ""Image"",
+          ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+          ""family"": ""I"",
+          ""mediaType"": ""image/tiff"",
+          ""deliveryChannels"": [""file""]
+        }}";
+
+        A.CallTo(() =>
+                EngineClient.SynchronousIngest(
+                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<CancellationToken>._))
+            .Returns(HttpStatusCode.OK);
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = await dbContext.Images.FindAsync(assetId);
+        asset.DeliveryChannels.Should().NotBeEquivalentTo("file");
+    }
+    
+    [Fact]
     public async Task Put_New_Asset_Preserves_InitialOrigin()
     {
         var assetId = new AssetId(99, 1, nameof(Put_New_Asset_Preserves_InitialOrigin));

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -547,7 +547,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [InlineData("wcDeliveryChannels")]
     public async Task Put_New_Asset_Supports_DeliveryChannels_Aliases(string deliveryChannelAlias)
     {
-        var assetId = new AssetId(99, 1, nameof(Put_New_Asset_Supports_DeliveryChannels_Aliases));
+        var assetId = new AssetId(99, 1, $"{nameof(Put_New_Asset_Supports_DeliveryChannels_Aliases)}-{deliveryChannelAlias}");
         var hydraImageBody = $@"{{
           ""@type"": ""Image"",
           ""origin"": ""https://example.org/{assetId.Asset}.tiff"",

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -62,6 +62,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         "API-Test", _ => { });
             })
+            .WithConfigValue("DeliveryChannelsEnabled", "true")
             .CreateClient(new WebApplicationFactoryClientOptions
             {
                 AllowAutoRedirect = false
@@ -540,7 +541,35 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+    
+    [Fact]
+    public async Task Put_New_Asset_Supports_WcDeliveryChannels()
+    {
+        var assetId = new AssetId(99, 1, nameof(Put_New_Asset_Supports_WcDeliveryChannels));
+        var hydraImageBody = $@"{{
+          ""@type"": ""Image"",
+          ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+          ""family"": ""I"",
+          ""mediaType"": ""image/tiff"",
+          ""wcDeliveryChannels"": [""file""]
+        }}";
 
+        A.CallTo(() =>
+                EngineClient.SynchronousIngest(
+                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<CancellationToken>._))
+            .Returns(HttpStatusCode.OK);
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = await dbContext.Images.FindAsync(assetId);
+        asset.DeliveryChannels.Should().BeEquivalentTo("file");
+    }
+    
     [Fact]
     public async Task Put_New_Asset_Preserves_InitialOrigin()
     {
@@ -957,34 +986,6 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-    
-    [Fact]
-    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled()
-    {
-        // Arrange 
-        var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
-
-        var testAsset = await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.Image,
-            ref1: "I am string 1", origin: "https://images.org/image2.tiff");
-        await dbContext.SaveChangesAsync();
-
-        var hydraImageBody = @"{
-  ""@type"": ""Image"",
-  ""string1"": ""I am edited"",
-  ""deliveryChannels"": [
-        ""iiif-img""
-]
-}";                        
-        // act
-        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var response = await httpClient.AsCustomer(99).PatchAsync(assetId.ToApiResourcePath(), content);
-        
-        // assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-
-        var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("Delivery channels are disabled");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
@@ -1,63 +1,27 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Amazon.S3;
-using API.Client;
-using API.Infrastructure.Messaging;
-using API.Tests.Integration.Infrastructure;
 using DLCS.Core.Types;
-using DLCS.HydraModel;
-using DLCS.Model.Assets;
-using DLCS.Model.Messaging;
-using DLCS.Repository;
-using DLCS.Repository.Entities;
-using DLCS.Repository.Messaging;
-using FakeItEasy;
-using Hydra.Collections;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
-using AssetFamily = DLCS.Model.Assets.AssetFamily;
-using ImageOptimisationPolicy = DLCS.Model.Policies.ImageOptimisationPolicy;
 
 namespace API.Tests.Integration;
 
 [Trait("Category", "Integration")]
-[Collection(StorageCollection.CollectionName)]
 public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<ProtagonistAppFactory<Startup>>
 {
-    private readonly DlcsContext dbContext;
     private readonly HttpClient httpClient;
-    private static readonly IAssetNotificationSender NotificationSender = A.Fake<IAssetNotificationSender>();
-    private readonly IAmazonS3 amazonS3;
-    private static readonly IEngineClient EngineClient = A.Fake<IEngineClient>();
     
     public ModifyAssetWithoutDeliveryChannelsTests(
-        StorageFixture storageFixture, 
         ProtagonistAppFactory<Startup> factory)
     {
-        var dbFixture = storageFixture.DbFixture;
-        amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
-        
-        dbContext = dbFixture.DbContext;
-        
         httpClient = factory
-            .WithConnectionString(dbFixture.ConnectionString)
-            .WithLocalStack(storageFixture.LocalStackFixture)
             .WithTestServices(services =>
             {
-                services.AddSingleton<IAssetNotificationSender>(_ => NotificationSender);
-                services.AddScoped<IEngineClient>(_ => EngineClient);
                 services.AddAuthentication("API-Test")
                     .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                         "API-Test", _ => { });
@@ -66,8 +30,6 @@ public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<Protagonist
             {
                 AllowAutoRedirect = false
             });
-        
-        dbFixture.CleanUp();
     }
     
     [Fact]
@@ -75,23 +37,19 @@ public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<Protagonist
     {
         // Arrange 
         var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
-
-        var testAsset = await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.Image,
-            ref1: "I am string 1", origin: "https://images.org/image2.tiff");
-        await dbContext.SaveChangesAsync();
-
         var hydraImageBody = @"{
           ""@type"": ""Image"",
           ""string1"": ""I am edited"",
           ""wcDeliveryChannels"": [
                 ""iiif-img""
             ]
-        }";                        
-        // act
+        }";    
+        
+        // Act
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
         var response = await httpClient.AsCustomer(99).PatchAsync(assetId.ToApiResourcePath(), content);
         
-        // assert
+        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
         var body = await response.Content.ReadAsStringAsync();

--- a/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
@@ -32,18 +32,20 @@ public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<Protagonist
             });
     }
     
-    [Fact]
-    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled()
+    [Theory]
+    [InlineData("deliveryChannels")]
+    [InlineData("wcDeliveryChannels")]
+    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled(string deliveryChannelAlias)
     {
         // Arrange 
         var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
           ""@type"": ""Image"",
           ""string1"": ""I am edited"",
-          ""wcDeliveryChannels"": [
+          ""{deliveryChannelAlias}"": [
                 ""iiif-img""
             ]
-        }";    
+        }}";    
         
         // Act
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");

--- a/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Amazon.S3;
+using API.Client;
+using API.Infrastructure.Messaging;
+using API.Tests.Integration.Infrastructure;
+using DLCS.Core.Types;
+using DLCS.HydraModel;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+using DLCS.Repository;
+using DLCS.Repository.Entities;
+using DLCS.Repository.Messaging;
+using FakeItEasy;
+using Hydra.Collections;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Test.Helpers.Integration;
+using Test.Helpers.Integration.Infrastructure;
+using AssetFamily = DLCS.Model.Assets.AssetFamily;
+using ImageOptimisationPolicy = DLCS.Model.Policies.ImageOptimisationPolicy;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(StorageCollection.CollectionName)]
+public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsContext dbContext;
+    private readonly HttpClient httpClient;
+    private static readonly IAssetNotificationSender NotificationSender = A.Fake<IAssetNotificationSender>();
+    private readonly IAmazonS3 amazonS3;
+    private static readonly IEngineClient EngineClient = A.Fake<IEngineClient>();
+    
+    public ModifyAssetWithoutDeliveryChannelsTests(
+        StorageFixture storageFixture, 
+        ProtagonistAppFactory<Startup> factory)
+    {
+        var dbFixture = storageFixture.DbFixture;
+        amazonS3 = storageFixture.LocalStackFixture.AWSS3ClientFactory();
+        
+        dbContext = dbFixture.DbContext;
+        
+        httpClient = factory
+            .WithConnectionString(dbFixture.ConnectionString)
+            .WithLocalStack(storageFixture.LocalStackFixture)
+            .WithTestServices(services =>
+            {
+                services.AddSingleton<IAssetNotificationSender>(_ => NotificationSender);
+                services.AddScoped<IEngineClient>(_ => EngineClient);
+                services.AddAuthentication("API-Test")
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        "API-Test", _ => { });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
+        
+        dbFixture.CleanUp();
+    }
+    
+    [Fact]
+    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled()
+    {
+        // Arrange 
+        var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
+
+        var testAsset = await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.Image,
+            ref1: "I am string 1", origin: "https://images.org/image2.tiff");
+        await dbContext.SaveChangesAsync();
+
+        var hydraImageBody = @"{
+          ""@type"": ""Image"",
+          ""string1"": ""I am edited"",
+          ""wcDeliveryChannels"": [
+                ""iiif-img""
+            ]
+        }";                        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PatchAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Delivery channels are disabled");
+    }
+}

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -201,9 +201,10 @@ public class Image : DlcsResource
     public string[]? DeliveryChannels { get; set; }
 
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
-        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = true)]
+    
     [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
-    public string[]? WcDeliveryChannels => DeliveryChannels;
+    public string[]? WcDeliveryChannels { set => DeliveryChannels = value; }
     
     [RdfProperty(Description = "The role or roles that a user must possess to view this image above maxUnauthorised. " +
                                "These are URIs of roles e.g., https://api.dlcs.io/customers/1/roles/requiresRegistration",

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -200,6 +200,11 @@ public class Image : DlcsResource
     [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
     public string[]? DeliveryChannels { get; set; }
 
+    [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
+    public string[]? WcDeliveryChannels => DeliveryChannels;
+    
     [RdfProperty(Description = "The role or roles that a user must possess to view this image above maxUnauthorised. " +
                                "These are URIs of roles e.g., https://api.dlcs.io/customers/1/roles/requiresRegistration",
         Range = "vocab:Role", ReadOnly = false, WriteOnly = false, SetManually = true)]

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -200,6 +200,11 @@ public class Image : DlcsResource
 
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = true)]
+    [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
+    public string[]? OldDeliveryChannels { set => DeliveryChannels = value; get => null; }
+    
+    [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
     public string[]? WcDeliveryChannels { set => DeliveryChannels = value; get => DeliveryChannels; }
     

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -195,16 +195,13 @@ public class Image : DlcsResource
     [JsonProperty(Order = 130, PropertyName = "textType")]
     public string? TextType { get; set; } // e.g., METS-ALTO, hOCR, TEI, text/plain etc
     
-    [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
-        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
-    [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
+    [JsonIgnore]
     public string[]? DeliveryChannels { get; set; }
 
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = true)]
-    
     [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
-    public string[]? WcDeliveryChannels { set => DeliveryChannels = value; }
+    public string[]? WcDeliveryChannels { set => DeliveryChannels = value; get => DeliveryChannels; }
     
     [RdfProperty(Description = "The role or roles that a user must possess to view this image above maxUnauthorised. " +
                                "These are URIs of roles e.g., https://api.dlcs.io/customers/1/roles/requiresRegistration",

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -201,7 +201,7 @@ public class Image : DlcsResource
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = true)]
     [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
-    public string[]? OldDeliveryChannels { set => DeliveryChannels = value; get => null; }
+    public string[]? OldDeliveryChannels { set => DeliveryChannels = value; get => DeliveryChannels; }
     
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]


### PR DESCRIPTION
Resolves #614

This PR:

- Adds `wcDeliveryChannels` as an alias for the `deliveryChannels` field in the Hydra model for `Image` 
- Adds a test for ensuring that it can be used to set the value of `DeliveryChannels`
- Prevents the `deliveryChannels` field from being returned in the JSON, returning `wcDeliveryChannels` instead
- Moves the `Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled` test into a separate class for asset tests that require delivery channels to be disabled