### PR TITLE
Handle size mismatches when generating thumbs

### DIFF
--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
@@ -3,13 +3,12 @@ using DLCS.Core.Exceptions;
 using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using Engine.Ingest.Image;
 using Engine.Ingest.Image.ImageServer.Clients;
-using Engine.Ingest.Image.ImageServer.Manipulation;
-using Engine.Settings;
+using Engine.Ingest.Image.ImageServer.Measuring;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
 using Test.Helpers.Http;
-using Test.Helpers.Settings;
 
 namespace Engine.Tests.Ingest.Image.ImageServer.Clients;
 
@@ -17,6 +16,7 @@ public class CantaloupeThumbsClientTests
 {
     private readonly ControllableHttpMessageHandler httpHandler;
     private readonly CantaloupeThumbsClient sut;
+    private readonly IImageMeasurer imageMeasurer;
 
     private readonly List<string> defaultThumbs = new()
     {
@@ -29,22 +29,24 @@ public class CantaloupeThumbsClientTests
     {
         httpHandler = new ControllableHttpMessageHandler();
         var fileSystem = A.Fake<IFileSystem>();
-        var imageManipulator = A.Fake<IImageManipulator>();
+        imageMeasurer = A.Fake<IImageMeasurer>();
 
         var httpClient = new HttpClient(httpHandler);
         httpClient.BaseAddress = new Uri("http://image-processor/");
-        sut = new CantaloupeThumbsClient(httpClient, fileSystem, imageManipulator, new NullLogger<CantaloupeThumbsClient>());
+        sut = new CantaloupeThumbsClient(httpClient, fileSystem, imageMeasurer, new NullLogger<CantaloupeThumbsClient>());
     }
     
     [Fact]
-    public async Task GenerateThumbnails_ReturnsSuccessfulResponse_WhenOk()
+    public async Task GenerateThumbnails_ReturnsThumbForSuccessfulResponse()
     {
         // Arrange
-        var assetId = new AssetId(2, 1, nameof(GenerateThumbnails_ReturnsSuccessfulResponse_WhenOk));
+        var assetId = new AssetId(2, 1, nameof(GenerateThumbnails_ReturnsThumbForSuccessfulResponse));
         var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
         httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK));
+        context.Asset.Width = 2000;
+        context.Asset.Height = 2000;
 
-        context.WithLocation(new ImageLocation()
+        context.WithLocation(new ImageLocation
         {
             S3 = "//some/location/with/s3"
         });
@@ -54,7 +56,8 @@ public class CantaloupeThumbsClientTests
 
         // Assert
         thumbs.Should().HaveCount(1);
-        thumbs[0].Path.Should().Be($"{Path.DirectorySeparatorChar}thumbs{Path.DirectorySeparatorChar}thumb1");
+        thumbs[0].Height.Should().Be(1024);
+        thumbs[0].Width.Should().Be(1024);
     }
     
     [Fact]
@@ -103,6 +106,8 @@ public class CantaloupeThumbsClientTests
         // Arrange
         var assetId = new AssetId(2, 1, nameof(GenerateThumbnails_Ignores400_AndProcessesRest));
         var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
+        context.Asset.Width = 200;
+        context.Asset.Height = 200;
 
         var thumbSizes = new List<string> { "!1024,1024", "!400,400" };
         
@@ -110,7 +115,7 @@ public class CantaloupeThumbsClientTests
         httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.BadRequest));
         httpHandler.RegisterCallback(_ => httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK)));
 
-        context.WithLocation(new ImageLocation()
+        context.WithLocation(new ImageLocation
         {
             S3 = "//some/location/with/s3"
         });
@@ -120,6 +125,132 @@ public class CantaloupeThumbsClientTests
 
         // Assert
         thumbs.Should().HaveCount(1);
-        thumbs[0].Path.Should().Be($"{Path.DirectorySeparatorChar}thumbs{Path.DirectorySeparatorChar}thumb2");
+        thumbs[0].Height.Should().Be(200);
+        thumbs[0].Width.Should().Be(200);
+    }
+
+    [Theory]
+    [MemberData(nameof(ThumbsAndResults))]
+    public async Task GenerateThumbnails_SizeHandling(Dictionary<string, ImageOnDiskResults> thumbsAndResult, int width,
+        int height, string reason)
+    {
+        // Arrange
+        var assetId = new AssetId(2, 1, nameof(GenerateThumbnails_SizeHandling));
+        var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
+        context.Asset.Width = width;
+        context.Asset.Height = height;
+
+        httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK));
+        httpHandler.RegisterCallback(_ => httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK)));
+
+        var thumbSizes = thumbsAndResult.Keys.ToList();
+        var expected = thumbsAndResult.Values.Select(v => v.Expected).ToList();
+        var fromImageServer = thumbsAndResult.Values.Select(v => v.ReturnedFromImageServer).ToArray();
+
+        A.CallTo(() => imageMeasurer.MeasureImage(A<string>._, A<CancellationToken>._))
+            .ReturnsNextFromSequence(fromImageServer);
+
+        context.WithLocation(new ImageLocation
+        {
+            S3 = "//some/location/with/s3"
+        });
+
+        // Act
+        var thumbs = await sut.GenerateThumbnails(context, thumbSizes, ThumbsRoot);
+
+        // Assert
+        thumbs.Should().BeEquivalentTo(expected, reason);
+    }
+
+    public static IEnumerable<object[]> ThumbsAndResults => new List<object[]>
+    {
+        new object[]
+        {
+            new Dictionary<string, ImageOnDiskResults>
+            {
+                ["!200,200"] = new(new ImageOnDisk { Width = 100, Height = 200 }), // matching
+                ["!250,250"] = new(new ImageOnDisk { Width = 124, Height = 250 }), // down by one on shortest edge 
+                ["!100,100"] = new(new ImageOnDisk { Width = 51, Height = 100 }), // up by one on shortest edge
+                ["200,"] = new(new ImageOnDisk { Width = 200, Height = 400 }), // matching
+                ["250,"] = new(new ImageOnDisk { Width = 250, Height = 499 }), // down by one on non-confined dimension 
+                ["100,"] = new(new ImageOnDisk { Width = 100, Height = 201 }), // up by one on non-confined dimension
+                [",200"] = new(new ImageOnDisk { Width = 100, Height = 200 }), // matching
+                [",250"] = new(new ImageOnDisk { Width = 124, Height = 250 }), // down by one on non-confined dimension 
+                [",100"] = new(new ImageOnDisk { Width = 51, Height = 100 }), // up by one on non-confined dimension
+            },
+            1000,
+            2000,
+            "Portrait images - valid sizes untouched",
+        },
+        new object[]
+        {
+            new Dictionary<string, ImageOnDiskResults>
+            {
+                ["!250,250"] = new(new ImageOnDisk { Width = 125, Height = 249 },
+                    new() { Width = 125, Height = 250 }), // down by one on shortest edge 
+                ["!100,100"] = new(new ImageOnDisk { Width = 50, Height = 101 },
+                    new() { Width = 50, Height = 100 }), // up by one on longest edge
+                ["250,"] = new(new ImageOnDisk { Width = 249, Height = 500 },
+                    new() { Width = 250, Height = 500 }), // down by one on confined dimension 
+                ["100,"] = new(new ImageOnDisk { Width = 101, Height = 200 },
+                    new() { Width = 100, Height = 200 }), // up by one on confined dimension
+                [",250"] = new(new ImageOnDisk { Width = 125, Height = 251 },
+                    new() { Width = 125, Height = 250 }), // down by one on confined dimension 
+                [",100"] = new(new ImageOnDisk { Width = 50, Height = 101 },
+                    new() { Width = 50, Height = 100 }), // up by one on confined dimension
+            },
+            1000,
+            2000,
+            "Portrait images - invalid sizes altered",
+        },
+        new object[]
+        {
+            new Dictionary<string, ImageOnDiskResults>
+            {
+                ["!200,200"] = new(new ImageOnDisk { Width = 200, Height = 100 }), // matching
+                ["!250,250"] = new(new ImageOnDisk { Width = 250, Height = 124 }), // down by one on shortest edge 
+                ["!100,100"] = new(new ImageOnDisk { Width = 100, Height = 51 }), // up by one on shortest edge
+                ["200,"] = new(new ImageOnDisk { Width = 400, Height = 200 }), // matching
+                ["250,"] = new(new ImageOnDisk { Width = 400, Height = 250 }), // down by one on non-confined dimension 
+                ["100,"] = new(new ImageOnDisk { Width = 201, Height = 100 }), // up by one on non-confined dimension
+                [",200"] = new(new ImageOnDisk { Width = 200, Height = 100 }), // matching
+                [",250"] = new(new ImageOnDisk { Width = 250, Height = 124 }), // down by one on non-confined dimension 
+                [",100"] = new(new ImageOnDisk { Width = 100, Height = 51 }), // up by one on non-confined dimension
+            },
+            2000,
+            1000,
+            "Landscape images - valid sizes untouched",
+        },
+        new object[]
+        {
+            new Dictionary<string, ImageOnDiskResults>
+            {
+                ["!250,250"] = new(new ImageOnDisk { Width = 249, Height = 125 },
+                    new() { Width = 250, Height = 125 }), // down by one on shortest edge 
+                ["250,"] = new(new ImageOnDisk { Width = 500, Height = 249 },
+                    new() { Width = 500, Height = 250 }), // down by one on confined dimension 
+                ["100,"] = new(new ImageOnDisk { Width = 200, Height = 101 },
+                    new() { Width = 200, Height = 100 }), // up by one on confined dimension
+                [",250"] = new(new ImageOnDisk { Width = 251, Height = 125 },
+                    new() { Width = 250, Height = 125 }), // down by one on confined dimension 
+                [",100"] = new(new ImageOnDisk { Width = 101, Height = 50 },
+                    new() { Width = 100, Height = 50 }), // up by one on confined dimension
+            },
+            2000,
+            1000,
+            "Landscape images - invalid sizes altered",
+        },
+    };
+
+    public class ImageOnDiskResults
+    {
+        public ImageOnDisk ReturnedFromImageServer { get; }
+        public ImageOnDisk Expected { get; }
+
+        public ImageOnDiskResults(ImageOnDisk returnedFromImageServer, ImageOnDisk? expected = null)
+        {
+            ReturnedFromImageServer = returnedFromImageServer;
+            Expected = expected ?? returnedFromImageServer;
+        }
     }
 }

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
@@ -23,7 +23,7 @@ public class ImageServerClientTests
     private readonly TestBucketWriter bucketWriter;
     private readonly IThumbCreator thumbnailCreator;
     private readonly IAppetiserClient appetiserClient;
-    private readonly ICantaloupeThumbsClient cantaloupeThumbsClient;
+    private readonly IThumbsClient thumbsClient;
     private readonly EngineSettings engineSettings;
     private readonly IStorageKeyGenerator storageKeyGenerator;
     private readonly ImageServerClient sut;
@@ -34,7 +34,7 @@ public class ImageServerClientTests
         fileSystem = A.Fake<IFileSystem>();
         bucketWriter = new TestBucketWriter("appetiser-test");
         appetiserClient = A.Fake<IAppetiserClient>();
-        cantaloupeThumbsClient = A.Fake<ICantaloupeThumbsClient>();
+        thumbsClient = A.Fake<IThumbsClient>();
         engineSettings = new EngineSettings
         {
             ImageIngest = new ImageIngestSettings
@@ -63,7 +63,7 @@ public class ImageServerClientTests
 
         var optionsMonitor = OptionsHelpers.GetOptionsMonitor(engineSettings);
         
-        sut = new ImageServerClient(appetiserClient, cantaloupeThumbsClient, bucketWriter, storageKeyGenerator, thumbnailCreator, fileSystem,
+        sut = new ImageServerClient(appetiserClient, thumbsClient, bucketWriter, storageKeyGenerator, thumbnailCreator, fileSystem,
             optionsMonitor, new NullLogger<ImageServerClient>());
     }
     
@@ -141,7 +141,7 @@ public class ImageServerClientTests
         // Assert
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .MustHaveHappened();
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappened();
     }
 
@@ -266,7 +266,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
         
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._, 
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()
@@ -301,7 +301,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
         
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._, 
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()
@@ -321,16 +321,16 @@ public class ImageServerClientTests
         await sut.ProcessImage(context);
 
         // Assert
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches( x => x.Count == 5), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened(); // union of delivery channel + default thumbs, with removed duplicates
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches( x => x.Contains("!1000,1000")), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened(); // from ingestion context asset (mimicking delivery channel)
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches( x => x.Contains("!1024,1024")), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened(); // from default thumbs
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches( x => x.Count(y => y == "!100,100") == 1), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened(); // from both
     }
@@ -344,7 +344,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
 
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._,
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()
@@ -376,13 +376,13 @@ public class ImageServerClientTests
         await sut.ProcessImage(context);
 
         // Assert
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches(x => x.Count == 4), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened();
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches(x => x.Contains("!1024,1024")), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened();
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._,
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._,
             A<List<string>>.That.Matches(x => x.Count(y => y == "!100,100") == 1), A<string>._, A<CancellationToken>._)
         ).MustHaveHappened();
     }
@@ -402,7 +402,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
         
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._, 
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()
@@ -445,7 +445,7 @@ public class ImageServerClientTests
         // Assert
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .MustHaveHappened();
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappened();
         A.CallTo(() => thumbnailCreator.CreateNewThumbs(context.Asset, A<IReadOnlyList<ImageOnDisk>>._))
             .MustHaveHappened();
@@ -474,7 +474,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
         
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._, 
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()
@@ -501,7 +501,7 @@ public class ImageServerClientTests
         // Assert
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .MustHaveHappened();
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
+        A.CallTo(() => thumbsClient.GenerateThumbnails(A<IngestionContext>._, A<List<string>>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappened();
         A.CallTo(() => thumbnailCreator.CreateNewThumbs(context.Asset, A<IReadOnlyList<ImageOnDisk>>._))
             .MustHaveHappened();
@@ -526,7 +526,7 @@ public class ImageServerClientTests
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
         
-        A.CallTo(() => cantaloupeThumbsClient.GenerateThumbnails(
+        A.CallTo(() => thumbsClient.GenerateThumbnails(
                 A<IngestionContext>._, 
                 A<List<string>>._, A<string>._, A<CancellationToken>._))
             .Returns(Task.FromResult(new List<ImageOnDisk>()

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -26,7 +26,7 @@ using Engine.Ingest.Image;
 using Engine.Ingest.Image.Completion;
 using Engine.Ingest.Image.ImageServer;
 using Engine.Ingest.Image.ImageServer.Clients;
-using Engine.Ingest.Image.ImageServer.Manipulation;
+using Engine.Ingest.Image.ImageServer.Measuring;
 using Engine.Ingest.Persistence;
 using Engine.Ingest.Timebased;
 using Engine.Ingest.Timebased.Completion;
@@ -101,7 +101,7 @@ public static class ServiceCollectionX
         {
             services.AddTransient<TimingHandler>();
             services.AddScoped<IImageProcessor, ImageServerClient>()
-                .AddScoped<IImageManipulator, ImageSharpManipulator>();
+                .AddScoped<IImageMeasurer, ImageSharpMeasurer>();
                 
             services.AddHttpClient<IAppetiserClient, AppetiserClient>(client =>
                 {
@@ -109,7 +109,7 @@ public static class ServiceCollectionX
                     client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
                 }).AddHttpMessageHandler<TimingHandler>();
             
-            services.AddHttpClient<ICantaloupeThumbsClient, CantaloupeThumbsClient>(client =>
+            services.AddHttpClient<IThumbsClient, CantaloupeThumbsClient>(client =>
             {
                 client.BaseAddress = engineSettings.ImageIngest.ThumbsProcessorUrl;
                 client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/IThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/IThumbsClient.cs
@@ -1,15 +1,15 @@
 ﻿namespace Engine.Ingest.Image.ImageServer.Clients;
 
-public interface ICantaloupeThumbsClient
+public interface IThumbsClient
 {
     /// <summary>
-    /// Calls cantaloupe for thumbs
+    /// Calls downstream service to generate thumbs
     /// </summary>
     /// <param name="context">The context of the request</param>
     /// <param name="thumbSizes">A list of thumbnail sizes to generate</param>
     /// <param name="thumbFolder">Root folder for saving thumbs</param>
     /// <param name="cancellationToken">The cancellation token</param>
-    /// <returns>A list of images on disk</returns>
+    /// <returns>A list of images on disk, containing dimensions and path</returns>
     public Task<List<ImageOnDisk>> GenerateThumbnails(IngestionContext context,
         List<string> thumbSizes, string thumbFolder, CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
 using DLCS.Core;
@@ -21,7 +20,7 @@ namespace Engine.Ingest.Image.ImageServer;
 public class ImageServerClient : IImageProcessor
 {
     private readonly IAppetiserClient appetiserClient;
-    private readonly ICantaloupeThumbsClient thumbsClient;
+    private readonly IThumbsClient thumbsClient;
     private readonly EngineSettings engineSettings;
     private readonly ILogger<ImageServerClient> logger;
     private readonly IBucketWriter bucketWriter;
@@ -31,7 +30,7 @@ public class ImageServerClient : IImageProcessor
 
     public ImageServerClient(
         IAppetiserClient appetiserClient,
-        ICantaloupeThumbsClient thumbsClient,
+        IThumbsClient thumbsClient,
         IBucketWriter bucketWriter,
         IStorageKeyGenerator storageKeyGenerator,
         IThumbCreator thumbCreator,

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Manipulation/IImageManipulator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Manipulation/IImageManipulator.cs
@@ -1,6 +1,0 @@
-﻿namespace Engine.Ingest.Image.ImageServer.Manipulation;
-
-public interface IImageManipulator
-{
-    public Task<SixLabors.ImageSharp.Image> LoadAsync(string path, CancellationToken cancellationToken = default);
-}

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Manipulation/ImageSharpManipulator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Manipulation/ImageSharpManipulator.cs
@@ -1,9 +1,0 @@
-﻿namespace Engine.Ingest.Image.ImageServer.Manipulation;
-
-public class ImageSharpManipulator : IImageManipulator
-{
-    public async Task<SixLabors.ImageSharp.Image> LoadAsync(string path, CancellationToken cancellationToken = default)
-    {
-        return await SixLabors.ImageSharp.Image.LoadAsync(path, cancellationToken);
-    }
-}

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/IImageMeasurer.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/IImageMeasurer.cs
@@ -1,0 +1,9 @@
+﻿namespace Engine.Ingest.Image.ImageServer.Measuring;
+
+public interface IImageMeasurer
+{
+    /// <summary>
+    /// Return <see cref="ImageOnDisk"/> object image at specified path 
+    /// </summary>
+    public Task<ImageOnDisk> MeasureImage(string path, CancellationToken cancellationToken = default);
+}

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
@@ -1,0 +1,16 @@
+﻿namespace Engine.Ingest.Image.ImageServer.Measuring;
+
+public class ImageSharpMeasurer : IImageMeasurer
+{
+    public async Task<ImageOnDisk> MeasureImage(string path, CancellationToken cancellationToken = default)
+    {
+        using var image = await SixLabors.ImageSharp.Image.LoadAsync(path, cancellationToken);
+        var imageOnDisk = new ImageOnDisk
+        {
+            Path = path,
+            Width = image.Width,
+            Height = image.Height
+        };
+        return imageOnDisk;
+    }
+}


### PR DESCRIPTION
If specified dimension (for `w,` and `,h`) or longest dimension (for `!w,h`) are incorrect use our calculated size.

Main changes are in `CantaloupeThumbsClient`. We now check returned sizes and compare against our calculated size, we will use the returned size unless:
* `!w,h` and the longest edge doesn't match - required as thumbs calculator/handling uses longest edge. Shorter edge can vary
* `w,` and width doesn't match - height can vary
* `,h` and height doesn't match - width can vary

_Other related changes_
Renamed `ICantaloupeThumbsClient` to `IThumbsClient`, with `CantaloupeThumbsClient` being single impl. Interface shouldn't change if we alter the downstream thumbs generating service.

Refactored `IImageManipulator` and `ImageSharpManipulator` to be `IImageMeasurer` and `ImageSharpMeasurer`. This avoids leaking `SixLabors.ImageSharp.Image` type to caller as it returns internal type `ImageOnDisk` and will allow switching to a different measuring impl in future.