### PR TITLE
Add JsonConverter for `string[]` Delivery Channels --> `DeliveryChannel[]` Delivery Channels

### DIFF
--- a/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
+++ b/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
@@ -50,17 +50,63 @@ public class ImageDeliveryChannelsConverterTests
           ""family"": ""I"",
           ""mediaType"": ""image/tiff"",
             ""deliveryChannels"": [
-                ""iiif-img"",
+                {
+                  ""channel"": ""iiif-img"",
+                  ""policy"": ""default""
+                },
                 {
                   ""channel"": ""thumbs"",
-                  ""policy"": ""my-thumbs-policy""
-                    
+                  ""policy"": ""my-thumbs-policy""   
                 },
                 {
                   ""channel"": ""file"",
                   ""policy"": ""none""
                 }
               ],
+        }";
+        
+        var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
+        
+        deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
+        deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
+        {
+            new()
+            {
+                Channel = "iiif-img",
+                Policy = "default"
+            },
+            new()
+            {
+                Channel = "thumbs",
+                Policy = "my-thumbs-policy"
+            },
+            new()
+            {
+                Channel = "file",
+                Policy = "none"
+            }
+        });
+    }
+    
+    [Fact]
+    public async Task DeliveryChannelsConverter_Supports_Mixed_Channels()
+    {
+        var hydraAssetBody = @"{
+          ""@type"": ""Image"",
+          ""origin"": ""https://example.org/asset.tiff"",
+          ""family"": ""I"",
+          ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+                ""iiif-img"",
+                {
+                  ""channel"": ""thumbs"",
+                  ""policy"": ""my-thumbs-policy""   
+                },
+                {
+                  ""channel"": ""file"",
+                  ""policy"": ""none""
+                }
+              ]
         }";
         
         var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);

--- a/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
+++ b/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
@@ -41,7 +41,6 @@ public class ImageDeliveryChannelsConverterTests
         });
     }
     
-    
     [Fact]
     public async Task DeliveryChannelsConverter_Supports_Complex_Channels()
     {
@@ -51,10 +50,7 @@ public class ImageDeliveryChannelsConverterTests
           ""family"": ""I"",
           ""mediaType"": ""image/tiff"",
             ""deliveryChannels"": [
-                {
-                  ""channel"": ""iiif-img"",
-                  ""policy"": ""default""
-                },
+                ""iiif-img"",
                 {
                   ""channel"": ""thumbs"",
                   ""policy"": ""my-thumbs-policy""
@@ -75,7 +71,7 @@ public class ImageDeliveryChannelsConverterTests
             new()
             {
                 Channel = "iiif-img",
-                Policy = "default"
+                Policy = null
             },
             new()
             {

--- a/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
+++ b/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
@@ -8,7 +8,7 @@ namespace DLCS.Hydra.Tests.Model.Converters;
 public class ImageDeliveryChannelsConverterTests
 {
     [Fact]
-    public async Task DeliveryChannelsConverter_Supports_Basic_Channels()
+    public void DeliveryChannelsConverter_Supports_Basic_Channels()
     {
         var hydraAssetBody = @"{
             ""@type"": ""Image"",
@@ -42,7 +42,7 @@ public class ImageDeliveryChannelsConverterTests
     }
     
     [Fact]
-    public async Task DeliveryChannelsConverter_Supports_Complex_Channels()
+    public void DeliveryChannelsConverter_Supports_Complex_Channels()
     {
         var hydraAssetBody = @"{
           ""@type"": ""Image"",
@@ -89,7 +89,7 @@ public class ImageDeliveryChannelsConverterTests
     }
     
     [Fact]
-    public async Task DeliveryChannelsConverter_Supports_Mixed_Channels()
+    public void DeliveryChannelsConverter_Supports_Mixed_Channels()
     {
         var hydraAssetBody = @"{
           ""@type"": ""Image"",

--- a/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
+++ b/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
@@ -10,6 +10,7 @@ public class ImageDeliveryChannelsConverterTests
     [Fact]
     public void DeliveryChannelsConverter_Supports_Basic_Channels()
     {
+        // Arrange
         var hydraAssetBody = @"{
             ""@type"": ""Image"",
             ""origin"": ""https://example.org/asset.tiff"",
@@ -18,8 +19,10 @@ public class ImageDeliveryChannelsConverterTests
             ""deliveryChannels"": [""iiif-img"",""thumbs"",""file""]
         }";
         
+        // Act
         var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
         
+        // Assert
         deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
         deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
         {
@@ -44,6 +47,7 @@ public class ImageDeliveryChannelsConverterTests
     [Fact]
     public void DeliveryChannelsConverter_Supports_Complex_Channels()
     {
+        // Arrange
         var hydraAssetBody = @"{
           ""@type"": ""Image"",
           ""origin"": ""https://example.org/asset.tiff"",
@@ -65,8 +69,10 @@ public class ImageDeliveryChannelsConverterTests
               ],
         }";
         
+        // Act
         var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
         
+        // Assert
         deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
         deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
         {
@@ -91,6 +97,7 @@ public class ImageDeliveryChannelsConverterTests
     [Fact]
     public void DeliveryChannelsConverter_Supports_Mixed_Channels()
     {
+        // Arrange
         var hydraAssetBody = @"{
           ""@type"": ""Image"",
           ""origin"": ""https://example.org/asset.tiff"",
@@ -109,8 +116,10 @@ public class ImageDeliveryChannelsConverterTests
               ]
         }";
         
+        // Act
         var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
         
+        // Assert
         deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
         deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
         {
@@ -130,5 +139,42 @@ public class ImageDeliveryChannelsConverterTests
                 Policy = "none"
             }
         });
+    }
+    
+    [Fact]
+    public void DeliveryChannelsConverter_ReturnsNull_When_Null()
+    {
+        // Arrange
+        var hydraAssetBody = @"{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/asset.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+        }";
+        
+        // Act
+        var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
+
+        // Assert
+        deliveryChannel!.DeliveryChannels!.Should().BeNull();
+    }
+    
+    [Fact]
+    public void DeliveryChannelsConverter_ReturnsEmptyArray_When_Empty()
+    {
+        // Arrange
+        var hydraAssetBody = @"{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/asset.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": """"
+        }";
+        
+        // Act
+        var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
+
+        // Assert
+        deliveryChannel!.DeliveryChannels!.Should().BeEmpty();
     }
 }

--- a/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
+++ b/src/protagonist/DLCS.Hydra.Tests/Model/Converters/ImageDeliveryChannelsConverterTests.cs
@@ -1,0 +1,92 @@
+﻿using DLCS.HydraModel;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace DLCS.Hydra.Tests.Model.Converters;
+
+public class ImageDeliveryChannelsConverterTests
+{
+    [Fact]
+    public async Task DeliveryChannelsConverter_Supports_Basic_Channels()
+    {
+        var hydraAssetBody = @"{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/asset.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [""iiif-img"",""thumbs"",""file""]
+        }";
+        
+        var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
+        
+        deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
+        deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
+        {
+            new()
+            {
+                Channel = "iiif-img",
+                Policy = null,
+            },
+            new()
+            {
+                Channel = "thumbs",
+                Policy = null,
+            },
+            new()
+            {
+                Channel = "file",
+                Policy = null,
+            }
+        });
+    }
+    
+    
+    [Fact]
+    public async Task DeliveryChannelsConverter_Supports_Complex_Channels()
+    {
+        var hydraAssetBody = @"{
+          ""@type"": ""Image"",
+          ""origin"": ""https://example.org/asset.tiff"",
+          ""family"": ""I"",
+          ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+                {
+                  ""channel"": ""iiif-img"",
+                  ""policy"": ""default""
+                },
+                {
+                  ""channel"": ""thumbs"",
+                  ""policy"": ""my-thumbs-policy""
+                    
+                },
+                {
+                  ""channel"": ""file"",
+                  ""policy"": ""none""
+                }
+              ],
+        }";
+        
+        var deliveryChannel = JsonConvert.DeserializeObject<Image>(hydraAssetBody);
+        
+        deliveryChannel!.DeliveryChannels!.Length.Should().Be(3);
+        deliveryChannel!.DeliveryChannels!.Should().BeEquivalentTo(new DeliveryChannel[]
+        {
+            new()
+            {
+                Channel = "iiif-img",
+                Policy = "default"
+            },
+            new()
+            {
+                Channel = "thumbs",
+                Policy = "my-thumbs-policy"
+            },
+            new()
+            {
+                Channel = "file",
+                Policy = "none"
+            }
+        });
+    }
+}

--- a/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
+++ b/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
@@ -4,14 +4,15 @@ using Newtonsoft.Json;
 
 namespace DLCS.HydraModel.Converters;
 
-public class ImageDeliveryChannelsConverter : JsonConverter
+public class ImageDeliveryChannelsConverter : JsonConverter<DeliveryChannel[]>
 {
-    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    public override void WriteJson(JsonWriter writer, DeliveryChannel[]? value, JsonSerializer serializer)
     {
-        serializer.Serialize(writer, value); // Serialize values normally
+        serializer.Serialize(writer, value); // Serialize the values normally
     }
 
-    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    public override DeliveryChannel[]? ReadJson(JsonReader reader, Type objectType, DeliveryChannel[]? existingValue, bool hasExistingValue,
+        JsonSerializer serializer)
     {
         List<DeliveryChannel> deliveryChannels = new();
         
@@ -47,10 +48,5 @@ public class ImageDeliveryChannelsConverter : JsonConverter
         }
         
         return deliveryChannels.ToArray();
-    }
-    
-    public override bool CanConvert(Type objectType)
-    {
-        return objectType == typeof(string[]) || objectType == typeof(DeliveryChannel[]);
     }
 }

--- a/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
+++ b/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
@@ -8,12 +8,13 @@ public class ImageDeliveryChannelsConverter : JsonConverter
 {
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
-        serializer.Serialize(writer, value);
+        serializer.Serialize(writer, value); // Serialize values normally
     }
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         List<DeliveryChannel> deliveryChannels = new();
+        
         if (reader.TokenType == JsonToken.StartArray)
         {
             while (reader.Read())
@@ -22,11 +23,16 @@ public class ImageDeliveryChannelsConverter : JsonConverter
                 {
                     break;
                 }
+                
+                // If an object is found, deserialize it as a hydra delivery channel
                 if (reader.TokenType == JsonToken.StartObject)
                 {
                     var newDeliveryChannel = serializer.Deserialize<DeliveryChannel>(reader);
+                    if (newDeliveryChannel == null) continue;
                     deliveryChannels.Add(newDeliveryChannel);
                 }
+                
+                // Otherwise, if a string is found it should be used as the channel for a new hydra delivery channel
                 if (reader.TokenType == JsonToken.String)
                 {
                     var channel = serializer.Deserialize<string>(reader);
@@ -45,6 +51,6 @@ public class ImageDeliveryChannelsConverter : JsonConverter
     
     public override bool CanConvert(Type objectType)
     {
-        return true;
+        return objectType == typeof(string[]) || objectType == typeof(DeliveryChannel[]);
     }
 }

--- a/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
+++ b/src/protagonist/DLCS.HydraModel/Converters/ImageDeliveryChannelsConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DLCS.HydraModel.Converters;
+
+public class ImageDeliveryChannelsConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        serializer.Serialize(writer, value);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        List<DeliveryChannel> deliveryChannels = new();
+        if (reader.TokenType == JsonToken.StartArray)
+        {
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndArray)
+                {
+                    break;
+                }
+                if (reader.TokenType == JsonToken.StartObject)
+                {
+                    var newDeliveryChannel = serializer.Deserialize<DeliveryChannel>(reader);
+                    deliveryChannels.Add(newDeliveryChannel);
+                }
+                if (reader.TokenType == JsonToken.String)
+                {
+                    var channel = serializer.Deserialize<string>(reader);
+                    var newDeliveryChannel = new DeliveryChannel()
+                    {
+                        Channel = channel
+                    };
+                    
+                    deliveryChannels.Add(newDeliveryChannel);
+                } 
+            }
+        }
+        
+        return deliveryChannels.ToArray();
+    }
+    
+    public override bool CanConvert(Type objectType)
+    {
+        return true;
+    }
+}

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -1,4 +1,5 @@
 using System;
+using DLCS.HydraModel.Converters;
 using Hydra;
 using Hydra.Model;
 using Newtonsoft.Json;
@@ -198,6 +199,7 @@ public class Image : DlcsResource
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 140, PropertyName = "deliveryChannels")]
+    [JsonConverter(typeof(ImageDeliveryChannelsConverter))]
     public DeliveryChannel[]? DeliveryChannels { get; set; }
     
     [RdfProperty(Description = "Delivery channel specifying how the asset will be available.",


### PR DESCRIPTION
Resolves #725

This PR adds a custom `JsonConverter` that allows the `DeliveryChannels` field in `HydraModel.Image` to support different kinds of formats.

An array of `HydraModel.DeliveryChannel`:

```
"deliveryChannels": [
    {
      "channel": "iiif-img",
      "policy": "default"
    },
    {
      "channel": "thumbs",
      "policy": ""my-thumbs-policy"
    }
]
```

An array of channel names:

```
"deliveryChannels": ["iiif-img","thumbs"]
```

Or a mix of both:

```
"deliveryChannels": [
    "iiif-img",
    {
      "channel": "thumbs",
      "policy": ""my-thumbs-policy"
    }
]
```