### PR TITLE
Allow API to emit and receive full delivery channel information

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -309,4 +309,54 @@ public class HydraImageValidatorTests
         var result = imageValidator.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
     }
+    
+    [Theory]
+    [InlineData("image/jpeg", "iiif-img")]
+    [InlineData("image/jpeg", "thumbs")]  
+    [InlineData("image/jpeg", "file")]
+    [InlineData("video/mp4", "iiif-av")]  
+    [InlineData("video/mp4", "file")]  
+    [InlineData("audio/mp3", "iiif-av")] 
+    [InlineData("audio/mp3", "file")] 
+    [InlineData("application/pdf", "file")]
+    public void DeliveryChannel_NoValidationError_WhenChannelValidForMediaType(string mediaType, string channel)
+    {
+        var apiSettings = new ApiSettings();
+        var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
+        var model = new DLCS.HydraModel.Image { 
+            MediaType = mediaType,
+            DeliveryChannels = new[]
+            {
+                new DeliveryChannel()
+                {
+                    Channel = channel,
+                }
+            } };
+        var result = imageValidator.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
+    }
+    
+    [Theory]
+    [InlineData("video/mp4", "iiif-img")]
+    [InlineData("video/mp4", "thumbs")]
+    [InlineData("image/jpeg", "iiif-av")]
+    [InlineData("application/pdf", "iiif-img")]
+    [InlineData("application/pdf", "thumbs")]
+    [InlineData("application/pdf", "iiif-av")]
+    public void DeliveryChannel_ValidationError_WhenWrongChannelForMediaType(string mediaType, string channel)
+    {
+        var apiSettings = new ApiSettings();
+        var imageValidator = new HydraImageValidator(Options.Create(apiSettings));
+        var model = new DLCS.HydraModel.Image { 
+            MediaType = mediaType,
+            DeliveryChannels = new[]
+        {
+            new DeliveryChannel()
+            {
+                Channel = channel,
+            }
+        } };
+        var result = imageValidator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+    }
 }

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -287,7 +287,7 @@ public class HydraImageValidatorTests
             },
             new DeliveryChannel()
             {
-                Channel = "File"
+                Channel = "file"
             }
         } };
         var result = imageValidator.TestValidate(model);
@@ -314,11 +314,15 @@ public class HydraImageValidatorTests
     [InlineData("image/jpeg", "iiif-img")]
     [InlineData("image/jpeg", "thumbs")]  
     [InlineData("image/jpeg", "file")]
+    [InlineData("image/jpeg", "none")]
     [InlineData("video/mp4", "iiif-av")]  
     [InlineData("video/mp4", "file")]  
+    [InlineData("video/mp4", "none")]  
     [InlineData("audio/mp3", "iiif-av")] 
     [InlineData("audio/mp3", "file")] 
+    [InlineData("audio/mp3", "none")] 
     [InlineData("application/pdf", "file")]
+    [InlineData("application/pdf", "none")]
     public void DeliveryChannel_NoValidationError_WhenChannelValidForMediaType(string mediaType, string channel)
     {
         var apiSettings = new ApiSettings();

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -75,6 +75,15 @@ public static class AssetConverter
             image.ImageOptimisationPolicy =
                 $"{urlRoots.BaseUrl}/imageOptimisationPolicies/{dbAsset.ImageOptimisationPolicy}";
         }
+        
+        if (!dbAsset.ImageDeliveryChannels.IsNullOrEmpty())
+        {
+            image.DeliveryChannels = dbAsset.ImageDeliveryChannels.Select(c => new DeliveryChannel()
+            {
+                Channel = c.Channel,
+                Policy = c.DeliveryChannelPolicy.Name
+            }).ToArray();
+        }
 
         return image;
     }

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -84,6 +84,10 @@ public static class AssetConverter
                 Policy = c.DeliveryChannelPolicy.Name
             }).ToArray();
         }
+        else
+        {
+            image.DeliveryChannels = Array.Empty<DeliveryChannel>();
+        }
 
         return image;
     }

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -79,10 +79,12 @@ public static class AssetConverter
         if (!dbAsset.ImageDeliveryChannels.IsNullOrEmpty())
         {
             image.DeliveryChannels = dbAsset.ImageDeliveryChannels.Select(c => new DeliveryChannel()
-            {
-                Channel = c.Channel,
-                Policy = c.DeliveryChannelPolicy.Name
-            }).ToArray();
+                {
+                    Channel = c.Channel,
+                    Policy = c.DeliveryChannelPolicy.System 
+                        ? c.DeliveryChannelPolicy.Name
+                        : $"{urlRoots.BaseUrl}/customers/{c.DeliveryChannelPolicy.Customer}/deliveryChannelPolicies/{c.Channel}/{c.DeliveryChannelPolicy.Name}"
+                }).ToArray();
         }
         else
         {

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -39,14 +39,14 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .WithMessage("Delivery channels are disabled");
 
         RuleForEach(a => a.WcDeliveryChannels)
-            .Must(dc => AssetDeliveryChannels.All.Contains(dc))
+            .Must(AssetDeliveryChannels.IsValidChannel)
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
     }
 
     private void ImageDeliveryChannelDependantValidation()
     {
         RuleForEach(a => a.DeliveryChannels)
-            .Must(dc => AssetDeliveryChannels.All.Contains(dc.Channel))
+            .Must(dc => AssetDeliveryChannels.IsValidChannel(dc.Channel))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
 
         RuleFor(a => a.DeliveryChannels)
@@ -56,7 +56,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
 
         RuleForEach(a => a.DeliveryChannels)
             .Must(c => !string.IsNullOrEmpty(c.Channel))
-            .WithMessage((a, c) => $"`channel` must be specified when supplying delivery channels to an asset");
+            .WithMessage("\"channel\" must be specified when supplying delivery channels to an asset");
             
         RuleForEach(a => a.DeliveryChannels)
             .Must((a, c) => AssetDeliveryChannels.IsChannelValidForMediaType(c.Channel!, a.MediaType!))

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -45,6 +45,10 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
 
     private void ImageDeliveryChannelDependantValidation()
     {
+        RuleForEach(a => a.DeliveryChannels)
+            .Must(dc => AssetDeliveryChannels.All.Contains(dc.Channel))
+            .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
+
         RuleFor(a => a.DeliveryChannels)
             .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.None))
             .When(a => a.DeliveryChannels!.Length > 1)
@@ -55,9 +59,9 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .WithMessage((a, c) => $"`channel` must be specified when supplying delivery channels to an asset");
             
         RuleForEach(a => a.DeliveryChannels)
-            .Must(a => AssetDeliveryChannels.IsChannelValidForMediaType(a.Channel!, a.Type))
+            .Must((a, c) => AssetDeliveryChannels.IsChannelValidForMediaType(c.Channel!, a.MediaType!))
             .When(a => !string.IsNullOrEmpty(a.MediaType))
-            .WithMessage((a,c) => $"{c.Channel} is not a valid delivery channel for asset of type {a.MediaType}");
+            .WithMessage((a,c) => $"\"{c.Channel}\" is not a valid delivery channel for asset of type \"{a.MediaType}\"");
     }
 
     // Validation rules that depend on DeliveryChannel being populated

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -49,6 +49,15 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.None))
             .When(a => a.DeliveryChannels!.Length > 1)
             .WithMessage("If \"none\" is the specified channel, then no other delivery channels are allowed");
+
+        RuleForEach(a => a.DeliveryChannels)
+            .Must(c => !string.IsNullOrEmpty(c.Channel))
+            .WithMessage((a, c) => $"`channel` must be specified when supplying delivery channels to an asset");
+            
+        RuleForEach(a => a.DeliveryChannels)
+            .Must(a => AssetDeliveryChannels.IsChannelValidForMediaType(a.Channel!, a.Type))
+            .When(a => !string.IsNullOrEmpty(a.MediaType))
+            .WithMessage((a,c) => $"{c.Channel} is not a valid delivery channel for asset of type {a.MediaType}");
     }
 
     // Validation rules that depend on DeliveryChannel being populated

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -62,6 +62,10 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .Must((a, c) => AssetDeliveryChannels.IsChannelValidForMediaType(c.Channel!, a.MediaType!))
             .When(a => !string.IsNullOrEmpty(a.MediaType))
             .WithMessage((a,c) => $"\"{c.Channel}\" is not a valid delivery channel for asset of type \"{a.MediaType}\"");
+    
+        RuleForEach(a => a.DeliveryChannels)
+            .Must((a, c) => a.DeliveryChannels!.Count(dc => dc.Channel == c.Channel) <= 1)
+            .WithMessage("\"deliveryChannels\" cannot contain duplicate channels.");
     }
 
     // Validation rules that depend on DeliveryChannel being populated

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -104,16 +104,7 @@ public class AssetNotificationSender : IAssetNotificationSender
             CustomerPathElement = customerPathElement
         };
 
-        if (!modifiedAsset.ImageDeliveryChannels.IsNullOrEmpty())
-        {
-            request.Asset.ImageDeliveryChannels = modifiedAsset.ImageDeliveryChannels.Select(x =>
-                new ImageDeliveryChannel()
-                {
-                    ImageId = x.ImageId,
-                    Channel = x.Channel,
-                    DeliveryChannelPolicyId = x.DeliveryChannelPolicyId
-                }).ToList();
-        }
+        modifiedAsset = RefreshImageDeliveryChannelsForAsset(modifiedAsset);
 
         return JsonSerializer.Serialize(request, settings);
     }
@@ -128,6 +119,9 @@ public class AssetNotificationSender : IAssetNotificationSender
             AssetAfterUpdate = modifiedAssetAfter, 
             CustomerPathElement = customerPathElement
         };
+
+        request.AssetBeforeUpdate = RefreshImageDeliveryChannelsForAsset(request.AssetBeforeUpdate);
+        request.AssetAfterUpdate = RefreshImageDeliveryChannelsForAsset(request.AssetAfterUpdate);
 
         return JsonSerializer.Serialize(request, settings);
     }
@@ -151,5 +145,21 @@ public class AssetNotificationSender : IAssetNotificationSender
             .ToList();
         
         return await topicPublisher.PublishToAssetModifiedTopic(toSend, cancellationToken);
+    }
+
+
+    private Asset RefreshImageDeliveryChannelsForAsset(Asset asset)
+    {
+        if (!asset.ImageDeliveryChannels.IsNullOrEmpty())
+        {
+            asset.ImageDeliveryChannels =  asset.ImageDeliveryChannels.Select(x => new ImageDeliveryChannel()
+            {
+                ImageId = x.ImageId,
+                Channel = x.Channel,
+                DeliveryChannelPolicyId = x.DeliveryChannelPolicyId
+            }).ToList();
+        }
+        
+        return asset;
     }
 }

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -4,14 +4,38 @@ using Newtonsoft.Json;
 
 namespace DLCS.HydraModel;
 
-public class DeliveryChannel
+
+[HydraClass(typeof(DeliveryChannelClass),
+    Description = "A delivery channel represents a way an asset on the DLCS can be served.",
+    UriTemplate = "")]
+public class DeliveryChannel : DlcsResource
 {
-    [JsonProperty(PropertyName = "@type")]
-    public string? Context => "vocab:DeliveryChannel";
+    public override string? Context => null;
     
+    [RdfProperty(Description = "The name of the DLCS delivery channel this is based on.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 11, PropertyName = "channel")]
     public string? Channel { get; set; }
     
+    [HydraLink(Description = "The policy assigned to this delivery channel.",
+        Range = "vocab:deliveryChannelPolicy", ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 12, PropertyName = "policy")]
     public string? Policy { get; set; }
+}
+
+public class DeliveryChannelClass: Class
+{
+    string operationId = "_:deliveryChannel_";
+    
+    public DeliveryChannelClass()
+    {
+        BootstrapViaReflection(typeof(DeliveryChannel));
+    }
+    
+    public override void DefineOperations()
+    {
+        SupportedOperations = CommonOperations.GetStandardResourceOperations(
+            operationId, "Delivery Channel", Id,
+            "GET", "POST", "PUT", "PATCH", "DELETE");
+    }
 }

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -4,35 +4,11 @@ using Newtonsoft.Json;
 
 namespace DLCS.HydraModel;
 
-[HydraClass(typeof(DeliveryChannelClass),
-    Description = "A delivery channel represents a way an asset on the DLCS can be served.",
-    UriTemplate = "")]
-public class DeliveryChannel : DlcsResource
+public class DeliveryChannel
 {
-    [RdfProperty(Description = "The name of the DLCS delivery channel this is based on.",
-        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 11, PropertyName = "channel")]
     public string? Channel { get; set; }
     
-    [HydraLink(Description = "The policy assigned to this delivery channel.",
-        Range = "vocab:deliveryChannelPolicy", ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 12, PropertyName = "policy")]
     public string? Policy { get; set; }
-}
-
-public class DeliveryChannelClass: Class
-{
-    string operationId = "_:deliveryChannel_";
-    
-    public DeliveryChannelClass()
-    {
-        BootstrapViaReflection(typeof(DeliveryChannel));
-    }
-    
-    public override void DefineOperations()
-    {
-        SupportedOperations = CommonOperations.GetStandardResourceOperations(
-            operationId, "Delivery Channel", Id,
-            "GET", "POST", "PUT", "PATCH", "DELETE");
-    }
 }

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -6,6 +6,9 @@ namespace DLCS.HydraModel;
 
 public class DeliveryChannel
 {
+    [JsonProperty(PropertyName = "@type")]
+    public string? Context => "vocab:DeliveryChannel";
+    
     [JsonProperty(Order = 11, PropertyName = "channel")]
     public string? Channel { get; set; }
     

--- a/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DeliveryChannel.cs
@@ -4,7 +4,6 @@ using Newtonsoft.Json;
 
 namespace DLCS.HydraModel;
 
-
 [HydraClass(typeof(DeliveryChannelClass),
     Description = "A delivery channel represents a way an asset on the DLCS can be served.",
     UriTemplate = "")]

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -17,7 +17,7 @@ public static class AssetDeliveryChannels
     /// <summary>
     /// All possible delivery channels
     /// </summary>
-    public static string[] All { get; } = { File, Timebased, Image, Thumbnails };
+    public static string[] All { get; } = { File, Timebased, Image, Thumbnails, None };
 
     /// <summary>
     /// All possible delivery channels as a comma-delimited string
@@ -48,7 +48,7 @@ public static class AssetDeliveryChannels
     /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
-    public static bool IsValidChannel(string deliveryChannel)
+    public static bool IsValidChannel(string? deliveryChannel)
         => All.Contains(deliveryChannel);
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
+using IIIF.Presentation.V3.Content;
 
 namespace DLCS.Model.Assets;
 
@@ -46,6 +48,22 @@ public static class AssetDeliveryChannels
     /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
-    public static bool IsValidChannel(string deliveryChannel) => 
-        All.Contains(deliveryChannel);
+    public static bool IsValidChannel(string deliveryChannel)
+        => All.Contains(deliveryChannel);
+
+    /// <summary>
+    /// Checks if a delivery channel is valid for a given media type
+    /// </summary>
+    public static bool IsChannelValidForMediaType(string deliveryChannel, string mediaType) 
+        => mediaType switch 
+        { 
+            Image => mediaType.StartsWith("image/"),
+            Thumbnails => mediaType.StartsWith("image/"),
+            Timebased => mediaType.StartsWith("video/") || mediaType.StartsWith("audio/"),
+            File => true, // A file can be matched to any media type
+            None => true, // Likewise for the 'none' channel
+            _ => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
+                $"Acceptable delivery-channels are: {AllString}")
+        };
 }
+

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
-using IIIF.Presentation.V3.Content;
 
 namespace DLCS.Model.Assets;
 

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -55,7 +55,7 @@ public static class AssetDeliveryChannels
     /// Checks if a delivery channel is valid for a given media type
     /// </summary>
     public static bool IsChannelValidForMediaType(string deliveryChannel, string mediaType) 
-        => mediaType switch 
+        => deliveryChannel switch 
         { 
             Image => mediaType.StartsWith("image/"),
             Thumbnails => mediaType.StartsWith("image/"),

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -173,7 +173,7 @@ public static class AssetPreparer
         {
             foreach (var dc in updateAsset.DeliveryChannels)
             {
-                if (!AssetDeliveryChannels.All.Contains(dc))
+                if (!AssetDeliveryChannels.IsValidChannel(dc))
                 {
                     return AssetPreparationResult.Failure(
                         $"'{dc}' is an invalid deliveryChannel. Valid values are: {AssetDeliveryChannels.AllString}.");

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -106,5 +106,8 @@ public class AssetRepository : AssetRepositoryCachingBase
     }
 
     protected override async Task<Asset?> GetAssetFromDatabase(AssetId assetId) =>
-        await dlcsContext.Images.AsNoTracking().SingleOrDefaultAsync(i => i.Id == assetId);
+        await dlcsContext.Images.AsNoTracking()
+            .Include(i => i.ImageDeliveryChannels)
+            .ThenInclude(i => i.DeliveryChannelPolicy)
+            .SingleOrDefaultAsync(i => i.Id == assetId);
 }


### PR DESCRIPTION
Resolves #624 

This PR adds the following:

- Delivery channels in the new format are now included when retrieving assets from the API
```
"deliveryChannels": [
    {
        "@type": "vocab:DeliveryChannel",
        "channel": "iiif-img",
        "policy": "default"
    },
    {
        "@type": "vocab:DeliveryChannel",
        "channel": "thumbs",
        "policy": ".../customers/1/deliveryChannelPolicies/thumbs/my-custom-thumbs"
    }
],
```
- A `IsChannelValidForMediaType()` helper has been added to `AssetDeliveryChannels` - this method returns true if the supplied channel is valid for the supplied media type
- `HydraImageValidator` has been expanded to make use of this new helper - assets that have been supplied with an invalid media type and delivery channel combination will be refused
- `HydraImageValidator` now rejects assets containing delivery channels that use the same channel
- The helpers in `AssetDeliveryChannels` now consider `none` as a valid channel type
- Integration and validation tests for the aforementioned changes and features