### PR TITLE
Handle cache invalidations when DeliveryChannel records altered

### DIFF
--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
@@ -72,7 +72,7 @@ public class DefaultDeliveryChannelRepository : IDefaultDeliveryChannelRepositor
     
     private async Task<List<DefaultDeliveryChannel>> GetDefaultDeliveryChannelsForCustomer(int customerId, int space)
     {
-        var key = $"defaultDeliveryChannels:{customerId}";
+        var key = CacheKeys.DefaultDeliveryChannels(customerId);
 
         var defaultDeliveryChannels = await appCache.GetOrAddAsync(key, async () =>
         {

--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DeliveryChannelPolicyRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DeliveryChannelPolicyRepository.cs
@@ -1,3 +1,4 @@
+using API.Features.DeliveryChannels.Helpers;
 using DLCS.Core.Caching;
 using DLCS.Model.DeliveryChannels;
 using DLCS.Model.Policies;
@@ -42,17 +43,8 @@ public class DeliveryChannelPolicyRepository : IDeliveryChannelPolicyRepository
                 .ToListAsync();
 
             return defaultDeliveryChannels;
-        }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long)); 
-        
-        return deliveryChannelPolicies.Single(p =>
-            (p.Customer == customerId &&
-             p.System == false &&
-             p.Channel == channel &&
-             p.Name == policy
-                 .Split('/').Last()) ||
-            (p.Customer == AdminCustomer &&
-             p.System &&
-             p.Channel == channel &&
-             p.Name == policy));
+        }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long));
+
+        return deliveryChannelPolicies.RetrieveDeliveryChannel(customerId, channel, policy);
     }
 }

--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DeliveryChannelPolicyRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DeliveryChannelPolicyRepository.cs
@@ -31,7 +31,7 @@ public class DeliveryChannelPolicyRepository : IDeliveryChannelPolicyRepository
 
     public async Task<DeliveryChannelPolicy> RetrieveDeliveryChannelPolicy(int customerId, string channel, string policy)
     {
-        var key = $"deliveryChannelPolicies:{customerId}";
+        var key = CacheKeys.DeliveryChannelPolicies(customerId);
         
         var deliveryChannelPolicies = await appCache.GetOrAddAsync(key, async () =>
         {

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -149,9 +149,9 @@ public class DefaultDeliveryChannelsController : HydraController
     }
     
     /// <summary>
-    /// Get an individual customer accessible default delivery channel (customer specific + system)
+    /// Delete an individual customer accessible default delivery channel (customer specific + system)
     /// </summary>
-    /// <returns>A Hydra JSON-LD default delivery channel object</returns>
+    /// <returns>A 204 status code on success, or problem detail response on failure</returns>
     [HttpDelete("{defaultDeliveryChannelId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -169,7 +169,7 @@ public class DefaultDeliveryChannelsController : HydraController
     
         return await HandleDelete(
             deleteCustomerDefaultDeliveryChannel,
-            errorTitle: "Get default delivery channel failed",
+            errorTitle: "Delete Default Delivery Channel failed",
             cancellationToken: cancellationToken
         );
     }

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -105,7 +105,7 @@ public class DefaultDeliveryChannelsController : HydraController
                 defaultDeliveryChannel.MediaType);
             
             return await HandleUpsert(command,
-                s => s.DefaultDeliveryChannel.ToHydra(GetUrlRoots().BaseUrl),
+                s => s.ToHydra(GetUrlRoots().BaseUrl),
                 errorTitle: "Failed to create Default Delivery Channel",
                 cancellationToken: cancellationToken);
         }
@@ -143,7 +143,7 @@ public class DefaultDeliveryChannelsController : HydraController
             defaultDeliveryChannelId);
 
         return await HandleUpsert(command, 
-            ch => ch.DefaultDeliveryChannel.ToHydra(GetUrlRoots().BaseUrl),
+            ch => ch.ToHydra(GetUrlRoots().BaseUrl),
             errorTitle: "Failed to update Default Delivery Channel",
             cancellationToken: cancellationToken);
     }

--- a/src/protagonist/API/Features/DeliveryChannels/DeliveryChannelPoliciesController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DeliveryChannelPoliciesController.cs
@@ -43,7 +43,7 @@ public class DeliveryChannelPoliciesController : HydraController
         [FromRoute] int customerId,
         CancellationToken cancellationToken)
     {
-        var request = new GetDeliveryChannelPolicyCollections(customerId, Request.GetDisplayUrl(Request.Path), Request.GetJsonLdId());
+        var request = new GetDeliveryChannelPolicyCollections(Request.GetDisplayUrl(Request.Path), Request.GetJsonLdId());
         var result = await Mediator.Send(request, cancellationToken);
         var policyCollections = new HydraCollection<HydraNestedCollection<DeliveryChannelPolicy>>()
         {
@@ -197,7 +197,7 @@ public class DeliveryChannelPoliciesController : HydraController
         hydraDeliveryChannelPolicy.CustomerId = customerId;
         
         var updateDeliveryChannelPolicy =
-            new UpdateDeliveryChannelPolicy(customerId, hydraDeliveryChannelPolicy.ToDlcsModel());
+            new UpsertDeliveryChannelPolicy(customerId, hydraDeliveryChannelPolicy.ToDlcsModel());
         
         return await HandleUpsert(updateDeliveryChannelPolicy, 
             s => s.ToHydra(GetUrlRoots().BaseUrl),
@@ -264,12 +264,16 @@ public class DeliveryChannelPoliciesController : HydraController
     public async Task<IActionResult> DeleteDeliveryChannelPolicy(
         [FromRoute] int customerId,
         [FromRoute] string deliveryChannelName,
-        [FromRoute] string deliveryChannelPolicyName)
+        [FromRoute] string deliveryChannelPolicyName,
+        CancellationToken cancellationToken)
     {
         var deleteDeliveryChannelPolicy =
             new DeleteDeliveryChannelPolicy(customerId, deliveryChannelName, deliveryChannelPolicyName);
 
-        return await HandleDelete(deleteDeliveryChannelPolicy);
+        return await HandleDelete(
+            deleteDeliveryChannelPolicy,
+            errorTitle: "Delete delivery channel policy failed",
+            cancellationToken);
     }
 
     private async Task<IActionResult> TryValidateHydraDeliveryChannelPolicy(

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/QueryableExtensions.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/QueryableExtensions.cs
@@ -7,7 +7,15 @@ public static class QueryableExtensions
 {
     private const int AdminCustomer = 1;
     
-    public static DeliveryChannelPolicy RetrieveDeliveryChannel(this IQueryable<DeliveryChannelPolicy> policies, int customerId, string channel, string policy)
+    /// <summary>
+    /// Find matching policy, this will be either (in order of precedence):
+    /// Non system policy where channel and name match OR
+    /// System policy where channel and name match.
+    ///
+    /// NOTE: will throw InvalidOperationException if no match found
+    /// </summary>
+    /// <exception cref="InvalidOperationException"> if record not found</exception>
+    public static DeliveryChannelPolicy RetrieveDeliveryChannel(this IEnumerable<DeliveryChannelPolicy> policies, int customerId, string channel, string policy)
     {
         return policies.Single(p =>
             (p.Customer == customerId &&

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/QueryableExtensions.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/QueryableExtensions.cs
@@ -1,21 +1,23 @@
 ﻿using System.Collections.Generic;
 using DLCS.Model.Policies;
+using Microsoft.EntityFrameworkCore;
 
 namespace API.Features.DeliveryChannels.Helpers;
 
 public static class QueryableExtensions
 {
     private const int AdminCustomer = 1;
-    
+
     /// <summary>
     /// Find matching policy, this will be either (in order of precedence):
     /// Non system policy where channel and name match OR
     /// System policy where channel and name match.
     ///
-    /// NOTE: will throw InvalidOperationException if no match found
+    /// NOTE: will throw a <see cref="InvalidOperationException"/> if no match found
     /// </summary>
     /// <exception cref="InvalidOperationException"> if record not found</exception>
-    public static DeliveryChannelPolicy RetrieveDeliveryChannel(this IEnumerable<DeliveryChannelPolicy> policies, int customerId, string channel, string policy)
+    public static DeliveryChannelPolicy RetrieveDeliveryChannel(this IEnumerable<DeliveryChannelPolicy> policies,
+        int customerId, string channel, string policy)
     {
         return policies.Single(p =>
             (p.Customer == customerId &&
@@ -27,5 +29,18 @@ public static class QueryableExtensions
              p.System == true &&
              p.Channel == channel &&
              p.Name == policy));
+    }
+
+    /// <summary>
+    /// Find exact matching policy
+    /// </summary>
+    public static Task<DeliveryChannelPolicy?> GetDeliveryChannel(this IQueryable<DeliveryChannelPolicy> policies,
+        int customerId, string channel, string policy, CancellationToken cancellationToken)
+    {
+        return policies.SingleOrDefaultAsync(p =>
+                p.Customer == customerId &&
+                p.Channel == channel &&
+                p.Name == policy,
+            cancellationToken);
     }
 }

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/CreateDeliveryChannelPolicy.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/CreateDeliveryChannelPolicy.cs
@@ -1,5 +1,5 @@
-﻿using API.Features.DeliveryChannels.Validation;
-using API.Infrastructure.Requests;
+﻿using API.Infrastructure.Requests;
+using API.Infrastructure.Requests.Pipelines;
 using DLCS.Core;
 using DLCS.Model.Policies;
 using DLCS.Repository;
@@ -9,7 +9,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Features.DeliveryChannels.Requests.DeliveryChannelPolicies;
 
-public class CreateDeliveryChannelPolicy : IRequest<ModifyEntityResult<DeliveryChannelPolicy>>
+/// <summary>
+/// Create a new DeliveryChannelPolicy for specified customer
+/// </summary>
+public class CreateDeliveryChannelPolicy : IRequest<ModifyEntityResult<DeliveryChannelPolicy>>, IInvalidateCaches
 {
     public int CustomerId { get; }
     
@@ -20,13 +23,16 @@ public class CreateDeliveryChannelPolicy : IRequest<ModifyEntityResult<DeliveryC
         CustomerId = customerId;
         DeliveryChannelPolicy = deliveryChannelPolicy;
     }
+
+    public string[] InvalidatedCacheKeys => new[]
+        { CacheKeys.DeliveryChannelPolicies(CustomerId), CacheKeys.DefaultDeliveryChannels(CustomerId) };
 }
 
 public class CreateDeliveryChannelPolicyHandler : IRequestHandler<CreateDeliveryChannelPolicy, ModifyEntityResult<DeliveryChannelPolicy>>
 {
     private readonly DlcsContext dbContext;
     
-    public CreateDeliveryChannelPolicyHandler(DlcsContext dbContext, DeliveryChannelPolicyDataValidator policyDataValidator)
+    public CreateDeliveryChannelPolicyHandler(DlcsContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/GetDeliveryChannelPolicy.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/GetDeliveryChannelPolicy.cs
@@ -1,4 +1,5 @@
-﻿using API.Infrastructure.Requests;
+﻿using API.Features.DeliveryChannels.Helpers;
+using API.Infrastructure.Requests;
 using DLCS.Model.Policies;
 using DLCS.Repository;
 using MediatR;
@@ -33,10 +34,7 @@ public class GetDeliveryChannelPolicyHandler : IRequestHandler<GetDeliveryChanne
     {
         var deliveryChannelPolicy = await dbContext.DeliveryChannelPolicies
             .AsNoTracking()
-            .SingleOrDefaultAsync(p => 
-                p.Customer == request.CustomerId && 
-                p.Channel == request.DeliveryChannelName &&
-                p.Name == request.DeliveryChannelPolicyName,
+            .GetDeliveryChannel(request.CustomerId, request.DeliveryChannelName, request.DeliveryChannelPolicyName,
                 cancellationToken);
         
         return deliveryChannelPolicy == null 

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/GetDeliveryChannelPolicyCollections.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DeliveryChannelPolicies/GetDeliveryChannelPolicyCollections.cs
@@ -7,13 +7,11 @@ namespace API.Features.DeliveryChannels.Requests.DeliveryChannelPolicies;
 
 public class GetDeliveryChannelPolicyCollections: IRequest<Dictionary<string,string>>
 {
-    public int CustomerId { get; }
     public string BaseUrl { get; }
     public string JsonLdId { get; }
     
-    public GetDeliveryChannelPolicyCollections(int customerId, string baseUrl, string jsonLdId)
+    public GetDeliveryChannelPolicyCollections(string baseUrl, string jsonLdId)
     {
-        CustomerId = customerId;
         BaseUrl = baseUrl;
         JsonLdId = jsonLdId;
     }
@@ -21,21 +19,14 @@ public class GetDeliveryChannelPolicyCollections: IRequest<Dictionary<string,str
 
 public class GetDeliveryChannelPolicyCollectionsHandler : IRequestHandler<GetDeliveryChannelPolicyCollections, Dictionary<string,string>>
 {
-    private readonly DlcsContext dbContext;
-    
-    public GetDeliveryChannelPolicyCollectionsHandler(DlcsContext dbContext)
-    {
-        this.dbContext = dbContext;
-    }
-    
     public async Task<Dictionary<string,string>> Handle(GetDeliveryChannelPolicyCollections request, CancellationToken cancellationToken)
     {
         var policyCollections = new Dictionary<string, string>()
         {
-            {AssetDeliveryChannels.Image, "Policies for IIIF Image service delivery"},
-            {AssetDeliveryChannels.Thumbnails, "Policies for thumbnails as IIIF Image Services"},
-            {AssetDeliveryChannels.Timebased, "Policies for Audio and Video delivery"},
-            {AssetDeliveryChannels.File, "Policies for File delivery"}
+            { AssetDeliveryChannels.Image, "Policies for IIIF Image service delivery" },
+            { AssetDeliveryChannels.Thumbnails, "Policies for thumbnails as IIIF Image Services" },
+            { AssetDeliveryChannels.Timebased, "Policies for Audio and Video delivery" },
+            { AssetDeliveryChannels.File, "Policies for File delivery" }
         };
 
         return policyCollections;

--- a/src/protagonist/API/Infrastructure/HydraController.cs
+++ b/src/protagonist/API/Infrastructure/HydraController.cs
@@ -86,7 +86,7 @@ public abstract class HydraController : Controller
     /// <param name="errorTitle">The title of the error</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult"/> is not understood</exception>
-    ///<returns>
+    /// <returns>
     /// ActionResult generated from DeleteResult. This will be 204 on success. Or a Hydra
     /// error and appropriate status code if failed.
     /// </returns>
@@ -111,7 +111,7 @@ public abstract class HydraController : Controller
     /// <param name="errorTitle">The title of the error</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult"/> is not understood</exception>
-    ///<returns>
+    /// <returns>
     /// ActionResult generated from DeleteResult. This will be 204 on success. Or a Hydra
     /// error and appropriate status code if failed.
     /// </returns>
@@ -130,7 +130,7 @@ public abstract class HydraController : Controller
 
     private IActionResult ConvertDeleteToHttp(DeleteResult result, string? message)
     {
-        // Note: this is temporary until HandleDelete used for all deletions
+        // Note: this is temporary until DeleteResult used for all deletions
         return result switch
         {
             DeleteResult.NotFound => this.HydraNotFound(),

--- a/src/protagonist/API/Infrastructure/HydraController.cs
+++ b/src/protagonist/API/Infrastructure/HydraController.cs
@@ -86,8 +86,11 @@ public abstract class HydraController : Controller
     /// <param name="errorTitle">The title of the error</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult"/> is not understood</exception>
+    ///<returns>
     /// ActionResult generated from DeleteResult. This will be 204 on success. Or a Hydra
     /// error and appropriate status code if failed.
+    /// </returns>
+    /// <remarks>This will be replaced with overload that takes DeleteEntityResult in future</remarks>
     protected async Task<IActionResult> HandleDelete(
         IRequest<ResultMessage<DeleteResult>> request,
         string? errorTitle = "Delete failed",
@@ -97,19 +100,49 @@ public abstract class HydraController : Controller
         {
             var result = await Mediator.Send(request, cancellationToken);
 
-            return result.Value switch
-            {
-                DeleteResult.NotFound => this.HydraNotFound(),
-                DeleteResult.Conflict => this.HydraProblem(result.Message, null, 409,
-                    "Delete failed"),
-                DeleteResult.Error => this.HydraProblem(result.Message, null, 500,
-                    "Error when deleting"),
-                DeleteResult.Deleted => NoContent(),
-                _ => throw new ArgumentOutOfRangeException(nameof(DeleteResult),$"No deletion value of {result.Value}")
-            };
+            return ConvertDeleteToHttp(result.Value, result.Message);;
         }, errorTitle);
     }
     
+    /// <summary>
+    /// Handles a deletion, turning DeleteResult to a http response
+    /// </summary>
+    /// <param name="request">The request/response to be sent through Mediatr</param>
+    /// <param name="errorTitle">The title of the error</param>
+    /// <param name="cancellationToken">Current cancellation token</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <see cref="DeleteResult"/> is not understood</exception>
+    ///<returns>
+    /// ActionResult generated from DeleteResult. This will be 204 on success. Or a Hydra
+    /// error and appropriate status code if failed.
+    /// </returns>
+    protected async Task<IActionResult> HandleDelete(
+        IRequest<DeleteEntityResult> request,
+        string? errorTitle = "Delete failed",
+        CancellationToken cancellationToken = default)
+    {
+        return await HandleHydraRequest(async () =>
+        {
+            var result = await Mediator.Send(request, cancellationToken);
+
+            return ConvertDeleteToHttp(result.Value, result.Message);
+        }, errorTitle);
+    }
+
+    private IActionResult ConvertDeleteToHttp(DeleteResult result, string? message)
+    {
+        // Note: this is temporary until HandleDelete used for all deletions
+        return result switch
+        {
+            DeleteResult.NotFound => this.HydraNotFound(),
+            DeleteResult.Conflict => this.HydraProblem(message, null, 409,
+                "Delete failed"),
+            DeleteResult.Error => this.HydraProblem(message, null, 500,
+                "Error when deleting"),
+            DeleteResult.Deleted => NoContent(),
+            _ => throw new ArgumentOutOfRangeException(nameof(DeleteResult),$"No deletion value of {result}")
+        };
+    }
+
     /// <summary>
     /// Handle a GET request - this takes a IRequest which returns a FetchEntityResult{T}.
     /// The request is sent and result is transformed to an http hydra result.  

--- a/src/protagonist/API/Infrastructure/Requests/DeleteEntityResult.cs
+++ b/src/protagonist/API/Infrastructure/Requests/DeleteEntityResult.cs
@@ -1,0 +1,26 @@
+﻿using DLCS.Core;
+
+namespace API.Infrastructure.Requests;
+
+/// <summary>
+/// Represents the result of a request to delete an entity
+/// </summary>
+public class DeleteEntityResult : IModifyRequest
+{
+    /// <summary>
+    /// The associated value.
+    /// </summary>
+    public DeleteResult Value { get; private init; }
+    
+    /// <summary>
+    /// The message related to the result
+    /// </summary>
+    public string? Message { get; private init; }
+    
+    public bool IsSuccess => Value == DeleteResult.Deleted;
+    
+    public static DeleteEntityResult Success => new() { Value = DeleteResult.Deleted };
+
+    public static DeleteEntityResult Failure(string message, DeleteResult result) =>
+        new() { Message = message, Value = result };
+}

--- a/src/protagonist/API/Infrastructure/Requests/FetchEntityResult.cs
+++ b/src/protagonist/API/Infrastructure/Requests/FetchEntityResult.cs
@@ -3,7 +3,7 @@ namespace API.Infrastructure.Requests;
 /// <summary>
 /// Represents the result of a request to load an entity
 /// </summary>
-/// <typeparam name="T">Type of entity being modified</typeparam>
+/// <typeparam name="T">Type of entity being loaded</typeparam>
 public class FetchEntityResult<T>
     where T : class
 {

--- a/src/protagonist/API/Infrastructure/Requests/IModifyRequest.cs
+++ b/src/protagonist/API/Infrastructure/Requests/IModifyRequest.cs
@@ -1,0 +1,12 @@
+﻿namespace API.Infrastructure.Requests;
+
+/// <summary>
+/// Marker interface for operations that alter an underlying entity
+/// </summary>
+public interface IModifyRequest
+{
+    /// <summary>
+    /// Whether record is deemed as success or not
+    /// </summary>
+    bool IsSuccess { get; }
+}

--- a/src/protagonist/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/protagonist/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -6,7 +6,7 @@ namespace API.Infrastructure.Requests;
 /// Represents the result of a request to modify an entity
 /// </summary>
 /// <typeparam name="T">Type of entity being modified</typeparam>
-public class ModifyEntityResult<T>
+public class ModifyEntityResult<T> : IModifyRequest
     where T : class
 {
     /// <summary>
@@ -34,4 +34,38 @@ public class ModifyEntityResult<T>
 
     public static ModifyEntityResult<T> Success(T entity, WriteResult result = WriteResult.Updated)
         => new() { Entity = entity, WriteResult = result, IsSuccess = true };
+}
+
+/// <summary>
+/// Represents the result of a request to modify an entity
+/// </summary>
+public class DeleteEntityResult : IModifyRequest
+{
+    /// <summary>
+    /// The associated value.
+    /// </summary>
+    public DeleteResult Value { get; private init; }
+    
+    /// <summary>
+    /// The message related to the result
+    /// </summary>
+    public string? Message { get; private init; }
+    
+    public bool IsSuccess => Value == DeleteResult.Deleted;
+    
+    public static DeleteEntityResult Success => new() { Value = DeleteResult.Deleted };
+
+    public static DeleteEntityResult Failure(string message, DeleteResult result) =>
+        new() { Message = message, Value = result };
+}
+
+/// <summary>
+/// Marker interface for operations that alter an underlying entity
+/// </summary>
+public interface IModifyRequest
+{
+    /// <summary>
+    /// Whether record is deemed as success or not
+    /// </summary>
+    bool IsSuccess { get; }
 }

--- a/src/protagonist/API/Infrastructure/Requests/ModifyEntityResult.cs
+++ b/src/protagonist/API/Infrastructure/Requests/ModifyEntityResult.cs
@@ -35,37 +35,3 @@ public class ModifyEntityResult<T> : IModifyRequest
     public static ModifyEntityResult<T> Success(T entity, WriteResult result = WriteResult.Updated)
         => new() { Entity = entity, WriteResult = result, IsSuccess = true };
 }
-
-/// <summary>
-/// Represents the result of a request to modify an entity
-/// </summary>
-public class DeleteEntityResult : IModifyRequest
-{
-    /// <summary>
-    /// The associated value.
-    /// </summary>
-    public DeleteResult Value { get; private init; }
-    
-    /// <summary>
-    /// The message related to the result
-    /// </summary>
-    public string? Message { get; private init; }
-    
-    public bool IsSuccess => Value == DeleteResult.Deleted;
-    
-    public static DeleteEntityResult Success => new() { Value = DeleteResult.Deleted };
-
-    public static DeleteEntityResult Failure(string message, DeleteResult result) =>
-        new() { Message = message, Value = result };
-}
-
-/// <summary>
-/// Marker interface for operations that alter an underlying entity
-/// </summary>
-public interface IModifyRequest
-{
-    /// <summary>
-    /// Whether record is deemed as success or not
-    /// </summary>
-    bool IsSuccess { get; }
-}

--- a/src/protagonist/API/Infrastructure/Requests/Pipelines/CacheInvalidationBehaviour.cs
+++ b/src/protagonist/API/Infrastructure/Requests/Pipelines/CacheInvalidationBehaviour.cs
@@ -1,0 +1,52 @@
+﻿using LazyCache;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace API.Infrastructure.Requests.Pipelines;
+
+/// <summary>
+/// Interface for Mediatr requests that invalidate cache records on success 
+/// </summary>
+public interface IInvalidateCaches
+{
+    /// <summary>
+    /// Collection of cache keys invalidated by successful operation
+    /// </summary>
+    public string[] InvalidatedCacheKeys { get; }
+}
+
+/// <summary>
+/// MediatR behaviour that will clear cacheKeys specified in request if request was successful 
+/// </summary>
+public class CacheInvalidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IInvalidateCaches, IRequest<TResponse>
+    where TResponse : IModifyRequest
+{
+    private readonly IAppCache appCache;
+    private readonly ILogger<CacheInvalidationBehaviour<TRequest, TResponse>> logger;
+
+    public CacheInvalidationBehaviour(IAppCache appCache,
+        ILogger<CacheInvalidationBehaviour<TRequest, TResponse>> logger)
+    {
+        this.appCache = appCache;
+        this.logger = logger;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    {
+        var nextResponse = await next();
+
+        if (nextResponse.IsSuccess) InvalidateCacheKeys(request);
+
+        return nextResponse;
+    }
+
+    private void InvalidateCacheKeys(IInvalidateCaches request)
+    {
+        foreach (var cacheKey in request.InvalidatedCacheKeys)
+        {
+            logger.LogDebug("Invalidating cacheKey {CacheKey}", cacheKey);
+            appCache.Remove(cacheKey);
+        }
+    } 
+}

--- a/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
@@ -4,6 +4,7 @@ using API.Features.Assets;
 using API.Features.Customer;
 using API.Features.DeliveryChannels;
 using API.Features.DeliveryChannels.DataAccess;
+using API.Infrastructure.Requests.Pipelines;
 using DLCS.AWS.Configuration;
 using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;
@@ -50,14 +51,15 @@ public static class ServiceCollectionX
                 memoryCacheOptions.CompactionPercentage = cacheSettings.MemoryCacheCompactionPercentage;
             })
             .AddLazyCache();
-    
+
     /// <summary>
     /// Add MediatR services and pipeline behaviours to service collection.
     /// </summary>
     public static IServiceCollection ConfigureMediatR(this IServiceCollection services)
         => services
             .AddMediatR(typeof(Startup))
-            .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+            .AddScoped(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>))
+            .AddScoped(typeof(IPipelineBehavior<,>), typeof(CacheInvalidationBehaviour<,>));
     
     /// <summary>
     /// Add required AWS services

--- a/src/protagonist/DLCS.Core.Tests/Collections/CollectionXTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/Collections/CollectionXTests.cs
@@ -143,4 +143,14 @@ public class CollectionXTests
 
         coll.ContainsOnly(123).Should().BeTrue();
     }
+    
+    [Fact]
+    public void AsArray_ReturnsExpected()
+    {
+        var item = DateTime.Now;
+
+        var list = item.AsArray();
+
+        list.Should().ContainSingle(i => i == item);
+    }
 }

--- a/src/protagonist/DLCS.Core/Collections/CollectionX.cs
+++ b/src/protagonist/DLCS.Core/Collections/CollectionX.cs
@@ -81,4 +81,12 @@ public static class CollectionX
             .GroupBy(m => m)
             .Where(g => g.Count() > 1)
             .Select(g => g.Key);
+
+    /// <summary>
+    /// Return an Array of {T} containing single item.
+    /// </summary>
+    /// <param name="item">Item to add to list</param>
+    /// <typeparam name="T">Type of item</typeparam>
+    /// <returns>List of one item</returns>
+    public static T[] AsArray<T>(this T item) => new T[] { item };
 }

--- a/src/protagonist/DLCS.Repository/CacheKeys.cs
+++ b/src/protagonist/DLCS.Repository/CacheKeys.cs
@@ -6,4 +6,6 @@
 public static class CacheKeys
 {
     public static string Customer(int customerId) => $"cust:{customerId}";
+    
+    public static string DefaultDeliveryChannels(int customerId) => $"defaultDeliveryChannels:{customerId}";
 }

--- a/src/protagonist/DLCS.Repository/CacheKeys.cs
+++ b/src/protagonist/DLCS.Repository/CacheKeys.cs
@@ -8,4 +8,6 @@ public static class CacheKeys
     public static string Customer(int customerId) => $"cust:{customerId}";
     
     public static string DefaultDeliveryChannels(int customerId) => $"defaultDeliveryChannels:{customerId}";
+
+    public static string DeliveryChannelPolicies(int customerId) => $"deliveryChannelPolicies:{customerId}";
 }


### PR DESCRIPTION
Resolves #798, tracks WDC-75

Invalidate caches when DeliveryChannelPolicy or DefaultDeliveryChannelPolicy create/update/delete request is successful:
* DefaultDeliveryChannelPolicy updates invalidate defaultDeliveryChannel cache for customer
* DeliveryChannelPolicy updates invalidate deliveryChannelPolicy cache + defaultDeliveryChannel (as this loads policy) cache for customer

Added following to achieve this:
* `IInvalidateCaches` - interface for mediatr commands. Has a single `string[]` property that lists keys to invalidate when command is successful.
* `IModifyRequest` - interface for mediatr command return type. `ModifyEntityResult` uses this as does new `DeleteEntityResult`.
* `DeleteEntityResult` - replaces use of `ResultMessage<DeleteResult>` for return type in delete operations, latter makes it more difficult to determine success/failure in pipeline as `ResultMessage<T>` is a general return type that could be used for other responses.
* `CacheInvalidationBehaviour` - when command is `IInvalidateCaches` and request is `IModifyRequest` the caches specified by latter will be invalidate on success.

Cache keys use when caching and invalidation are now in `CacheKeys` - eventually all keys should be moved to here.