### PR TITLE
Default delivery channels management for a space

### DIFF
--- a/src/protagonist/API.Tests/Integration/DefaultDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/DefaultDeliveryChannelsTests.cs
@@ -19,12 +19,12 @@ namespace API.Tests.Integration;
 
 [Trait("Category", "Integration")]
 [Collection(CollectionDefinitions.DatabaseCollection.CollectionName)]
-public class CustomerDefaultDeliveryChannelsTest : IClassFixture<ProtagonistAppFactory<Startup>>
+public class DefaultDeliveryChannelsTests : IClassFixture<ProtagonistAppFactory<Startup>>
 {
     private readonly HttpClient httpClient;
     private readonly DlcsContext dlcsContext;
 
-    public CustomerDefaultDeliveryChannelsTest(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
+    public DefaultDeliveryChannelsTests(DlcsDatabaseFixture dbFixture, ProtagonistAppFactory<Startup> factory)
     {
         dlcsContext = dbFixture.DbContext;
         httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(dbFixture, "API-Test");
@@ -130,9 +130,6 @@ public class CustomerDefaultDeliveryChannelsTest : IClassFixture<ProtagonistAppF
         // Act
         var content = new StringContent(newDefaultDeliveryChannelJson, Encoding.UTF8, "application/json");
         var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
-
-        var test = await response.Content.ReadAsStringAsync();
-        
         var data = await response.ReadAsHydraResponseAsync<DefaultDeliveryChannel>();
 
         var dbEntry =
@@ -508,5 +505,213 @@ public class CustomerDefaultDeliveryChannelsTest : IClassFixture<ProtagonistAppF
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task Get_RetrieveAllDefaultDeliveryChannelsForCustomerAndSpace_DoesNotRetrieveDevaultValues_200()
+    {
+        // Arrange
+        const int customerId = 1;
+        const int space = 5;
+        var path = $"customers/{customerId}/spaces/{space}/defaultDeliveryChannels";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+        var data = await response.ReadAsHydraResponseAsync<HydraCollection<DefaultDeliveryChannel>>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        data.Members.Count().Should().Be(0);
+    }
+    
+    [Fact]
+    public async Task Get_RetrieveADefaultDeliveryChannelForCustomerWithSpace_200()
+    {
+        // Arrange
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""api-test-customer-space-2"",
+  ""displayName"": ""My New Customer""
+}";
+        var customerContent = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        var customerResponse = await httpClient.AsAdmin().PostAsync("/customers", customerContent);
+        var customerData = await customerResponse.ReadAsHydraResponseAsync<Customer>();
+        var customerId = int.Parse(customerData.Id!.Split('/').Last());
+        var mediaType = "audio/mp3";
+        const int space = 5;
+
+        var deliveryChannelPolicy = dlcsContext.DeliveryChannelPolicies.First(d => d.Customer == customerId &&
+            d.Name == "default-audio");
+        
+        var dbEntry = dlcsContext.DefaultDeliveryChannels.Add(new DLCS.Model.DeliveryChannels.DefaultDeliveryChannel()
+        {
+            Customer = customerId,
+            MediaType = mediaType,
+            DeliveryChannelPolicyId = deliveryChannelPolicy.Id,
+            Space = space
+        });
+        await dlcsContext.SaveChangesAsync();
+
+        var path = $"customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Entity.Id}";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).GetAsync(path);
+        var data = await response.ReadAsHydraResponseAsync<DefaultDeliveryChannel>();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        data.MediaType.Should().Be(mediaType);
+        data.Id.Should().Be($"{httpClient.BaseAddress}customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Entity.Id.ToString()}");
+    }
+    
+    [Fact]
+    public async Task Post_CreatesDefaultDeliveryChannelsSpaceNotAvailableInCustomer_200()
+    {
+        // Arrange
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""api-test-customer-space"",
+  ""displayName"": ""My New Customer""
+}";
+        var customerContent = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        
+        var customerResponse = await httpClient.AsAdmin().PostAsync("/customers", customerContent);
+        var customerData = await customerResponse.ReadAsHydraResponseAsync<Customer>();
+        var customerId = int.Parse(customerData.Id!.Split('/').Last());
+        const int space = 5;
+        var path = $"customers/{customerId}/spaces/{space}/defaultDeliveryChannels";
+
+        string newDefaultDeliveryChannelJson = JsonConvert.SerializeObject(new DefaultDeliveryChannel()
+        {
+            MediaType = "image/tiff",
+            Policy = "default",
+            Channel = "iiif-img"
+        });
+        
+        // Act
+        var content = new StringContent(newDefaultDeliveryChannelJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+
+        // Assert
+        var data = await response.ReadAsHydraResponseAsync<DefaultDeliveryChannel>();
+
+        var dbEntry =
+            dlcsContext.DefaultDeliveryChannels.Include(d => d.DeliveryChannelPolicy)
+                .Single(d => d.Customer == customerId &&
+                             d.MediaType == "image/tiff" &&
+                             d.DeliveryChannelPolicy.Channel == "iiif-img" &&
+                             d.Space == space);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        data.MediaType.Should().Be("image/tiff");
+        data.Id.Should().Be($"{httpClient.BaseAddress}customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Id.ToString()}");
+        dbEntry.DeliveryChannelPolicy.Name.Should().Be("default");
+
+        var retrievalFromCustomer = await httpClient.AsCustomer(customerId)
+            .GetAsync($"customers/spaces/{space}/defaultDeliveryChannels/{dbEntry.Id}");
+
+        retrievalFromCustomer.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Theory]
+    [InlineData("audio/mp3", "audio/*", "https://api.dlcs.io/customers/2/deliveryChannelPolicies/iiif-av/default-audio", "iiif-av")]
+    [InlineData("video/mp4", "video/*", "default-video", "iiif-av")]
+    [InlineData("image/tiff", "image/*", "default", "iiif-img")]
+    [InlineData("image/*", "image/*", "use-original", "iiif-img")]
+    public async Task Put_UpdatesDefaultDeliveryChannelForCustomerInSpace_200(string mediaType, string initialMediaType, string policyName, string channel)
+    {
+        // Arrange
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""api-test-customer-space-2"",
+  ""displayName"": ""My New Customer""
+}";
+        var customerContent = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        var customerResponse = await httpClient.AsAdmin().PostAsync("/customers", customerContent);
+        var customerData = await customerResponse.ReadAsHydraResponseAsync<Customer>();
+        var customerId = int.Parse(customerData.Id!.Split('/').Last());
+        const int space = 5;
+
+        var deliveryChannelPolicy = dlcsContext.DeliveryChannelPolicies.First(d => (d.Customer == customerId &&
+            d.Name == policyName.Split("/", StringSplitOptions.None).Last()) || (d.Customer == 1 &&
+            d.Name == policyName.Split("/", StringSplitOptions.None).Last()));
+        
+        var dbEntry = dlcsContext.DefaultDeliveryChannels.Add(new DLCS.Model.DeliveryChannels.DefaultDeliveryChannel()
+        {
+            Customer = customerId,
+            MediaType = mediaType,
+            DeliveryChannelPolicyId = deliveryChannelPolicy.Id,
+            Space = space
+        });
+
+        await dlcsContext.SaveChangesAsync();
+        
+        var path = $"customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Entity.Id}";
+
+        string newDefaultDeliveryChannelJson = JsonConvert.SerializeObject(new DefaultDeliveryChannel()
+        {
+            MediaType = mediaType,
+            Policy = policyName,
+            Channel = channel
+        });
+        
+        // Act
+        var content = new StringContent(newDefaultDeliveryChannelJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerId).PutAsync(path, content);
+
+        // Assert
+        var data = await response.ReadAsHydraResponseAsync<DefaultDeliveryChannel>();
+        
+        var modifiedDbEntry =
+            dlcsContext.DefaultDeliveryChannels .Include(d => d.DeliveryChannelPolicy)
+                .Single(d => d.Customer == customerId && 
+                             d.MediaType == mediaType && d.DeliveryChannelPolicy.Channel == channel && d.Space == space);
+        
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        data.MediaType.Should().Be(mediaType);
+        data.Id.Should().Be($"{httpClient.BaseAddress}customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Entity.Id.ToString()}");
+        modifiedDbEntry.DeliveryChannelPolicy.Name.Should().Be(policyName.Split("/").Last());
+    }
+    
+    [Fact]
+    public async Task Delete_DeleteADefaultDeliveryChannelForCustomerAndSpace_200()
+    {
+        // Arrange
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""api-test-customer-space-3"",
+  ""displayName"": ""My New Customer""
+}";
+        var customerContent = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+        var customerResponse = await httpClient.AsAdmin().PostAsync("/customers", customerContent);
+        var customerData = await customerResponse.ReadAsHydraResponseAsync<Customer>();
+        var customerId = int.Parse(customerData.Id!.Split('/').Last());
+        
+        var mediaType = "audio/mp3";
+        const int space = 5;
+
+        var deliveryChannelPolicy = dlcsContext.DeliveryChannelPolicies.First(d => d.Customer == customerId &&
+            d.Name == "default-audio");
+        
+        var dbEntry = dlcsContext.DefaultDeliveryChannels.Add(new DLCS.Model.DeliveryChannels.DefaultDeliveryChannel()
+        {
+            Customer = customerId,
+            MediaType = mediaType,
+            DeliveryChannelPolicyId = deliveryChannelPolicy.Id,
+            Space = space
+        });
+        await dlcsContext.SaveChangesAsync();
+        
+        var path = $"customers/{customerId}/spaces/{space}/defaultDeliveryChannels/{dbEntry.Entity.Id}";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).DeleteAsync(path);
+
+        var defaultDeliveryChannelAfterDelete = dlcsContext.DefaultDeliveryChannels.FirstOrDefault(d => 
+            d.Customer == customerId && d.MediaType == mediaType && d.Space == space);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        defaultDeliveryChannelAfterDelete.Should().BeNull();
     }
 }

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -15,12 +15,11 @@ namespace API.Features.DeliveryChannels;
 /// DLCS REST API Operations for Default Delivery Channels
 /// </summary>
 [Route("/customers/{customerId}/defaultDeliveryChannels")]
+[Route("/customers/{customerId}/spaces/{space}/defaultDeliveryChannels")]
 [ApiController]
-public class CustomerDefaultDeliveryChannelsController : HydraController
+public class DefaultDeliveryChannelsController : HydraController
 {
-    private const int DefaultSpace = 0;
-    
-    public CustomerDefaultDeliveryChannelsController(
+    public DefaultDeliveryChannelsController(
         IMediator mediator,
         IOptions<ApiSettings> options) : base(options.Value, mediator)
     {
@@ -34,10 +33,13 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
     /// <returns>Collection of Hydra JSON-LD default delivery channel objects</returns>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetCustomerDefaultDeliveryChannels([FromRoute] int customerId,
+    public async Task<IActionResult> GetCustomerDefaultDeliveryChannels(
+        [FromRoute] int customerId, 
+        [FromRoute] int space,
         CancellationToken cancellationToken)
     {
-        var getCustomerDefaultDeliveryChannels = new GetDefaultDeliveryChannels(customerId, DefaultSpace);
+
+        var getCustomerDefaultDeliveryChannels = new GetDefaultDeliveryChannels(customerId, space);
 
         return await HandlePagedFetch<DLCS.Model.DeliveryChannels.DefaultDeliveryChannel, GetDefaultDeliveryChannels,
             DefaultDeliveryChannel>(
@@ -57,9 +59,10 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetCustomerDefaultDeliveryChannel(
         Guid defaultDeliveryChannelId,
+        [FromRoute] int space,
         CancellationToken cancellationToken)
     {
-        var getCustomerDefaultDeliveryChannel = new GetDefaultDeliveryChannel(defaultDeliveryChannelId);
+        var getCustomerDefaultDeliveryChannel = new GetDefaultDeliveryChannel(defaultDeliveryChannelId, space);
 
         return await HandleFetch(
             getCustomerDefaultDeliveryChannel,
@@ -76,7 +79,9 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> CreateCustomerDefaultDeliveryChannel([FromRoute] int customerId,
+    public async Task<IActionResult> CreateCustomerDefaultDeliveryChannel(
+        [FromRoute] int customerId,
+        [FromRoute] int space,
         [FromBody] DefaultDeliveryChannel defaultDeliveryChannel,
         [FromServices] HydraDefaultDeliveryChannelValidator validator,
         CancellationToken cancellationToken)
@@ -90,7 +95,7 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
         try
         {
             var command = new CreateDefaultDeliveryChannel(customerId,
-                DefaultSpace,
+                space,
                 defaultDeliveryChannel.Policy,
                 defaultDeliveryChannel.Channel,
                 defaultDeliveryChannel.MediaType);
@@ -112,7 +117,9 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
     /// <returns>A Hydra JSON-LD default delivery channel object</returns>
     [HttpPut("{defaultDeliveryChannelId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IActionResult> UpdateCustomerDefaultDeliveryChannel([FromRoute] int customerId,
+    public async Task<IActionResult> UpdateCustomerDefaultDeliveryChannel(
+        [FromRoute] int customerId,
+        [FromRoute] int space,
         [FromBody]DefaultDeliveryChannel defaultDeliveryChannel,
         [FromServices] HydraDefaultDeliveryChannelValidator validator,
         Guid defaultDeliveryChannelId,
@@ -125,7 +132,7 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
         }
 
         var command = new UpdateDefaultDeliveryChannel(customerId, 
-            DefaultSpace, 
+            space, 
             defaultDeliveryChannel.Policy,
             defaultDeliveryChannel.Channel,
             defaultDeliveryChannel.MediaType, 
@@ -145,11 +152,16 @@ public class CustomerDefaultDeliveryChannelsController : HydraController
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> DeleteCustomerDefaultDeliveryChannel([FromRoute] int customerId,
+    public async Task<IActionResult> DeleteCustomerDefaultDeliveryChannel(
+        [FromRoute] int customerId,
+        [FromRoute] int space,
         Guid defaultDeliveryChannelId,
         CancellationToken cancellationToken)
     {
-        var deleteCustomerDefaultDeliveryChannel = new DeleteDefaultDeliveryChannel(customerId, defaultDeliveryChannelId);
+        var deleteCustomerDefaultDeliveryChannel = new DeleteDefaultDeliveryChannel(
+            customerId, 
+            space,
+            defaultDeliveryChannelId);
     
         return await HandleDelete(
             deleteCustomerDefaultDeliveryChannel,

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
@@ -7,13 +7,16 @@ namespace API.Features.DeliveryChannels.Requests.DefaultDeliveryChannels;
 
 public class DeleteDefaultDeliveryChannel : IRequest<ResultMessage<DeleteResult>>
 {
-    public DeleteDefaultDeliveryChannel(int customer, Guid defaultDeliveryChannelId)
+    public DeleteDefaultDeliveryChannel(int customer, int space, Guid defaultDeliveryChannelId)
     {
         Customer = customer;
+        Space = space;
         DefaultDeliveryChannelId = defaultDeliveryChannelId;
     }
     
     public int Customer { get; }
+    
+    public int Space { get; }
     
     public Guid DefaultDeliveryChannelId { get; }
 }
@@ -31,7 +34,8 @@ public class DeleteDefaultDeliveryChannelHandler : IRequestHandler<DeleteDefault
     {
         var defaultDeliveryChannel = await dbContext.DefaultDeliveryChannels.SingleOrDefaultAsync(
             ch => ch.Customer == request.Customer && 
-                  ch.Id == request.DefaultDeliveryChannelId,
+                  ch.Id == request.DefaultDeliveryChannelId &&
+                  ch.Space == request.Space,
             cancellationToken: cancellationToken);
 
         if (defaultDeliveryChannel == null)

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannel.cs
@@ -10,9 +10,12 @@ public class GetDefaultDeliveryChannel : IRequest<FetchEntityResult<DefaultDeliv
 {
     public Guid DefaultDeliveryChannelId { get; }
     
-    public GetDefaultDeliveryChannel(Guid defaultDeliveryChannelId)
+    public int Space { get; }
+    
+    public GetDefaultDeliveryChannel(Guid defaultDeliveryChannelId, int space)
     {
         DefaultDeliveryChannelId = defaultDeliveryChannelId;
+        Space = space;
     }
 }
 
@@ -31,7 +34,9 @@ public class GetDefaultDeliveryChannelHandler : IRequestHandler<GetDefaultDelive
     {
         var defaultDeliveryChannel = await dlcsContext.DefaultDeliveryChannels.AsNoTracking()
             .Include(d => d.DeliveryChannelPolicy)
-            .SingleOrDefaultAsync(b => b.Id == request.DefaultDeliveryChannelId,
+            .SingleOrDefaultAsync(d => 
+                d.Id == request.DefaultDeliveryChannelId && 
+                d.Space == request.Space,
                 cancellationToken);
 
         return defaultDeliveryChannel == null

--- a/src/protagonist/DLCS.HydraModel/DefaultDeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DefaultDeliveryChannel.cs
@@ -26,7 +26,7 @@ public class DefaultDeliveryChannel : DlcsResource
         }
         else
         {
-            Init(baseUrl, true, customerId, id, space);
+            Init(baseUrl, true, customerId, space, id);
         }
     }
     


### PR DESCRIPTION
Resolves #721 

This pr updates the `defaultDeliveryChannels` endpoint to work on the space level as well as the customer level.

It adds the following endpoints:

- `GET /customers/{customer}/spaces/{space}/defaultDeliveryChannels`
- `POST /customers/{customer/spaces/{space/defaultDeliveryChannels`
- `GET /customers/{customer}/spaces/{space}/defaultDeliveryChannels/{id}`
- `PUT /customers/{customer}/spaces/{space}/defaultDeliveryChannels/{id}`
- `DELETE /customers/{customer}/spaces/{space}/defaultDeliveryChannels/{id}`