### PR TITLE
Remove storage and use of low.jpg

### DIFF
--- a/src/protagonist/API/Features/NamedQueries/Requests/CreateNamedQuery.cs
+++ b/src/protagonist/API/Features/NamedQueries/Requests/CreateNamedQuery.cs
@@ -31,10 +31,10 @@ public class CreateNamedQueryHandler : IRequestHandler<CreateNamedQuery, ModifyE
     
     public async Task<ModifyEntityResult<NamedQuery>> Handle(CreateNamedQuery request, CancellationToken cancellationToken)
     {
-        var existingNamedQuery = await dbContext.NamedQueries.AsNoTracking().SingleOrDefaultAsync(
+        var existingNamedQuery = await dbContext.NamedQueries.AnyAsync(
             nq => nq.Customer == request.CustomerId && nq.Name == request.NamedQuery.Name, cancellationToken);
         
-        if (existingNamedQuery != null)
+        if (existingNamedQuery)
         {
             return ModifyEntityResult<NamedQuery>.Failure("A named query with that name already exists",
                 WriteResult.Conflict);

--- a/src/protagonist/API/Features/NamedQueries/Requests/DeleteNamedQuery.cs
+++ b/src/protagonist/API/Features/NamedQueries/Requests/DeleteNamedQuery.cs
@@ -29,20 +29,20 @@ public class DeleteNamedQueryHandler : IRequestHandler<DeleteNamedQuery, ResultM
 
     public async Task<ResultMessage<DeleteResult>> Handle(DeleteNamedQuery request, CancellationToken cancellationToken)
     {
-        var deleteResult = DeleteResult.NotFound;
-        var message = string.Empty;
-        
         var namedQuery = await dbContext.NamedQueries.SingleOrDefaultAsync(
             nq => nq.Customer == request.CustomerId && 
                     nq.Id == request.NamedQueryId,
                     cancellationToken: cancellationToken);
 
-        if (namedQuery == null) return new ResultMessage<DeleteResult>(message, deleteResult);
+        if (namedQuery == null)
+        {
+            return new ResultMessage<DeleteResult>("Couldn't find a named query with the id {request.NamedQuery.Id}",
+                DeleteResult.NotFound);
+        }
 
         dbContext.NamedQueries.Remove(namedQuery);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        deleteResult = DeleteResult.Deleted;
+        await dbContext.SaveChangesAsync(cancellationToken); ;
 
-        return new ResultMessage<DeleteResult>(message, deleteResult);
+        return new ResultMessage<DeleteResult>(string.Empty, DeleteResult.Deleted);
     }
 }

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -98,7 +98,6 @@ public class CustomerQueueController : HydraController
         [FromRoute] int customerId,
         [FromBody] HydraCollection<DLCS.HydraModel.Image> images,
         [FromServices] QueuePostValidator validator,
-        [FromServices] OldHydraDeliveryChannelsConverter oldHydraDcConverter,
         CancellationToken cancellationToken)
     {
         UpdateMembers(customerId, images.Members);

--- a/src/protagonist/DLCS.AWS.Tests/S3/S3StorageKeyGeneratorTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/S3/S3StorageKeyGeneratorTests.cs
@@ -147,21 +147,6 @@ public class S3StorageKeyGeneratorTests
     }
     
     [Fact]
-    public void GetLargestThumbnailLocation_ReturnsExpected()
-    {
-        // Arrange
-        const string expected = "10/20/foo-bar/low.jpg";
-        var asset = new AssetId(10, 20, "foo-bar");
-        
-        // Act
-        var actual = sut.GetLargestThumbnailLocation(asset);
-        
-        // Assert
-        actual.Key.Should().Be(expected);
-        actual.Bucket.Should().Be("test-thumbs");
-    }
-    
-    [Fact]
     public void GetThumbnailsRoot_ReturnsExpected()
     {
         // Arrange

--- a/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
@@ -59,6 +59,7 @@ public interface IStorageKeyGenerator
     /// </summary>
     /// <param name="assetId">Unique identifier for Asset</param>
     /// <returns><see cref="ObjectInBucket"/> for largest thumbnail</returns>
+    [Obsolete]
     ObjectInBucket GetLargestThumbnailLocation(AssetId assetId);
 
     /// <summary>

--- a/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/IStorageKeyGenerator.cs
@@ -52,16 +52,7 @@ public interface IStorageKeyGenerator
     /// <param name="assetId">Unique identifier for Asset</param>
     /// <returns><see cref="ObjectInBucket"/> for sizes json</returns>
     ObjectInBucket GetThumbsSizesJsonLocation(AssetId assetId);
-
-    /// <summary>
-    /// Get <see cref="ObjectInBucket"/> for largest pre-generated thumbnail.
-    /// i.e. low.jpg
-    /// </summary>
-    /// <param name="assetId">Unique identifier for Asset</param>
-    /// <returns><see cref="ObjectInBucket"/> for largest thumbnail</returns>
-    [Obsolete]
-    ObjectInBucket GetLargestThumbnailLocation(AssetId assetId);
-
+    
     /// <summary>
     /// Get <see cref="ObjectInBucket"/> for root location of thumbnails for asset, rather than an individual file
     /// </summary>

--- a/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
@@ -105,6 +105,7 @@ public class S3StorageKeyGenerator : IStorageKeyGenerator
         return new ObjectInBucket(s3Options.ThumbsBucket, key);
     }
 
+    [Obsolete]
     public ObjectInBucket GetLargestThumbnailLocation(AssetId assetId)
     {
         var key = $"{GetStorageKey(assetId)}/{LargestThumbKey}";

--- a/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3StorageKeyGenerator.cs
@@ -36,11 +36,6 @@ public class S3StorageKeyGenerator : IStorageKeyGenerator
     public const string MetadataKey = "metadata";
     
     /// <summary>
-    /// Key of the largest pre-generated thumbnail
-    /// </summary>
-    public const string LargestThumbKey = "low.jpg";
-    
-    /// <summary>
     /// S3 slug where open thumbnails are stored.
     /// </summary>
     public const string OpenSlug = "open";
@@ -104,14 +99,7 @@ public class S3StorageKeyGenerator : IStorageKeyGenerator
         var key = $"{GetStorageKey(assetId)}/{SizesJsonKey}";
         return new ObjectInBucket(s3Options.ThumbsBucket, key);
     }
-
-    [Obsolete]
-    public ObjectInBucket GetLargestThumbnailLocation(AssetId assetId)
-    {
-        var key = $"{GetStorageKey(assetId)}/{LargestThumbKey}";
-        return new ObjectInBucket(s3Options.ThumbsBucket, key);
-    }
-
+    
     public ObjectInBucket GetThumbnailsRoot(AssetId assetId)
     {
         var key = $"{GetStorageKey(assetId)}/";

--- a/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
@@ -1,4 +1,6 @@
-﻿using DLCS.Model.IIIF;
+﻿using System.Collections.Generic;
+using DLCS.Model.IIIF;
+using IIIF;
 using IIIF.ImageApi;
 
 namespace DLCS.Model.Tests.IIIF;
@@ -14,5 +16,68 @@ public class IIIFXTests
     {
         var sizeParameter = new SizeParameter { Width = width, Height = height };
         sizeParameter.GetMaxDimension().Should().Be(expected);
+    }
+
+    [Fact]
+    public void SizeClosestTo_Correct_MatchingLongestEdge()
+    {
+        // Arrange
+        var tooSmall = new Size(10, 20);
+        var expected = new Size(100, 200);
+        var matchMinDimension = new Size(200, 400);
+        var candidates = new List<Size> { tooSmall, expected, matchMinDimension, };
+
+        // Act
+        var actual = candidates.SizeClosestTo(200);
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void SizeClosestTo_Correct_ClosestSmaller()
+    {
+        // Arrange
+        var tooSmall = new Size(10, 20);
+        var expected = new Size(100, 200);
+        var tooLarge = new Size(200, 400);
+        var candidates = new List<Size> { tooSmall, expected, tooLarge, };
+
+        // Act
+        var actual = candidates.SizeClosestTo(250);
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void SizeClosestTo_Correct_ClosestLarger()
+    {
+        // Arrange
+        var tooSmall = new Size(10, 20);
+        var small = new Size(100, 200);
+        var expected = new Size(200, 400);
+        var candidates = new List<Size> { tooSmall, small, expected, };
+
+        // Act
+        var actual = candidates.SizeClosestTo(350);
+        
+        // Assert
+        actual.Should().Be(expected);
+    }
+    
+    [Fact]
+    public void SizeClosestTo_PicksLargerSize_IfEquidistant()
+    {
+        // Arrange
+        var smaller = new Size(100, 200);
+        var expected = new Size(200, 400);
+        var candidates = new List<Size> { expected, smaller, };
+
+        // Act
+        var actual = candidates.SizeClosestTo(300);
+        
+        // Assert
+        actual.Should().Be(expected);
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -104,7 +104,7 @@ public class Asset
     /// <summary>
     /// A list of metadata attached to this asset
     /// </summary>
-    public ICollection<AssetApplicationMetadata> AssetApplicationMetadata { get; set; }
+    public ICollection<AssetApplicationMetadata>? AssetApplicationMetadata { get; set; }
 
     public Asset()
     {

--- a/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
+++ b/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using IIIF;
 using Newtonsoft.Json;
 
@@ -43,4 +44,13 @@ public class ThumbnailSizes
         Count++;
         Open.Add(size.ToArray());
     }
+}
+
+public static class ThumbnailSizesX
+{
+    /// <summary>
+    /// Get a list of all available sizes (Auth and Open)
+    /// </summary>
+    public static IEnumerable<int[]> GetAllSizes(this ThumbnailSizes sizes)
+        => sizes.Auth.Union(sizes.Open);
 }

--- a/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
+++ b/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using IIIF;
 using IIIF.ImageApi;
 
 namespace DLCS.Model.IIIF;
@@ -13,4 +17,21 @@ public static class IIIFX
     /// </summary>
     public static int GetMaxDimension(this SizeParameter sizeParameter)
         => Math.Max(sizeParameter.Width ?? 0, sizeParameter.Height ?? 0);
+
+    /// <summary>
+    /// From provided sizes, return the Size that has MaxDimension closest to specified targetSize
+    ///
+    /// e.g. [[100, 200], [250, 500] [500, 1000]], targetSize = 800 would return [500, 1000]
+    /// </summary>
+    /// <param name="sizes">List of sizes to query</param>
+    /// <param name="targetSize">Ideal MaxDimension to find</param>
+    /// <returns><see cref="Size"/> closes to specified value</returns>
+    public static Size SizeClosestTo(this IEnumerable<Size> sizes, int targetSize)
+    {
+        var closestSize = sizes
+            .OrderBy(s => s.MaxDimension)
+            .Aggregate((x, y) =>
+                Math.Abs(x.MaxDimension - targetSize) < Math.Abs(y.MaxDimension - targetSize) ? x : y);
+        return closestSize;
+    }
 }

--- a/src/protagonist/DLCS.Repository/NamedQueries/Parsing/IIIFNamedQueryParser.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Parsing/IIIFNamedQueryParser.cs
@@ -12,8 +12,6 @@ public class IIIFNamedQueryParser : BaseNamedQueryParser<IIIFParsedNamedQuery>
     // IIIF specific
     private const string Manifest = "manifest";
     
-    // TODO sequenceformat, canvasformat, idformat 
-
     public IIIFNamedQueryParser(ILogger<IIIFNamedQueryParser> logger)
         : base(logger)
     {

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -128,9 +128,6 @@ public class ThumbCreatorTests
         thumbsCreated.Should().Be(3);
 
         bucketWriter
-            .ShouldHaveKey("10/20/foo/low.jpg")
-            .WithFilePath("1000.jpg");
-        bucketWriter
             .ShouldHaveKey("10/20/foo/o/1000.jpg")
             .WithFilePath("1000.jpg");
         bucketWriter

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -18,7 +18,7 @@ public class ThumbCreatorTests
     private readonly IAssetApplicationMetadataRepository assetApplicationMetadataRepository;
     private readonly List<ImageDeliveryChannel> thumbsDeliveryChannel = new()
     {
-        new ImageDeliveryChannel()
+        new ImageDeliveryChannel
         {
             DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ThumbsDefault,
             Channel = AssetDeliveryChannels.Thumbnails
@@ -30,9 +30,7 @@ public class ThumbCreatorTests
         bucketWriter = new TestBucketWriter();
         var storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
         assetApplicationMetadataRepository = A.Fake<IAssetApplicationMetadataRepository>();
-
-        A.CallTo(() => storageKeyGenerator.GetLargestThumbnailLocation(A<AssetId>._))
-            .ReturnsLazily((AssetId assetId) => new ObjectInBucket("thumbs-bucket", $"{assetId}/low.jpg"));
+        
         A.CallTo(() => storageKeyGenerator.GetThumbsSizesJsonLocation(A<AssetId>._))
             .ReturnsLazily((AssetId assetId) => new ObjectInBucket("thumbs-bucket", $"{assetId}/s.json"));
         A.CallTo(() => storageKeyGenerator.GetThumbnailLocation(A<AssetId>._, A<int>._, A<bool>._))
@@ -84,9 +82,6 @@ public class ThumbCreatorTests
         // Assert
         thumbsCreated.Should().Be(3);
 
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/low.jpg")
-            .WithFilePath("1000.jpg");
         bucketWriter
             .ShouldHaveKey("10/20/foo/o/1000.jpg")
             .WithFilePath("1000.jpg");
@@ -179,10 +174,7 @@ public class ThumbCreatorTests
         
         // Assert
         thumbsCreated.Should().Be(3);
-
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/low.jpg")
-            .WithFilePath("1000.jpg");
+        
         bucketWriter
             .ShouldHaveKey("10/20/foo/a/1000.jpg")
             .WithFilePath("1000.jpg");
@@ -228,10 +220,7 @@ public class ThumbCreatorTests
         
         // Assert
         thumbsCreated.Should().Be(2);
-
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/low.jpg")
-            .WithFilePath("1000.jpg");
+        
         bucketWriter
             .ShouldHaveKey("10/20/foo/o/440.jpg")
             .WithFilePath("1000.jpg");
@@ -272,10 +261,7 @@ public class ThumbCreatorTests
         
         // Assert
         thumbsCreated.Should().Be(3);
-
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/low.jpg")
-            .WithFilePath("1000.jpg");
+        
         bucketWriter
             .ShouldHaveKey("10/20/foo/a/1000.jpg")
             .WithFilePath("1000.jpg");

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -166,7 +166,6 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // S3 assets created
         BucketWriter.ShouldHaveKey(assetId.ToString()).ForBucket(LocalStackFixture.StorageBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/low.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/200.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/400.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/1024.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
@@ -270,7 +269,6 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         // S3 assets created
         BucketWriter.ShouldHaveKey(assetId.ToString()).ForBucket(LocalStackFixture.StorageBucketName);
-        BucketWriter.ShouldHaveKey($"{assetId}/low.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/200.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/400.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);
         BucketWriter.ShouldHaveKey($"{assetId}/open/1024.jpg").ForBucket(LocalStackFixture.ThumbsBucketName);

--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -97,8 +97,7 @@ public class ThumbCreator : IThumbCreator
         return new Size(0, 0);
     }
 
-    private async Task UploadThumbs(AssetId assetId, ImageOnDisk thumbCandidate, Size thumb,
-        bool isOpen)
+    private async Task UploadThumbs(AssetId assetId, ImageOnDisk thumbCandidate, Size thumb, bool isOpen)
     {
         var thumbKey = storageKeyGenerator.GetThumbnailLocation(assetId, thumb.MaxDimension, isOpen);
         await bucketWriter.WriteFileToBucket(thumbKey, thumbCandidate.Path, MIMEHelper.JPEG);

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
@@ -1,0 +1,163 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Policies;
+using IIIF;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Orchestrator.Infrastructure;
+using Orchestrator.Settings;
+using Test.Helpers.Data;
+
+namespace Orchestrator.Tests.Infrastructure;
+
+public class MetadataWithFallbackThumbSizeProviderTests
+{
+    private const int DeliveryChannelPolicyId = 999;
+    private readonly MetadataWithFallbackThumbSizeProvider sut;
+    private readonly IPolicyRepository policyRepository;
+    public MetadataWithFallbackThumbSizeProviderTests()
+    {
+        policyRepository = A.Fake<IPolicyRepository>();
+
+        var orchestratorSettings = Options.Create(new OrchestratorSettings());
+        sut = new MetadataWithFallbackThumbSizeProvider(policyRepository, orchestratorSettings,
+            new NullLogger<MetadataWithFallbackThumbSizeProvider>());
+    }
+
+    [Fact]
+    public async Task GetAvailableThumbSizesForImage_ReturnsOpenFromMetadata_IfMetadataAttached_AndOpenOnly()
+    {
+        // Arrange
+        const string thumbsMetadata = "{\"a\": [[769, 1024],[300,400]], \"o\": [[150, 200],[75, 100]]}";
+        var expected = new List<Size> { new(150, 200), new(75, 100) };
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = new Asset(assetId).WithTestThumbnailMetadata(thumbsMetadata);
+        
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, true);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetAvailableThumbSizesForImage_ReturnsAllFromMetadata_IfMetadataAttached_AndNotOpenOnly()
+    {
+        // Arrange
+        const string thumbsMetadata = "{\"a\": [[769, 1024],[300,400]], \"o\": [[150, 200],[75, 100]]}";
+        var expected = new List<Size> { new(769, 1024), new(300, 400), new(150, 200), new(75, 100) };
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = new Asset(assetId).WithTestThumbnailMetadata(thumbsMetadata);
+        
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, false);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetAvailableThumbSizesForImage_ReturnsEmptyList_IfMetadataAttached_ButNoThumbs(bool openOnly)
+    {
+        // Arrange
+        const string thumbsMetadata = "{\"a\": [], \"o\": []}";
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = new Asset(assetId).WithTestThumbnailMetadata(thumbsMetadata);
+        
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, openOnly);
+        
+        // Assert
+        actual.Should().BeEmpty();
+    }
+    
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GetAvailableThumbSizesForImage_ReturnsEmptyList_IfNoMetadata_AndNoThumbsChannel(bool openOnly)
+    {
+        // Arrange
+        var asset = new Asset(AssetIdGenerator.GetAssetId());
+        
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, openOnly);
+        
+        // Assert
+        actual.Should().BeEmpty();
+    }
+    
+    [Fact]
+    public async Task GetAvailableThumbSizesForImage_ReturnsCalculatedAvailableSizes_IfNoMetadataAttached_AndOpenOnly()
+    {
+        // Arrange
+        // only confined sizes calculated (so 100, is ignored)
+        var expected = new List<Size> { new(200, 400), new(100, 200) }; 
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = GetAssetWithThumbsChannel(assetId, 1000, 2000, 500);
+        
+        var policy = new DeliveryChannelPolicy
+        {
+            PolicyData = "[\"!1000,1000\", \"!400,400\", \"!200,200\", \"100,\"]",
+            Channel = "thumbs",
+            Id = DeliveryChannelPolicyId,
+        };
+        A.CallTo(() =>
+                policyRepository.GetThumbnailPolicy(DeliveryChannelPolicyId, asset.Customer, A<CancellationToken>._))
+            .Returns(policy);
+            
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, true);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public async Task GetAvailableThumbSizesForImage_ReturnsAllCalculatedSizes_IfNoMetadataAttached_AndNotOpenOnly()
+    {
+        // Arrange
+        // only confined sizes calculated (so 100, is ignored)
+        var expected = new List<Size> { new(500, 1000), new(200, 400), new(100, 200) }; 
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = GetAssetWithThumbsChannel(assetId, 1000, 2000, 250);
+        
+        var policy = new DeliveryChannelPolicy
+        {
+            PolicyData = "[\"!1000,1000\", \"!400,400\", \"!200,200\", \"100,\"]",
+            Channel = "thumbs",
+            Id = DeliveryChannelPolicyId,
+        };
+        A.CallTo(() =>
+                policyRepository.GetThumbnailPolicy(DeliveryChannelPolicyId, asset.Customer, A<CancellationToken>._))
+            .Returns(policy);
+            
+        // Act
+        var actual = await sut.GetThumbSizesForImage(asset, false);
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    private Asset GetAssetWithThumbsChannel(AssetId assetId, int w, int h, int maxUnauth)
+    {
+        var asset = new Asset(assetId)
+        {
+            Width = w,
+            Height = h,
+            MaxUnauthorised = maxUnauth,
+            ImageDeliveryChannels = new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = AssetDeliveryChannels.Thumbnails,
+                    DeliveryChannelPolicyId = DeliveryChannelPolicyId
+                }
+            }
+        };
+        return asset;
+    }
+}

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
@@ -231,7 +231,7 @@ public class FireballPdfCreatorTests
             }
         };
 
-        A.CallTo(() => thumbSizeProvider.GetAvailableThumbSizesForImage(A<Asset>._))
+        A.CallTo(() => thumbSizeProvider.GetThumbSizesForImage(A<Asset>._, false))
             .Returns(new List<Size> { new(500, 500) });
 
         var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
@@ -14,8 +14,10 @@ using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
 using FakeItEasy;
 using FizzWare.NBuilder;
+using IIIF;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.NamedQueries.PDF;
 using Orchestrator.Settings;
 using Test.Helpers.Http;
@@ -25,6 +27,7 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF;
 public class FireballPdfCreatorTests
 {
     private readonly IBucketReader bucketReader;
+    private readonly IThumbSizeCalculator thumbSizeCalculator;
     private readonly ControllableHttpMessageHandler httpHandler;
     private readonly FireballPdfCreator sut;
     private const int Customer = 99;
@@ -45,6 +48,7 @@ public class FireballPdfCreatorTests
     
         bucketReader = A.Fake<IBucketReader>();
         bucketWriter = A.Fake<IBucketWriter>();
+        thumbSizeCalculator = A.Fake<IThumbSizeCalculator>();
         
         httpHandler = new ControllableHttpMessageHandler();
         var httpClient = new HttpClient(httpHandler)
@@ -63,7 +67,7 @@ public class FireballPdfCreatorTests
                 }
             }));
 
-        sut = new FireballPdfCreator(bucketReader, bucketWriter, namedQuerySettings,
+        sut = new FireballPdfCreator(bucketReader, bucketWriter, namedQuerySettings, thumbSizeCalculator,
             new NullLogger<FireballPdfCreator>(), httpClient, bucketKeyGenerator);
     }
 
@@ -215,17 +219,20 @@ public class FireballPdfCreatorTests
             },
             new ()
             {
-                Roles = String.Empty,
+                Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = -1
             },
             new ()
             {
-                Roles = String.Empty,
+                Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = -1
             }
         };
+
+        A.CallTo(() => thumbSizeCalculator.GetAvailableThumbSizesForImage(A<Asset>._))
+            .Returns(new List<Size> { new(500, 500) });
 
         var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
         responseMessage.Content =
@@ -242,7 +249,7 @@ public class FireballPdfCreatorTests
         await sut.PersistProjection(parsedNamedQuery, images);
         
         // Assert
-        playbook.Pages.Select(p => p.Type).Should()
-            .BeEquivalentTo(expectedPageTypes, opts => opts.WithStrictOrdering());
+        playbook.Pages.Select(p => p.Type)
+            .Should().BeEquivalentTo(expectedPageTypes, opts => opts.WithStrictOrdering());
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
@@ -27,7 +27,7 @@ namespace Orchestrator.Tests.Infrastructure.NamedQueries.PDF;
 public class FireballPdfCreatorTests
 {
     private readonly IBucketReader bucketReader;
-    private readonly IThumbSizeCalculator thumbSizeCalculator;
+    private readonly IThumbSizeProvider thumbSizeProvider;
     private readonly ControllableHttpMessageHandler httpHandler;
     private readonly FireballPdfCreator sut;
     private const int Customer = 99;
@@ -48,7 +48,7 @@ public class FireballPdfCreatorTests
     
         bucketReader = A.Fake<IBucketReader>();
         bucketWriter = A.Fake<IBucketWriter>();
-        thumbSizeCalculator = A.Fake<IThumbSizeCalculator>();
+        thumbSizeProvider = A.Fake<IThumbSizeProvider>();
         
         httpHandler = new ControllableHttpMessageHandler();
         var httpClient = new HttpClient(httpHandler)
@@ -67,7 +67,7 @@ public class FireballPdfCreatorTests
                 }
             }));
 
-        sut = new FireballPdfCreator(bucketReader, bucketWriter, namedQuerySettings, thumbSizeCalculator,
+        sut = new FireballPdfCreator(bucketReader, bucketWriter, namedQuerySettings, thumbSizeProvider,
             new NullLogger<FireballPdfCreator>(), httpClient, bucketKeyGenerator);
     }
 
@@ -231,7 +231,7 @@ public class FireballPdfCreatorTests
             }
         };
 
-        A.CallTo(() => thumbSizeCalculator.GetAvailableThumbSizesForImage(A<Asset>._))
+        A.CallTo(() => thumbSizeProvider.GetAvailableThumbSizesForImage(A<Asset>._))
             .Returns(new List<Size> { new(500, 500) });
 
         var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -215,7 +215,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels)
-            .AddTestThumbnailMetadata();
+            .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -240,7 +240,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").AddTestThumbnailMetadata();
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -332,7 +332,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels)
-            .AddTestThumbnailMetadata();
+            .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/{id}";
@@ -357,7 +357,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetId.FromString($"99/1/{nameof(Get_ManifestForImage_ReturnsManifest)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").AddTestThumbnailMetadata();
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/{id}";

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -61,18 +61,18 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
                 }
             });
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-2"), num1: 1, ref1: "my-ref")
-            .AddTestThumbnailMetadata();
+            .WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "default").AddTestThumbnailMetadata();
+            maxUnauthorised: 10, roles: "default").WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 4, ref1: "my-ref",
-            notForDelivery: true).AddTestThumbnailMetadata();
+            notForDelivery: true).WithTestThumbnailMetadata();
 
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/auth-1"), num1: 2, ref1: "auth-ref",
-            roles: "clickthrough").AddTestThumbnailMetadata();
+            roles: "clickthrough").WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/auth-2"), num1: 1, ref1: "auth-ref",
-            roles: "clickthrough").AddTestThumbnailMetadata();
+            roles: "clickthrough").WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/no-auth"), num1: 3, ref1: "auth-ref")
-            .AddTestThumbnailMetadata();
+            .WithTestThumbnailMetadata();
 
         dbFixture.DbContext.SaveChanges();
     }
@@ -248,13 +248,13 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
         });
 
         await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/third"), num1: 1, num2: 10, ref1: "z",
-            ref2: "grace").AddTestThumbnailMetadata();;
+            ref2: "grace").WithTestThumbnailMetadata();;
         await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/first"), num1: 1, num2: 20, ref1: "c",
-            ref2: "grace").AddTestThumbnailMetadata();;
+            ref2: "grace").WithTestThumbnailMetadata();;
         await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/fourth"), num1: 2, num2: 10, ref1: "a",
-            ref2: "grace").AddTestThumbnailMetadata();;
+            ref2: "grace").WithTestThumbnailMetadata();;
         await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/second"), num1: 1, num2: 10, ref1: "x",
-            ref2: "grace").AddTestThumbnailMetadata();;
+            ref2: "grace").WithTestThumbnailMetadata();;
         await dbFixture.DbContext.SaveChangesAsync();
 
         var expectedOrder = new[] { "99/1/first", "99/1/second", "99/1/third", "99/1/fourth" };

--- a/src/protagonist/Orchestrator.Tests/Usings.cs
+++ b/src/protagonist/Orchestrator.Tests/Usings.cs
@@ -1,3 +1,4 @@
 global using System.Threading.Tasks;
+global using FakeItEasy;
 global using FluentAssertions;
 global using Xunit;

--- a/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
@@ -11,6 +11,7 @@ using IIIF;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.EntityFrameworkCore;
+using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.NamedQueries;
 using Version = IIIF.Presentation.Version;
@@ -38,7 +39,8 @@ public class IIIFNamedQueryProjector
     {
         var parsedNamedQuery = namedQueryResult.ParsedQuery.ThrowIfNull(nameof(request.Query))!;
 
-        var assets = await namedQueryResult.Results.IncludeRequiredDataForManifest()
+        var assets = await namedQueryResult.Results
+            .IncludeDataForThumbs()
             .AsSplitQuery()
             .ToListAsync(cancellationToken);
         if (assets.Count == 0) return null;

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -9,6 +9,7 @@ using IIIF;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.Mediatr;
 using Orchestrator.Models;
@@ -61,7 +62,8 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
     {
         var assetId = request.AssetRequest.GetAssetId();
 
-        var asset = await dlcsContext.Images.IncludeRequiredDataForManifest()
+        var asset = await dlcsContext.Images
+            .IncludeDataForThumbs()
             .FirstOrDefaultAsync(a => a.Id == assetId, cancellationToken);
 
         if (asset is not { Family: AssetFamily.Image, NotForDelivery: false })

--- a/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
@@ -3,17 +3,17 @@ using DLCS.Model.Assets;
 using DLCS.Model.Assets.Metadata;
 using Microsoft.EntityFrameworkCore;
 
-namespace Orchestrator.Features.Manifests;
+namespace Orchestrator.Infrastructure;
 
-public static class AssetManifestX
+public static class AssetQueryableX
 {
     /// <summary>
     /// Includes data from additional tables required to build manifests
     /// </summary>
-    public static IQueryable<Asset> IncludeRequiredDataForManifest(this IQueryable<Asset> assets)
+    public static IQueryable<Asset> IncludeDataForThumbs(this IQueryable<Asset> assets)
     {
         return assets.Include(a =>
-                a.AssetApplicationMetadata.Where(md => md.MetadataType == AssetApplicationMetadataTypes.ThumbSizes))
+                Enumerable.Where<AssetApplicationMetadata>(a.AssetApplicationMetadata, md => md.MetadataType == AssetApplicationMetadataTypes.ThumbSizes))
             .Include(a => a.ImageDeliveryChannels);
     }
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -166,7 +166,7 @@ public class IIIFCanvasFactory
     
     private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
     {
-        var thumbnailSizes = await thumbSizeProvider.GetAvailableThumbSizesForImage(asset);
+        var thumbnailSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, true);
         return new ImageSizeDetails
         {
             MaxDerivativeSize = thumbnailSizes.MaxBy(s => s.MaxDimension)!,

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -32,16 +32,16 @@ public class IIIFCanvasFactory
 {
     private readonly IAssetPathGenerator assetPathGenerator;
     private readonly OrchestratorSettings orchestratorSettings;
-    private readonly IThumbSizeCalculator thumbSizeCalculator;
+    private readonly IThumbSizeProvider thumbSizeProvider;
     private const string MetadataLanguage = "none";
     
     public IIIFCanvasFactory(
         IAssetPathGenerator assetPathGenerator,
         IOptions<OrchestratorSettings> orchestratorSettings,
-        IThumbSizeCalculator thumbSizeCalculator)
+        IThumbSizeProvider thumbSizeProvider)
     {
         this.assetPathGenerator = assetPathGenerator;
-        this.thumbSizeCalculator = thumbSizeCalculator;
+        this.thumbSizeProvider = thumbSizeProvider;
         this.orchestratorSettings = orchestratorSettings.Value;
     }
 
@@ -166,7 +166,7 @@ public class IIIFCanvasFactory
     
     private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
     {
-        var thumbnailSizes = await thumbSizeCalculator.GetAvailableThumbSizesForImage(asset);
+        var thumbnailSizes = await thumbSizeProvider.GetAvailableThumbSizesForImage(asset);
         return new ImageSizeDetails
         {
             MaxDerivativeSize = thumbnailSizes.MaxBy(s => s.MaxDimension)!,

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -32,13 +32,13 @@ public class IIIFCanvasFactory
 {
     private readonly IAssetPathGenerator assetPathGenerator;
     private readonly OrchestratorSettings orchestratorSettings;
-    private readonly ThumbSizeCalculator thumbSizeCalculator;
+    private readonly IThumbSizeCalculator thumbSizeCalculator;
     private const string MetadataLanguage = "none";
     
     public IIIFCanvasFactory(
         IAssetPathGenerator assetPathGenerator,
         IOptions<OrchestratorSettings> orchestratorSettings,
-        ThumbSizeCalculator thumbSizeCalculator)
+        IThumbSizeCalculator thumbSizeCalculator)
     {
         this.assetPathGenerator = assetPathGenerator;
         this.thumbSizeCalculator = thumbSizeCalculator;

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
-using DLCS.Core.Guard;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
-using DLCS.Model.Assets.Metadata;
 using DLCS.Model.IIIF;
 using DLCS.Model.PathElements;
-using DLCS.Model.Policies;
 using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
 using IIIF;
@@ -21,7 +17,6 @@ using IIIF.Presentation.V2.Strings;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orchestrator.Settings;
 using ImageApi = IIIF.ImageApi;
@@ -36,21 +31,17 @@ namespace Orchestrator.Infrastructure.IIIF;
 public class IIIFCanvasFactory
 {
     private readonly IAssetPathGenerator assetPathGenerator;
-    private readonly IPolicyRepository policyRepository;
-    private readonly ILogger<IIIFCanvasFactory> logger;
     private readonly OrchestratorSettings orchestratorSettings;
-    private readonly Dictionary<int, List<ImageApi.SizeParameter>> thumbnailPolicies = new();
+    private readonly ThumbSizeCalculator thumbSizeCalculator;
     private const string MetadataLanguage = "none";
     
     public IIIFCanvasFactory(
         IAssetPathGenerator assetPathGenerator,
         IOptions<OrchestratorSettings> orchestratorSettings,
-        IPolicyRepository policyRepository,
-        ILogger<IIIFCanvasFactory> logger)
+        ThumbSizeCalculator thumbSizeCalculator)
     {
         this.assetPathGenerator = assetPathGenerator;
-        this.policyRepository = policyRepository;
-        this.logger = logger;
+        this.thumbSizeCalculator = thumbSizeCalculator;
         this.orchestratorSettings = orchestratorSettings.Value;
     }
 
@@ -116,35 +107,6 @@ public class IIIFCanvasFactory
         return canvases;
     }
 
-    private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
-    {
-        var thumbnailSizes = asset.AssetApplicationMetadata.GetThumbsMetadata();
-        
-        if (thumbnailSizes != null)
-        {
-            logger.LogDebug("ThumbSizes metadata found for {AssetId}", asset.Id);
-            if (thumbnailSizes.Open.Any())
-            {
-                var largest = thumbnailSizes.Open.MaxBy(x => x.Sum());
-        
-                return new ImageSizeDetails
-                {
-                    MaxDerivativeSize = new Size(largest![0], largest[1]),
-                    OpenThumbnails = thumbnailSizes.Open.Select(t => new Size(t[0], t[1])).ToList()
-                };
-            }
-        }
-
-        if ((orchestratorSettings.ThumbsMetadataDate ?? DateTime.MaxValue) < asset.Finished)
-        {
-            logger.LogWarning(
-                "No metadata found for asset {AssetId} with finished date {FinishedDate} and fallback disabled", asset.Id,
-                asset.Finished);
-        }
-        
-        return await GetThumbnailSizesForImage(asset);
-    }
-
     /// <summary>
     /// Generate IIIF V2 canvases for assets.
     /// </summary>
@@ -202,6 +164,16 @@ public class IIIFCanvasFactory
         return canvases;
     }
     
+    private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
+    {
+        var thumbnailSizes = await thumbSizeCalculator.GetAvailableThumbSizesForImage(asset);
+        return new ImageSizeDetails
+        {
+            MaxDerivativeSize = thumbnailSizes.MaxBy(s => s.MaxDimension)!,
+            OpenThumbnails = thumbnailSizes
+        };
+    }
+    
     private List<IService> GetImageServiceForThumbnail(Asset asset, CustomerPathElement customerPathElement,
         List<Size> thumbnailSizes)
     {
@@ -229,55 +201,6 @@ public class IIIFCanvasFactory
         }
 
         return services;
-    }
-
-    private async Task<ImageSizeDetails> GetThumbnailSizesForImage(Asset asset)
-    {
-        logger.LogDebug("Calculating thumbnail sizes for {AssetId}", asset.Id);
-        var sizeParameters = await GetThumbnailDeliveryChannelPolicyForImage(asset);
-        
-        var thumbnailSizesForImage = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions);
-
-        if (thumbnailSizesForImage.IsNullOrEmpty())
-        {
-            var largestThumbnail = sizeParameters
-                .Where(s => s.Confined)
-                .MaxBy(s => s.GetMaxDimension())
-                .ThrowIfNull("largestThumbnail");
-
-            return new ImageSizeDetails
-            {
-                OpenThumbnails = new List<Size>(0),
-                MaxDerivativeSize = Size.Confine(largestThumbnail.GetMaxDimension(), new Size(asset.Width.Value, asset.Height.Value))
-            };
-        }
-
-        return new ImageSizeDetails
-        {
-            OpenThumbnails = thumbnailSizesForImage,
-            MaxDerivativeSize = new Size(maxDimensions.maxAvailableWidth, maxDimensions.maxAvailableHeight)
-        };
-    }
-
-    private async Task<List<ImageApi.SizeParameter>> GetThumbnailDeliveryChannelPolicyForImage(Asset image)
-    {
-        var thumbnailDeliveryChannel = image.ImageDeliveryChannels.GetThumbsChannel();
-
-        if (thumbnailDeliveryChannel is null) return new List<ImageApi.SizeParameter>();
-
-        if (thumbnailPolicies.TryGetValue(thumbnailDeliveryChannel.DeliveryChannelPolicyId, out var thumbnailPolicy))
-        {
-            return thumbnailPolicy;
-        }
-
-        var thumbnailPolicyFromDb =
-            await policyRepository.GetThumbnailPolicy(thumbnailDeliveryChannel.DeliveryChannelPolicyId, image.Customer);
-
-        var sizeParameters = thumbnailPolicyFromDb
-            .ThrowIfNull(nameof(thumbnailPolicyFromDb))
-            .ThumbsDataAsSizeParameters();
-        thumbnailPolicies[thumbnailDeliveryChannel.DeliveryChannelPolicyId] = sizeParameters;
-        return sizeParameters;
     }
 
     private string GetFullQualifiedThumbPath(Asset asset, CustomerPathElement customerPathElement,

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -167,10 +167,15 @@ public class IIIFCanvasFactory
     private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
     {
         var thumbnailSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, true);
+
+        var maxDerivativeSize = thumbnailSizes.IsNullOrEmpty()
+            ? Size.Confine(orchestratorSettings.TargetThumbnailSize, new Size(asset.Width ?? 0, asset.Height ?? 0))
+            : thumbnailSizes.MaxBy(s => s.MaxDimension)!;
+        
         return new ImageSizeDetails
         {
-            MaxDerivativeSize = thumbnailSizes.MaxBy(s => s.MaxDimension)!,
-            OpenThumbnails = thumbnailSizes
+            MaxDerivativeSize = maxDerivativeSize,
+            OpenThumbnails = thumbnailSizes,
         };
     }
     

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -286,10 +286,7 @@ public class IIIFCanvasFactory
         var targetThumb = orchestratorSettings.TargetThumbnailSize;
 
         // Get the thumbnail size that is closest to the system-wide TargetThumbnailSize
-        var closestSize = availableThumbs
-            .OrderBy(s => s.MaxDimension)
-            .Aggregate((x, y) =>
-                Math.Abs(x.MaxDimension - targetThumb) < Math.Abs(y.MaxDimension - targetThumb) ? x : y);
+        var closestSize = availableThumbs.SizeClosestTo(targetThumb);
 
         return GetFullQualifiedImagePath(asset, customerPathElement, closestSize, true);
     }

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -18,7 +18,7 @@ namespace Orchestrator.Infrastructure;
 public interface IThumbSizeProvider
 {
     /// <summary>
-    /// Get available sizes for thumbnails (if any). ie it will only return "Open" thumb sizes
+    /// Get available sizes for thumbnails. Can optionally return only available (ie "Open") or all thumb sizes
     /// </summary>
     Task<List<Size>> GetThumbSizesForImage(Asset asset, bool openOnly);
 }
@@ -40,11 +40,11 @@ public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
     }
     
     /// <summary>
-    /// Get available sizes for thumbnails (if any). ie it will only return "Open" thumb sizes
+    /// Get available sizes for thumbnails. Can optionally return only available (ie "Open") or all thumb sizes
     ///
     /// This will _not_ hit S3 to read available thumbs, it will:
     /// Attempt to read from asset.AssetApplicationMetadata. If found return. Else
-    /// Get thumbnail policy and calculate available sizes. 
+    /// Get thumbnail policy and calculate sizes. 
     /// </summary>
     public async Task<List<Size>> GetThumbSizesForImage(Asset asset, bool openOnly)
     {

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -14,15 +14,23 @@ using ImageApi = IIIF.ImageApi;
 
 namespace Orchestrator.Infrastructure;
 
-public class ThumbSizeCalculator
+public interface IThumbSizeCalculator
+{
+    /// <summary>
+    /// Get available sizes for thumbnails (if any). ie it will only return "Open" thumb sizes
+    /// </summary>
+    Task<List<Size>> GetAvailableThumbSizesForImage(Asset asset);
+}
+
+public class MetadataWithFallbackThumbSizeCalculator : IThumbSizeCalculator
 {
     private readonly IPolicyRepository policyRepository;
-    private readonly ILogger<ThumbSizeCalculator> logger;
+    private readonly ILogger<MetadataWithFallbackThumbSizeCalculator> logger;
     private readonly OrchestratorSettings orchestratorSettings;
     private readonly Dictionary<int, List<ImageApi.SizeParameter>> thumbnailPolicies = new();
 
-    public ThumbSizeCalculator(IPolicyRepository policyRepository, 
-        ILogger<ThumbSizeCalculator> logger,
+    public MetadataWithFallbackThumbSizeCalculator(IPolicyRepository policyRepository, 
+        ILogger<MetadataWithFallbackThumbSizeCalculator> logger,
         IOptions<OrchestratorSettings> orchestratorOptions)
     {
         this.policyRepository = policyRepository;

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -14,7 +14,7 @@ using ImageApi = IIIF.ImageApi;
 
 namespace Orchestrator.Infrastructure;
 
-public interface IThumbSizeCalculator
+public interface IThumbSizeProvider
 {
     /// <summary>
     /// Get available sizes for thumbnails (if any). ie it will only return "Open" thumb sizes
@@ -22,15 +22,15 @@ public interface IThumbSizeCalculator
     Task<List<Size>> GetAvailableThumbSizesForImage(Asset asset);
 }
 
-public class MetadataWithFallbackThumbSizeCalculator : IThumbSizeCalculator
+public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
 {
     private readonly IPolicyRepository policyRepository;
-    private readonly ILogger<MetadataWithFallbackThumbSizeCalculator> logger;
+    private readonly ILogger<MetadataWithFallbackThumbSizeProvider> logger;
     private readonly OrchestratorSettings orchestratorSettings;
     private readonly Dictionary<int, List<ImageApi.SizeParameter>> thumbnailPolicies = new();
 
-    public MetadataWithFallbackThumbSizeCalculator(IPolicyRepository policyRepository, 
-        ILogger<MetadataWithFallbackThumbSizeCalculator> logger,
+    public MetadataWithFallbackThumbSizeProvider(IPolicyRepository policyRepository, 
+        ILogger<MetadataWithFallbackThumbSizeProvider> logger,
         IOptions<OrchestratorSettings> orchestratorOptions)
     {
         this.policyRepository = policyRepository;

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
@@ -29,7 +29,7 @@ namespace Orchestrator.Infrastructure.NamedQueries.PDF;
 public class FireballPdfCreator : BaseProjectionCreator<PdfParsedNamedQuery>
 {
     private const string PdfEndpoint = "pdf";
-    private readonly IThumbSizeCalculator thumbSizeCalculator;
+    private readonly IThumbSizeProvider thumbSizeProvider;
     private readonly HttpClient fireballClient;
     private readonly JsonSerializerSettings jsonSerializerSettings;
 
@@ -37,13 +37,13 @@ public class FireballPdfCreator : BaseProjectionCreator<PdfParsedNamedQuery>
         IBucketReader bucketReader,
         IBucketWriter bucketWriter,
         IOptions<NamedQuerySettings> namedQuerySettings,
-        IThumbSizeCalculator thumbSizeCalculator,
+        IThumbSizeProvider thumbSizeProvider,
         ILogger<FireballPdfCreator> logger,
         HttpClient fireballClient,
         IStorageKeyGenerator storageKeyGenerator
     ) : base(bucketReader, bucketWriter, namedQuerySettings, storageKeyGenerator, logger)
     {
-        this.thumbSizeCalculator = thumbSizeCalculator;
+        this.thumbSizeProvider = thumbSizeProvider;
         this.fireballClient = fireballClient;
         jsonSerializerSettings = new JsonSerializerSettings
         {
@@ -116,7 +116,7 @@ public class FireballPdfCreator : BaseProjectionCreator<PdfParsedNamedQuery>
 
     private async Task<ObjectInBucket> GetThumbnailLocation(Asset asset)
     {
-        var availableSizes = await thumbSizeCalculator.GetAvailableThumbSizesForImage(asset);
+        var availableSizes = await thumbSizeProvider.GetAvailableThumbSizesForImage(asset);
         var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize);
         return StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension);
     }

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
@@ -116,7 +116,7 @@ public class FireballPdfCreator : BaseProjectionCreator<PdfParsedNamedQuery>
 
     private async Task<ObjectInBucket> GetThumbnailLocation(Asset asset)
     {
-        var availableSizes = await thumbSizeProvider.GetAvailableThumbSizesForImage(asset);
+        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, false);
         var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize);
         return StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension);
     }

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
@@ -61,7 +61,10 @@ public class StoredNamedQueryManager
             return existingResult;
         }
 
-        var imageResults = await namedQueryResult.Results.ToListAsync(cancellationToken);
+        var imageResults = await namedQueryResult.Results
+            .IncludeDataForThumbs()
+            .AsSplitQuery()
+            .ToListAsync(cancellationToken);
         if (imageResults.Count == 0)
         {
             logger.LogWarning("No results found for stored file {S3StorageKey}, aborting", parsedNamedQuery.StorageKey);

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
@@ -5,8 +5,10 @@ using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.AWS.S3;
+using DLCS.Core.Streams;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
+using DLCS.Model.IIIF;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.NamedQueries.Persistence;
@@ -20,11 +22,17 @@ namespace Orchestrator.Infrastructure.NamedQueries.Zip;
 /// </summary>
 public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
 {
-    public ImageThumbZipCreator(IBucketReader bucketReader, IBucketWriter bucketWriter,
-        IOptions<NamedQuerySettings> namedQuerySettings, IStorageKeyGenerator storageKeyGenerator,
+    private readonly IThumbSizeProvider thumbSizeProvider;
+    public ImageThumbZipCreator(
+        IBucketReader bucketReader, 
+        IBucketWriter bucketWriter,
+        IThumbSizeProvider thumbSizeProvider,
+        IOptions<NamedQuerySettings> namedQuerySettings, 
+        IStorageKeyGenerator storageKeyGenerator,
         ILogger<ImageThumbZipCreator> logger) :
         base(bucketReader, bucketWriter, namedQuerySettings, storageKeyGenerator, logger)
     {
+        this.thumbSizeProvider = thumbSizeProvider;
     }
 
     protected override async Task<CreateProjectionResult> CreateFile(ZipParsedNamedQuery parsedNamedQuery,
@@ -99,17 +107,16 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
             return;
         }
 
-        var largestThumb = StorageKeyGenerator.GetLargestThumbnailLocation(image.Id);
-        var largestThumbStream = await BucketReader.GetObjectContentFromBucket(largestThumb);
-        if (largestThumbStream == null || largestThumbStream == Stream.Null)
+        var thumbStream = await GetThumbnailStream(image);
+        if (thumbStream.IsNull())
         {
-            Logger.LogWarning("Could not find largest thumb for {Image} of {S3Key}", image.Id, storageKey);
+            Logger.LogWarning("Could not find thumb for {Image} of {S3Key}", image.Id, storageKey);
             return;
         }
 
         var archiveEntry = zipArchive.CreateEntry($"{image.Id.Asset}.jpg");
         await using var archiveEntryStream = archiveEntry.Open();
-        await largestThumbStream.CopyToAsync(archiveEntryStream);
+        await thumbStream.CopyToAsync(archiveEntryStream);
     }
 
     private static void DeleteZipFileIfExists(string zipFilePath)
@@ -126,5 +133,15 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
         return NamedQuerySettings.ZipFolderTemplate
             .Replace("{customer}", parsedNamedQuery.Customer.ToString())
             .Replace("{storage-key}", pathSafeStorageKey);
+    }
+    
+    private async Task<Stream?> GetThumbnailStream(Asset asset)
+    {
+        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, false);
+        var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize);
+        var thumbnailLocation = StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension);
+        
+        var thumbStream = await BucketReader.GetObjectContentFromBucket(thumbnailLocation);
+        return thumbStream;
     }
 }

--- a/src/protagonist/Orchestrator/Infrastructure/ThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ThumbSizeCalculator.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DLCS.Core.Guard;
+using DLCS.Model.Assets;
+using DLCS.Model.Assets.Metadata;
+using DLCS.Model.Policies;
+using IIIF;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Orchestrator.Settings;
+using ImageApi = IIIF.ImageApi;
+
+namespace Orchestrator.Infrastructure;
+
+public class ThumbSizeCalculator
+{
+    private readonly IPolicyRepository policyRepository;
+    private readonly ILogger<ThumbSizeCalculator> logger;
+    private readonly OrchestratorSettings orchestratorSettings;
+    private readonly Dictionary<int, List<ImageApi.SizeParameter>> thumbnailPolicies = new();
+
+    public ThumbSizeCalculator(IPolicyRepository policyRepository, 
+        ILogger<ThumbSizeCalculator> logger,
+        IOptions<OrchestratorSettings> orchestratorOptions)
+    {
+        this.policyRepository = policyRepository;
+        this.logger = logger;
+        orchestratorSettings = orchestratorOptions.Value;
+    }
+    
+    /// <summary>
+    /// Get available sizes for thumbnails (if any). ie it will only return "Open" thumb sizes
+    ///
+    /// This will _not_ hit S3 to read available thumbs, it will:
+    /// Attempt to read from asset.AssetApplicationMetadata. If found return. Else
+    /// Get thumbnail policy and calculate available sizes. 
+    /// </summary>
+    public async Task<List<Size>> GetAvailableThumbSizesForImage(Asset asset)
+    {
+        var thumbnailSizes = asset.AssetApplicationMetadata?.GetThumbsMetadata();
+        
+        if (thumbnailSizes != null)
+        {
+            logger.LogDebug("ThumbSizes metadata found for {AssetId}", asset.Id);
+            return thumbnailSizes.Open.Select(t => new Size(t[0], t[1])).ToList();
+        }
+
+        if ((orchestratorSettings.ThumbsMetadataDate ?? DateTime.MaxValue) < asset.Finished)
+        {
+            logger.LogWarning(
+                "No thumbs metadata found for asset {AssetId} with finished date {FinishedDate}", asset.Id,
+                asset.Finished);
+        }
+        
+        return await GetThumbnailSizesForImage(asset) ?? Enumerable.Empty<Size>().ToList();
+    }
+
+    private async Task<List<Size>?> GetThumbnailSizesForImage(Asset asset)
+    {
+        logger.LogDebug("Calculating thumbnail sizes for {AssetId}", asset.Id);
+        var sizeParameters = await GetThumbnailPolicyAsSizeParams(asset);
+
+        var thumbnailSizesForImage = asset.GetAvailableThumbSizes(sizeParameters, out _);
+        return thumbnailSizesForImage;
+    }
+
+    private async Task<List<ImageApi.SizeParameter>> GetThumbnailPolicyAsSizeParams(Asset image)
+    {
+        var thumbnailDeliveryChannel = image.ImageDeliveryChannels.GetThumbsChannel();
+
+        if (thumbnailDeliveryChannel is null) return Enumerable.Empty<ImageApi.SizeParameter>().ToList();
+
+        if (thumbnailPolicies.TryGetValue(thumbnailDeliveryChannel.DeliveryChannelPolicyId, out var thumbnailPolicy))
+        {
+            return thumbnailPolicy;
+        }
+
+        var thumbnailPolicyFromDb =
+            await policyRepository.GetThumbnailPolicy(thumbnailDeliveryChannel.DeliveryChannelPolicyId, image.Customer);
+
+        var sizeParameters = thumbnailPolicyFromDb
+            .ThrowIfNull(nameof(thumbnailPolicyFromDb))
+            .ThumbsDataAsSizeParameters();
+        thumbnailPolicies[thumbnailDeliveryChannel.DeliveryChannelPolicyId] = sizeParameters;
+        return sizeParameters;
+    }
+}

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -255,6 +255,11 @@ public class NamedQuerySettings
     /// Customer-specific overrides; keyed by customer Id
     /// </summary>
     public Dictionary<string, CustomerOverride> CustomerOverrides { get; set; } = new();
+
+    /// <summary>
+    /// For NQ projection the thumbnail closest to this size will be selected
+    /// </summary>
+    public int ProjectionThumbsize { get; set; } = 1000;
 }
 
 public class CustomerOverride

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -70,6 +70,7 @@ public class Startup
             .AddSingleton<FileRequestHandler>()
             .AddSingleton<S3ProxyPathGenerator>()
             .AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>()
+            .AddScoped<ThumbSizeCalculator>()
             .AddScoped<IIIFManifestBuilder>()
             .AddScoped<IIIFCanvasFactory>()
             .AddSingleton<AssetRequestProcessor>()

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -70,7 +70,7 @@ public class Startup
             .AddSingleton<FileRequestHandler>()
             .AddSingleton<S3ProxyPathGenerator>()
             .AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>()
-            .AddScoped<ThumbSizeCalculator>()
+            .AddScoped<IThumbSizeCalculator, MetadataWithFallbackThumbSizeCalculator>()
             .AddScoped<IIIFManifestBuilder>()
             .AddScoped<IIIFCanvasFactory>()
             .AddSingleton<AssetRequestProcessor>()

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -70,7 +70,7 @@ public class Startup
             .AddSingleton<FileRequestHandler>()
             .AddSingleton<S3ProxyPathGenerator>()
             .AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>()
-            .AddScoped<IThumbSizeCalculator, MetadataWithFallbackThumbSizeCalculator>()
+            .AddScoped<IThumbSizeProvider, MetadataWithFallbackThumbSizeProvider>()
             .AddScoped<IIIFManifestBuilder>()
             .AddScoped<IIIFCanvasFactory>()
             .AddSingleton<AssetRequestProcessor>()

--- a/src/protagonist/Test.Helpers/Data/AssetIdGenerator.cs
+++ b/src/protagonist/Test.Helpers/Data/AssetIdGenerator.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.CompilerServices;
+using DLCS.Core.Types;
+
+namespace Test.Helpers.Data;
+
+public static class AssetIdGenerator
+{
+    /// <summary>
+    /// Generate new <see cref="AssetId"/> using calling function as "asset" part by default
+    /// </summary>
+    public static AssetId GetAssetId(int customer = 99, int space = 1, [CallerMemberName] string asset = "") 
+        => new(customer, space, asset);
+}

--- a/src/protagonist/Test.Helpers/Data/EntityHelpers.cs
+++ b/src/protagonist/Test.Helpers/Data/EntityHelpers.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using DLCS.Model.Assets;
+using DLCS.Model.Assets.Metadata;
+
+namespace Test.Helpers.Data;
+
+/// <summary>
+/// Collection of helper methods for generating test entities
+/// </summary>
+public static class EntityHelpers
+{
+    public static Asset WithTestThumbnailMetadata(this Asset asset,
+        string metadataValue = "{\"a\": [], \"o\": [[75, 100], [150, 200], [300, 400], [769, 1024]]}")
+    {
+        asset.AssetApplicationMetadata ??= new List<AssetApplicationMetadata>();
+        asset.AssetApplicationMetadata.Add(new AssetApplicationMetadata
+        {
+            AssetId = asset.Id,
+            MetadataType = AssetApplicationMetadataTypes.ThumbSizes,
+            MetadataValue = metadataValue,
+            Created = DateTime.UtcNow,
+            Modified = DateTime.UtcNow
+        });
+        return asset;
+    }
+}

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -14,6 +14,7 @@ using DLCS.Model.Storage;
 using DLCS.Repository.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Test.Helpers.Data;
 
 namespace Test.Helpers.Integration;
 
@@ -198,22 +199,12 @@ public static class DatabaseTestDataPopulation
             Created = DateTime.UtcNow,
             Modified = DateTime.UtcNow
         });
-    
-    public static ValueTask<EntityEntry<Asset>> AddTestThumbnailMetadata(
-        this  ValueTask<EntityEntry<Asset>> asset,
-        string metadataValue = "{\"a\": [], \"o\": [[75, 100], [150, 200], [300, 400], [769, 1024]]}")
-    {
-        asset.Result.Entity.AssetApplicationMetadata ??= new List<AssetApplicationMetadata>();
-        
-        asset.Result.Entity.AssetApplicationMetadata.Add(new AssetApplicationMetadata()
-        {
-            AssetId = asset.Result.Entity.Id,
-            MetadataType = AssetApplicationMetadataTypes.ThumbSizes,
-            MetadataValue = metadataValue,
-            Created = DateTime.UtcNow,
-            Modified = DateTime.UtcNow
-        });
 
+    public static ValueTask<EntityEntry<Asset>> WithTestThumbnailMetadata(
+        this ValueTask<EntityEntry<Asset>> asset,
+        string metadataValue = "{\"a\": [], \"o\": [[769,1024],[300,400],[150,200],[75,100]]}")
+    {
+        asset.Result.Entity.WithTestThumbnailMetadata(metadataValue);
         return asset;
     }
 }


### PR DESCRIPTION
Resolves #813 (WDC-81)

This PR updates engine to no longer store `low.jpg` (a copy of the largest thumb regardless of accessibility). Instead we only store 1 single copy of each thumbnail and calculate the size when requested. This affects:
* single-item manifest
* NQ projection to manifest
* NQ projection to pdf
* NQ projection to zip archive

Refactored logic from `IIIFCanvasFactory` to introduce `SizeClosestTo` - this takes available sizes and target size.

Refactored thumb calculation logic from `IIIFCanvasFactory`, introduced in #810, into `MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider` . This logic will:
* Attempt to read thumb sizes from `AssetApplicationMetadata`. If found, return sizes. Else,
* Read thumbs DeliveryChannelPolicy and calculate sizes on the fly - *note only confined sizes are calculated*

Also added a couple of helpers to make writing tests easier