### PR TITLE
Populate missing deliveryChannel payloads in API results

### DIFF
--- a/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
@@ -233,6 +233,6 @@ public class AssetConverterTests
         var hydraAsset = assetPreparationResult.UpdatedAsset!.ToHydra(dlcsAssetUrlRoot);
         
         // Assert
-        hydraAsset.WcDeliveryChannels.Should().BeEquivalentTo("iiif-img", "iiif-av", "file");
+        hydraAsset.WcDeliveryChannels.Should().BeEquivalentTo("iiif-img", "thumbs", "file");
     }
 }

--- a/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/AssetConverterTests.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Collections.Generic;
 using API.Converters;
 using API.Exceptions;
 using DLCS.Core.Types;
 using DLCS.HydraModel;
+using DLCS.Model.Assets;
+using AssetFamily = DLCS.HydraModel.AssetFamily;
+using DeliveryChannelPolicy = DLCS.Model.Policies.DeliveryChannelPolicy;
 
 namespace API.Tests.Converters;
 
@@ -179,5 +183,56 @@ public class AssetConverterTests
         
         // Assert
         asset.DeliveryChannels.Should().BeInAscendingOrder();
+    }
+    
+    [Fact]
+    public void ToHydraModel_Converts_ImageDeliveryChannels_To_WcDeliveryChannels()
+    {
+        // Arrange
+        var dlcsAssetId = new AssetId(0, 1, "test-asset");
+        var dlcsAssetUrlRoot = new UrlRoots()
+        {
+            BaseUrl = "https://api.example.com/",
+            ResourceRoot = "https://resource.example.com/"
+        };
+        var dlcsAsset = new Asset(dlcsAssetId)
+        {
+            Origin = "https://example-origin.com/my-image.jpeg",
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+            {
+                new()
+                {
+                    Channel = "iiif-img",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                    {
+                        Name = "img-policy"
+                    }
+                },
+                new()
+                {
+                    Channel = "thumbs",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                    {
+                        Name = "thumbs-policy"
+                    }
+                },
+                new()
+                {
+                    Channel = "file",
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                    {
+                        Name = "none",
+                    }
+                }
+            }
+        };
+        var assetPreparationResult = AssetPreparer.PrepareAssetForUpsert(null, dlcsAsset, false,
+            false, new []{' '});
+        
+        // Act
+        var hydraAsset = assetPreparationResult.UpdatedAsset!.ToHydra(dlcsAssetUrlRoot);
+        
+        // Assert
+        hydraAsset.WcDeliveryChannels.Should().BeEquivalentTo("iiif-img", "iiif-av", "file");
     }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueWithOldDeliveryChannelEmulationTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueWithOldDeliveryChannelEmulationTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Text;
 using API.Tests.Integration.Infrastructure;
 using DLCS.Repository;
+using DLCS.Repository.Assets;
 using DLCS.Repository.Messaging;
 using FakeItEasy;
 using Microsoft.AspNetCore.Authentication;
@@ -75,8 +76,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -117,8 +117,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -158,8 +157,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -199,8 +197,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -240,8 +237,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -281,8 +277,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(
@@ -322,8 +317,7 @@ public class CustomerQueueWithOldDeliveryChannelEmulationTests : IClassFixture<P
         response.StatusCode.Should().Be(HttpStatusCode.Created);
 
         var assetInDatabase = await dbContext.Images
-            .Include(a => a.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .SingleAsync(a => a.Customer == customerId && a.Space == space);
         
         assetInDatabase.ImageDeliveryChannels.Should().Satisfy(

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -1166,9 +1166,9 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange 
         var assetId = new AssetId(99, 1, 
             $"{nameof(Patch_Asset_Leaves_ImageDeliveryChannels_Intact_WhenDeliveryChannelsNull)}");
-        await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.File, 
-            origin: "https://files.org/example.pdf",
-            imageDeliveryChannels: new List<ImageDeliveryChannel>()
+        
+        await dbContext.Images.AddTestAsset(assetId, customer: 99, space: 1, family: AssetFamily.Image, 
+            origin: "https://files.org/example.jpeg", imageDeliveryChannels: new List<ImageDeliveryChannel>()
             {
                 new()
                 {
@@ -1472,12 +1472,13 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Patch_Images_Leaves_ImageDeliveryChannels_Intact_WhenDeliveryChannelsNull()
     {
+        // Arrange
         await dbContext.Spaces.AddTestSpace(99, 3004);
         
         var assetId = AssetId.FromString($"99/3003/{nameof(Patch_Images_Leaves_ImageDeliveryChannels_Intact_WhenDeliveryChannelsNull)}");
         
-        await dbContext.Images.AddTestAsset(assetId, customer: 99, space: 3004, 
-            imageDeliveryChannels: new List<ImageDeliveryChannel>()
+        await dbContext.Images.AddTestAsset(assetId, customer: 99, space: 3004, family: AssetFamily.Image, 
+            origin: "https://files.org/example.jpeg", imageDeliveryChannels: new List<ImageDeliveryChannel>() 
         {
             new()
             {
@@ -1507,11 +1508,11 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
            }}]
         }}";
                 
-        // act
+        // Act
         var content = new StringContent(hydraCollectionBody, Encoding.UTF8, "application/json");
         var response = await httpClient.AsCustomer(99).PatchAsync("/customers/99/spaces/3004/images", content);
 
-        // assert
+        // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         
         var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels)

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -58,7 +58,6 @@ public static class AssetConverter
             MediaType = dbAsset.MediaType,
             Family = (AssetFamily)dbAsset.Family,
             Roles = dbAsset.RolesList.ToArray(),
-            WcDeliveryChannels = ConvertImageDeliveryChannelsToWc(dbAsset.ImageDeliveryChannels)
         };
 
         if (dbAsset.Batch > 0)
@@ -87,6 +86,7 @@ public static class AssetConverter
                         ? c.DeliveryChannelPolicy.Name
                         : $"{urlRoots.BaseUrl}/customers/{c.DeliveryChannelPolicy.Customer}/deliveryChannelPolicies/{c.Channel}/{c.DeliveryChannelPolicy.Name}"
                 }).ToArray();
+            image.WcDeliveryChannels = ConvertImageDeliveryChannelsToWc(dbAsset.ImageDeliveryChannels);
         }
         else
         {
@@ -425,6 +425,8 @@ public static class AssetConverter
     /// Converts ImageDeliveryChannels into the old format (WcDeliveryChannels)
     /// </summary>
     /// <param name="imageDeliveryChannels"></param>
-    public static string[] ConvertImageDeliveryChannelsToWc(ICollection<ImageDeliveryChannel> imageDeliveryChannels)
-        => imageDeliveryChannels.Select(dc => dc.Channel).ToArray();
+    private static string[] ConvertImageDeliveryChannelsToWc(ICollection<ImageDeliveryChannel>? imageDeliveryChannels)
+        => imageDeliveryChannels.IsNullOrEmpty() 
+            ? Array.Empty<string>() 
+            : imageDeliveryChannels.Select(dc => dc.Channel).ToArray();
 }

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -424,9 +424,6 @@ public static class AssetConverter
     /// <summary>
     /// Converts ImageDeliveryChannels into the old format (WcDeliveryChannels)
     /// </summary>
-    /// <param name="imageDeliveryChannels"></param>
-    private static string[] ConvertImageDeliveryChannelsToWc(ICollection<ImageDeliveryChannel>? imageDeliveryChannels)
-        => imageDeliveryChannels.IsNullOrEmpty() 
-            ? Array.Empty<string>() 
-            : imageDeliveryChannels.Select(dc => dc.Channel).ToArray();
+    private static string[] ConvertImageDeliveryChannelsToWc(ICollection<ImageDeliveryChannel> imageDeliveryChannels)
+        => imageDeliveryChannels.Select(dc => dc.Channel).ToArray();
 }

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using API.Exceptions;
 using DLCS.Core.Collections;
 using DLCS.Core.Strings;
@@ -57,7 +58,7 @@ public static class AssetConverter
             MediaType = dbAsset.MediaType,
             Family = (AssetFamily)dbAsset.Family,
             Roles = dbAsset.RolesList.ToArray(),
-            WcDeliveryChannels = dbAsset.DeliveryChannels
+            WcDeliveryChannels = ConvertImageDeliveryChannelsToWc(dbAsset.ImageDeliveryChannels)
         };
 
         if (dbAsset.Batch > 0)
@@ -419,4 +420,11 @@ public static class AssetConverter
 
         return assetFilter;
     }
+
+    /// <summary>
+    /// Converts ImageDeliveryChannels into the old format (WcDeliveryChannels)
+    /// </summary>
+    /// <param name="imageDeliveryChannels"></param>
+    public static string[] ConvertImageDeliveryChannelsToWc(ICollection<ImageDeliveryChannel> imageDeliveryChannels)
+        => imageDeliveryChannels.Select(dc => dc.Channel).ToArray();
 }

--- a/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
+++ b/src/protagonist/API/Features/Assets/ApiAssetRepository.cs
@@ -41,8 +41,7 @@ public class ApiAssetRepository : IApiAssetRepository
 
         Task<Asset?> LoadAssetFromDb(AssetId id) =>
             images
-                .Include(i => i.ImageDeliveryChannels)
-                .ThenInclude(i => i.DeliveryChannelPolicy)
+                .IncludeDeliveryChannelsWithPolicy()
                 .SingleOrDefaultAsync(i => i.Id == id);
 
         if (noCache) assetCachingHelper.RemoveAssetFromCache(assetId);

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -3,6 +3,7 @@ using API.Features.Customer.Validation;
 using API.Infrastructure.Requests;
 using DLCS.Model.Assets;
 using DLCS.Repository;
+using DLCS.Repository.Assets;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -40,8 +41,7 @@ public class GetMultipleImagesByIdHandler
 
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
-            .Include(i => i.ImageDeliveryChannels)
-            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .IncludeDeliveryChannelsWithPolicy()
             .ToListAsync(cancellationToken);
 
         return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -40,6 +40,7 @@ public class GetMultipleImagesByIdHandler
 
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
+            .Include(i => i.ImageDeliveryChannels)
             .ToListAsync(cancellationToken);
 
         return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -42,6 +42,7 @@ public class GetMultipleImagesByIdHandler
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
             .IncludeDeliveryChannelsWithPolicy()
+            .AsSplitQuery()
             .ToListAsync(cancellationToken);
 
         return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -41,6 +41,7 @@ public class GetMultipleImagesByIdHandler
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
             .Include(i => i.ImageDeliveryChannels)
+            .ThenInclude(dc => dc.DeliveryChannelPolicy)
             .ToListAsync(cancellationToken);
 
         return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);

--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -59,6 +59,8 @@ public class DeliveryChannelProcessor
 
     private bool DeliveryChannelsRequireReprocessing(Asset originalAsset, DeliveryChannelsBeforeProcessing[] deliveryChannelsBeforeProcessing)
     {
+        // PUT prevents empty delivery channels from being passed here, but PATCH doesn't
+        if (deliveryChannelsBeforeProcessing.IsNullOrEmpty()) return false;
         if (originalAsset.ImageDeliveryChannels.Count != deliveryChannelsBeforeProcessing.Length) return true;
         
         foreach (var deliveryChannel in deliveryChannelsBeforeProcessing)

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -51,6 +51,7 @@ public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntity
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
                 .Include(a => a.ImageDeliveryChannels)
+                .ThenInclude(dc => dc.DeliveryChannelPolicy)
                 .ApplyAssetFilter(request.AssetFilter, true),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -50,6 +50,7 @@ public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
+                .Include(a => a.ImageDeliveryChannels)
                 .ApplyAssetFilter(request.AssetFilter, true),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -50,8 +50,7 @@ public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
-                .Include(a => a.ImageDeliveryChannels)
-                .ThenInclude(dc => dc.DeliveryChannelPolicy)
+                .IncludeDeliveryChannelsWithPolicy()
                 .ApplyAssetFilter(request.AssetFilter, true),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -50,8 +50,9 @@ public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
+                .ApplyAssetFilter(request.AssetFilter, true)
                 .IncludeDeliveryChannelsWithPolicy()
-                .ApplyAssetFilter(request.AssetFilter, true),
+                .AsSplitQuery(),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);
 

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -62,6 +62,7 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Space == request.SpaceId)
+                .Include(a => a.ImageDeliveryChannels)
                 .ApplyAssetFilter(request.AssetFilter),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -63,6 +63,7 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, FetchEntity
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Space == request.SpaceId)
                 .Include(a => a.ImageDeliveryChannels)
+                .ThenInclude(dc => dc.DeliveryChannelPolicy)
                 .ApplyAssetFilter(request.AssetFilter),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -62,8 +62,7 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Space == request.SpaceId)
-                .Include(a => a.ImageDeliveryChannels)
-                .ThenInclude(dc => dc.DeliveryChannelPolicy)
+                .IncludeDeliveryChannelsWithPolicy()
                 .ApplyAssetFilter(request.AssetFilter),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -62,8 +62,9 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, FetchEntity
             request,
             i => i
                 .Where(a => a.Customer == request.CustomerId && a.Space == request.SpaceId)
+                .ApplyAssetFilter(request.AssetFilter)
                 .IncludeDeliveryChannelsWithPolicy()
-                .ApplyAssetFilter(request.AssetFilter),
+                .AsSplitQuery(),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);
         

--- a/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 using DLCS.Model.Page;
+using Microsoft.EntityFrameworkCore;
 
 namespace DLCS.Repository.Assets;
 
@@ -114,4 +115,11 @@ public static class AssetQueryX
 
         return filtered;
     }
+    
+    /// <summary>
+    /// Include asset delivery channels and their associated policies.
+    /// </summary>
+    public static IQueryable<Asset> IncludeDeliveryChannelsWithPolicy(this IQueryable<Asset> assetQuery)
+        => assetQuery.Include(a => a.ImageDeliveryChannels)
+            .ThenInclude(dc => dc.DeliveryChannelPolicy);
 }

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -4,6 +4,7 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Storage;
 using DLCS.Repository;
+using DLCS.Repository.Assets;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -83,8 +84,7 @@ public class EngineAssetRepository : IEngineAssetRepository
     }
 
     public ValueTask<Asset?> GetAsset(AssetId assetId, CancellationToken cancellationToken = default)
-        => new(dlcsContext.Images.Include(i => i.ImageDeliveryChannels)
-            .ThenInclude(i => i.DeliveryChannelPolicy)
+        => new(dlcsContext.Images.IncludeDeliveryChannelsWithPolicy()
             .SingleOrDefaultAsync(i => i.Id == assetId, cancellationToken));
 
     public async Task<long?> GetImageSize(AssetId assetId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Resolves #796

This PR fixes a problem where a few API routes that return a Hydra asset (either alone or in a collection) would leave `deliveryChannels` blank. It also updates the `.ToHydra()` method to convert the asset's `ImageDeliveryChannels` into `wcDeliveryChannels`.

It also fixes a bug where updating an asset via PATCH without specifying any delivery channels would wipe those currently assigned to it from the DB.