### PR TITLE
Update engine to use an asset from the database, as opposed to the request

### DIFF
--- a/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
@@ -99,7 +99,6 @@ public class AssetConverterTests
         var queued = created.AddHours(1);
         var dequeued = queued.AddHours(1);
         var finished = dequeued.AddHours(1);
-        var initialOrigin = "https://example.org/initial-origin";
         var origin = "https://example.org/origin";
         var roles = new[] { "role1", "role2" };
         var tags = new[] { "tag1", "tag2" };
@@ -126,7 +125,6 @@ public class AssetConverterTests
             String1 = "1",
             String2 = "2",
             String3 = "3",
-            InitialOrigin = initialOrigin,
             Origin = origin,
             Roles = roles,
             Tags = tags,
@@ -149,7 +147,6 @@ public class AssetConverterTests
         asset.Family.Should().Be(DLCS.Model.Assets.AssetFamily.Image);
         asset.Ingesting.Should().Be(true);
         asset.Origin.Should().Be(origin);
-        asset.InitialOrigin.Should().Be(initialOrigin); // not patchable but still carried on the Asset class.
         asset.NumberReference1.Should().Be(1);
         asset.NumberReference2.Should().Be(2);
         asset.NumberReference3.Should().Be(3);

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -38,7 +38,6 @@ public static class AssetConverter
             ThumbnailImageService = $"{urlRoots.ResourceRoot}thumbs/{dbAsset.Id}",
             Created = dbAsset.Created,
             Origin = dbAsset.Origin,
-            InitialOrigin = dbAsset.InitialOrigin,
             MaxUnauthorised = dbAsset.MaxUnauthorised,
             Finished = dbAsset.Finished,
             Ingesting = dbAsset.Ingesting,
@@ -308,12 +307,6 @@ public static class AssetConverter
         else if (hydraImage.ImageOptimisationPolicy.HasText())
         {
             asset.ImageOptimisationPolicy = hydraImage.ImageOptimisationPolicy;
-        }
-        
-        // This can only arrive on a new Asset
-        if (hydraImage.InitialOrigin != null)
-        {
-            asset.InitialOrigin = hydraImage.InitialOrigin;
         }
         
         return asset;

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -152,13 +152,7 @@ public class AssetProcessor
             }
 
             var assetAfterSave = await assetRepository.Save(updatedAsset, existingAsset != null, cancellationToken);
-
-            // Restore fields that are not persisted but are required
-            if (updatedAsset.InitialOrigin.HasText())
-            {
-                assetAfterSave.InitialOrigin = assetBeforeProcessing.Asset.InitialOrigin;
-            }
-
+            
             return new ProcessAssetResult
             {
                 ExistingAsset = existingAsset,

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -70,12 +70,6 @@ public class Image : DlcsResource
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 15, PropertyName = "origin")]
     public string? Origin { get; set; }
-    
-    [RdfProperty(Description = "Endpoint to use the first time the image is retrieved. This allows an initial " +
-                               "ingest from a short term s3 bucket (for example) but subsequent references from an https URI.",
-        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
-    [JsonProperty(Order = 16, PropertyName = "initialOrigin")]
-    public string? InitialOrigin { get; set; }
 
     [RdfProperty(Description = "Maximum size of request allowed before roles are enforced " +
                                "- relates to the effective WHOLE image size, not the individual tile size." +

--- a/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
@@ -18,7 +18,6 @@ public class ImageWithFile : Image
         StorageIdentifier = StorageIdentifier,
         Created = Created,
         Origin = Origin,
-        InitialOrigin = InitialOrigin,
         Tags = Tags,
         Roles = Roles,
         String1 = String1,

--- a/src/protagonist/DLCS.Mock/ApiApp/MockHelp.cs
+++ b/src/protagonist/DLCS.Mock/ApiApp/MockHelp.cs
@@ -51,7 +51,7 @@ public static class MockHelp
     
 
     public static Image MakeImage(string baseUrl, int customerId, int space, string modelId, 
-        DateTime created, string? origin, string? initialOrigin,
+        DateTime created, string? origin,
         int? width, int? height, int? maxUnauthorised,
         DateTime? queued, DateTime? dequeued, DateTime? finished, bool ingesting, string error,
         string[]? tags, string? string1, string? string2, string? string3,
@@ -66,7 +66,6 @@ public static class MockHelp
         image.Thumbnail400 = "https://mock.thumbs.dlcs.io" + mockDlcsPathTemplate + "/full/400,/0/default.jpg";
         image.Created = created;
         image.Origin = origin;
-        image.InitialOrigin = initialOrigin;
         image.Width = width;
         image.Height = height;
         image.MaxUnauthorised = maxUnauthorised;

--- a/src/protagonist/DLCS.Mock/ApiApp/MockModel.cs
+++ b/src/protagonist/DLCS.Mock/ApiApp/MockModel.cs
@@ -168,7 +168,7 @@ public class MockModel
             if (ongoing && i < 4) finished = DateTime.Now.AddSeconds(-60 + 9 * i);
             var id = Guid.NewGuid().ToString().Substring(0, 8) + i.ToString().PadLeft(5, '0');
             var image = MockHelp.MakeImage(BaseUrl, space.CustomerId, space.ModelId ?? 0, id,
-                DateTime.Now, "https://customer.com/images/" + id + ".tiff", null,
+                DateTime.Now, "https://customer.com/images/" + id + ".tiff",
                 r.Next(2000,11000), r.Next(3000,11000), space.MaxUnauthorised,
                 queued, dequeued, finished, !finished.HasValue, null,
                 space.DefaultTags, "b12345678", null, null, i, 0, 0,

--- a/src/protagonist/DLCS.Mock/Controllers/QueueController.cs
+++ b/src/protagonist/DLCS.Mock/Controllers/QueueController.cs
@@ -43,7 +43,7 @@ public class QueueController : ControllerBase
         foreach (var incomingImage in images.Members)
         {
             var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, incomingImage.Space, incomingImage.ModelId, 
-                DateTime.UtcNow, incomingImage.Origin, incomingImage.InitialOrigin,
+                DateTime.UtcNow, incomingImage.Origin, 
                 0, 0, incomingImage.MaxUnauthorised, null, null, null, true, null, 
                 incomingImage.Tags, incomingImage.String1, incomingImage.String2, incomingImage.String3,
                 incomingImage.Number1, incomingImage.Number2, incomingImage.Number3,

--- a/src/protagonist/DLCS.Mock/Controllers/SpaceImagesController.cs
+++ b/src/protagonist/DLCS.Mock/Controllers/SpaceImagesController.cs
@@ -101,7 +101,7 @@ public class SpaceImagesController : ControllerBase
     public Image Image(int customerId, int spaceId, string id, [FromBody]Image incomingImage)
     {
         var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, spaceId, incomingImage.ModelId,
-                DateTime.UtcNow, incomingImage.Origin, incomingImage.InitialOrigin,
+                DateTime.UtcNow, incomingImage.Origin,
                 0, 0, incomingImage.MaxUnauthorised, null, null, null, true, null,
                 incomingImage.Tags, incomingImage.String1, incomingImage.String2, incomingImage.String3,
                 incomingImage.Number1, incomingImage.Number2, incomingImage.Number3,

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -96,15 +96,6 @@ public class Asset
     /// OR MaxUnauthorised >= 0
     /// </summary>
     public bool RequiresAuth => !string.IsNullOrWhiteSpace(Roles) || MaxUnauthorised >= 0;
-    
-    // TODO - how to handle this? Split model + entity?
-    public string? InitialOrigin { get; set; }
-    
-    /// <summary>
-    /// Get origin to use for ingestion. This will be 'initialOrigin' if present, else origin.
-    /// </summary>
-    public string GetIngestOrigin()
-        => string.IsNullOrWhiteSpace(InitialOrigin) ? Origin : InitialOrigin;
 
     /// <summary>
     /// Full thumbnail policy object for Asset

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -263,11 +263,6 @@ public static class AssetPreparer
             {
                 return AssetPreparationResult.Failure("Family cannot be edited.");
             }
-
-            if (updateAsset.InitialOrigin != null)
-            {
-                return AssetPreparationResult.Failure("Cannot edit the InitialOrigin of an asset.");
-            }
         }
 
         return null;
@@ -340,7 +335,6 @@ public static class AssetPreparer
             Ingesting = false,
             ImageOptimisationPolicy = string.Empty,
             ThumbnailPolicy = string.Empty,
-            InitialOrigin = string.Empty,
             DeliveryChannels = null,
             MediaType = "unknown"
         };

--- a/src/protagonist/DLCS.Repository/Customers/CustomerOriginStrategyBase.cs
+++ b/src/protagonist/DLCS.Repository/Customers/CustomerOriginStrategyBase.cs
@@ -61,8 +61,7 @@ public abstract class CustomerOriginStrategyBase : ICustomerOriginStrategyReposi
     public async Task<CustomerOriginStrategy> GetCustomerOriginStrategy(Asset asset, bool initialIngestion = false)
     {
         var customerStrategies = await GetCustomerOriginStrategies(asset.Customer);
-        var assetOrigin = initialIngestion ? asset.GetIngestOrigin() : asset.Origin;
-        var matching = FindMatchingStrategy(assetOrigin, customerStrategies) ?? DefaultStrategy;
+        var matching = FindMatchingStrategy(asset.Origin, customerStrategies) ?? DefaultStrategy;
         
         logger.LogTrace("Using strategy: {Strategy} ('{StrategyId}') for handling asset '{AssetId}'",
             matching.Strategy, matching.Id, asset.Id);

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -386,8 +386,6 @@ public partial class DlcsContext : DbContext
                     dc => string.Join(',', dc.OrderBy(v => v)),
                     dc => dc.Split(",", StringSplitOptions.RemoveEmptyEntries).ToArray(),
                     stringArrayComparer);
-
-            entity.Ignore(e => e.InitialOrigin);
         });
 
         modelBuilder.Entity<ImageLocation>(entity =>

--- a/src/protagonist/DLCS.Repository/Messaging/LegacyJsonMessageHelpers.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/LegacyJsonMessageHelpers.cs
@@ -182,13 +182,7 @@ internal static class LegacyJsonMessageHelpers
         {
             // writer.WriteValue(String.Format("{0}/thumbnailPolicies/{1}", Context.BaseURL, this.ThumbnailPolicy));
         }
-
-        if (!String.IsNullOrEmpty(asset.InitialOrigin))
-        {
-            writer.WritePropertyName("initialOrigin");
-            writer.WriteValue(asset.InitialOrigin);
-        }
-
+        
         writer.WritePropertyName("family");
         writer.WriteValue((char)(asset.Family ?? AssetFamily.Image));
 

--- a/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Appetiser/AppetiserClientTests.cs
@@ -272,8 +272,7 @@ public class AppetiserClientTests
 
         var context = GetIngestionContext(imageOptimisationPolicy: "use-original", optimised: true);
         context.Asset.Origin = "https://s3.amazonaws.com/dlcs-storage/2/1/foo-bar";
-        context.Asset.InitialOrigin = "https://s3.amazonaws.com/dlcs-storage-ignored/2/1/foo-bar";
-        
+
         const string expected = "s3://dlcs-storage/2/1/foo-bar";
 
         A.CallTo(() => storageKeyGenerator.GetS3Uri(A<ObjectInBucket>._, A<bool>._))

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -18,6 +18,7 @@ using Stubbery;
 using Test.Helpers;
 using Test.Helpers.Integration;
 using Test.Helpers.Storage;
+using Z.EntityFramework.Plus;
 
 namespace Engine.Tests.Integration;
 
@@ -170,7 +171,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         storage.Size.Should().NotBe(950);
     }
     
-    [Fact]
+    [Fact(Skip = "delivery channel work")]
     public async Task IngestAsset_Success_HttpOrigin_InitialOrigin_AllOpen()
     {
         // Arrange
@@ -227,15 +228,13 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var assetId = AssetId.FromString($"99/1/{nameof(IngestAsset_Success_ChangesMediaTypeToContentType_WhenCalledWithUnknownImageType)}");
 
         // Note - API will have set this up before handing off
-        var initial = $"{apiStub.Address}/image";
-        var origin = $"{apiStub.Address}/this-will-fail";
+        var origin = $"{apiStub.Address}/image";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: "fast-higher", mediaType: "image/unknown", width: 0, height: 0, duration: 0,
             deliveryChannels: imageDeliveryChannels);
-        var asset = entity.Entity;
-        asset.InitialOrigin = initial;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        
+        var message = new IngestAssetRequest(entity.Entity, DateTime.UtcNow);
 
         // Act
         var jsonContent =

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -170,57 +170,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var storage = await dbContext.ImageStorages.SingleAsync(a => a.Id == assetId);
         storage.Size.Should().NotBe(950);
     }
-    
-    [Fact(Skip = "delivery channel work")]
-    public async Task IngestAsset_Success_HttpOrigin_InitialOrigin_AllOpen()
-    {
-        // Arrange
-        var assetId = AssetId.FromString($"99/1/{nameof(IngestAsset_Success_HttpOrigin_InitialOrigin_AllOpen)}");
 
-        // Note - API will have set this up before handing off
-        var initial = $"{apiStub.Address}/image";
-        var origin = $"{apiStub.Address}/this-will-fail";
-        var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
-            imageOptimisationPolicy: "fast-higher", mediaType: "image/tiff", width: 0, height: 0, duration: 0,
-            deliveryChannels: imageDeliveryChannels);
-        var asset = entity.Entity;
-        asset.InitialOrigin = initial;
-        await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
-
-        // Act
-        var jsonContent =
-            new StringContent(JsonSerializer.Serialize(message, settings), Encoding.UTF8, "application/json");
-        var result = await httpClient.PostAsync("asset-ingest", jsonContent);
-
-        // Assert
-        result.Should().BeSuccessful();
-        
-        // S3 assets created
-        BucketWriter.ShouldHaveKey(assetId.ToString()).ForBucket(LocalStackFixture.StorageBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/low.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/open/200.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/open/400.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/open/800.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/s.json").ForBucket(LocalStackFixture.ThumbsBucketName);
-        
-        // Database records updated
-        var updatedAsset = await dbContext.Images.SingleAsync(a => a.Id == assetId);
-        updatedAsset.Width.Should().Be(500);
-        updatedAsset.Height.Should().Be(1000);
-        updatedAsset.Ingesting.Should().BeFalse();
-        updatedAsset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
-        updatedAsset.MediaType.Should().Be("image/tiff");
-        updatedAsset.Error.Should().BeEmpty();
-
-        var location = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);
-        location.Nas.Should().BeEmpty();
-        location.S3.Should().Be($"s3://us-east-1/{LocalStackFixture.StorageBucketName}/{assetId}");
-
-        var storage = await dbContext.ImageStorages.SingleAsync(a => a.Id == assetId);
-        storage.Size.Should().BeGreaterThan(0);
-    }
-    
     [Fact]
     public async Task IngestAsset_Success_ChangesMediaTypeToContentType_WhenCalledWithUnknownImageType()
     {

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -83,7 +83,7 @@ public class EngineAssetRepository : IEngineAssetRepository
     }
 
     public ValueTask<Asset?> GetAsset(AssetId assetId, CancellationToken cancellationToken = default)
-        => new(dlcsContext.Images.Include(i => i.ImageDeliveryChannels)
+        => new(dlcsContext.Images.AsNoTracking().Include(i => i.ImageDeliveryChannels)
             .ThenInclude(i => i.DeliveryChannelPolicy)
             .SingleOrDefaultAsync(i => i.Id == assetId, cancellationToken));
 
@@ -99,9 +99,8 @@ public class EngineAssetRepository : IEngineAssetRepository
     
     private async Task<bool> NonBatchedSave(CancellationToken cancellationToken)
     {
-        var modifiedRows = dlcsContext.ChangeTracker.Entries().Count(e => e.State == EntityState.Modified);
         var updatedRows = await dlcsContext.SaveChangesAsync(cancellationToken);
-        return updatedRows > 0 || modifiedRows == 0;
+        return updatedRows > 0;
     }
 
     private async Task<bool> BatchSave(int batchId, CancellationToken cancellationToken)
@@ -122,9 +121,8 @@ public class EngineAssetRepository : IEngineAssetRepository
             {
                 await transaction.CommitAsync(cancellationToken);
             }
-
-            var modifiedRows = dlcsContext.ChangeTracker.Entries().Count(e => e.State == EntityState.Modified);
-            return updatedRows > 0 || modifiedRows == 0;
+            
+            return updatedRows > 0;
         }
         finally
         {

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -4,14 +4,18 @@ using DLCS.AWS.S3;
 using DLCS.AWS.SQS;
 using DLCS.Core.Caching;
 using DLCS.Core.FileSystem;
+using DLCS.Model;
+using DLCS.Model.Assets;
 using DLCS.Model.Auth;
 using DLCS.Model.Customers;
 using DLCS.Model.Policies;
 using DLCS.Model.Processing;
 using DLCS.Model.Storage;
 using DLCS.Repository;
+using DLCS.Repository.Assets;
 using DLCS.Repository.Auth;
 using DLCS.Repository.Customers;
+using DLCS.Repository.Entities;
 using DLCS.Repository.Policies;
 using DLCS.Repository.Processing;
 using DLCS.Repository.Storage;
@@ -118,6 +122,8 @@ public static class ServiceCollectionX
     public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration)
         => services
             .AddScoped<IPolicyRepository, PolicyRepository>()
+            .AddScoped<IAssetRepository, AssetRepository>()
+            .AddScoped<IEntityCounterRepository, EntityCounterRepository>()
             .AddScoped<IEngineAssetRepository, EngineAssetRepository>()
             .AddScoped<ICustomerOriginStrategyRepository, CustomerOriginStrategyRepository>()
             .AddSingleton<ICredentialsRepository, DapperCredentialsRepository>()

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -4,18 +4,14 @@ using DLCS.AWS.S3;
 using DLCS.AWS.SQS;
 using DLCS.Core.Caching;
 using DLCS.Core.FileSystem;
-using DLCS.Model;
-using DLCS.Model.Assets;
 using DLCS.Model.Auth;
 using DLCS.Model.Customers;
 using DLCS.Model.Policies;
 using DLCS.Model.Processing;
 using DLCS.Model.Storage;
 using DLCS.Repository;
-using DLCS.Repository.Assets;
 using DLCS.Repository.Auth;
 using DLCS.Repository.Customers;
-using DLCS.Repository.Entities;
 using DLCS.Repository.Policies;
 using DLCS.Repository.Processing;
 using DLCS.Repository.Storage;
@@ -122,8 +118,6 @@ public static class ServiceCollectionX
     public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration)
         => services
             .AddScoped<IPolicyRepository, PolicyRepository>()
-            .AddScoped<IAssetRepository, AssetRepository>()
-            .AddScoped<IEntityCounterRepository, EntityCounterRepository>()
             .AddScoped<IEngineAssetRepository, EngineAssetRepository>()
             .AddScoped<ICustomerOriginStrategyRepository, CustomerOriginStrategyRepository>()
             .AddSingleton<ICredentialsRepository, DapperCredentialsRepository>()

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -31,17 +31,20 @@ public class AssetIngester : IAssetIngester
     private readonly ILogger<AssetIngester> logger;
     private readonly ICustomerOriginStrategyRepository customerOriginRepository;
     private readonly IPolicyRepository policyRepository;
+    private readonly IAssetRepository assetRepository;
 
     public AssetIngester(
         IPolicyRepository policyRepository, 
         ICustomerOriginStrategyRepository customerOriginRepository,
         ILogger<AssetIngester> logger,
-        IngestExecutor executor)
+        IngestExecutor executor,
+        IAssetRepository assetRepository)
     {
         this.policyRepository = policyRepository;
         this.customerOriginRepository = customerOriginRepository;
         this.logger = logger;
         this.executor = executor;
+        this.assetRepository = assetRepository;
     }
 
     /// <summary>
@@ -70,14 +73,22 @@ public class AssetIngester : IAssetIngester
     /// <returns>Result of ingest operations</returns>
     public async Task<IngestResult> Ingest(IngestAssetRequest request, CancellationToken cancellationToken = default)
     {
+        var asset = await assetRepository.GetAsset(request.Asset.Id);
+
+        if (asset == null)
+        {
+            logger.LogError("Could not find an asset for asset id {AssetId}", request.Asset.Id);
+            return new IngestResult(asset, IngestResultStatus.Failed);
+        }
+        
         // get any matching CustomerOriginStrategy 
-        var customerOriginStrategy = await customerOriginRepository.GetCustomerOriginStrategy(request.Asset, true);
+        var customerOriginStrategy = await customerOriginRepository.GetCustomerOriginStrategy(asset, true);
             
         // set Thumbnail and ImageOptimisation policies on Asset
-        await HydrateAssetPolicies(request.Asset);
+        await HydrateAssetPolicies(asset);
 
         // now ingest the asset
-        var status = await executor.IngestAsset(request.Asset, customerOriginStrategy, cancellationToken);
+        var status = await executor.IngestAsset(asset, customerOriginStrategy, cancellationToken);
         return status;
     }
 

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -2,6 +2,7 @@
 using DLCS.Model.Customers;
 using DLCS.Model.Messaging;
 using DLCS.Model.Policies;
+using Engine.Data;
 using Engine.Ingest.Models;
 
 namespace Engine.Ingest;
@@ -31,20 +32,20 @@ public class AssetIngester : IAssetIngester
     private readonly ILogger<AssetIngester> logger;
     private readonly ICustomerOriginStrategyRepository customerOriginRepository;
     private readonly IPolicyRepository policyRepository;
-    private readonly IAssetRepository assetRepository;
+    private readonly IEngineAssetRepository engineAssetRepository;
 
     public AssetIngester(
         IPolicyRepository policyRepository, 
         ICustomerOriginStrategyRepository customerOriginRepository,
         ILogger<AssetIngester> logger,
         IngestExecutor executor,
-        IAssetRepository assetRepository)
+        IEngineAssetRepository engineAssetRepository)
     {
         this.policyRepository = policyRepository;
         this.customerOriginRepository = customerOriginRepository;
         this.logger = logger;
         this.executor = executor;
-        this.assetRepository = assetRepository;
+        this.engineAssetRepository = engineAssetRepository;
     }
 
     /// <summary>
@@ -73,7 +74,7 @@ public class AssetIngester : IAssetIngester
     /// <returns>Result of ingest operations</returns>
     public async Task<IngestResult> Ingest(IngestAssetRequest request, CancellationToken cancellationToken = default)
     {
-        var asset = await assetRepository.GetAsset(request.Asset.Id);
+        var asset = await engineAssetRepository.GetAsset(request.Asset.Id, cancellationToken);
 
         if (asset == null)
         {

--- a/src/protagonist/Engine/Ingest/Models/LegacyIngestEventConverter.cs
+++ b/src/protagonist/Engine/Ingest/Models/LegacyIngestEventConverter.cs
@@ -72,9 +72,6 @@ public static class LegacyIngestEventConverter
         asset.Ingesting = parsedJson.TryGetPropertyValue("ingesting", out var ingesting)
             ? ingesting.GetValue<bool>()
             : null;
-        asset.InitialOrigin = parsedJson.TryGetPropertyValue("initialOrigin", out var initialOrigin)
-            ? initialOrigin.GetValue<string>()
-            : null;
         asset.MediaType = parsedJson.TryGetPropertyValue("mediaType", out var mediaType)
             ? mediaType.GetValue<string>()
             : null;

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToDisk.cs
@@ -67,7 +67,7 @@ public class AssetToDisk : AssetMoverBase, IAssetToDisk
         destinationTemplate.ThrowIfNullOrWhiteSpace(nameof(destinationTemplate));
 
         await using var originResponse =
-            await originFetcher.LoadAssetFromLocation(context.Asset.Id, context.Asset.GetIngestOrigin(),
+            await originFetcher.LoadAssetFromLocation(context.Asset.Id, context.Asset.Origin,
                 customerOriginStrategy, cancellationToken);
 
         if (originResponse == null || originResponse.Stream.IsNull())
@@ -124,7 +124,7 @@ public class AssetToDisk : AssetMoverBase, IAssetToDisk
         {
             var uniqueName = asset.Id.Asset;
             
-            var guess = GuessContentType(asset.GetIngestOrigin());
+            var guess = GuessContentType(asset.Origin);
             if (string.IsNullOrEmpty(guess))
             {
                 guess = GuessContentType(uniqueName);

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
@@ -87,14 +87,14 @@ public class AssetToS3 : AssetMoverBase, IAssetToS3
         CancellationToken cancellationToken)
     {
         var assetId = context.Asset.Id;
-        var source = RegionalisedObjectInBucket.Parse(context.Asset.GetIngestOrigin());
+        var source = RegionalisedObjectInBucket.Parse(context.Asset.Origin);
 
         if (source == null)
         {
             // TODO - better error type
-            logger.LogError("Unable to parse ingest origin {Origin} to ObjectInBucket", context.Asset.GetIngestOrigin());
+            logger.LogError("Unable to parse ingest origin {Origin} to ObjectInBucket", context.Asset.Origin);
             throw new InvalidOperationException(
-                $"Unable to parse ingest origin {context.Asset.GetIngestOrigin()} to ObjectInBucket");
+                $"Unable to parse ingest origin {context.Asset.Origin} to ObjectInBucket");
         }
         
         logger.LogDebug("Copying asset '{AssetId}' directly from bucket to bucket. {Source} - {Dest}", context.Asset.Id,
@@ -108,7 +108,7 @@ public class AssetToS3 : AssetMoverBase, IAssetToS3
         if (copyResult.Result is not LargeObjectStatus.Success and not LargeObjectStatus.FileTooLarge)
         {
             throw new ApplicationException(
-                $"Failed to copy timebased asset {context.Asset.Id} directly from '{context.Asset.GetIngestOrigin()}' to {destination.GetS3Uri()}. Result: {copyResult.Result}");
+                $"Failed to copy timebased asset {context.Asset.Id} directly from '{context.Asset.Origin}' to {destination.GetS3Uri()}. Result: {copyResult.Result}");
         }
 
         var assetFromOrigin = new AssetFromOrigin(assetId, copyResult.Size ?? 0, destination.GetS3Uri().ToString(),
@@ -127,7 +127,7 @@ public class AssetToS3 : AssetMoverBase, IAssetToS3
     {
         logger.LogDebug("Copying asset '{AssetId}' indirectly from bucket to bucket. {Source} - {Dest}",
             context.Asset.Id,
-            context.Asset.GetIngestOrigin(), destination.GetS3Uri());
+            context.Asset.Origin, destination.GetS3Uri());
         var assetId = context.Asset.Id;
         string? downloadedFile = null;
 
@@ -150,7 +150,7 @@ public class AssetToS3 : AssetMoverBase, IAssetToS3
             if (!success)
             {
                 throw new ApplicationException(
-                    $"Failed to copy timebased asset {assetId} indirectly from '{context.Asset.GetIngestOrigin()}' to {destination}");
+                    $"Failed to copy timebased asset {assetId} indirectly from '{context.Asset.Origin}' to {destination}");
             }
 
             return new AssetFromOrigin(assetId, assetOnDisk.AssetSize, destination.GetS3Uri().ToString(),

--- a/src/protagonist/Portal/Features/Batches/Requests/IngestFromCsv.cs
+++ b/src/protagonist/Portal/Features/Batches/Requests/IngestFromCsv.cs
@@ -121,7 +121,6 @@ public class IngestFromCsvHandler : IRequestHandler<IngestFromCsv, IngestFromCsv
                         Number1 = record.Number1,
                         Number2 = record.Number2,
                         Number3 = record.Number3,
-                        InitialOrigin = record.InitialOrigin,
                         Family = AssetFamily.Image,
                         MediaType = "image/jp2"
                     });


### PR DESCRIPTION
Resolves #622  

This PR updates engine ingest to use an asset from the database, compared to an asset from the request