### PR TITLE
Add retry logic to thumbs processor

### DIFF
--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -61,7 +61,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private async Task<ImageOnDisk?> GenerateSingleThumbnail(string thumbFolder,
         string convertedS3Location, string size, AssetId assetId, int count, List<ImageOnDisk> thumbsResponse,
-        Size imageSize, bool retry, CancellationToken cancellationToken)
+        Size imageSize, bool shouldRetry, CancellationToken cancellationToken)
     {
         using var response =
             await cantaloupeClient.GetAsync(
@@ -76,7 +76,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
         if (response.IsSuccessStatusCode)
         {
-            return await SaveImageToDisk(response, size, thumbFolder, count, retry, convertedS3Location,
+            return await SaveImageToDisk(response, size, thumbFolder, count, shouldRetry, convertedS3Location,
                 assetId, thumbsResponse, imageSize, cancellationToken);
         }
 
@@ -85,7 +85,7 @@ public class CantaloupeThumbsClient : IThumbsClient
     }
 
     private async Task<ImageOnDisk> SaveImageToDisk(HttpResponseMessage response, string size, string thumbFolder,
-        int count, bool retry, string convertedS3Location, AssetId assetId, List<ImageOnDisk> thumbsResponse,
+        int count, bool shouldRetry, string convertedS3Location, AssetId assetId, List<ImageOnDisk> thumbsResponse,
         Size imageSize, CancellationToken cancellationToken)
     {
         await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
@@ -99,9 +99,9 @@ public class CantaloupeThumbsClient : IThumbsClient
 
         return (imageOnDisk switch
         {
-            null when retry => await GenerateSingleThumbnail(thumbFolder, convertedS3Location, size, assetId, count,
+            null when shouldRetry => await GenerateSingleThumbnail(thumbFolder, convertedS3Location, size, assetId, count,
                 thumbsResponse, imageSize, false, cancellationToken),
-            null when !retry => throw new InvalidOperationException("Failed to retrieve image on disk"),
+            null when !shouldRetry => throw new InvalidOperationException("Failed to measure image on disk"),
             _ => imageOnDisk
         })!;
     }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -69,7 +69,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
         if (response.StatusCode == HttpStatusCode.BadRequest)
         {
-            // This is likely an error for the individual thumb size, so just continue
+            // This is likely an error for the individual thumb size, so don't throw an error
             await LogErrorResponse(response, assetId, size, LogLevel.Information, cancellationToken);
             return null;
         }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/IImageMeasurer.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/IImageMeasurer.cs
@@ -5,5 +5,5 @@ public interface IImageMeasurer
     /// <summary>
     /// Return <see cref="ImageOnDisk"/> object image at specified path 
     /// </summary>
-    public Task<ImageOnDisk> MeasureImage(string path, CancellationToken cancellationToken = default);
+    public Task<ImageOnDisk?> MeasureImage(string path, CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
@@ -1,16 +1,39 @@
-﻿namespace Engine.Ingest.Image.ImageServer.Measuring;
+﻿using SixLabors.ImageSharp;
+
+namespace Engine.Ingest.Image.ImageServer.Measuring;
 
 public class ImageSharpMeasurer : IImageMeasurer
 {
-    public async Task<ImageOnDisk> MeasureImage(string path, CancellationToken cancellationToken = default)
+    private readonly ILogger<ImageSharpMeasurer> logger;
+    
+    public ImageSharpMeasurer(ILogger<ImageSharpMeasurer> logger)
     {
-        using var image = await SixLabors.ImageSharp.Image.LoadAsync(path, cancellationToken);
-        var imageOnDisk = new ImageOnDisk
+        this.logger = logger;
+    }
+    
+    public async Task<ImageOnDisk?> MeasureImage(string path, CancellationToken cancellationToken = default)
+    {
+        try
         {
-            Path = path,
-            Width = image.Width,
-            Height = image.Height
-        };
-        return imageOnDisk;
+            using var image = await SixLabors.ImageSharp.Image.LoadAsync(path, cancellationToken);
+            var imageOnDisk = new ImageOnDisk
+            {
+                Path = path,
+                Width = image.Width,
+                Height = image.Height
+            };
+
+            await using var test = new FileStream(path, FileMode.Open);
+            test.Seek(10, SeekOrigin.End);
+            using var testTwo = await SixLabors.ImageSharp.Image.LoadAsync(test, cancellationToken);
+            
+            return imageOnDisk;
+        }
+        catch (UnknownImageFormatException exception)
+        {
+            logger.LogError(exception, "Error loading image from disk");
+        }
+
+        return null;
     }
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Measuring/ImageSharpMeasurer.cs
@@ -23,10 +23,6 @@ public class ImageSharpMeasurer : IImageMeasurer
                 Height = image.Height
             };
 
-            await using var test = new FileStream(path, FileMode.Open);
-            test.Seek(10, SeekOrigin.End);
-            using var testTwo = await SixLabors.ImageSharp.Image.LoadAsync(test, cancellationToken);
-            
             return imageOnDisk;
         }
         catch (UnknownImageFormatException exception)


### PR DESCRIPTION
This PR adds retry logic to the thumbs processor based on failures in the image measurer.  This specifically addresses an issue seen where Cantaloupe returned a broken thumbnail which image sharp was unable to open correctly. When this occurs, thumbs processor will retry the thumbnail once, and if it still fails, will throw an error