### PR TITLE
Ensure s.json ordering

### DIFF
--- a/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -111,8 +111,6 @@ public static class ThumbnailCalculator
 
     private static ResizableSize GetLongestEdgeAndSize(List<Size> sizes, ImageRequest imageRequest)
     {
-        // TODO - handle there being none "open"?
-        
         var sizeCandidate = GetLongestEdge(sizes, imageRequest);
         
         if (sizeCandidate.KnownSize)

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -107,6 +107,54 @@ public class ThumbCreatorTests
     }
     
     [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_LargestFirst()
+    {
+        // Arrange
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, MaxUnauthorised = -1,
+            ImageDeliveryChannels = thumbsDeliveryChannel
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" },
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+        };
+        
+        const string thumbSizes = "{\"o\":[[606,1000],[302,500],[60,100]],\"a\":[]}";
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(3);
+
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/low.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/1000.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents(thumbSizes);
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+        A.CallTo(() =>
+            assetApplicationMetadataRepository.UpsertApplicationMetadata(assetId, "ThumbSizes", thumbSizes,
+                A<CancellationToken>._)).MustHaveHappened();
+    }
+    
+    [Fact]
     public async Task CreateNewThumbs_UploadsExpected_LargestAuth()
     {
         // Arrange

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -1,9 +1,10 @@
 ﻿using System.Net;
 using DLCS.Core.Exceptions;
 using DLCS.Core.FileSystem;
+using DLCS.Core.Types;
 using Engine.Ingest.Image.ImageServer.Manipulation;
-using Engine.Settings;
-using Microsoft.Extensions.Options;
+using IIIF;
+using IIIF.ImageApi;
 
 namespace Engine.Ingest.Image.ImageServer.Clients;
 
@@ -32,6 +33,8 @@ public class CantaloupeThumbsClient : ICantaloupeThumbsClient
         CancellationToken cancellationToken = default)
     {
         var thumbsResponse = new List<ImageOnDisk>();
+        var imageSize = new Size(context.Asset.Width ?? 0, context.Asset.Height ?? 0);
+        var assetId = context.AssetId;
 
         const string pathReplacement = "%2f";
         var convertedS3Location = context.ImageLocation.S3.Replace("/", pathReplacement);
@@ -39,38 +42,27 @@ public class CantaloupeThumbsClient : ICantaloupeThumbsClient
         var count = 0;
         foreach (var size in thumbSizes)
         {
+            ++count;
             using var response =
                 await cantaloupeClient.GetAsync(
                     $"iiif/3/{convertedS3Location}/full/{size}/0/default.jpg", cancellationToken);
-
+            
             if (response.StatusCode == HttpStatusCode.BadRequest)
             {
                 // This is likely an error for the individual thumb size, so just continue
-                await LogErrorResponse(response, LogLevel.Information, cancellationToken);
+                await LogErrorResponse(response, assetId, size, LogLevel.Information, cancellationToken);
                 continue;
             }
             
             if (response.IsSuccessStatusCode)
             {
-                await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-
-                var localThumbsPath = Path.Join(thumbFolder, $"thumb{++count}");
-                logger.LogDebug("Saving thumb for {ThumbSize} to {ThumbLocation}", size, localThumbsPath);
-                
-                await fileSystem.CreateFileFromStream(localThumbsPath, responseStream, cancellationToken);
-                
-                using var image = await imageManipulator.LoadAsync(localThumbsPath, cancellationToken);
-
-                thumbsResponse.Add(new ImageOnDisk()
-                {
-                    Path = localThumbsPath,
-                    Width = image.Width,
-                    Height = image.Height
-                });
+                var imageOnDisk = await SaveImageToDisk(response, size, thumbFolder, count, cancellationToken);
+                thumbsResponse.Add(imageOnDisk);
+                ValidateReturnedSize(size, Math.Max(imageOnDisk.Width, imageOnDisk.Height), imageSize, assetId);
             }
             else
             {
-                await LogErrorResponse(response, LogLevel.Error, cancellationToken);
+                await LogErrorResponse(response, assetId, size, LogLevel.Error, cancellationToken);
                 throw new HttpException(response.StatusCode, "failed to retrieve data from the thumbs processor");
             }
         }
@@ -78,10 +70,45 @@ public class CantaloupeThumbsClient : ICantaloupeThumbsClient
         return thumbsResponse;
     }
 
-    private async Task LogErrorResponse(HttpResponseMessage response, LogLevel logLevel, CancellationToken cancellationToken)
+    private async Task<ImageOnDisk> SaveImageToDisk(HttpResponseMessage response, string size, string thumbFolder,
+        int count, CancellationToken cancellationToken)
+    {
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+        var localThumbsPath = Path.Join(thumbFolder, $"thumb{count}");
+        logger.LogDebug("Saving thumb for {ThumbSize} to {ThumbLocation}", size, localThumbsPath);
+                
+        await fileSystem.CreateFileFromStream(localThumbsPath, responseStream, cancellationToken);
+                
+        using var image = await imageManipulator.LoadAsync(localThumbsPath, cancellationToken);
+
+        var imageOnDisk = new ImageOnDisk
+        {
+            Path = localThumbsPath,
+            Width = image.Width,
+            Height = image.Height
+        };
+        return imageOnDisk;
+    }
+
+    private async Task LogErrorResponse(HttpResponseMessage response, AssetId assetId, string size, LogLevel logLevel, CancellationToken cancellationToken)
     {
         var errorResponse = await response.Content.ReadAsStringAsync(cancellationToken);
-        logger.Log(logLevel, "Cantaloupe responded with status code {StatusCode} and body {ErrorResponse}",
-            response.StatusCode, errorResponse);
+        logger.Log(logLevel,
+            "Cantaloupe responded with status code {StatusCode} when processing Asset {AssetId}, size '{Size}' and body {ErrorResponse}",
+            response.StatusCode, assetId, size, errorResponse);
+    }
+    
+    private void ValidateReturnedSize(string sizeParam, int actualMaxDimension, Size originSize, AssetId assetId)
+    {
+        var sizeParameter = SizeParameter.Parse(sizeParam);
+        var expectedSize = sizeParameter.GetResultingSize(originSize);
+        var expectedMax = expectedSize.MaxDimension;
+        if (expectedMax != actualMaxDimension)
+        {
+            logger.LogWarning(
+                "Possible size mismatch for asset {AssetId}, size {Size}. Expected maxDimension to be {ExpectedMax} but got {ActualMax}",
+                assetId, sizeParam, expectedMax, actualMaxDimension);
+        }
     }
 }


### PR DESCRIPTION
Main change in PR is an update to `ThumbCreator` to reintroduce behaviour to ensure thumb sizes in `s.json` are ordered from largest -> smallest (determined by longest edge as we are not supporting thumb sizes that mutate aspect ratio). This is the single point where `s.json` and `AssetApplicationMetadata` are written so removes need for any callers to reorder. e.g. 

`ThumbnailCalculator` expects sizes to be ordered and without this it doesn't properly identify larger/smaller sizes for Orchestrator optimisations.

Second change was to log a warning in `CantaloupeThumbsClient` if the returned MaxDimension does not match the expected MaxDimension.