### PR TITLE
Prevent new assets from receiving invalid default delivery channels

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -443,12 +443,6 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         await dbContext.SaveChangesAsync();
         
-        A.CallTo(() =>
-                EngineClient.SynchronousIngest(
-                    A<Asset>.That.Matches(r => r.Id == assetId),
-                    A<CancellationToken>._))
-            .Returns(HttpStatusCode.OK);
-        
         // act
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
         var response = await httpClient.AsCustomer(customerId).PutAsync(assetId.ToApiResourcePath(), content);

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -451,7 +451,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // act
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+        var response = await httpClient.AsCustomer(customerId).PutAsync(assetId.ToApiResourcePath(), content);
 
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -415,6 +415,49 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_NewImageAsset_FailsToCreateAsset_WhenMatchingDefaultDeliveryChannelsAreInvalid()
+    {
+        // arrange
+        const int customerId = 9901;
+        var assetId = new AssetId(customerId, 1, nameof(Put_NewImageAsset_FailsToCreateAsset_WhenMatchingDefaultDeliveryChannelsAreInvalid));
+        var hydraImageBody = $@"{{
+          ""@type"": ""Image"",
+          ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+          ""mediaType"": ""application/tiff""
+        }}";
+
+        await dbContext.Spaces.AddTestSpace(customerId, 1);
+        
+        dbContext.DefaultDeliveryChannels.Add(new DLCS.Model.DeliveryChannels.DefaultDeliveryChannel()
+        {
+            Customer = customerId,
+            MediaType = "application/*",
+            DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.FileNone,
+        });
+        dbContext.DefaultDeliveryChannels.Add(new DLCS.Model.DeliveryChannels.DefaultDeliveryChannel()
+        {
+            Customer = customerId,
+            MediaType = "application/*",
+            DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.None,
+        });
+
+        await dbContext.SaveChangesAsync();
+        
+        A.CallTo(() =>
+                EngineClient.SynchronousIngest(
+                    A<Asset>.That.Matches(r => r.Id == assetId),
+                    A<CancellationToken>._))
+            .Returns(HttpStatusCode.OK);
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }  
+    
+    [Fact]
     public async Task Put_NewImageAsset_CreatesAsset_WhenMediaTypeAndFamilyNotSetWithLegacyEnabled()
     {
         const int customer = 325665;

--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -199,7 +199,7 @@ public class DeliveryChannelProcessor
         if (matchedDeliveryChannels.Any(x => x.Channel == AssetDeliveryChannels.None) &&
             matchedDeliveryChannels.Count != 1)
         {
-            throw new APIException($"An asset can only be automatically assigned a delivery channel of type 'None' when it is the only one available. " +
+            throw new APIException("An asset can only be automatically assigned a delivery channel of type 'None' when it is the only one available. " +
                                    $"Please check your default delivery channel configuration for media type '{asset.MediaType}'")
             {
                 StatusCode = 400

--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -196,6 +196,16 @@ public class DeliveryChannelProcessor
             await defaultDeliveryChannelRepository.MatchedDeliveryChannels(asset.MediaType!, asset.Space,
                 asset.Customer);
 
+        if (matchedDeliveryChannels.Any(x => x.Channel == AssetDeliveryChannels.None) &&
+            matchedDeliveryChannels.Count != 1)
+        {
+            throw new APIException($"An asset can only be automatically assigned a delivery channel of type 'None' when it is the only one available. " +
+                                   $"Please check your default delivery channel configuration for media type '{asset.MediaType}'")
+            {
+                StatusCode = 400
+            };
+        }
+        
         foreach (var deliveryChannel in matchedDeliveryChannels)
         {
             asset.ImageDeliveryChannels.Add(new ImageDeliveryChannel

--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -200,7 +200,7 @@ public class DeliveryChannelProcessor
             matchedDeliveryChannels.Count != 1)
         {
             throw new APIException("An asset can only be automatically assigned a delivery channel of type 'None' when it is the only one available. " +
-                                   $"Please check your default delivery channel configuration for media type '{asset.MediaType}'")
+                                   "Please check your default delivery channel configuration.")
             {
                 StatusCode = 400
             };


### PR DESCRIPTION
Resolves #788

This PR prevents new assets from being created if the default delivery channels matched to them are invalid - i.e, contain `none` alongside real channel types.