### PR TITLE
Update CleanupHandler to use `ImageDeliveryChannel` delivery channels

### DIFF
--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -102,7 +102,7 @@ public class AssetDeletedHandler : IMessageHandler
             $"{customerName}/{asset.Id.Space}/{asset.Id.Asset}"
         };
         
-        if (asset.DeliveryChannels.IsNullOrEmpty())
+        if (asset.ImageDeliveryChannels.IsNullOrEmpty())
         {
             logger.LogDebug("Received message body with no 'deliveryChannels' property. {@Request}", 
                 asset);
@@ -110,7 +110,7 @@ public class AssetDeletedHandler : IMessageHandler
         else
         {
             invalidationUriList = SetDeliveryChannelInvalidations(asset.Id!, 
-                asset.DeliveryChannels.ToList(), idList);
+                asset.ImageDeliveryChannels, idList);
         }
         
         if (!asset.Family.HasValue)
@@ -139,16 +139,16 @@ public class AssetDeletedHandler : IMessageHandler
         return true;
     }
 
-    private static List<string> SetDeliveryChannelInvalidations(AssetId assetId, List<string> deliveryChannels,
+    private static List<string> SetDeliveryChannelInvalidations(AssetId assetId, ICollection<ImageDeliveryChannel> deliveryChannels,
         List<string> idList)
     {
-        List<string> invalidationUriList = new List<string>();
+        var invalidationUriList = new List<string>();
 
         foreach (var deliveryChannel in deliveryChannels)
         {
             foreach (var id in idList)
             {
-                switch (deliveryChannel)
+                switch (deliveryChannel.Channel)
                 {
                     case AssetDeliveryChannels.Image:
                         invalidationUriList.Add($"/iiif-img/{id}/*");
@@ -157,6 +157,9 @@ public class AssetDeletedHandler : IMessageHandler
                         invalidationUriList.Add($"/thumbs/{id}/*");
                         invalidationUriList.Add($"/thumbs/v2/{id}/*");
                         invalidationUriList.Add($"/thumbs/v3/{id}/*");
+                        invalidationUriList.Add($"/iiif-manifest/{id}");
+                        invalidationUriList.Add($"/iiif-manifest/v2/{id}");
+                        invalidationUriList.Add($"/iiif-manifest/v3/{id}");
                         break;
                     case AssetDeliveryChannels.File:
                         invalidationUriList.Add($"/file/{id}");

--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -107,15 +107,19 @@ public class AssetDeletedHandler : IMessageHandler
             invalidationUriList = SetDeliveryChannelInvalidations(asset.Id!, 
                 asset.ImageDeliveryChannels, idList);
         }
-        else if (asset.Family is AssetFamily.Image)
+        else if (asset.Family.HasValue)
         {
-            logger.LogDebug("Received message body with no 'deliveryChannels' property - using 'family' as a fallback. {@Request}",
-                asset);
-            foreach (var id in idList)
+            if(asset.Family == AssetFamily.Image)
             {
-                invalidationUriList.Add($"/iiif-manifest/{id}");
-                invalidationUriList.Add($"/iiif-manifest/v2/{id}");
-                invalidationUriList.Add($"/iiif-manifest/v3/{id}");
+                logger.LogDebug(
+                    "Received message body with no 'deliveryChannels' property - using 'family' as a fallback. {@Request}",
+                    asset);
+                foreach (var id in idList)
+                {
+                    invalidationUriList.Add($"/iiif-manifest/{id}");
+                    invalidationUriList.Add($"/iiif-manifest/v2/{id}");
+                    invalidationUriList.Add($"/iiif-manifest/v3/{id}");
+                }
             }
         }
         else

--- a/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
@@ -288,9 +288,18 @@ public class AssetDeletedHandlerTests
                 Id = new AssetId(1, 99, "foo"),
                 ImageDeliveryChannels = new List<ImageDeliveryChannel>()
                 {
-                    new() { Channel = "iiif-img" },
-                    new() { Channel = "iiif-av" },
-                    new() { Channel = "file" },
+                    new()
+                    {
+                        Channel = "iiif-img"
+                    },
+                    new()
+                    {
+                        Channel = "iiif-av"
+                    },
+                    new()
+                    {
+                        Channel = "file"
+                    }
                 }
             },
             DeleteFrom = ImageCacheType.Cdn,

--- a/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetDeletedHandlerTests.cs
@@ -286,7 +286,12 @@ public class AssetDeletedHandlerTests
             Asset = new Asset()
             {
                 Id = new AssetId(1, 99, "foo"),
-                DeliveryChannels = new[] {"iiif-img","iiif-av", "file" }
+                ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+                {
+                    new() { Channel = "iiif-img" },
+                    new() { Channel = "iiif-av" },
+                    new() { Channel = "file" },
+                }
             },
             DeleteFrom = ImageCacheType.Cdn,
             CustomerPathElement = new CustomerPathElement(99, "someName")

--- a/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetRepository.cs
@@ -39,7 +39,9 @@ public class AssetRepository : AssetRepositoryCachingBase
     {
         try
         {
-            var asset = await dlcsContext.Images.SingleOrDefaultAsync(i => i.Id == assetId);
+            var asset = await dlcsContext.Images
+                .Include(a => a.ImageDeliveryChannels)
+                .SingleOrDefaultAsync(i => i.Id == assetId);
             if (asset == null)
             {
                 Logger.LogDebug("Attempt to delete non-existent asset {AssetId}", assetId);


### PR DESCRIPTION
Resolves #691

This PR updates CleanupHandler to use the new `ImageDeliveryChannel` based `deliveryChannel` values to determine what needs to be invalidated.