### PR TITLE
Don't include query params in manifest ids

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -182,10 +182,29 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Get_ReturnsV2Manifest_WithCorrectId_IgnoringQueryParam()
+    {
+        // Arrange
+        const string path = "iiif-resource/v2/99/test-named-query/my-ref/1";
+        const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
+        
+        // Act
+        var response = await httpClient.GetAsync($"{path}?foo=bar");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should().Be($"http://localhost/{path}");
+    }
+    
+    [Fact]
     public async Task Get_ReturnsV3ManifestWithCorrectCount_ViaConneg()
     {
         // Arrange
         const string path = "iiif-resource/99/test-named-query/my-ref/1";
+        
         const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
         
         // Act
@@ -217,6 +236,24 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
         response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse.SelectToken("items").Count().Should().Be(3);
+    }
+    
+    [Fact]
+    public async Task Get_ReturnsV3Manifest_WithCorrectId_IgnoringQueryParam()
+    {
+        // Arrange
+        const string path = "iiif-resource/v3/99/test-named-query/my-ref/1";
+        const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
+        
+        // Act
+        var response = await httpClient.GetAsync($"{path}?foo=bar");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["id"].ToString().Should().Be($"http://localhost/{path}");
     }
     
     [Fact]

--- a/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
@@ -57,7 +57,7 @@ public class IIIFNamedQueryProjector
         CancellationToken cancellationToken)
     {
         var sequenceRootUrl = request.GetDisplayUrl("/iiif-query/");
-        var manifestId = request.GetDisplayUrl();
+        var manifestId = GetManifestId(request);
         var label = GetManifestLabel(parsedNamedQuery);
         var manifest =
             await manifestBuilder.GenerateV2Manifest(results, customerPathElement, manifestId, label, sequenceRootUrl,
@@ -70,7 +70,7 @@ public class IIIFNamedQueryProjector
         CustomerPathElement customerPathElement, List<Asset> results, HttpRequest request,
         CancellationToken cancellationToken)
     {
-        var manifestId = request.GetDisplayUrl();
+        var manifestId = GetManifestId(request);
         var label = GetManifestLabel(parsedNamedQuery);
         var manifest =
             await manifestBuilder.GenerateV3Manifest(results, customerPathElement, manifestId, label,
@@ -78,6 +78,9 @@ public class IIIFNamedQueryProjector
         
         return manifest;
     }
+
+    private static string GetManifestId(HttpRequest request) =>
+        request.GetDisplayUrl(request.Path.Value, includeQueryParams: false);
 
     private static string GetManifestLabel(IIIFParsedNamedQuery parsedNamedQuery)
         => $"Generated from '{parsedNamedQuery.NamedQueryName}' named query";

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -101,5 +101,5 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
     }
 
     private string GetFullyQualifiedId(BaseAssetRequest baseAssetRequest)
-        => assetPathGenerator.GetFullPathForRequest(baseAssetRequest, true);
+        => assetPathGenerator.GetFullPathForRequest(baseAssetRequest, true, false);
 }

--- a/src/protagonist/Test.Helpers/Data/AssetIdGenerator.cs
+++ b/src/protagonist/Test.Helpers/Data/AssetIdGenerator.cs
@@ -8,6 +8,7 @@ public static class AssetIdGenerator
     /// <summary>
     /// Generate new <see cref="AssetId"/> using calling function as "asset" part by default
     /// </summary>
-    public static AssetId GetAssetId(int customer = 99, int space = 1, [CallerMemberName] string asset = "") 
-        => new(customer, space, asset);
+    public static AssetId GetAssetId(int customer = 99, int space = 1, [CallerMemberName] string asset = "",
+        string assetPostfix = "")
+        => new(customer, space, $"{asset}{assetPostfix}");
 }


### PR DESCRIPTION
Modified tests to use new AssetIdGenerator helper