### PR TITLE
Update logic for Orchestrator and Engine to determine if an Asset has a particular deliveryChannel

### DIFF
--- a/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
@@ -357,7 +357,9 @@ public class ApiAssetRepositoryTests
         // Assert
         result.Result.Should().Be(DeleteResult.Deleted);
         result.DeletedEntity.Should()
-            .BeEquivalentTo(dbAsset.Entity, options => options.Excluding(a => a.Created),
+            .BeEquivalentTo(dbAsset.Entity, options => options
+                    .Excluding(a => a.Created)
+                    .Excluding(a => a.ImageDeliveryChannels),
                 "returned object is as deleted, exclude created as datetime can be off by a few ms");
         result.DeletedEntity.Created.Should().BeCloseTo(dbAsset.Entity.Created.Value, TimeSpan.FromSeconds(1));
 

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using API.Client;
 using API.Tests.Integration.Infrastructure;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Repository;
 using DLCS.Repository.Messaging;
@@ -799,7 +800,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
             EngineClient.AsynchronousIngestBatch(
-                A<IReadOnlyCollection<IngestAssetRequest>>._, false,
+                A<IReadOnlyCollection<(IngestAssetRequest, Asset)>>._, false,
                 A<CancellationToken>._)).Returns(3);
         
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
@@ -843,7 +844,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Items queued for processing
         A.CallTo(() =>
             EngineClient.AsynchronousIngestBatch(
-                A<IReadOnlyCollection<IngestAssetRequest>>.That.Matches(i => i.Count == 3), false,
+                A<IReadOnlyCollection<(IngestAssetRequest, Asset)>>.That.Matches(i => i.Count == 3), false,
                 A<CancellationToken>._)).MustHaveHappened();
     }
     
@@ -1025,7 +1026,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
             EngineClient.AsynchronousIngestBatch(
-                A<IReadOnlyCollection<IngestAssetRequest>>._, true,
+                A<IReadOnlyCollection<(IngestAssetRequest, Asset)>>._, true,
                 A<CancellationToken>._)).Returns(3);
         
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
@@ -1069,7 +1070,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Items queued for processing
         A.CallTo(() =>
             EngineClient.AsynchronousIngestBatch(
-                A<IReadOnlyCollection<IngestAssetRequest>>.That.Matches(i => i.Count == 4), true,
+                A<IReadOnlyCollection<(IngestAssetRequest, Asset)>>.That.Matches(i => i.Count == 4), true,
                 A<CancellationToken>._)).MustHaveHappened();
     }
     

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -85,7 +85,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -140,7 +140,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -184,7 +184,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -241,7 +241,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -361,7 +361,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -383,7 +383,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -412,7 +412,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -450,7 +450,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -487,7 +487,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
+                    A<Asset>._,
                     A<CancellationToken>._))
             .Returns(true);
         
@@ -518,7 +519,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),  
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -552,7 +555,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -584,7 +589,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.TooManyRequests);  // Random status to verify it filters down
         
@@ -609,7 +616,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
             EngineClient.SynchronousIngest(
-                A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                A<Asset>._,
+                false,
                 A<CancellationToken>._))
         .Returns(HttpStatusCode.OK);
         
@@ -644,7 +653,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
+                    A<Asset>._,
+        false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.InternalServerError);
         
@@ -674,7 +685,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
+                    A<Asset>._,
                     A<CancellationToken>._))
             .Returns(true);
         
@@ -708,7 +720,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
                     A<CancellationToken>._))
             .Returns(true);
         
@@ -741,7 +754,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -772,7 +787,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }}";
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
                     A<CancellationToken>._))
             .Returns(false);
         
@@ -816,7 +832,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -846,7 +864,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -933,7 +953,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .MustNotHaveHappened();
         
@@ -959,7 +981,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -971,7 +995,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),  
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .MustHaveHappened();
         
@@ -998,7 +1024,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
                     A<CancellationToken>._))
             .Returns(true);
 
@@ -1010,7 +1037,8 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         A.CallTo(() =>
                 EngineClient.AsynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), 
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
                     A<CancellationToken>._))
             .MustHaveHappened();
         
@@ -1041,7 +1069,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),                     
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -1052,7 +1082,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // assert
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .MustHaveHappened();
         
@@ -1226,7 +1258,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // make a callback for engine
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._,
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
         
@@ -1244,7 +1278,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Engine was called during this process.
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),  A<Asset>._, false,
                     A<CancellationToken>._))
             .MustHaveHappened();
         
@@ -1495,7 +1529,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -1510,7 +1546,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Engine called
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .MustHaveHappened();
 
@@ -1533,7 +1571,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -1548,7 +1588,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Engine called
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .MustHaveHappened();
 
@@ -1573,7 +1615,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), 
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .Returns(HttpStatusCode.OK);
 
@@ -1588,7 +1632,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Engine called
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
+                    A<Asset>._, 
+                    false,
                     A<CancellationToken>._))
             .MustHaveHappened();
 
@@ -1615,7 +1661,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         A.CallTo(() =>
                 EngineClient.SynchronousIngest(
-                    A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId), false,
+                    A<IngestAssetRequest>.That.Matches(r => r.Id == assetId), A<Asset>._, false,
                     A<CancellationToken>._))
             .Returns(engine);
 

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using DLCS.Model.Assets;
 using FluentAssertions;
 using Xunit;
@@ -18,7 +19,7 @@ public class AssetDeliveryChannelsTests
     [Fact]
     public void HasDeliveryChannel_False_IfChannelsEmpty()
     {
-        var asset = new Asset { DeliveryChannels = Array.Empty<string>() };
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>() };
 
         asset.HasDeliveryChannel("anything").Should().BeFalse();
     }
@@ -26,7 +27,13 @@ public class AssetDeliveryChannelsTests
     [Fact]
     public void HasDeliveryChannel_Throws_IfUnknown()
     {
-        var asset = new Asset { DeliveryChannels = new[] { "iiif-img" } };
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.Image
+            }
+        } };
 
         Action action = () => asset.HasDeliveryChannel("anything");
 
@@ -39,7 +46,13 @@ public class AssetDeliveryChannelsTests
     [InlineData(AssetDeliveryChannels.Timebased)]
     public void HasDeliveryChannel_True(string channel)
     {
-        var asset = new Asset { DeliveryChannels = AssetDeliveryChannels.All };
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = channel
+            }
+        } };
 
         asset.HasDeliveryChannel(channel).Should().BeTrue();
     }
@@ -55,7 +68,7 @@ public class AssetDeliveryChannelsTests
     [Fact]
     public void HasSingleDeliveryChannel_False_IfChannelsEmpty()
     {
-        var asset = new Asset { DeliveryChannels = Array.Empty<string>() };
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>() };
 
         asset.HasSingleDeliveryChannel("anything").Should().BeFalse();
     }
@@ -66,7 +79,15 @@ public class AssetDeliveryChannelsTests
     [InlineData(AssetDeliveryChannels.Timebased)]
     public void HasSingleDeliveryChannel_False_IfContainsButNotSingle(string channel)
     {
-        var asset = new Asset { DeliveryChannels = AssetDeliveryChannels.All };
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()};
+        
+        foreach (var deliveryChannel in AssetDeliveryChannels.All)
+        {
+            asset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = deliveryChannel
+            });
+        }
 
         asset.HasSingleDeliveryChannel(channel).Should().BeFalse();
     }
@@ -77,8 +98,14 @@ public class AssetDeliveryChannelsTests
     [InlineData(AssetDeliveryChannels.Timebased)]
     public void HasSingleDeliveryChannel_True(string channel)
     {
-        var asset = new Asset { DeliveryChannels = new[]{channel} };
-
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = channel
+            }
+        } };
+        
         asset.HasSingleDeliveryChannel(channel).Should().BeTrue();
     }
 }

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -70,15 +70,26 @@ public class AssetPreparerTests
         result.ErrorMessage.Should().Be("Duration cannot be edited.");
     }
     
-    [Theory (Skip = "delivery channel work")]
+    [Theory]
     [InlineData("audio/mp4")]
     [InlineData("video/mp4")]
     public void PrepareAssetForUpsert_CanUpdateDuration_IfFileChannel_AndAudioOrVideo(string mediaType)
     {
         // Arrange
         var updateAsset = new Asset { Duration = 100 };
-        var existingAsset = new Asset { MediaType = mediaType, DeliveryChannels = new[] { "file" }, Duration = 99 };
-        
+        var existingAsset = new Asset 
+        { 
+            MediaType = mediaType, 
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+            {
+                new()
+                {
+                    Channel = AssetDeliveryChannels.File
+                }
+            }, 
+            Duration = 99 
+        };
+
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
         
@@ -109,7 +120,7 @@ public class AssetPreparerTests
         result.ErrorMessage.Should().Be("Width cannot be edited.");
     }
     
-    [Theory (Skip = "delivery channel work")]
+    [Theory]
     [InlineData("application/pdf", "file")]
     [InlineData("video/mp4", "file")]
     [InlineData("image/tiff", "file")]
@@ -117,7 +128,14 @@ public class AssetPreparerTests
     {
         // Arrange
         var updateAsset = new Asset { Width = 100 };
-        var existingAsset = new Asset { DeliveryChannels = dc.Split(","), MediaType = mediaType, Width = 99 };
+        var existingAsset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>(), MediaType = mediaType, Width = 99 };
+        foreach (var channel in dc.Split(","))
+        {
+            existingAsset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = channel
+            });
+        }
         
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
@@ -149,7 +167,7 @@ public class AssetPreparerTests
         result.ErrorMessage.Should().Be("Height cannot be edited.");
     }
     
-    [Theory (Skip = "delivery channel work")]
+    [Theory]
     [InlineData("application/pdf", "file")]
     [InlineData("video/mp4", "file")]
     [InlineData("image/tiff", "file")]
@@ -157,7 +175,14 @@ public class AssetPreparerTests
     {
         // Arrange
         var updateAsset = new Asset { Height = 100 };
-        var existingAsset = new Asset { DeliveryChannels = dc.Split(","), MediaType = mediaType, Height = 99 };
+        var existingAsset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>(), MediaType = mediaType, Height = 99 };
+        foreach (var channel in dc.Split(","))
+        {
+            existingAsset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = channel
+            });
+        }
         
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
@@ -264,7 +289,14 @@ public class AssetPreparerTests
     public void PrepareAssetForUpsert_SetsAssetFamilyIfNotSet(string dc, AssetFamily expected)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(","), Id = new AssetId(1, 1, "100")  };
+        var updateAsset = new Asset { Origin = "required", ImageDeliveryChannels = new List<ImageDeliveryChannel>(), Id = new AssetId(1, 1, "100")  };
+        foreach (var channel in dc.Split(","))
+        {
+            updateAsset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = channel
+            });
+        }
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -301,10 +333,18 @@ public class AssetPreparerTests
         // Arrange
         var updateAsset = new Asset { 
             Origin = "required", 
-            DeliveryChannels = dc.Split(","), 
+            ImageDeliveryChannels =new List<ImageDeliveryChannel>(), 
             Family = current, 
             Id = new AssetId(1, 1, "100")
         };
+        
+        foreach (var channel in dc.Split(","))
+        {
+            updateAsset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = channel
+            });
+        }
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(null, updateAsset, false, false, restrictedCharacters);
@@ -323,8 +363,25 @@ public class AssetPreparerTests
         AssetFamily expected)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "required", DeliveryChannels = dc.Split(",") };
-        var existingAsset = new Asset { Family = current, DeliveryChannels = new[] { "fake" } };
+        var updateAsset = new Asset { Origin = "required", ImageDeliveryChannels = new List<ImageDeliveryChannel>()};
+        foreach (var channel in dc.Split(","))
+        {
+            updateAsset.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = channel
+            });
+        }
+        
+        var existingAsset = new Asset
+        {
+            Family = current, ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+            {
+                new()
+                {
+                    Channel = "fake"
+                }
+            }
+        };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetPreparerTests.cs
@@ -270,8 +270,8 @@ public class AssetPreparerTests
         string reason)
     {
         // Arrange
-        var updateAsset = new Asset { Origin = "https://whatever", DeliveryChannels = update };
-        var existingAsset = new Asset { Origin = "https://whatever", DeliveryChannels = existing };
+        var updateAsset = new Asset { Origin = "https://whatever", ImageDeliveryChannels = GenerateImageDeliveryChannels(update) };
+        var existingAsset = new Asset { Origin = "https://whatever", ImageDeliveryChannels =  GenerateImageDeliveryChannels(existing) };
 
         // Act
         var result = AssetPreparer.PrepareAssetForUpsert(existingAsset, updateAsset, false, false, restrictedCharacters);
@@ -279,7 +279,22 @@ public class AssetPreparerTests
         // Assert
         result.RequiresReingest.Should().BeTrue(reason);
     }
-    
+
+    private List<ImageDeliveryChannel> GenerateImageDeliveryChannels(string[] deliveryChannels)
+    {
+        var imageDeliveryChannels = new List<ImageDeliveryChannel>();
+
+        foreach (var deliveryChannel in deliveryChannels)
+        {
+            imageDeliveryChannels.Add(new ImageDeliveryChannel()
+            {
+                Channel = deliveryChannel
+            });
+        }
+
+        return imageDeliveryChannels;
+    }
+
     [Theory]
     [InlineData("file", AssetFamily.File)]
     [InlineData("file,iiif-img", AssetFamily.Image)]

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -27,21 +27,23 @@ public static class AssetDeliveryChannels
     /// </summary>
     public static bool HasDeliveryChannel(this Asset asset, string deliveryChannel)
     {
-        if (asset.DeliveryChannels.IsNullOrEmpty()) return false;
+        if (asset.ImageDeliveryChannels.IsNullOrEmpty()) return false;
         if (!All.Contains(deliveryChannel))
         {
             throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
                 $"Acceptable delivery-channels are: {AllString}");
         }
 
-        return asset.DeliveryChannels.Contains(deliveryChannel);
+        return asset.ImageDeliveryChannels.Any(i => i.Channel == deliveryChannel);
     }
-    
+
     /// <summary>
     /// Checks if asset has specified deliveryChannel only (e.g. 1 channel and it matches specified value
     /// </summary>
-    public static bool HasSingleDeliveryChannel(this Asset asset, string deliveryChannel) 
-        => asset.DeliveryChannels.ContainsOnly(deliveryChannel);
+    public static bool HasSingleDeliveryChannel(this Asset asset, string deliveryChannel)
+        => asset.ImageDeliveryChannels != null &&
+           asset.ImageDeliveryChannels.Count == 1 && 
+           asset.HasDeliveryChannel(deliveryChannel);
     
     /// <summary>
     /// Checks if string is a valid delivery channel

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -168,11 +168,11 @@ public static class AssetPreparer
             // However, this DOES allow the *creation* of a NotForDelivery asset.
         }
 
-        if (!updateAsset.DeliveryChannels.IsNullOrEmpty())
+        if (!updateAsset.ImageDeliveryChannels.IsNullOrEmpty())
         {
-            foreach (var dc in updateAsset.DeliveryChannels)
+            foreach (var dc in updateAsset.ImageDeliveryChannels)
             {
-                if (!AssetDeliveryChannels.All.Contains(dc))
+                if (AssetDeliveryChannels.All.All(x => x != dc.Channel))
                 {
                     return AssetPreparationResult.Failure(
                         $"'{dc}' is an invalid deliveryChannel. Valid values are: {AssetDeliveryChannels.AllString}.");
@@ -212,7 +212,7 @@ public static class AssetPreparer
         {
             // Allow updating dimensions if _existing_ channel is "file" only as these won't have been set by
             // an automated process
-            var isFileOnly = existingAsset.DeliveryChannels.ContainsOnly(AssetDeliveryChannels.File);
+            var isFileOnly = existingAsset.HasSingleDeliveryChannel(AssetDeliveryChannels.File);
             
             if (updateAsset.Width.HasValue && updateAsset.Width != 0 && updateAsset.Width != existingAsset.Width)
             {

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -98,10 +98,9 @@ public static class AssetPreparer
                 requiresReingest = true;
             }
 
-            if (updateAsset.DeliveryChannels != null &&
-                !updateAsset.DeliveryChannels.SequenceEqual(existingAsset.DeliveryChannels))
+            if (updateAsset.ImageDeliveryChannels != null && !updateAsset.ImageDeliveryChannels.SequenceEqual(existingAsset.ImageDeliveryChannels))
             {
-                // Changing DeliveryChannel can alter how the image should be processed
+                // Changing ImageDeliveryChannel can alter how the image should be processed
                 requiresReingest = true;
                 reCalculateFamily = true;
             }
@@ -173,7 +172,7 @@ public static class AssetPreparer
         {
             foreach (var dc in updateAsset.DeliveryChannels)
             {
-                if (!AssetDeliveryChannels.IsValidChannel(dc))
+                if (!AssetDeliveryChannels.All.Contains(dc))
                 {
                     return AssetPreparationResult.Failure(
                         $"'{dc}' is an invalid deliveryChannel. Valid values are: {AssetDeliveryChannels.AllString}.");

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -17,7 +17,6 @@ public class ImageDeliveryChannel
     /// </summary>
     public AssetId ImageId { get; set; }
     
-    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
     public Asset Asset { get; set; }
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -1,8 +1,8 @@
 ﻿#nullable disable
 
+using System.Text.Json.Serialization;
 using DLCS.Core.Types;
 using DLCS.Model.Policies;
-
 namespace DLCS.Model.Assets;
 
 public class ImageDeliveryChannel
@@ -17,6 +17,7 @@ public class ImageDeliveryChannel
     /// </summary>
     public AssetId ImageId { get; set; }
     
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
     public Asset Asset { get; set; }
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -1,6 +1,5 @@
 ﻿#nullable disable
 
-using System.Text.Json.Serialization;
 using DLCS.Core.Types;
 using DLCS.Model.Policies;
 namespace DLCS.Model.Assets;

--- a/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.Json.Serialization;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 
 namespace DLCS.Model.Messaging;
@@ -17,17 +18,17 @@ public class IngestAssetRequest
     /// <summary>
     /// Get Asset to be ingested.
     /// </summary>
-    public Asset Asset { get; }
+    public AssetId Id { get; }
 
     [JsonConstructor]
-    public IngestAssetRequest(Asset asset, DateTime? created)
+    public IngestAssetRequest(AssetId id, DateTime? created)
     {
-        Asset = asset;
+        Id = id;
         Created = created;
     }
 
     public override string ToString()
     {
-        return $"IngestAssetRequest at {Created} for Asset {Asset.Id}";
+        return $"IngestAssetRequest at {Created} for Asset {Id}";
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
@@ -47,7 +47,7 @@ public class EngineClientTests
             Family = family
         };
         
-        var ingestRequest = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
         HttpRequestMessage message = null;
         httpHandler.RegisterCallback(r => message = r);
         httpHandler.GetResponseMessage("{ \"engine\": \"hello\" }", HttpStatusCode.OK);
@@ -55,7 +55,7 @@ public class EngineClientTests
         var sut = GetSut(true);
         
         // Act
-        var statusCode = await sut.SynchronousIngest(ingestRequest, false);
+        var statusCode = await sut.SynchronousIngest(ingestRequest, asset);
         
         // Assert
         statusCode.Should().Be(HttpStatusCode.OK);
@@ -83,7 +83,7 @@ public class EngineClientTests
             NumberReference1 = 1234
         };
         
-        var ingestRequest = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
         HttpRequestMessage message = null;
         httpHandler.RegisterCallback(r => message = r);
         httpHandler.GetResponseMessage("{ \"engine\": \"hello\" }", HttpStatusCode.OK);
@@ -91,7 +91,7 @@ public class EngineClientTests
         var sut = GetSut(false);
         
         // Act
-        var statusCode = await sut.SynchronousIngest(ingestRequest, false);
+        var statusCode = await sut.SynchronousIngest(ingestRequest, asset);
         
         // Assert
         statusCode.Should().Be(HttpStatusCode.OK);
@@ -105,12 +105,7 @@ public class EngineClientTests
                 ReferenceHandler = ReferenceHandler.Preserve
             });
         
-        body.Asset.Should().BeEquivalentTo(new Asset
-        {
-            Id = ingestRequest.Asset.Id,
-            Tags = string.Empty,
-            Roles = string.Empty
-        });
+        body.Id.Should().Be(ingestRequest.Id);
     }
     
     [Fact]
@@ -122,7 +117,7 @@ public class EngineClientTests
             Family = AssetFamily.Image
         };
         
-        var ingestRequest = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         var sut = GetSut(true);
         string jsonString = string.Empty;
@@ -132,7 +127,7 @@ public class EngineClientTests
             .Returns(true);
         
         // Act
-        await sut.AsynchronousIngest(ingestRequest);
+        await sut.AsynchronousIngest(ingestRequest, asset);
         
         // Assert
         var jObj = JObject.Parse(jsonString);
@@ -152,7 +147,7 @@ public class EngineClientTests
             NumberReference1 = 1234
         };
         
-        var ingestRequest = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
         var sut = GetSut(false);
 
         string jsonString = string.Empty;
@@ -162,7 +157,7 @@ public class EngineClientTests
             .Returns(true);
 
         // Act
-        await sut.AsynchronousIngest(ingestRequest);
+        await sut.AsynchronousIngest(ingestRequest, asset);
         
         // Assert
         var body = JsonSerializer.Deserialize<IngestAssetRequest>(jsonString,
@@ -171,12 +166,7 @@ public class EngineClientTests
             ReferenceHandler = ReferenceHandler.Preserve
         });
 
-        body.Asset.Should().BeEquivalentTo(new Asset
-        {
-            Id = ingestRequest.Asset.Id,
-            Tags = string.Empty,
-            Roles = string.Empty
-        });
+        body.Id.Should().Be(ingestRequest.Id);
     }
 
     private EngineClient GetSut(bool useLegacyMessageFormat)

--- a/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -100,15 +100,15 @@ public class DapperAssetRepository : AssetRepositoryCachingBase, IDapperConfigRe
     }
 
     private const string AssetSql = @"
-SELECT public.""Images"".""Id"", ""Customer"", ""Space"", ""Created"", ""Origin"", ""Tags"", ""Roles"", 
+SELECT ""Images"".""Id"", ""Customer"", ""Space"", ""Created"", ""Origin"", ""Tags"", ""Roles"", 
 ""PreservedUri"", ""Reference1"", ""Reference2"", ""Reference3"", ""MaxUnauthorised"", 
 ""NumberReference1"", ""NumberReference2"", ""NumberReference3"", ""Width"", 
 ""Height"", ""Error"", ""Batch"", ""Finished"", ""Ingesting"", ""ImageOptimisationPolicy"", 
 ""ThumbnailPolicy"", ""Family"", ""MediaType"", ""Duration"", ""NotForDelivery"", ""DeliveryChannels"",  
 IDC.""Channel"", IDC.""DeliveryChannelPolicyId""
-  FROM public.""Images""
-  LEFT OUTER JOIN ""ImageDeliveryChannels"" IDC on public.""Images"".""Id"" = IDC.""ImageId""
-  WHERE public.""Images"".""Id""=@Id;";
+  FROM ""Images""
+  LEFT OUTER JOIN ""ImageDeliveryChannels"" IDC on ""Images"".""Id"" = IDC.""ImageId""
+  WHERE ""Images"".""Id""=@Id;";
 
     private const string ImageLocationSql =
         "SELECT \"Id\", \"S3\", \"Nas\" FROM public.\"ImageLocation\" WHERE \"Id\"=@Id;";

--- a/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Core.Types;
@@ -36,53 +38,77 @@ public class DapperAssetRepository : AssetRepositoryCachingBase, IDapperConfigRe
     protected override async Task<Asset?> GetAssetFromDatabase(AssetId assetId)
     {
         var id = assetId.ToString();
-        dynamic? rawAsset = await this.QuerySingleOrDefaultAsync(AssetSql, new { Id = id });
-        if (rawAsset == null)
+        IEnumerable<dynamic> rawAsset = await this.QueryAsync(AssetSql, new { Id = id });
+        var convertedRawAsset = rawAsset.ToList();
+        if (!convertedRawAsset.Any())
         {
             return null;
         }
 
+        var firstAsset = convertedRawAsset[0];
+
         return new Asset
         {
-            Batch = rawAsset.Batch,
-            Created = rawAsset.Created,
-            Customer = rawAsset.Customer,
-            Duration = rawAsset.Duration,
-            Error = rawAsset.Error,
-            Family = (AssetFamily)rawAsset.Family.ToString()[0],
-            Finished = rawAsset.Finished,
-            Height = rawAsset.Height,
-            Id = AssetId.FromString(rawAsset.Id),
-            Ingesting = rawAsset.Ingesting,
-            Origin = rawAsset.Origin,
-            Reference1 = rawAsset.Reference1,
-            Reference2 = rawAsset.Reference2,
-            Reference3 = rawAsset.Reference3,
-            Roles = rawAsset.Roles,
-            Space = rawAsset.Space,
-            Tags = rawAsset.Tags,
-            Width = rawAsset.Width,
-            MaxUnauthorised = rawAsset.MaxUnauthorised,
-            MediaType = rawAsset.MediaType,
-            NumberReference1 = rawAsset.NumberReference1,
-            NumberReference2 = rawAsset.NumberReference2,
-            NumberReference3 = rawAsset.NumberReference3,
-            PreservedUri = rawAsset.PreservedUri,
-            ThumbnailPolicy = rawAsset.ThumbnailPolicy,
-            ImageOptimisationPolicy = rawAsset.ImageOptimisationPolicy,
-            NotForDelivery = rawAsset.NotForDelivery,
-            DeliveryChannels = rawAsset.DeliveryChannels.ToString().Split(",")
+            Batch = firstAsset.Batch,
+            Created = firstAsset.Created,
+            Customer = firstAsset.Customer,
+            Duration = firstAsset.Duration,
+            Error = firstAsset.Error,
+            Family = (AssetFamily)firstAsset.Family.ToString()[0],
+            Finished = firstAsset.Finished,
+            Height = firstAsset.Height,
+            Id = AssetId.FromString(firstAsset.Id),
+            Ingesting = firstAsset.Ingesting,
+            Origin = firstAsset.Origin,
+            Reference1 = firstAsset.Reference1,
+            Reference2 = firstAsset.Reference2,
+            Reference3 = firstAsset.Reference3,
+            Roles = firstAsset.Roles,
+            Space = firstAsset.Space,
+            Tags = firstAsset.Tags,
+            Width = firstAsset.Width,
+            MaxUnauthorised = firstAsset.MaxUnauthorised,
+            MediaType = firstAsset.MediaType,
+            NumberReference1 = firstAsset.NumberReference1,
+            NumberReference2 = firstAsset.NumberReference2,
+            NumberReference3 = firstAsset.NumberReference3,
+            PreservedUri = firstAsset.PreservedUri,
+            ThumbnailPolicy = firstAsset.ThumbnailPolicy,
+            ImageOptimisationPolicy = firstAsset.ImageOptimisationPolicy,
+            NotForDelivery = firstAsset.NotForDelivery,
+            DeliveryChannels = firstAsset.DeliveryChannels.ToString().Split(","),
+            ImageDeliveryChannels = GenerateImageDeliveryChannels(convertedRawAsset)
         };
     }
 
+    private List<ImageDeliveryChannel> GenerateImageDeliveryChannels(List<dynamic> rawAsset)
+    {
+        var imageDeliveryChannels = new List<ImageDeliveryChannel>();
+        foreach (dynamic rawDeliveryChannel in rawAsset)
+        {
+            if (rawDeliveryChannel.Channel != null) // avoids issues with left outer join returning assets without 'ImageDeliveryChannels'
+            {
+                imageDeliveryChannels.Add(new ImageDeliveryChannel()
+                {
+                    Channel = rawDeliveryChannel.Channel,
+                    DeliveryChannelPolicyId = rawDeliveryChannel.DeliveryChannelPolicyId
+                });
+            }
+        }
+
+        return imageDeliveryChannels;
+    }
+
     private const string AssetSql = @"
-SELECT ""Id"", ""Customer"", ""Space"", ""Created"", ""Origin"", ""Tags"", ""Roles"", 
+SELECT public.""Images"".""Id"", ""Customer"", ""Space"", ""Created"", ""Origin"", ""Tags"", ""Roles"", 
 ""PreservedUri"", ""Reference1"", ""Reference2"", ""Reference3"", ""MaxUnauthorised"", 
 ""NumberReference1"", ""NumberReference2"", ""NumberReference3"", ""Width"", 
 ""Height"", ""Error"", ""Batch"", ""Finished"", ""Ingesting"", ""ImageOptimisationPolicy"", 
-""ThumbnailPolicy"", ""Family"", ""MediaType"", ""Duration"", ""NotForDelivery"", ""DeliveryChannels""
+""ThumbnailPolicy"", ""Family"", ""MediaType"", ""Duration"", ""NotForDelivery"", ""DeliveryChannels"",  
+IDC.""Channel"", IDC.""DeliveryChannelPolicyId""
   FROM public.""Images""
-  WHERE ""Id""=@Id;";
+  LEFT OUTER JOIN ""ImageDeliveryChannels"" IDC on public.""Images"".""Id"" = IDC.""ImageId""
+  WHERE public.""Images"".""Id""=@Id;";
 
     private const string ImageLocationSql =
         "SELECT \"Id\", \"S3\", \"Nas\" FROM public.\"ImageLocation\" WHERE \"Id\"=@Id;";

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -150,7 +150,7 @@ public class EngineClient : IEngineClient
         }
     }
 
-    public IngestAssetRequest GetMinimalIngestAssetRequest(IngestAssetRequest ingestAssetRequest)
+    private IngestAssetRequest GetMinimalIngestAssetRequest(IngestAssetRequest ingestAssetRequest)
     {
         return new IngestAssetRequest(new Asset(){ Id = ingestAssetRequest.Asset.Id }, ingestAssetRequest.Created);
     }

--- a/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 
 namespace DLCS.Repository.Messaging;
@@ -13,27 +14,31 @@ public interface IEngineClient
     /// This shouldn't be used frequently as it can be relatively long running.
     /// </summary>
     /// <param name="ingestAssetRequest">Request containing details of asset to ingest</param>
+    /// <param name="asset">The asset the request is for</param>
     /// <param name="derivativesOnly">If true, only derivatives will be generated</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>HttpStatusCode returned from engine.</returns>
-    Task<HttpStatusCode> SynchronousIngest(IngestAssetRequest ingestAssetRequest, bool derivativesOnly = false,
+    Task<HttpStatusCode> SynchronousIngest(IngestAssetRequest ingestAssetRequest, 
+        Asset asset,
+        bool derivativesOnly = false,
         CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Queue an ingest request for engine to asynchronously process.
     /// </summary>
     /// <param name="ingestAssetRequest">Request containing details of asset to ingest</param>
+    /// <param name="asset">The asset the request is for</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Boolean representing whether request successfully queued</returns>
-    Task<bool> AsynchronousIngest(IngestAssetRequest ingestAssetRequest, CancellationToken cancellationToken = default);
+    Task<bool> AsynchronousIngest(IngestAssetRequest ingestAssetRequest, Asset asset, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Queue a batch of ingest requests for engine to process
     /// </summary>
-    /// <param name="ingestAssetRequests">List of requests containing details of assets to ingest</param>
+    /// <param name="ingestRequest">List of requests containing details of assets to ingest</param>
     /// <param name="isPriority">Whether request is for priority ingest</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Count of items successfully processed</returns>
-    Task<int> AsynchronousIngestBatch(IReadOnlyCollection<IngestAssetRequest> ingestAssetRequests,
+    Task<int> AsynchronousIngestBatch(IReadOnlyCollection<(IngestAssetRequest ingestAssetRequest, Asset asset)> ingestRequest,
         bool isPriority, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IngestNotificationSender.cs
@@ -34,8 +34,8 @@ public class IngestNotificationSender : IIngestNotificationSender
         await customerQueueRepository.IncrementSize(assetToIngest.Customer, QueueNames.Default,
             cancellationToken: cancellationToken);
         
-        var ingestAssetRequest = new IngestAssetRequest(assetToIngest, DateTime.UtcNow);
-        var success = await engineClient.AsynchronousIngest(ingestAssetRequest, cancellationToken);
+        var ingestAssetRequest = new IngestAssetRequest(assetToIngest.Id, DateTime.UtcNow);
+        var success = await engineClient.AsynchronousIngest(ingestAssetRequest, assetToIngest, cancellationToken);
         
         if (!success)
         {
@@ -59,7 +59,7 @@ public class IngestNotificationSender : IIngestNotificationSender
         var customerId = assets[0].Customer;
         await customerQueueRepository.IncrementSize(customerId, queue, assets.Count, cancellationToken);
         
-        var ingestAssetRequests = assets.Select(a => new IngestAssetRequest(a, DateTime.UtcNow)).ToList();
+        var ingestAssetRequests = assets.Select(a => (new IngestAssetRequest(a.Id, DateTime.UtcNow), a)).ToList();
         var sentCount = await engineClient.AsynchronousIngestBatch(ingestAssetRequests, isPriority, cancellationToken);
 
         if (sentCount != assets.Count)
@@ -77,8 +77,8 @@ public class IngestNotificationSender : IIngestNotificationSender
     public async Task<HttpStatusCode> SendImmediateIngestAssetRequest(Asset assetToIngest, bool derivativesOnly,
         CancellationToken cancellationToken = default)
     {
-        var ingestAssetRequest = new IngestAssetRequest(assetToIngest, DateTime.UtcNow);
-        var statusCode = await engineClient.SynchronousIngest(ingestAssetRequest, derivativesOnly, cancellationToken);
+        var ingestAssetRequest = new IngestAssetRequest(assetToIngest.Id, DateTime.UtcNow);
+        var statusCode = await engineClient.SynchronousIngest(ingestAssetRequest, assetToIngest, derivativesOnly, cancellationToken);
         return statusCode;
     }
 }

--- a/src/protagonist/DLCS.Repository/Messaging/LegacyJsonMessageHelpers.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/LegacyJsonMessageHelpers.cs
@@ -14,14 +14,14 @@ namespace DLCS.Repository.Messaging;
 /// </summary>
 internal static class LegacyJsonMessageHelpers
 {
-    public static async Task<string> GetLegacyJsonString(IngestAssetRequest ingestAssetRequest, bool derivativesOnly)
+    public static async Task<string> GetLegacyJsonString(Asset asset, bool derivativesOnly)
     {
         var stringParams = new Dictionary<string, string>
         {
-            ["id"] = ingestAssetRequest.Asset.Id.ToString(),
-            ["customer"] = ingestAssetRequest.Asset.Customer.ToString(),
-            ["space"] = ingestAssetRequest.Asset.Space.ToString(),
-            ["image"] = AsJsonStringForMessaging(ingestAssetRequest.Asset)
+            ["id"] = asset.Id.ToString(),
+            ["customer"] = asset.Customer.ToString(),
+            ["space"] = asset.Space.ToString(),
+            ["image"] = AsJsonStringForMessaging(asset)
         };
 
         // we'll never set initialorigin in our limited first port of this

--- a/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
+++ b/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
@@ -401,7 +401,7 @@ public class EngineAssetRepositoryTests
         var assetId = AssetId.FromString($"99/1/{nameof(UpdateIngestedAsset_DoesNotUpdateBatch_IfIngestNotFinished)}");
         const int batchId = -111;
         await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 1);
-        await dbContext.Images.AddTestAsset(assetId, batch: batchId);
+        dbContext.Images.AddTestAsset(assetId, batch: batchId);
         await dbContext.SaveChangesAsync();
 
         var newAsset = new Asset

--- a/src/protagonist/Engine.Tests/Ingest/Models/LegacyIngestEventConverterTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Models/LegacyIngestEventConverterTests.cs
@@ -80,7 +80,7 @@ public class LegacyIngestEventConverterTests
         var result = request.ConvertToAssetRequest();
 
         // Assert
-        result.Asset.Should().BeEquivalentTo(expected);
+        result.Id.Should().BeEquivalentTo(expected.Id);
     }
 
     private LegacyIngestEvent Create(Dictionary<string, string> paramsDict)

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -94,7 +94,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =
@@ -150,7 +150,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbContext.CustomerStorages.AddTestCustomerStorage(customer: customerId, sizeOfStored: 950,
             storagePolicy: "medium");
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =
@@ -192,7 +192,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         asset.ImageDeliveryChannels = imageDeliveryChannels;
         await dbContext.SaveChangesAsync();
         
-        var message = new IngestAssetRequest(entity.Entity, DateTime.UtcNow);
+        var message = new IngestAssetRequest(entity.Entity.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =
@@ -246,7 +246,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbContext.CustomerStorages.AddTestCustomerStorage(customer: customerId, sizeOfStored: 99,
             storagePolicy: "small");
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =
@@ -294,7 +294,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbContext.CustomerStorages.AddTestCustomerStorage(customer: customerId, sizeOfStored: 950,
             storagePolicy: "medium");
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =
@@ -335,7 +335,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         // Act
         var jsonContent =

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -18,7 +18,6 @@ using Stubbery;
 using Test.Helpers;
 using Test.Helpers.Integration;
 using Test.Helpers.Storage;
-using Z.EntityFramework.Plus;
 
 namespace Engine.Tests.Integration;
 
@@ -34,7 +33,14 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
     private readonly DlcsContext dbContext;
     private static readonly TestBucketWriter BucketWriter = new();
     private readonly ApiStub apiStub;
-    private readonly string[] imageDeliveryChannels = { AssetDeliveryChannels.Image };
+    private readonly List<ImageDeliveryChannel> imageDeliveryChannels = new()
+    {
+        new ImageDeliveryChannel()
+        {
+            Channel = AssetDeliveryChannels.Image,
+            DeliveryChannelPolicyId = 1
+        }
+    };
 
     public ImageIngestTests(ProtagonistAppFactory<Startup> appFactory, EngineFixture engineFixture)
     {
@@ -85,7 +91,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var origin = $"{apiStub.Address}/image";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: "fast-higher", mediaType: "image/tiff", width: 0, height: 0, duration: 0,
-            deliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
         var message = new IngestAssetRequest(asset, DateTime.UtcNow);
@@ -136,7 +142,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: "fast-higher", mediaType: "image/tiff", width: 0, height: 0, duration: 0,
-            deliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.Customers.AddTestCustomer(customerId);
         await dbContext.Spaces.AddTestSpace(customerId, 2);
@@ -181,7 +187,9 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var origin = $"{apiStub.Address}/image";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: "fast-higher", mediaType: "image/unknown", width: 0, height: 0, duration: 0,
-            deliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
+        var asset = entity.Entity;
+        asset.ImageDeliveryChannels = imageDeliveryChannels;
         await dbContext.SaveChangesAsync();
         
         var message = new IngestAssetRequest(entity.Entity, DateTime.UtcNow);
@@ -231,7 +239,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var origin = $"{apiStub.Address}/image";
 
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin, customer: customerId,
-            width: 0, height: 0, duration: 0, mediaType: "image/tiff", deliveryChannels: imageDeliveryChannels);
+            width: 0, height: 0, duration: 0, mediaType: "image/tiff", imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.Customers.AddTestCustomer(customerId);
         await dbContext.Spaces.AddTestSpace(customerId, 1);
@@ -278,7 +286,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var origin = $"{apiStub.Address}/image";
 
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin, customer: customerId,
-            width: 0, height: 0, duration: 0, mediaType: "image/tiff", deliveryChannels: imageDeliveryChannels);
+            width: 0, height: 0, duration: 0, mediaType: "image/tiff", imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.Customers.AddTestCustomer(customerId);
         await dbContext.Spaces.AddTestSpace(customerId, 3);
@@ -324,7 +332,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var origin = $"{apiStub.Address}/this-will-fail";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: "fast-higher", mediaType: "image/tiff", width: 0, height: 0, duration: 0,
-            deliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
         var message = new IngestAssetRequest(asset, DateTime.UtcNow);

--- a/src/protagonist/Engine.Tests/Integration/IngestResponseTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/IngestResponseTests.cs
@@ -42,9 +42,9 @@ public class IngestResponseTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = AssetId.FromString($"1/2/{ingestResult}");
-        var message = new IngestAssetRequest(new Asset(assetId), DateTime.UtcNow);
+        var message = new IngestAssetRequest(assetId, DateTime.UtcNow);
         A.CallTo(() =>
-            assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+            assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
                 A<CancellationToken>._)).Returns(new IngestResult(null, ingestResult));
 
         // Act
@@ -95,9 +95,9 @@ public class IngestResponseTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = AssetId.FromString($"1/2/{ingestResult}");
-        var message = new IngestAssetRequest(new Asset(assetId), DateTime.UtcNow);
+        var message = new IngestAssetRequest(assetId, DateTime.UtcNow);
         A.CallTo(() =>
-            assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Asset.Id == assetId),
+            assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
                 A<CancellationToken>._)).Returns(new IngestResult(null, ingestResult));
 
         // Act

--- a/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
@@ -37,7 +37,8 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
     {
         new ImageDeliveryChannel
         {
-            Channel = AssetDeliveryChannels.Timebased
+            Channel = AssetDeliveryChannels.Timebased,
+            DeliveryChannelPolicyId = 6
         }
     };
 
@@ -184,9 +185,9 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
     }
 
     [Theory]
-    [InlineData("video", "/full/full/max/max/0/default.webm")]
-    [InlineData("audio", "/full/max/default.mp3")]
-    public async Task IngestAsset_SetsFileSizeCorrectly_IfAlsoAvailableForFileChannel(string type, string expectedKey)
+    [InlineData("video", "/full/full/max/max/0/default.webm", 6)]
+    [InlineData("audio", "/full/max/default.mp3", 5)]
+    public async Task IngestAsset_SetsFileSizeCorrectly_IfAlsoAvailableForFileChannel(string type, string expectedKey, int deliveryChannelPolicyId)
     {
         // Arrange
         var assetId = AssetId.FromString($"99/1/{nameof(IngestAsset_SetsFileSizeCorrectly_IfAlsoAvailableForFileChannel)}-{type}");
@@ -196,11 +197,13 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
         {
             new()
             {
-                Channel = AssetDeliveryChannels.Timebased
+                Channel = AssetDeliveryChannels.Timebased,
+                DeliveryChannelPolicyId = deliveryChannelPolicyId
             },
             new()
             {
-                Channel = AssetDeliveryChannels.File
+                Channel = AssetDeliveryChannels.File,
+                DeliveryChannelPolicyId = 3
             }
         };
         

--- a/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
@@ -92,7 +92,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
             imageDeliveryChannels: timebasedDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         A.CallTo(() => ElasticTranscoderWrapper.CreateJob(
                 A<string>._,
@@ -147,7 +147,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
             imageDeliveryChannels: timebasedDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         A.CallTo(() => ElasticTranscoderWrapper.CreateJob(
                 A<string>._,
@@ -213,7 +213,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
             imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        var message = new IngestAssetRequest(asset, DateTime.UtcNow);
+        var message = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
 
         A.CallTo(() => ElasticTranscoderWrapper.CreateJob(
                 A<string>._,

--- a/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
@@ -33,7 +33,13 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
     private static readonly TestBucketWriter BucketWriter = new();
     private static readonly IElasticTranscoderWrapper ElasticTranscoderWrapper = A.Fake<IElasticTranscoderWrapper>();
     private readonly ApiStub apiStub;
-    private readonly string[] timebasedDeliveryChannels = { AssetDeliveryChannels.Timebased };
+    private readonly List<ImageDeliveryChannel> timebasedDeliveryChannels = new()
+    {
+        new ImageDeliveryChannel
+        {
+            Channel = AssetDeliveryChannels.Timebased
+        }
+    };
 
     public TimebasedIngestTests(ProtagonistAppFactory<Startup> appFactory, EngineFixture engineFixture)
     {
@@ -57,7 +63,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
             .Header("Content-Type", "video/mpeg");
         apiStub.Get("/audio", (request, args) => "anything")
             .Header("Content-Type", "audio/mpeg");
-        
+
         engineFixture.DbFixture.CleanUp();
 
         A.CallTo(() => ElasticTranscoderWrapper.GetPipelineId("protagonist-pipeline", A<CancellationToken>._))
@@ -82,7 +88,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
         var origin = $"{apiStub.Address}/{type}";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: $"{type}-max", mediaType: $"{type}/mpeg", family: AssetFamily.Timebased,
-            deliveryChannels: timebasedDeliveryChannels);
+            imageDeliveryChannels: timebasedDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
         var message = new IngestAssetRequest(asset, DateTime.UtcNow);
@@ -137,7 +143,7 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
         var origin = $"{apiStub.Address}/{type}";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: $"{type}-max", mediaType: $"{type}/mpeg", family: AssetFamily.Timebased,
-            deliveryChannels: timebasedDeliveryChannels);
+            imageDeliveryChannels: timebasedDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
         var message = new IngestAssetRequest(asset, DateTime.UtcNow);
@@ -185,11 +191,23 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
         // Arrange
         var assetId = AssetId.FromString($"99/1/{nameof(IngestAsset_SetsFileSizeCorrectly_IfAlsoAvailableForFileChannel)}-{type}");
         const string jobId = "1234567890123-abcdef";
+
+        var imageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.Timebased
+            },
+            new()
+            {
+                Channel = AssetDeliveryChannels.File
+            }
+        };
         
         var origin = $"{apiStub.Address}/{type}";
         var entity = await dbContext.Images.AddTestAsset(assetId, ingesting: true, origin: origin,
             imageOptimisationPolicy: $"{type}-max", mediaType: $"{type}/mpeg", family: AssetFamily.Timebased,
-            deliveryChannels: new[] { "iiif-av", "file" });
+            imageDeliveryChannels: imageDeliveryChannels);
         var asset = entity.Entity;
         await dbContext.SaveChangesAsync();
         var message = new IngestAssetRequest(asset, DateTime.UtcNow);

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -64,7 +64,7 @@ public class AssetIngester : IAssetIngester
         catch (Exception e)
         {
             logger.LogError(e, "Exception ingesting IncomingIngest - {Message}", request.Message);
-            return Task.FromResult(new IngestResult(internalIngestRequest?.Asset, IngestResultStatus.Failed));
+            return Task.FromResult(new IngestResult(new Asset() { Id = internalIngestRequest?.Id}, IngestResultStatus.Failed));
         }
     }
 
@@ -74,11 +74,11 @@ public class AssetIngester : IAssetIngester
     /// <returns>Result of ingest operations</returns>
     public async Task<IngestResult> Ingest(IngestAssetRequest request, CancellationToken cancellationToken = default)
     {
-        var asset = await engineAssetRepository.GetAsset(request.Asset.Id, cancellationToken);
+        var asset = await engineAssetRepository.GetAsset(request.Id, cancellationToken);
 
         if (asset == null)
         {
-            logger.LogError("Could not find an asset for asset id {AssetId}", request.Asset.Id);
+            logger.LogError("Could not find an asset for asset id {AssetId}", request.Id);
             return new IngestResult(asset, IngestResultStatus.Failed);
         }
         

--- a/src/protagonist/Engine/Ingest/Models/LegacyIngestEventConverter.cs
+++ b/src/protagonist/Engine/Ingest/Models/LegacyIngestEventConverter.cs
@@ -28,7 +28,7 @@ public static class LegacyIngestEventConverter
         {
             var formattedJson = incomingRequest.AssetJson.Replace("\r\n", string.Empty);
             var asset = ConvertJsonToAsset(formattedJson);
-            return new IngestAssetRequest(asset, incomingRequest.Created);
+            return new IngestAssetRequest(asset.Id, incomingRequest.Created);
         }
         catch (JsonException e)
         {

--- a/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using Amazon.S3;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Auth;
 using DLCS.Model.Customers;
 using Microsoft.AspNetCore.Mvc;
@@ -28,6 +30,13 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     private readonly HttpClient httpClient;
     private readonly IAmazonS3 amazonS3;
     private readonly string stubAddress;
+    private readonly List<ImageDeliveryChannel> deliveryChannelsForFile = new()
+    {
+        new ImageDeliveryChannel()
+        {
+            Channel = AssetDeliveryChannels.File
+        }
+    };
 
     private const string ValidAuth = "Basic dW5hbWU6cHdvcmQ=";
 
@@ -119,7 +128,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNotForDelivery)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true, deliveryChannels: new[] { "file" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true, imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -136,7 +145,13 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNotFileDeliveryChannel)}{deliveryChannel}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { deliveryChannel });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = deliveryChannel
+            }
+        });
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -152,7 +167,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_NotOptimisedOrigin_ReturnsFileFromDLCSStorage)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "text/plain",
-            origin: $"{stubAddress}/testfile", deliveryChannels: new[] { "file" });
+            origin: $"{stubAddress}/testfile", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
 
         var expectedPath = new Uri($"https://protagonist-storage.s3.eu-west-1.amazonaws.com/{id}/original");
@@ -172,7 +187,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_NotInDlcsStorage_NotAtOrigin_Returns404)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "text/plain",
-            origin: $"{stubAddress}/not-found", deliveryChannels: new[] { "file" });
+            origin: $"{stubAddress}/not-found", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -189,7 +204,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_NotInDlcsStorage_FallsbackToHttpOrigin_ReturnsFile)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "text/plain",
-            origin: $"{stubAddress}/testfile", deliveryChannels: new[] { "file" });
+            origin: $"{stubAddress}/testfile", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -208,7 +223,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_NotInDlcsStorage_FallsbackToBasicAuthHttpOrigin_ReturnsFile)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "text/plain",
-            origin: $"{stubAddress}/authfile", deliveryChannels: new[] { "file" });
+            origin: $"{stubAddress}/authfile", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.CustomerOriginStrategies.AddAsync(new CustomerOriginStrategy
         {
             Credentials = validCreds, Customer = 99, Id = "basic-auth-file", 
@@ -231,7 +246,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_NotInDlcsStorage_FallsbackToBasicAuthHttpOrigin_ReturnsFile)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "application/pdf",
-            origin: $"{stubAddress}/forbiddenfile", deliveryChannels: new[] { "file" });
+            origin: $"{stubAddress}/forbiddenfile", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.CustomerOriginStrategies.AddAsync(new CustomerOriginStrategy
         {
             Credentials = validCreds, Customer = 99, Id = "basic-forbidden-file", 
@@ -255,7 +270,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbFixture.DbContext.Images.AddTestAsset(id, 
             mediaType: "text/plain",
             origin: $"http://{LocalStackFixture.OriginBucketName}.s3.amazonaws.com/{s3Key}", 
-            deliveryChannels: new[] { "file" });
+            imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
 
         var expectedPath = new Uri($"https://s3.amazonaws.com/{LocalStackFixture.OriginBucketName}/{s3Key}");
@@ -274,7 +289,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_OptimisedOrigin_ReturnsFile)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", deliveryChannels: new[] { "file" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -290,7 +305,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_RequiresAuth_Returns401_IfInvalidNoCookie)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", deliveryChannels: new[] { "file" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", imageDeliveryChannels: deliveryChannelsForFile);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
@@ -308,7 +323,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_RequiresAuth_Returns401_IfExpiredCookie)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", deliveryChannels: new[] { "file" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", imageDeliveryChannels: deliveryChannelsForFile);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -335,7 +350,7 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbFixture.DbContext.Images.AddTestAsset(id, 
             roles: "clickthrough",
             origin: $"http://{LocalStackFixture.OriginBucketName}.s3.amazonaws.com/{s3Key}", 
-            deliveryChannels: new[] { "file" });
+            imageDeliveryChannels: deliveryChannelsForFile);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());

--- a/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/FileHandlingTests.cs
@@ -34,7 +34,8 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         new ImageDeliveryChannel()
         {
-            Channel = AssetDeliveryChannels.File
+            Channel = AssetDeliveryChannels.File,
+            DeliveryChannelPolicyId = 4
         }
     };
 
@@ -139,9 +140,9 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Theory]
-    [InlineData("iiif-img")]
-    [InlineData("iiif-av")]
-    public async Task Get_Returns404_IfNotFileDeliveryChannel(string deliveryChannel)
+    [InlineData("iiif-img", 1)]
+    [InlineData("iiif-av", 6)]
+    public async Task Get_Returns404_IfNotFileDeliveryChannel(string deliveryChannel, int deliveryChannelPolicyId)
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNotFileDeliveryChannel)}{deliveryChannel}");
@@ -149,7 +150,8 @@ public class FileHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         {
             new()
             {
-                Channel = deliveryChannel
+                Channel = deliveryChannel,
+                DeliveryChannelPolicyId = deliveryChannelPolicyId
             }
         });
         await dbFixture.DbContext.SaveChangesAsync();

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -48,7 +48,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         new ImageDeliveryChannel()
         {
-            Channel = AssetDeliveryChannels.Image
+            Channel = AssetDeliveryChannels.Image,
+            DeliveryChannelPolicyId = 1
         }
     };
 
@@ -1604,9 +1605,10 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         {
             await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>()
             {
-                new ImageDeliveryChannel()
+                new()
                 {
-                    Channel = AssetDeliveryChannels.File
+                    Channel = AssetDeliveryChannels.File,
+                    DeliveryChannelPolicyId = 3
                 }
             });
             await dbFixture.DbContext.SaveChangesAsync();

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -9,6 +9,7 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Auth.Entities;
 using IIIF;
 using IIIF.ImageApi;
@@ -42,6 +43,14 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     private readonly IAmazonS3 amazonS3;
     private readonly FakeImageOrchestrator orchestrator = new();
     private const string SizesJsonContent = "{\"o\":[[800,800],[400,400],[200,200]],\"a\":[]}";
+
+    private readonly List<ImageDeliveryChannel> deliveryChannelsForImage = new()
+    {
+        new ImageDeliveryChannel()
+        {
+            Channel = AssetDeliveryChannels.Image
+        }
+    };
 
     public ImageHandlingTests(ProtagonistAppFactory<Startup> factory, StorageFixture storageFixture)
     {
@@ -176,7 +185,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}");
         var namedId = $"test/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}";
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -213,7 +222,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_Correct_IgnoresQueryParamOnRequestUri)}");
         var namedId = $"test/1/{nameof(GetInfoJson_Correct_IgnoresQueryParamOnRequestUri)}";
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -246,7 +255,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -289,7 +298,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_RestrictedImage_NoRole_HasMaxWidthSet)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -318,7 +327,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_NoRole_HasMaxWidthSet)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -348,7 +357,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_ReturnsImageServerSizes_IfS3GetFails)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Sizes from FakeImageServerClient
@@ -386,7 +395,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -434,7 +443,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -473,7 +482,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -516,7 +525,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaConneg)}");
         const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/image/2/context.json\"";
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -563,7 +572,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}"); 
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/image/3/context.json\"";
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -600,7 +609,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg)}");
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/image/3/context.json\"";
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -631,7 +640,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OpenImage_Correct)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -658,7 +667,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OrchestratesImage_IfServedFromS3)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -689,7 +698,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_DoesNotOrchestratesImage_IfServedFromImageServer)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -711,7 +720,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_DoesNotOrchestratesImage_IfQueryParamPassed)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -733,7 +742,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OpenImage_ForwardedFor_Correct)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -767,7 +776,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const string authServiceName = "my-auth-service";
         const string logoutServiceName = "my-logout-service";
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
             Customer = 99, Id = roleName, Name = "test-role", AuthService = authServiceName
@@ -817,7 +826,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const string logoutServiceName = "my-logout-service";
 
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
             Customer = 99, Id = roleName, Name = "test-role", AuthService = authServiceName
@@ -866,7 +875,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_NoRole_HasNoService)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -899,7 +908,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString(
             $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401WithoutServices)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "unknown-role", maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -930,7 +939,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString(
             $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfNoBearerTokenProvided)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -959,7 +968,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString(
             $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfUnknownBearerTokenProvided)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -990,7 +999,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString(
             $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfExpiredBearerTokenProvided)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -1026,7 +1035,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var id = AssetId.FromString(
             $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns200_AndRefreshesToken_IfValidBearerTokenProvided)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -1119,7 +1128,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/test-auth-nocook{type}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1139,7 +1148,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/test-auth-invalidcook{type}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1161,7 +1170,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/test-auth-expcook{type}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -1188,7 +1197,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/test-auth-cook-tile{type}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -1225,7 +1234,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var id = AssetId.FromString($"99/1/test-auth-cook{type}");
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -1267,7 +1276,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var id = AssetId.FromString("99/1/known-thumb");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri("http://thumbs/thumbs/99/1/known-thumb/full/!200,200/0/default.jpg");
@@ -1294,7 +1303,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[400,400], [200,200]]}",
         });
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!123,123/0/default.jpg");
@@ -1322,7 +1331,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[400,400], [200,200]]}",
         });
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1349,7 +1358,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1377,7 +1386,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1405,7 +1414,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!600,600/0/default.jpg");
@@ -1448,7 +1457,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var id = AssetId.FromString($"99/1/{imageName}");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1481,7 +1490,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var id = AssetId.FromString($"99/1/{imageName}");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1515,7 +1524,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         FakeImageOrchestrator.ConfiguredResponse[id] = OrchestrationResult.NotFound;
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1544,7 +1553,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         FakeImageOrchestrator.ConfiguredResponse[id] = OrchestrationResult.Error;
 
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
-            deliveryChannels: new[] { "iiif-img" });
+            imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.CustomHeaders.AddTestCustomHeader("x-test-key", "foo bar");
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1570,7 +1579,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         if (await dbFixture.DbContext.Images.FindAsync(id) == null)
         {
             await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true,
-                deliveryChannels: new[] { "iiif-img" });
+                imageDeliveryChannels: deliveryChannelsForImage);
             await dbFixture.DbContext.SaveChangesAsync();
         }
 
@@ -1593,7 +1602,13 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // test runs 3 times so only add on first run
         if (await dbFixture.DbContext.Images.FindAsync(id) == null)
         {
-            await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "file" });
+            await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>()
+            {
+                new ImageDeliveryChannel()
+                {
+                    Channel = AssetDeliveryChannels.File
+                }
+            });
             await dbFixture.DbContext.SaveChangesAsync();
         }
 

--- a/src/protagonist/Orchestrator.Tests/Integration/RefreshInfoJsonHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/RefreshInfoJsonHandlingTests.cs
@@ -65,7 +65,8 @@ public class RefreshInfoJsonHandlingTests : IClassFixture<ProtagonistAppFactory<
         {
             new()
             {
-                Channel = AssetDeliveryChannels.Image
+                Channel = AssetDeliveryChannels.Image,
+                DeliveryChannelPolicyId = 1
             }
         });
         await dbFixture.DbContext.SaveChangesAsync();

--- a/src/protagonist/Orchestrator.Tests/Integration/RefreshInfoJsonHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/RefreshInfoJsonHandlingTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using Amazon.S3;
 using Amazon.S3.Model;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using IIIF.ImageApi.V3;
 using IIIF.Serialisation;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -59,7 +61,13 @@ public class RefreshInfoJsonHandlingTests : IClassFixture<ProtagonistAppFactory<
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_Refreshed_IfAlreadyInS3_ButOutOfDate)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "iiif-img" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.Image
+            }
+        });
         await dbFixture.DbContext.SaveChangesAsync();
 
         var s3StorageKey = $"{id}/info/Cantaloupe/v3/info.json";

--- a/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -27,7 +27,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     {
         new ImageDeliveryChannel()
         {
-            Channel = AssetDeliveryChannels.Timebased
+            Channel = AssetDeliveryChannels.Timebased,
+            DeliveryChannelPolicyId = 5
         }
     };
 
@@ -130,7 +131,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         {
             new()
             {
-                Channel = AssetDeliveryChannels.File
+                Channel = AssetDeliveryChannels.File,
+                DeliveryChannelPolicyId = 3
             }
         });
         await dbFixture.DbContext.SaveChangesAsync();

--- a/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Orchestrator.Tests.Integration.Infrastructure;
@@ -21,6 +23,13 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
 {
     private readonly DlcsDatabaseFixture dbFixture;
     private readonly HttpClient httpClient;
+    private readonly List<ImageDeliveryChannel> deliveryChannelsForTimebased = new()
+    {
+        new ImageDeliveryChannel()
+        {
+            Channel = AssetDeliveryChannels.Timebased
+        }
+    };
 
     public TimebasedHandlingTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture dbFixture)
     {
@@ -102,7 +111,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNotForDelivery)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true, deliveryChannels: new[] { "iiif-av" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true, imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -117,7 +126,13 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNoTimebasedChannel)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, deliveryChannels: new[] { "file" });
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.File
+            }
+        });
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -133,7 +148,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/test-noauth");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: -1,
-            origin: "/test/space", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath =
             new Uri(
@@ -155,7 +170,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/test-auth");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "basic", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -172,7 +187,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/bearer-fail");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "basic", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
         const string bearerToken = "ababababab";
 
@@ -193,7 +208,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/bearer-pass");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -218,7 +233,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/bearer-head");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -243,7 +258,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/bearer-head-invalid");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -267,7 +282,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/cookie-fail");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "basic", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -287,7 +302,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/cookie-pass");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -317,7 +332,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/cookie-head");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());
@@ -342,7 +357,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         // Arrange
         var id = AssetId.FromString("99/1/cookie-head-invalid");
         await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
-            origin: "/test/space", roles: "clickthrough", deliveryChannels: new[] { "iiif-av" });
+            origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
                 DlcsDatabaseFixture.ClickThroughAuthService.AsList());

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -42,8 +42,9 @@ public static class DatabaseTestDataPopulation
         string error = "",
         string imageOptimisationPolicy = "",
         DateTime? finished = null,
-        string[] deliveryChannels = null)
-        => assets.AddAsync(new Asset
+        List<ImageDeliveryChannel> imageDeliveryChannels = null)
+    {
+        return  assets.AddAsync(new Asset
         {
             Created = DateTime.UtcNow, Customer = customer, Space = space, Id = id, Origin = origin,
             Width = width, Height = height, Roles = roles, Family = family, MediaType = mediaType,
@@ -52,8 +53,9 @@ public static class DatabaseTestDataPopulation
             NumberReference1 = num1, NumberReference2 = num2, NumberReference3 = num3,
             NotForDelivery = notForDelivery, Tags = "", PreservedUri = "", Error = error,
             ImageOptimisationPolicy = imageOptimisationPolicy, Batch = batch, Ingesting = ingesting,
-            Duration = duration, Finished = finished, DeliveryChannels = deliveryChannels ?? Array.Empty<string>()
+            Duration = duration, Finished = finished, ImageDeliveryChannels = imageDeliveryChannels ?? new List<ImageDeliveryChannel>()
         });
+    }
 
     public static ValueTask<EntityEntry<AuthToken>> AddTestToken(this DbSet<AuthToken> authTokens,
         int customer = 99, int ttl = 100, DateTime? expires = null, string? sessionUserId = null,


### PR DESCRIPTION
Resolves #621 

This PR updates the engine and orchestrator to use `ImageDeliveryChannels` to determine delivery channels, as opposed to the `DeliveryChannels` array
