### PR TITLE
Add Hydra model for delivery channels

### DIFF
--- a/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
@@ -133,7 +133,7 @@ public class AssetConverterTests
             MaxUnauthorised = 400,
             MediaType = mediaType,
             ThumbnailPolicy = thumbnailPolicy,
-            DeliveryChannels = deliveryChannel
+            WcDeliveryChannels = deliveryChannel
         };
 
         var asset = hydraImage.ToDlcsModel(1);
@@ -174,7 +174,7 @@ public class AssetConverterTests
         {
             Id = AssetApiId,
             Space = 99,
-            DeliveryChannels = deliveryChannel
+            WcDeliveryChannels = deliveryChannel
         };
         
         // Act

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -54,7 +54,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            Width = 10, DeliveryChannels = dc.Split(","), MediaType = mediaType
+            Width = 10, WcDeliveryChannels = dc.Split(","), MediaType = mediaType
         };
         var result = sut.TestValidate(model);
         result
@@ -70,7 +70,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            MediaType = mediaType, DeliveryChannels = new[] { "file" }, Width = 10
+            MediaType = mediaType, WcDeliveryChannels = new[] { "file" }, Width = 10
         };
         var result = sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.Width);
@@ -94,7 +94,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            Height = 10, DeliveryChannels = dc.Split(","), MediaType = mediaType
+            Height = 10, WcDeliveryChannels = dc.Split(","), MediaType = mediaType
         };
         var result = sut.TestValidate(model);
         result
@@ -110,7 +110,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            MediaType = mediaType, DeliveryChannels = new[] { "file" }, Height = 10
+            MediaType = mediaType, WcDeliveryChannels = new[] { "file" }, Height = 10
         };
         var result = sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.Height);
@@ -134,7 +134,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            Duration = 10, DeliveryChannels = dc.Split(","), MediaType = mediaType
+            Duration = 10, WcDeliveryChannels = dc.Split(","), MediaType = mediaType
         };
         var result = sut.TestValidate(model);
         result
@@ -150,7 +150,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            MediaType = mediaType, DeliveryChannels = new[] { "file" }, Duration = 10
+            MediaType = mediaType, WcDeliveryChannels = new[] { "file" }, Duration = 10
         };
         var result = sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.Duration);
@@ -180,7 +180,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            DeliveryChannels = dc.Split(","),
+            WcDeliveryChannels = dc.Split(","),
             MediaType = "image/jpeg",
             ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
         };
@@ -197,7 +197,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image
         {
-            DeliveryChannels = dc.Split(","),
+            WcDeliveryChannels = dc.Split(","),
             MediaType = "image/jpeg",
             ImageOptimisationPolicy = KnownImageOptimisationPolicy.UseOriginalId
         };
@@ -210,7 +210,7 @@ public class HydraImageValidatorTests
     {
         var model = new DLCS.HydraModel.Image();
         var result = sut.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
+        result.ShouldNotHaveValidationErrorFor(a => a.WcDeliveryChannels);
     }
     
     [Theory]
@@ -220,17 +220,17 @@ public class HydraImageValidatorTests
     [InlineData("file,iiif-av,iiif-img")]
     public void DeliveryChannel_CanContainKnownValues(string knownValues)
     {
-        var model = new DLCS.HydraModel.Image { DeliveryChannels = knownValues.Split(',') };
+        var model = new DLCS.HydraModel.Image { WcDeliveryChannels = knownValues.Split(',') };
         var result = sut.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
+        result.ShouldNotHaveValidationErrorFor(a => a.WcDeliveryChannels);
     }
     
     [Fact]
     public void DeliveryChannel_UnknownValue()
     {
-        var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "foo" } };
+        var model = new DLCS.HydraModel.Image { WcDeliveryChannels = new[] { "foo" } };
         var result = sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+        result.ShouldHaveValidationErrorFor(a => a.WcDeliveryChannels);
     }
     
         
@@ -239,9 +239,9 @@ public class HydraImageValidatorTests
     {
         var apiSettings = new ApiSettings();
         var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
-        var model = new DLCS.HydraModel.Image { DeliveryChannels = new[] { "iiif-img" } };
+        var model = new DLCS.HydraModel.Image { WcDeliveryChannels = new[] { "iiif-img" } };
         var result = imageValidator.TestValidate(model);
-        result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+        result.ShouldHaveValidationErrorFor(a => a.WcDeliveryChannels);
     }
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsDisabled()
@@ -250,6 +250,6 @@ public class HydraImageValidatorTests
         var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
         var model = new DLCS.HydraModel.Image();
         var result = imageValidator.TestValidate(model);
-        result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
+        result.ShouldNotHaveValidationErrorFor(a => a.WcDeliveryChannels);
     }
 }

--- a/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/ImageBatchPatchValidatorTests.cs
@@ -137,10 +137,10 @@ public class ImageBatchPatchValidatorTests
     {
         var model = new HydraCollection<Image> { Members = new[]
         {
-            new Image { DeliveryChannels = new []{"iiif-img","thumbs"}}
+            new Image { WcDeliveryChannels = new []{"iiif-img","thumbs"}}
         } };
         var result = sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor("Members[0].DeliveryChannels");
+        result.ShouldHaveValidationErrorFor("Members[0].WcDeliveryChannels");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -997,14 +997,14 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
           ""id"": ""one"",
           ""origin"": ""https://example.org/foo.jpg"",
           ""space"": 2,
-          ""deliveryChannels"": [""iiif-img""],
+          ""wcDeliveryChannels"": [""iiif-img""],
           ""family"": ""I"",
           ""mediaType"": ""image/jpeg""
         },
         {
           ""id"": ""two"",
           ""origin"": ""https://example.org/foo.png"",
-          ""deliveryChannels"": [""iiif-img""],
+          ""wcDeliveryChannels"": [""iiif-img""],
           ""space"": 2,
           ""mediaType"": ""image/png""
         },

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -542,18 +542,16 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-    [Theory]
-    [InlineData("deliveryChannels")]
-    [InlineData("wcDeliveryChannels")]
-    public async Task Put_New_Asset_Supports_DeliveryChannels_Aliases(string deliveryChannelAlias)
+    [Fact]
+    public async Task Put_New_Asset_Supports_WcDeliveryChannels()
     {
-        var assetId = new AssetId(99, 1, $"{nameof(Put_New_Asset_Supports_DeliveryChannels_Aliases)}-{deliveryChannelAlias}");
+        var assetId = new AssetId(99, 1, nameof(Put_New_Asset_Supports_WcDeliveryChannels));
         var hydraImageBody = $@"{{
           ""@type"": ""Image"",
           ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
           ""family"": ""I"",
           ""mediaType"": ""image/tiff"",
-          ""{deliveryChannelAlias}"": [""file""]
+          ""wcDeliveryChannels"": [""file""]
         }}";
 
         A.CallTo(() =>

--- a/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetWithoutDeliveryChannelsTests.cs
@@ -32,17 +32,15 @@ public class ModifyAssetWithoutDeliveryChannelsTests : IClassFixture<Protagonist
             });
     }
     
-    [Theory]
-    [InlineData("deliveryChannels")]
-    [InlineData("wcDeliveryChannels")]
-    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled(string deliveryChannelAlias)
+    [Fact]
+    public async Task Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled()
     {
         // Arrange 
         var assetId = new AssetId(99, 1, $"{nameof(Patch_Asset_Fails_When_Delivery_Channels_Are_Disabled)}");
         var hydraImageBody = $@"{{
           ""@type"": ""Image"",
           ""string1"": ""I am edited"",
-          ""{deliveryChannelAlias}"": [
+          ""wcDeliveryChannels"": [
                 ""iiif-img""
             ]
         }}";    

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -56,7 +56,7 @@ public static class AssetConverter
             MediaType = dbAsset.MediaType,
             Family = (AssetFamily)dbAsset.Family,
             Roles = dbAsset.RolesList.ToArray(),
-            DeliveryChannels = dbAsset.DeliveryChannels
+            WcDeliveryChannels = dbAsset.DeliveryChannels
         };
         
         if (dbAsset.Batch > 0)
@@ -270,9 +270,9 @@ public static class AssetConverter
             asset.MediaType = hydraImage.MediaType;
         }
         
-        if (hydraImage.DeliveryChannels != null)
+        if (hydraImage.WcDeliveryChannels != null)
         {
-            asset.DeliveryChannels = hydraImage.DeliveryChannels.OrderBy(dc => dc).Select(dc => dc.ToLower()).ToArray();
+            asset.DeliveryChannels = hydraImage.WcDeliveryChannels.OrderBy(dc => dc).Select(dc => dc.ToLower()).ToArray();
         }
 
         var thumbnailPolicy = hydraImage.ThumbnailPolicy.GetLastPathElement("thumbnailPolicies/");

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -26,7 +26,7 @@ public static class LegacyModeConverter
             
             image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ?? DefaultMediaType;
             
-            if (image.Origin is not null && image.Family is null && image.DeliveryChannels.IsNullOrEmpty())
+            if (image.Origin is not null && image.Family is null && image.WcDeliveryChannels.IsNullOrEmpty())
             {
                   image.Family = AssetFamily.Image;
             }

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -152,7 +152,7 @@ public class ImageController : HydraController
         [FromBody] DLCS.HydraModel.Image hydraAsset,
         CancellationToken cancellationToken)
     {
-        if (!apiSettings.DeliveryChannelsEnabled && !hydraAsset.DeliveryChannels.IsNullOrEmpty())
+        if (!apiSettings.DeliveryChannelsEnabled && !hydraAsset.WcDeliveryChannels.IsNullOrEmpty())
         {
             var assetId = new AssetId(customerId, spaceId, imageId);
             return this.HydraProblem("Delivery channels are disabled", assetId.ToString(), 400, "Bad Request");

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -18,7 +18,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         // Required fields
         RuleFor(a => a.MediaType).NotEmpty().WithMessage("Media type must be specified");
 
-        When(a => !a.DeliveryChannels.IsNullOrEmpty(), DeliveryChannelDependantValidation)
+        When(a => !a.WcDeliveryChannels.IsNullOrEmpty(), DeliveryChannelDependantValidation)
             .Otherwise(() =>
             {
                 RuleFor(a => a.Width).Empty().WithMessage("Should not include width");
@@ -32,11 +32,11 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
 
         // Other validation
-        RuleFor(a => a.DeliveryChannels).Must(d => d.IsNullOrEmpty())
+        RuleFor(a => a.WcDeliveryChannels).Must(d => d.IsNullOrEmpty())
             .When(_ => !apiSettings.Value.DeliveryChannelsEnabled)
             .WithMessage("Delivery channels are disabled");
 
-        RuleForEach(a => a.DeliveryChannels)
+        RuleForEach(a => a.WcDeliveryChannels)
             .Must(dc => AssetDeliveryChannels.All.Contains(dc))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
     }
@@ -46,7 +46,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
     {
         RuleFor(a => a.ImageOptimisationPolicy)
             .Must(iop => !KnownImageOptimisationPolicy.IsNoOpIdentifier(iop))
-            .When(a => !a.DeliveryChannels.ContainsOnly(AssetDeliveryChannels.File))
+            .When(a => !a.WcDeliveryChannels.ContainsOnly(AssetDeliveryChannels.File))
             .WithMessage(
                 $"ImageOptimisationPolicy {KnownImageOptimisationPolicy.NoneId} only valid for 'file' delivery channel");
 
@@ -54,23 +54,23 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .Empty()
             .WithMessage("Should not include width")
             .Unless(a =>
-                a.DeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsAudio(a.MediaType));
+                a.WcDeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsAudio(a.MediaType));
         
         RuleFor(a => a.Height)
             .Empty()
             .WithMessage("Should not include height")
             .Unless(a => 
-                a.DeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsAudio(a.MediaType));
+                a.WcDeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsAudio(a.MediaType));
         
         RuleFor(a => a.Duration)
             .Empty()
             .WithMessage("Should not include duration")
             .Unless(a =>
-                a.DeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsImage(a.MediaType));
+                a.WcDeliveryChannels.ContainsOnly(AssetDeliveryChannels.File) && !MIMEHelper.IsImage(a.MediaType));
 
         RuleFor(a => a.ImageOptimisationPolicy)
             .Must(iop => !KnownImageOptimisationPolicy.IsUseOriginalIdentifier(iop))
-            .When(a => !a.DeliveryChannels!.Contains(AssetDeliveryChannels.Image))
+            .When(a => !a.WcDeliveryChannels!.Contains(AssetDeliveryChannels.Image))
             .WithMessage(
                 $"ImageOptimisationPolicy '{KnownImageOptimisationPolicy.UseOriginalId}' only valid for image delivery-channel");
     }

--- a/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/ImageBatchPatchValidator.cs
@@ -35,7 +35,7 @@ public class ImageBatchPatchValidator : AbstractValidator<HydraCollection<DLCS.H
             members.RuleFor(a => a.Origin).Empty().WithMessage("Origin cannot be set in a bulk patching operation");
             members.RuleFor(a => a.ImageOptimisationPolicy).Empty().WithMessage("Image optimisation policies cannot be set in a bulk patching operation");
             members.RuleFor(a => a.MaxUnauthorised).Empty().WithMessage("MaxUnauthorised cannot be set in a bulk patching operation");
-            members.RuleFor(a => a.DeliveryChannels).Empty().WithMessage("Delivery channels cannot be set in a bulk patching operation");
+            members.RuleFor(a => a.WcDeliveryChannels).Empty().WithMessage("Delivery channels cannot be set in a bulk patching operation");
             members.RuleFor(a => a.ThumbnailPolicy).Empty().WithMessage("Thumbnail policy cannot be set in a bulk patching operation");
         });
     }

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -33,6 +33,6 @@ public class DeliveryChannelClass: Class
     {
         SupportedOperations = CommonOperations.GetStandardResourceOperations(
             operationId, "Delivery Channel", Id,
-            "GET", "POST", "PUT");
+            "GET", "POST", "PUT", "PATCH", "DELETE");
     }
 }

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -1,0 +1,67 @@
+﻿using Hydra;
+using Hydra.Model;
+using Newtonsoft.Json;
+
+namespace DLCS.HydraModel;
+
+[HydraClass(typeof(DeliveryChannelClass),
+    Description = "A delivery channel represents a way an asset on the DLCS can be served.",
+    UriTemplate = "/customers/{0}/defaultDeliveryChannels/{1}, /customers/{0}/spaces/{1}/defaultDeliveryChannels/{2}")]
+public class DeliveryChannel : DlcsResource
+{
+    public DeliveryChannel()
+    {
+        
+    }
+    
+    public DeliveryChannel(string baseUrl, int customerId, string deliveryChannelId, int? spaceId)
+    {
+        ModelId = deliveryChannelId;
+        CustomerId = customerId;
+        SpaceId = spaceId;
+        if (spaceId.HasValue)
+        {
+            Init(baseUrl, false, customerId, spaceId, deliveryChannelId);
+        }
+        else
+        {
+            Init(baseUrl, false, customerId, deliveryChannelId);
+        }
+    }
+    
+    [JsonIgnore]
+    public int CustomerId { get; set; }
+    
+    [JsonIgnore]
+    public int? SpaceId { get; set; }
+    
+    [JsonIgnore]
+    public string? ModelId { get; set; }
+    
+    [RdfProperty(Description = "The name of the DLCS delivery channel this is based on.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 11, PropertyName = "channel")]
+    public string? Channel { get; set; }
+    
+    [HydraLink(Description = "The policy assigned to this delivery channel.",
+        Range = "vocab:deliveryChannelPolicy", ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 12, PropertyName = "policy")]
+    public string? Policy { get; set; }
+}
+
+public class DeliveryChannelClass: Class
+{
+    string operationId = "_:deliveryChannel_";
+    
+    public DeliveryChannelClass()
+    {
+        BootstrapViaReflection(typeof(DeliveryChannel));
+    }
+    
+    public override void DefineOperations()
+    {
+        SupportedOperations = CommonOperations.GetStandardResourceOperations(
+            operationId, "Delivery Channel", Id,
+            "GET", "PUT", "DELETE");
+    }
+}

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -6,38 +6,9 @@ namespace DLCS.HydraModel;
 
 [HydraClass(typeof(DeliveryChannelClass),
     Description = "A delivery channel represents a way an asset on the DLCS can be served.",
-    UriTemplate = "/customers/{0}/defaultDeliveryChannels/{1}, /customers/{0}/spaces/{1}/defaultDeliveryChannels/{2}")]
+    UriTemplate = "")]
 public class DeliveryChannel : DlcsResource
 {
-    public DeliveryChannel()
-    {
-        
-    }
-    
-    public DeliveryChannel(string baseUrl, int customerId, string deliveryChannelId, int? spaceId)
-    {
-        ModelId = deliveryChannelId;
-        CustomerId = customerId;
-        SpaceId = spaceId;
-        if (spaceId.HasValue)
-        {
-            Init(baseUrl, false, customerId, spaceId, deliveryChannelId);
-        }
-        else
-        {
-            Init(baseUrl, false, customerId, deliveryChannelId);
-        }
-    }
-    
-    [JsonIgnore]
-    public int CustomerId { get; set; }
-    
-    [JsonIgnore]
-    public int? SpaceId { get; set; }
-    
-    [JsonIgnore]
-    public string? ModelId { get; set; }
-    
     [RdfProperty(Description = "The name of the DLCS delivery channel this is based on.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 11, PropertyName = "channel")]
@@ -62,6 +33,6 @@ public class DeliveryChannelClass: Class
     {
         SupportedOperations = CommonOperations.GetStandardResourceOperations(
             operationId, "Delivery Channel", Id,
-            "GET", "PUT", "DELETE");
+            "GET", "POST", "PUT");
     }
 }

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -197,6 +197,11 @@ public class Image : DlcsResource
     
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
+    public DeliveryChannel[]? DeliveryChannels { get; set; }
+    
+    [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
     public string[]? WcDeliveryChannels { get; set; }
     

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -195,18 +195,10 @@ public class Image : DlcsResource
     [JsonProperty(Order = 130, PropertyName = "textType")]
     public string? TextType { get; set; } // e.g., METS-ALTO, hOCR, TEI, text/plain etc
     
-    [JsonIgnore]
-    public string[]? DeliveryChannels { get; set; }
-
-    [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
-        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = true)]
-    [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
-    public string[]? OldDeliveryChannels { set => DeliveryChannels = value; get => DeliveryChannels; }
-    
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 141, PropertyName = "wcDeliveryChannels")]
-    public string[]? WcDeliveryChannels { set => DeliveryChannels = value; get => DeliveryChannels; }
+    public string[]? WcDeliveryChannels { get; set; }
     
     [RdfProperty(Description = "The role or roles that a user must possess to view this image above maxUnauthorised. " +
                                "These are URIs of roles e.g., https://api.dlcs.io/customers/1/roles/requiresRegistration",


### PR DESCRIPTION
Resolves #717

This PR adds a new `DeliveryChannel` Hydra class and replaces the `string[] DeliveryChannels` property in `HydraModel.Image` with `DeliveryChannel[] DeliveryChannels`. It also removes the `OldDeliveryChannels` property.

