### PR TITLE
Remove as no tracking from the engine asset repository

### DIFF
--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -161,20 +161,6 @@ public class EngineAssetRepository : IEngineAssetRepository
         {
             asset.MarkAsFinished();
         }
-
-        dlcsContext.Images.Attach(asset);
-        var entry = dlcsContext.Entry(asset);
-        entry.Property(p => p.Width).IsModified = true;
-        entry.Property(p => p.Height).IsModified = true;
-        entry.Property(p => p.Duration).IsModified = true;
-        entry.Property(p => p.Error).IsModified = true;
-        entry.Property(p => p.Ingesting).IsModified = true;
-        entry.Property(p => p.Finished).IsModified = true;
-
-        if (asset.MediaType.HasText() && asset.MediaType != "unknown")
-        {
-            entry.Property(p => p.MediaType).IsModified = true;
-        }
     }
 
     private Task<int> TryFinishBatch(int batchId, CancellationToken cancellationToken)

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -162,7 +162,14 @@ public class EngineAssetRepository : IEngineAssetRepository
             asset.MarkAsFinished();
         }
 
+        dlcsContext.Images.Attach(asset);
         var entry = dlcsContext.Entry(asset);
+        entry.Property(p => p.Width).IsModified = true;
+        entry.Property(p => p.Height).IsModified = true;
+        entry.Property(p => p.Duration).IsModified = true;
+        entry.Property(p => p.Error).IsModified = true;
+        entry.Property(p => p.Ingesting).IsModified = true;
+        entry.Property(p => p.Finished).IsModified = true;
 
         if (asset.MediaType.HasText() && asset.MediaType != "unknown")
         {

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -161,6 +161,12 @@ public class EngineAssetRepository : IEngineAssetRepository
         {
             asset.MarkAsFinished();
         }
+        
+        var entry = dlcsContext.Entry(asset);
+        if (asset.MediaType.HasText() && asset.MediaType != "unknown")
+        {
+            entry.Property(p => p.MediaType).IsModified = true;
+        }
     }
 
     private Task<int> TryFinishBatch(int batchId, CancellationToken cancellationToken)

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -73,7 +73,6 @@ public class EngineAssetRepository : IEngineAssetRepository
                 await IncreaseCustomerStorage(imageStorage, cancellationToken);
             }
             
-
             return updatedRows || !ingestFinished; // if the ingest hasn't finished, rows can be not updated - meaning success
         }
         catch (Exception ex)


### PR DESCRIPTION
Resolves #758

This PR removes no tracking from the `EngineAssetRepository` as it's not neccessary