### PR TITLE
Treat region parameters that cover the entire image as 'full' in Orchestrator

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -344,6 +344,32 @@ public class ImageRequestHandlerTests
         result.Path.Should().Be("thumbs/2/2/test-image/0,0,512,512/256,256/0/default.jpg");
     }
     
+    [Fact]
+    public async Task HandleRequest_ProxiesToThumbs_IfRegionAndOriginSquare_AndKnownSize()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/2/2/test-image/square/256,256/0/default.jpg";
+        
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 256, 256 } },
+                Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
+                Channels = AvailableDeliveryChannel.Image
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+            
+        // Assert
+        result.Target.Should().Be(ProxyDestination.Thumbs);
+        result.Path.Should().Be("thumbs/2/2/test-image/square/256,256/0/default.jpg");
+    }
+    
     [Theory]
     [InlineData(AssetAccessResult.Open)]
     [InlineData(AssetAccessResult.Authorized)]

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -318,6 +318,32 @@ public class ImageRequestHandlerTests
         result.Path.Should().Be("thumbs/2/2/test-image/full/!150,150/0/default.jpg");
     }
     
+    [Fact]
+    public async Task HandleRequest_ProxiesToThumbs_IfRegionEquivalentToFull_AndKnownSize()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/iiif-img/2/2/test-image/0,0,512,512/256,256/0/default.jpg";
+        
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 256, 256 } },
+                Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
+                Channels = AvailableDeliveryChannel.Image
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context) as ProxyActionResult;
+            
+        // Assert
+        result.Target.Should().Be(ProxyDestination.Thumbs);
+        result.Path.Should().Be("thumbs/2/2/test-image/0,0,512,512/256,256/0/default.jpg");
+    }
+    
     [Theory]
     [InlineData(AssetAccessResult.Open)]
     [InlineData(AssetAccessResult.Authorized)]

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -163,11 +163,25 @@ public class ImageRequestHandler
     private static bool IsRequestFullOrEquivalent(ImageAssetDeliveryRequest assetRequest,
         OrchestrationImage orchestrationImage)
     {
-        if (assetRequest.IIIFImageRequest.Region.Full) return true;
-        
-        return assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
-               orchestrationImage.Width == assetRequest.IIIFImageRequest.Region.W &&
-               orchestrationImage.Height == assetRequest.IIIFImageRequest.Region.H;
+        if (assetRequest.IIIFImageRequest.Region.Full)
+        {
+            return true;
+        }
+
+        if (assetRequest.IIIFImageRequest.Region.Square &&
+            orchestrationImage.Width == orchestrationImage.Height)
+        {
+            return true;
+        }
+
+        if (assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
+            orchestrationImage.Width == assetRequest.IIIFImageRequest.Region.W &&
+            orchestrationImage.Height == assetRequest.IIIFImageRequest.Region.H)
+        {
+            return true;
+        }
+
+        return false;
     }
     
     private async Task<bool> IsRequestUnauthorised(ImageAssetDeliveryRequest assetRequest,

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -116,7 +116,7 @@ public class ImageRequestHandler
             }
         }
         
-        if (IsRequestFullOrEquivalent(assetRequest, orchestrationImage))
+        if (IsRequestedRegionFullOrEquivalent(assetRequest.IIIFImageRequest.Region, orchestrationImage))
         {
             // /full/ request but not /full/max/ - can it be handled by thumbnail service?
             if (!assetRequest.IIIFImageRequest.Size.Max)
@@ -156,24 +156,24 @@ public class ImageRequestHandler
         return GenerateImageServerProxyResult(orchestrationImage, assetRequest, specialServer: false);
     }
     
-    private static bool IsRequestFullOrEquivalent(ImageAssetDeliveryRequest assetRequest,
+    private static bool IsRequestedRegionFullOrEquivalent(RegionParameter requestedRegion,
         OrchestrationImage orchestrationImage)
     {
-        if (assetRequest.IIIFImageRequest.Region.Full)
+        if (requestedRegion.Full)
         {
             return true;
         }
 
-        if (assetRequest.IIIFImageRequest.Region.Square &&
+        if (requestedRegion.Square &&
             orchestrationImage.Width == orchestrationImage.Height)
         {
             return true;
         }
 
-        if (!assetRequest.IIIFImageRequest.Region.Percent &&
-            assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
-            orchestrationImage.Width == (int)assetRequest.IIIFImageRequest.Region.W &&
-            orchestrationImage.Height == (int)assetRequest.IIIFImageRequest.Region.H)
+        if (!requestedRegion.Percent &&
+            requestedRegion.X + requestedRegion.Y == 0 &&
+            orchestrationImage.Width == (int)requestedRegion.W &&
+            orchestrationImage.Height == (int)requestedRegion.H)
         {
             return true;
         }

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -176,8 +176,8 @@ public class ImageRequestHandler
 
         if (!assetRequest.IIIFImageRequest.Region.Percent &&
             assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
-            orchestrationImage.Width == assetRequest.IIIFImageRequest.Region.W &&
-            orchestrationImage.Height == assetRequest.IIIFImageRequest.Region.H)
+            orchestrationImage.Width == (int)assetRequest.IIIFImageRequest.Region.W &&
+            orchestrationImage.Height == (int)assetRequest.IIIFImageRequest.Region.H)
         {
             return true;
         }

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -139,7 +139,7 @@ public class ImageRequestHandler
         }
 
         // /full/ that cannot be handled by thumbs (e.g. format, size, rotation, quality), handle with special-server
-        if (IsRequestFullOrEquivalent(assetRequest, orchestrationImage))
+        if (assetRequest.IIIFImageRequest.Region.Full)
         {
             if (orchestrationImage.S3Location.IsNullOrEmpty())
             {

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -115,32 +115,31 @@ public class ImageRequestHandler
                 return new StatusCodeResult(HttpStatusCode.Unauthorized);
             }
         }
-
-        // /full/ request but not /full/max/ - can it be handled by thumbnail service?
-        if (RegionFullNotMax(assetRequest, orchestrationImage))
+        
+        if (IsRequestFullOrEquivalent(assetRequest, orchestrationImage))
         {
-            var canHandleByThumbResponse = CanRequestBeHandledByThumb(assetRequest, orchestrationImage);
-            if (canHandleByThumbResponse.CanHandle)
+            // /full/ request but not /full/max/ - can it be handled by thumbnail service?
+            if (!assetRequest.IIIFImageRequest.Size.Max)
             {
-                logger.LogDebug("'{Path}' can be handled by thumb, proxying to thumbs. IsResize: {IsResize}",
-                    httpContext.Request.Path, canHandleByThumbResponse.IsResize);
+                var canHandleByThumbResponse = CanRequestBeHandledByThumb(assetRequest, orchestrationImage);
+                if (canHandleByThumbResponse.CanHandle)
+                {
+                    logger.LogDebug("'{Path}' can be handled by thumb, proxying to thumbs. IsResize: {IsResize}",
+                        httpContext.Request.Path, canHandleByThumbResponse.IsResize);
 
-                var pathReplacement = canHandleByThumbResponse.IsResize
-                    ? orchestratorSettings.Value.Proxy.ThumbResizePath
-                    : orchestratorSettings.Value.Proxy.ThumbsPath;
-                var proxyDestination = canHandleByThumbResponse.IsResize
-                    ? ProxyDestination.ResizeThumbs
-                    : ProxyDestination.Thumbs;
-                var proxyResult = new ProxyActionResult(proxyDestination,
-                    orchestrationImage.RequiresAuth,
-                    httpContext.Request.Path.ToString().Replace("iiif-img", pathReplacement));
-                return proxyResult;
+                    var pathReplacement = canHandleByThumbResponse.IsResize
+                        ? orchestratorSettings.Value.Proxy.ThumbResizePath
+                        : orchestratorSettings.Value.Proxy.ThumbsPath;
+                    var proxyDestination = canHandleByThumbResponse.IsResize
+                        ? ProxyDestination.ResizeThumbs
+                        : ProxyDestination.Thumbs;
+                    var proxyResult = new ProxyActionResult(proxyDestination,
+                        orchestrationImage.RequiresAuth,
+                        httpContext.Request.Path.ToString().Replace("iiif-img", pathReplacement));
+                    return proxyResult;
+                } 
             }
-        }
-
-        // /full/ that cannot be handled by thumbs (e.g. format, size, rotation, quality), handle with special-server
-        if (assetRequest.IIIFImageRequest.Region.Full)
-        {
+            // /full/ that cannot be handled by thumbs (e.g. format, size, rotation, quality), handle with special-server
             if (orchestrationImage.S3Location.IsNullOrEmpty())
             {
                 // Rare occurence - fall through to image server which will handle reingest request
@@ -152,14 +151,11 @@ public class ImageRequestHandler
                 return GenerateImageServerProxyResult(orchestrationImage, assetRequest, specialServer: true);
             }
         }
-
+        
         // Fallback to image-server, with orchestration if required
         return GenerateImageServerProxyResult(orchestrationImage, assetRequest, specialServer: false);
     }
-
-    private static bool RegionFullNotMax(ImageAssetDeliveryRequest assetRequest, OrchestrationImage orchestrationImage) 
-        => IsRequestFullOrEquivalent(assetRequest, orchestrationImage) && !assetRequest.IIIFImageRequest.Size.Max;
-
+    
     private static bool IsRequestFullOrEquivalent(ImageAssetDeliveryRequest assetRequest,
         OrchestrationImage orchestrationImage)
     {

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -174,7 +174,8 @@ public class ImageRequestHandler
             return true;
         }
 
-        if (assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
+        if (!assetRequest.IIIFImageRequest.Region.Percent &&
+            assetRequest.IIIFImageRequest.Region.X + assetRequest.IIIFImageRequest.Region.Y == 0 &&
             orchestrationImage.Width == assetRequest.IIIFImageRequest.Region.W &&
             orchestrationImage.Height == assetRequest.IIIFImageRequest.Region.H)
         {


### PR DESCRIPTION
Resolves #781

This PR updates `ImageRequestHandler` to treat IIIF image requests that request a region covering the entire image (e.g `0,0,512,512` for a 512x512 image) as `full`. It also includes tests that verify this behaviour.