### PR TITLE
Getting timebased assets to work with the new image delivery channels

### DIFF
--- a/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/TranscoderTemplateTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/TranscoderTemplateTests.cs
@@ -9,12 +9,10 @@ public class TranscoderTemplatesTests
     public void GetDestinationPath_Null_IfPresetNoInExpectedFormat()
     {
         // Act
-        var (template, preset) =
-            TranscoderTemplates.ProcessPreset("video/mpg", new AssetId(1, 2, "foo"), "mp3preset", "foo", null);
+        var template = TranscoderTemplates.ProcessPreset("video/mpg", new AssetId(1, 2, "foo"), "foo", null);
             
         // Assert
         template.Should().BeNull();
-        preset.Should().BeNull();
     }
         
     [Fact]
@@ -25,12 +23,10 @@ public class TranscoderTemplatesTests
         const string expected = "_jobid_/1/5/foo/full/max/default.mp3";
             
         // Act
-        var (template, preset) =
-            TranscoderTemplates.ProcessPreset("audio/wav", asset, "some preset", "_jobid_", "mp3");
+        var template = TranscoderTemplates.ProcessPreset("audio/wav", asset,  "_jobid_", "mp3");
             
         // Assert
         template.Should().Be(expected);
-        preset.Should().Be("some preset");
     }
         
     [Fact]
@@ -41,12 +37,10 @@ public class TranscoderTemplatesTests
         const string expected = "_jobid_/1/5/foo/full/full/max/max/0/default.webm";
             
         // Act
-        var (template, preset) =
-            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "some preset", "_jobid_", "webm");
+        var template = TranscoderTemplates.ProcessPreset("video/mpeg", asset, "_jobid_", "webm");
             
         // Assert
         template.Should().Be(expected);
-        preset.Should().Be("some preset");
     }
         
     [Fact]
@@ -54,8 +48,7 @@ public class TranscoderTemplatesTests
     {
         // Act
         Action action = () =>
-            TranscoderTemplates.ProcessPreset("binary/octet-stream", new AssetId(1, 5, "foo"), 
-                "some preset",
+            TranscoderTemplates.ProcessPreset("binary/octet-stream", new AssetId(1, 5, "foo"),
                 "_jobid_",
                 "webm");
 
@@ -70,8 +63,7 @@ public class TranscoderTemplatesTests
         // Arrange
         var asset = new AssetId(1, 5, "foo");
         const string expected = "1/5/foo/full/max/default.mp3";
-        var (template, _) =
-            TranscoderTemplates.ProcessPreset("audio/wav", asset, "some preset", Guid.NewGuid().ToString(), "mp3");
+        var template = TranscoderTemplates.ProcessPreset("audio/wav", asset, Guid.NewGuid().ToString(), "mp3");
             
         // Act
         var result = TranscoderTemplates.GetFinalDestinationKey(template);
@@ -86,8 +78,7 @@ public class TranscoderTemplatesTests
         // Arrange
         var asset = new AssetId(1, 5, "foo");
         const string expected = "1/5/foo/full/full/max/max/0/default.webm";
-        var (template, _) =
-            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "some preset", Guid.NewGuid().ToString(), "webm");
+        var template = TranscoderTemplates.ProcessPreset("video/mpeg", asset, Guid.NewGuid().ToString(), "webm");
             
         // Act
         var result = TranscoderTemplates.GetFinalDestinationKey(template);

--- a/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/TranscoderTemplateTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/TranscoderTemplateTests.cs
@@ -10,7 +10,7 @@ public class TranscoderTemplatesTests
     {
         // Act
         var (template, preset) =
-            TranscoderTemplates.ProcessPreset("video/mpg", new AssetId(1, 2, "foo"), "mp3preset", "foo");
+            TranscoderTemplates.ProcessPreset("video/mpg", new AssetId(1, 2, "foo"), "mp3preset", "foo", null);
             
         // Assert
         template.Should().BeNull();
@@ -26,11 +26,11 @@ public class TranscoderTemplatesTests
             
         // Act
         var (template, preset) =
-            TranscoderTemplates.ProcessPreset("audio/wav", asset, "my-preset(mp3)", "_jobid_");
+            TranscoderTemplates.ProcessPreset("audio/wav", asset, "some preset", "_jobid_", "mp3");
             
         // Assert
         template.Should().Be(expected);
-        preset.Should().Be("my-preset");
+        preset.Should().Be("some preset");
     }
         
     [Fact]
@@ -42,11 +42,11 @@ public class TranscoderTemplatesTests
             
         // Act
         var (template, preset) =
-            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "my-preset(webm)", "_jobid_");
+            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "some preset", "_jobid_", "webm");
             
         // Assert
         template.Should().Be(expected);
-        preset.Should().Be("my-preset");
+        preset.Should().Be("some preset");
     }
         
     [Fact]
@@ -54,8 +54,10 @@ public class TranscoderTemplatesTests
     {
         // Act
         Action action = () =>
-            TranscoderTemplates.ProcessPreset("binary/octet-stream", new AssetId(1, 5, "foo"), "my-preset(webm)",
-                "_jobid_");
+            TranscoderTemplates.ProcessPreset("binary/octet-stream", new AssetId(1, 5, "foo"), 
+                "some preset",
+                "_jobid_",
+                "webm");
 
         // Assert
         action.Should().Throw<InvalidOperationException>()
@@ -69,7 +71,7 @@ public class TranscoderTemplatesTests
         var asset = new AssetId(1, 5, "foo");
         const string expected = "1/5/foo/full/max/default.mp3";
         var (template, _) =
-            TranscoderTemplates.ProcessPreset("audio/wav", asset, "my-preset(mp3)", Guid.NewGuid().ToString());
+            TranscoderTemplates.ProcessPreset("audio/wav", asset, "some preset", Guid.NewGuid().ToString(), "mp3");
             
         // Act
         var result = TranscoderTemplates.GetFinalDestinationKey(template);
@@ -85,7 +87,7 @@ public class TranscoderTemplatesTests
         var asset = new AssetId(1, 5, "foo");
         const string expected = "1/5/foo/full/full/max/max/0/default.webm";
         var (template, _) =
-            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "my-preset(webm)", Guid.NewGuid().ToString());
+            TranscoderTemplates.ProcessPreset("video/mpeg", asset, "some preset", Guid.NewGuid().ToString(), "webm");
             
         // Act
         var result = TranscoderTemplates.GetFinalDestinationKey(template);

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
@@ -1,16 +1,12 @@
-﻿using System.Text.RegularExpressions;
-using DLCS.AWS.S3;
+﻿using DLCS.AWS.S3;
 using DLCS.Core;
+using DLCS.Core.Collections;
 using DLCS.Core.Types;
 
 namespace DLCS.AWS.ElasticTranscoder;
 
 public static class TranscoderTemplates
 {
-    // technical details will contain a comma separated list of presets to use with the extension in brackets at the end
-    // e.g. Wellcome Standard MP4(mp4),Wellcome Standard WebM(webm)
-    private static readonly Regex PresetRegex = new(@"^(.*?)\((.*?)\)$", RegexOptions.Compiled);
-
     /// <summary>
     /// Get the destination path where transcoded asset should be output to and the cleaned up presetName. 
     /// </summary>
@@ -18,23 +14,20 @@ public static class TranscoderTemplates
     /// <param name="assetId">Id of asset being ingested.</param>
     /// <param name="preset">The preset id from ImageOptimisationPolicy</param>
     /// <param name="jobId">Unique identifier for job</param>
+    /// <param name="presetExtension">The extension to use in the path</param>
     /// <returns></returns>
     public static (string? template, string? presetName) ProcessPreset(string mediaType, AssetId assetId, string preset,
-        string jobId)
+        string jobId, string? presetExtension)
     {
-        var match = PresetRegex.Match(preset);
-
-        if (!match.Success) return (null, null);
-
-        var presetName = match.Groups[1].Value;
-        var presetExtension = match.Groups[2].Value;
+        if (presetExtension.IsNullOrEmpty()) return (null, null);
+        
         var template = GetDestinationTemplate(mediaType);
 
         var path = template
             .Replace("{jobId}", jobId)
             .Replace("{asset}", S3StorageKeyGenerator.GetStorageKey(assetId))
             .Replace("{extension}", presetExtension);
-        return (path, presetName);
+        return (path, preset);
     }
 
     /// <summary>

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
@@ -12,14 +12,13 @@ public static class TranscoderTemplates
     /// </summary>
     /// <param name="mediaType">The media-type/content-type for asset.</param>
     /// <param name="assetId">Id of asset being ingested.</param>
-    /// <param name="preset">The preset id from ImageOptimisationPolicy</param>
     /// <param name="jobId">Unique identifier for job</param>
     /// <param name="presetExtension">The extension to use in the path</param>
     /// <returns></returns>
-    public static (string? template, string? presetName) ProcessPreset(string mediaType, AssetId assetId, string preset,
+    public static string? ProcessPreset(string mediaType, AssetId assetId,
         string jobId, string? presetExtension)
     {
-        if (presetExtension.IsNullOrEmpty()) return (null, null);
+        if (presetExtension.IsNullOrEmpty()) return null;
         
         var template = GetDestinationTemplate(mediaType);
 
@@ -27,7 +26,7 @@ public static class TranscoderTemplates
             .Replace("{jobId}", jobId)
             .Replace("{asset}", S3StorageKeyGenerator.GetStorageKey(assetId))
             .Replace("{extension}", presetExtension);
-        return (path, preset);
+        return path;
     }
 
     /// <summary>

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
@@ -63,7 +63,6 @@ public class ElasticTranscoderTests
     public async Task InitiateTranscodeOperation_Fail_IfPolicyDataNoExtension()
     {
         // Arrange
-        // Arrange
         var asset = new Asset(AssetId.FromString("20/10/asset-id"))
         {
             MediaType = "video/mp4",
@@ -149,7 +148,6 @@ public class ElasticTranscoderTests
                     DeliveryChannelPolicyId = 1
                 }
             }
-            
         };
 
         var context = new IngestionContext(asset);
@@ -271,7 +269,6 @@ public class ElasticTranscoderTests
             }
         };
 
-        
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin(asset.Id, 123, "s3://loc/ation", "video/mpeg"));
 

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
@@ -28,7 +28,9 @@ public class ElasticTranscoderTests
             {
                 DeliveryChannelMappings = new Dictionary<string, string>
                 {
-                    ["Standard WebM"] = "my-custom-preset",
+                    ["video-webm-preset"] = "Standard WebM",
+                    ["video-mp4-preset"] = "Standard mp4",
+                    ["audio-mp3-preset"] = "Standard audio"
                 },
                 PipelineName = "foo-pipeline"
             }
@@ -43,10 +45,6 @@ public class ElasticTranscoderTests
     {
         // Arrange
         var asset = new Asset(AssetId.FromString("1/2/hello"));
-        asset.WithImageOptimisationPolicy(new ImageOptimisationPolicy
-        {
-            TechnicalDetails = Array.Empty<string>()
-        });
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin());
 
@@ -62,14 +60,62 @@ public class ElasticTranscoderTests
     }
     
     [Fact]
+    public async Task InitiateTranscodeOperation_Fail_IfPolicyDataNoExtension()
+    {
+        // Arrange
+        // Arrange
+        var asset = new Asset(AssetId.FromString("20/10/asset-id"))
+        {
+            MediaType = "video/mp4",
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = "iiif-av",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
+                    {
+                        Id = 1,
+                        PolicyData = "[\"noExtensionPolicy\"]"
+                    },
+                    DeliveryChannelPolicyId = 1
+                }
+            }
+        };
+        var context = new IngestionContext(asset);
+        context.WithAssetFromOrigin(new AssetFromOrigin());
+
+        A.CallTo(() => elasticTranscoderWrapper.GetPipelineId("foo-pipeline", A<CancellationToken>._))
+            .Returns("1234567890123-abcdef");
+
+        // Act
+        var result = await sut.InitiateTranscodeOperation(context, new Dictionary<string, string>());
+
+        // Assert
+        asset.Error.Should().Be("Unable to generate ElasticTranscoder outputs");
+        result.Should().BeFalse();
+    }
+    
+    [Fact]
     public async Task InitiateTranscodeOperation_Fail_IfUnableToMakesCreateJobRequest()
     {
         // Arrange
-        var asset = new Asset(AssetId.FromString("20/10/asset-id")) { MediaType = "video/mp4" };
-        asset.WithImageOptimisationPolicy(new ImageOptimisationPolicy
+        var asset = new Asset(AssetId.FromString("20/10/asset-id"))
         {
-            TechnicalDetails = new[] { "Standard WebM(webm)", "auto-preset(mp4)" }
-        });
+            MediaType = "video/mp4",
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = "iiif-av",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
+                    {
+                        Id = 1,
+                        PolicyData = "[\"video-webm-preset\", \"video-mp4-preset\"]"
+                    },
+                    DeliveryChannelPolicyId = 1
+                }
+            }
+        };
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin(asset.Id, 123, "s3://loc/ation", "video/mpeg"));
 
@@ -88,11 +134,24 @@ public class ElasticTranscoderTests
     public async Task InitiateTranscodeOperation_MakesCreateJobRequest()
     {
         // Arrange
-        var asset = new Asset(AssetId.FromString("20/10/asset-id")) { MediaType = "video/mp4" };
-        asset.WithImageOptimisationPolicy(new ImageOptimisationPolicy
-        {
-            TechnicalDetails = new[] { "Standard WebM(webm)", "auto-preset(mp4)" }
-        });
+        var asset = new Asset(AssetId.FromString("20/10/asset-id")) {
+            MediaType = "video/mp4", 
+            ImageDeliveryChannels = new List<ImageDeliveryChannel> 
+            {
+                new()
+                {
+                    Channel = "iiif-av",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
+                    {
+                        Id = 1,
+                        PolicyData = "[\"video-webm-preset\", \"video-mp4-preset\"]"
+                    },
+                    DeliveryChannelPolicyId = 1
+                }
+            }
+            
+        };
+
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin(asset.Id, 123, "s3://loc/ation", "video/mpeg"));
 
@@ -102,7 +161,8 @@ public class ElasticTranscoderTests
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
             .Returns(new Dictionary<string, string>()
             {
-                ["my-custom-preset"] = "1111111111111-aaaaaa",
+                ["Standard WebM"] = "1111111111111-aaaaaa",
+                ["Standard mp4"] = "1111111111111-aaaaab",
                 ["auto-preset"] = "9999999999999-bbbbbb"
             });
 
@@ -141,11 +201,24 @@ public class ElasticTranscoderTests
     public async Task InitiateTranscodeOperation_ReturnsFalseAndSetsError_IfErrorStatusCodeFromET(HttpStatusCode statusCode)
     {
         // Arrange
-        var asset = new Asset(AssetId.FromString("20/10/asset-id")) { MediaType = "video/mp4" };
-        asset.WithImageOptimisationPolicy(new ImageOptimisationPolicy
+        var asset = new Asset(AssetId.FromString("20/10/asset-id"))
         {
-            TechnicalDetails = new[]{ "Standard WebM(webm)", "auto-preset(mp4)" }
-        });
+            MediaType = "video/mp4",
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = "iiif-av",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
+                    {
+                        Id = 1,
+                        PolicyData = "[\"video-mp4-preset\"]"
+                    },
+                    DeliveryChannelPolicyId = 1
+                } 
+            }
+        };
+        
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin(asset.Id, 123, "s3://loc/ation", "video/mpeg"));
 
@@ -155,7 +228,7 @@ public class ElasticTranscoderTests
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
             .Returns(new Dictionary<string, string>()
             {
-                ["my-custom-preset"] = "1111111111111-aaaaaa",
+                ["Standard mp4"] = "1111111111111-aaaaab",
                 ["auto-preset"] = "9999999999999-bbbbbb"
             });
 
@@ -180,11 +253,25 @@ public class ElasticTranscoderTests
     public async Task InitiateTranscodeOperation_ReturnsTrue_IfSuccessStatusCodeFromET(HttpStatusCode statusCode)
     {
         // Arrange
-        var asset = new Asset(AssetId.FromString("20/10/asset-id")) { MediaType = "video/mp4" };
-        asset.WithImageOptimisationPolicy(new ImageOptimisationPolicy
+        var asset = new Asset(AssetId.FromString("20/10/asset-id"))
         {
-            TechnicalDetails = new[]{ "Standard WebM(webm)", "auto-preset(mp4)" }
-        });
+            MediaType = "video/mp4",
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = "iiif-av",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
+                    {
+                        Id = 1,
+                        PolicyData = "[\"video-mp4-preset\"]"
+                    },
+                    DeliveryChannelPolicyId = 1
+                } 
+            }
+        };
+
+        
         var context = new IngestionContext(asset);
         context.WithAssetFromOrigin(new AssetFromOrigin(asset.Id, 123, "s3://loc/ation", "video/mpeg"));
 
@@ -195,7 +282,7 @@ public class ElasticTranscoderTests
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
             .Returns(new Dictionary<string, string>
             {
-                ["my-custom-preset"] = "1111111111111-aaaaaa",
+                ["Standard mp4"] = "1111111111111-aaaaab",
                 ["auto-preset"] = "9999999999999-bbbbbb"
             });
 

--- a/src/protagonist/Engine.Tests/appsettings.Testing.json
+++ b/src/protagonist/Engine.Tests/appsettings.Testing.json
@@ -10,7 +10,11 @@
     },
     "DownloadTemplate": "/scratch/{customer}/{space}/{image}",
     "TimebasedIngest": {
-        "PipelineName": "protagonist-pipeline"
+        "PipelineName": "protagonist-pipeline",
+        "DeliveryChannelMappings": {
+            "audio-mp3-128": "System preset: Audio MP3 - 128k",
+            "video-mp4-720p": "System preset: Generic 720p"
+        }
     },
     "AWS": {
         "UseLocalStack": true,

--- a/src/protagonist/Engine/Ingest/Timebased/Models/TimeBasedPolicy.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Models/TimeBasedPolicy.cs
@@ -1,0 +1,16 @@
+﻿namespace Engine.Ingest.Timebased.Models;
+
+public class TimeBasedPolicy
+{
+    public TimeBasedPolicy(string policy)
+    {
+        var policySplit = policy.Split('-');
+
+        ChannelType = policySplit[0];
+        Extension = policySplit[1];
+    }
+    
+    public string ChannelType { get; init; }
+
+    public string Extension { get; init; }
+}

--- a/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
@@ -94,13 +94,13 @@ public class ElasticTranscoder : IMediaTranscoder
                 continue;
             }
             
-            var (destinationPath, presetName) =
-                TranscoderTemplates.ProcessPreset(mediaType, assetId, mappedPresetName, jobId, timeBasedPolicy.Split('-')[1]);
+            var destinationPath = TranscoderTemplates.ProcessPreset(
+                mediaType, assetId, jobId, timeBasedPolicy.Split('-')[1]);
 
             // TODO - handle not found
             if (!presets.TryGetValue(mappedPresetName, out var presetId))
             {
-                logger.LogWarning("Mapping for preset '{PresetName}' not found!", presetName);
+                logger.LogWarning("Mapping for preset '{PresetName}' not found!", mappedPresetName);
                 continue;
             }
 

--- a/src/protagonist/Engine/appsettings.json
+++ b/src/protagonist/Engine/appsettings.json
@@ -32,5 +32,11 @@
         "LongTtlSecs": 1800
       }
     }
+  },
+  "TimebasedIngest": {
+    "DeliveryChannelMappings": {
+      "video-mp4-720p": "System preset: Generic 720p",
+      "audio-mp3-128": "System preset: Audio MP3 - 128k"
+    }
   }
 }


### PR DESCRIPTION
Resolves #726 

This PR allows timebased assets to be processed correctly by engine.  It does this by relying on the new `ImageDeliveryChannels` object and appsettings under `TimebasedIngest.DeliveryChannelMappings`.