### PR TITLE
Add AV settings to Engine

### DIFF
--- a/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
@@ -33,7 +33,7 @@ public class IngestControllerTests
     public void ReturnAllowedAvOptions_ReturnsAvOptions_WhenCalled()
     {
         // Arrange and Act
-        var avReturn = sut.ReturnAllowedAvOptions();
+        var avReturn = sut.GetAllowedAvOptions();
         
         var options = avReturn as OkObjectResult;
         var avOptions = options.Value as List<string>;
@@ -57,7 +57,7 @@ public class IngestControllerTests
         var ingestController = new IngestController(ingester, Options.Create(engineSettings));
         
         // Act
-        var avReturn = ingestController.ReturnAllowedAvOptions();
+        var avReturn = ingestController.GetAllowedAvOptions();
         
         var options = avReturn as OkObjectResult;
         var avOptions = options.Value as List<string>;

--- a/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
@@ -1,0 +1,69 @@
+﻿using Engine.Ingest;
+using Engine.Settings;
+using FakeItEasy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Engine.Tests.Ingest;
+
+public class IngestControllerTests
+{
+    private IngestController sut;
+    private IAssetIngester ingester;
+
+    public IngestControllerTests()
+    {
+        ingester =  A.Fake<IAssetIngester>();
+        var engineSettings = new EngineSettings
+        {
+            TimebasedIngest = new TimebasedIngestSettings()
+            {
+                DeliveryChannelMappings = new Dictionary<string, string>()
+                {
+                    {"somePolicy", "An amazon policy"},
+                    {"somePolicy2", "An amazon policy 2"}
+                }
+            }
+        };
+
+        sut = new IngestController(ingester, Options.Create(engineSettings));
+    }
+
+    [Fact]
+    public void ReturnAllowedAvOptions_ReturnsAvOptions_WhenCalled()
+    {
+        // Arrange and Act
+        var avReturn = sut.ReturnAllowedAvOptions();
+        
+        var options = avReturn as OkObjectResult;
+        var avOptions = options.Value as List<string>;
+
+        // Assert
+        options.StatusCode.Should().Be(200);
+        avOptions.Count.Should().Be(2);
+        avOptions.Should().Contain("somePolicy");
+        avOptions.Should().Contain("somePolicy2");
+    }
+    
+    [Fact]
+    public void ReturnAllowedAvOptions_ReturnsEmptyList_WhenCalledWithDefaultSettings()
+    {
+        // Arrange and
+        var engineSettings = new EngineSettings()
+        {
+            TimebasedIngest = new TimebasedIngestSettings()
+        };
+        
+        var ingestController = new IngestController(ingester, Options.Create(engineSettings));
+        
+        // Act
+        var avReturn = ingestController.ReturnAllowedAvOptions();
+        
+        var options = avReturn as OkObjectResult;
+        var avOptions = options.Value as List<string>;
+
+        // Assert
+        options.StatusCode.Should().Be(200);
+        avOptions.Count.Should().Be(0);
+    }
+}

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
@@ -26,7 +26,7 @@ public class ElasticTranscoderTests
         {
             TimebasedIngest = new TimebasedIngestSettings
             {
-                TranscoderMappings = new Dictionary<string, string>
+                DeliveryChannelMappings = new Dictionary<string, string>
                 {
                     ["Standard WebM"] = "my-custom-preset",
                 },

--- a/src/protagonist/Engine/Ingest/IngestController.cs
+++ b/src/protagonist/Engine/Ingest/IngestController.cs
@@ -57,13 +57,13 @@ public class IngestController : Controller
     }
     
     /// <summary>
-    /// Synchronously ingest an asset 
+    /// Retrieve allowed av options
     /// </summary>
     [HttpGet]
     [Route("allowed-av")]
-    public async Task<IActionResult> Return(CancellationToken cancellationToken)
+    public IActionResult ReturnAllowedAvOptions()
     {
-        return Ok(timebasedIngestSettings.DeliveryChannelMappings.Keys);
+        return Ok(timebasedIngestSettings.DeliveryChannelMappings.Keys.ToList());
     }
 
     private IActionResult ConvertToStatusCode(object message, IngestResultStatus result)

--- a/src/protagonist/Engine/Ingest/IngestController.cs
+++ b/src/protagonist/Engine/Ingest/IngestController.cs
@@ -61,7 +61,7 @@ public class IngestController : Controller
     /// </summary>
     [HttpGet]
     [Route("allowed-av")]
-    public IActionResult ReturnAllowedAvOptions()
+    public IActionResult GetAllowedAvOptions()
     {
         return Ok(timebasedIngestSettings.DeliveryChannelMappings.Keys.ToList());
     }

--- a/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
@@ -86,7 +86,7 @@ public class ElasticTranscoder : IMediaTranscoder
                 TranscoderTemplates.ProcessPreset(mediaType, assetId, technicalDetail, jobId);
 
             // TODO - handle empty path/presetname
-            var mappedPresetName = settings.TranscoderMappings.TryGetValue(presetName, out var mappedName)
+            var mappedPresetName = settings.DeliveryChannelMappings.TryGetValue(presetName, out var mappedName)
                 ? mappedName
                 : presetName;
 

--- a/src/protagonist/Engine/Settings/EngineSettings.cs
+++ b/src/protagonist/Engine/Settings/EngineSettings.cs
@@ -78,12 +78,12 @@ public class ImageIngestSettings
     /// Root folder for use by Image-Processor sidecar
     /// </summary>
     public string ImageProcessorRoot { get; set; }
-    
+
     /// <summary>
     /// Base url for calling orchestrator.
     /// </summary>
     public Uri OrchestratorBaseUrl { get; set; }
-        
+
     /// <summary>
     /// Timeout, in ms, to wait for calls to orchestrator
     /// </summary>
@@ -98,12 +98,11 @@ public class ImageIngestSettings
     /// The character to use when replacing an open bracket character
     /// </summary>
     public string OpenBracketReplacement { get; set; } = "_";
-    
+
     /// <summary>
     /// The character to use when replacing a closing bracket character
     /// </summary>
     public string CloseBracketReplacement { get; set; } = "_";
-    
 
     /// <summary>
     /// Get the root folder, if forImageProcessor will ensure that it is compatible with needs of image-processor
@@ -133,5 +132,5 @@ public class TimebasedIngestSettings
     /// <summary>
     /// Mapping of 'friendly' to 'real' transcoder names
     /// </summary>
-    public Dictionary<string, string> TranscoderMappings { get; set; } = new();
+    public Dictionary<string, string> DeliveryChannelMappings { get; set; } = new();
 }


### PR DESCRIPTION
This PR is related to #726 

It provides an additional endpoint used to provide valid `iiif-av` policies for use by the API

This is tracked by a sub-task [here](https://digirati.atlassian.net/browse/WDC-57)