### PR TITLE
Await unawaited task when setting None policy

### DIFF
--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -96,7 +96,7 @@ public class DeliveryChannelProcessor
         // If 'none' specified then it's the only valid option
         if (deliveryChannelsBeforeProcessing.Count(d => d.Channel == AssetDeliveryChannels.None) == 1)
         {
-            AddExplicitNoneChannel(asset);
+            await AddExplicitNoneChannel(asset);
             return true;
         }
 
@@ -174,10 +174,10 @@ public class DeliveryChannelProcessor
         return deliveryChannelPolicy;
     }
 
-    private void AddExplicitNoneChannel(Asset asset)
+    private async Task AddExplicitNoneChannel(Asset asset)
     {
         logger.LogTrace("assigning 'none' channel for asset {AssetId}", asset.Id);
-        var deliveryChannelPolicy = deliveryChannelPolicyRepository.RetrieveDeliveryChannelPolicy(asset.Customer,
+        var deliveryChannelPolicy = await deliveryChannelPolicyRepository.RetrieveDeliveryChannelPolicy(asset.Customer,
             AssetDeliveryChannels.None, FileNonePolicy);
 
         // "none" channel can only exist on it's own so remove any others that may be there already prior to adding


### PR DESCRIPTION
Bug introduced in #778. When switching `IDeliveryChannelPolicyRepository` to be `async` I missed an `await`. This is normally flagged in IDE but the the `.Id` property on returned task was accessed, which is a [valid property of a Task and of same type](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.id?view=net-6.0) hence IDE not flagging. Resulted in seemingly random id property being set for 'none'