### PR TITLE
Fix API returning 500 when an image is supplied with an unknown channel

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -26,6 +26,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Test.Helpers.Data;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
 using AssetFamily = DLCS.Model.Assets.AssetFamily;
@@ -284,7 +285,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Put_NewImageAsset_BadRequest_WhenDeliveryChannelInvalid()
     {
         // arrange
-        var assetId = new AssetId(99, 1, nameof(Put_NewImageAsset_BadRequest_WhenDeliveryChannelInvalid));
+        var assetId = AssetIdGenerator.GetAssetId();
         var hydraImageBody = $@"{{
             ""@type"": ""Image"",
             ""origin"": ""https://example.org/my-image.png"",

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -279,7 +279,32 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
                                                                 x.DeliveryChannelPolicyId == KnownDeliveryChannelPolicies.ImageDefault);
         asset.ImageDeliveryChannels.Should().ContainSingle(x => x.Channel == "thumbs");
     }
-    
+
+    [Fact]
+    public async Task Put_NewImageAsset_BadRequest_WhenDeliveryChannelInvalid()
+    {
+        // arrange
+        var assetId = new AssetId(99, 1, nameof(Put_NewImageAsset_BadRequest_WhenDeliveryChannelInvalid));
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/my-image.png"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/png"",
+            ""deliveryChannels"": [
+            {{
+                ""channel"":""bad-delivery-channel"",
+                ""policy"":""default""
+            }}]
+        }}";  
+        
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(99).PutAsync(assetId.ToApiResourcePath(), content);
+        
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     [Theory]
     [InlineData("T", "video/mp4", "mp4",  "iiif-img")]
     [InlineData("T", "video/mp4", "mp4", "thumbs")]

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -69,7 +69,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .WithMessage("'channel' must be specified when supplying delivery channels to an asset");
             
         RuleForEach(a => a.DeliveryChannels)
-            .Must((a, c) => DeliveryChannelIsValidForMediaType(c.Channel, a.MediaType!))
+            .Must((a, c) => AssetDeliveryChannels.IsChannelValidForMediaType(c.Channel, a.MediaType!, false))
             .When(a => !string.IsNullOrEmpty(a.MediaType))
             .WithMessage((a,c) => $"'{c.Channel}' is not a valid delivery channel for asset of type '{a.MediaType}'");
     
@@ -110,17 +110,5 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .When(a => !a.WcDeliveryChannels!.Contains(AssetDeliveryChannels.Image))
             .WithMessage(
                 $"ImageOptimisationPolicy '{KnownImageOptimisationPolicy.UseOriginalId}' only valid for image delivery-channel");
-    }
-
-    private bool DeliveryChannelIsValidForMediaType(string channel, string mediaType)
-    {
-        try
-        {
-            return AssetDeliveryChannels.IsChannelValidForMediaType(channel, mediaType);
-        }
-        catch(ArgumentOutOfRangeException)
-        {
-            return false;
-        }
     }
 }

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -69,9 +69,9 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .WithMessage("'channel' must be specified when supplying delivery channels to an asset");
             
         RuleForEach(a => a.DeliveryChannels)
-            .Must((a, c) => AssetDeliveryChannels.IsChannelValidForMediaType(c.Channel, a.MediaType!))
+            .Must((a, c) => DeliveryChannelIsValidForMediaType(c.Channel, a.MediaType!))
             .When(a => !string.IsNullOrEmpty(a.MediaType))
-            .WithMessage((a,c) => $"'{c.Channel}' is not a valid delivery channel for asset of type \"{a.MediaType}\"");
+            .WithMessage((a,c) => $"'{c.Channel}' is not a valid delivery channel for asset of type '{a.MediaType}'");
     
         RuleForEach(a => a.DeliveryChannels)
             .Must((a, c) => a.DeliveryChannels!.Count(dc => dc.Channel == c.Channel) <= 1)
@@ -110,5 +110,17 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .When(a => !a.WcDeliveryChannels!.Contains(AssetDeliveryChannels.Image))
             .WithMessage(
                 $"ImageOptimisationPolicy '{KnownImageOptimisationPolicy.UseOriginalId}' only valid for image delivery-channel");
+    }
+
+    private bool DeliveryChannelIsValidForMediaType(string channel, string mediaType)
+    {
+        try
+        {
+            return AssetDeliveryChannels.IsChannelValidForMediaType(channel, mediaType);
+        }
+        catch(ArgumentOutOfRangeException)
+        {
+            return false;
+        }
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -54,7 +54,7 @@ public static class AssetDeliveryChannels
     /// <summary>
     /// Checks if a delivery channel is valid for a given media type
     /// </summary>
-    public static bool IsChannelValidForMediaType(string deliveryChannel, string mediaType) 
+    public static bool IsChannelValidForMediaType(string deliveryChannel, string mediaType, bool throwIfChannelUnknown = true) 
         => deliveryChannel switch 
         { 
             Image => mediaType.StartsWith("image/"),
@@ -62,8 +62,9 @@ public static class AssetDeliveryChannels
             Timebased => mediaType.StartsWith("video/") || mediaType.StartsWith("audio/"),
             File => true, // A file can be matched to any media type
             None => true, // Likewise for the 'none' channel
-            _ => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
-                $"Acceptable delivery-channels are: {AllString}")
+            _ when throwIfChannelUnknown => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
+                $"Acceptable delivery-channels are: {AllString}"),
+            _ => false,
         };
 }
 


### PR DESCRIPTION
Resolves #822 and WDC-85

This PR fixes a bug which caused the API to return 500 on attempting to PUT an image containing an unknown channel. It also adds a test confirming that 400 is sent in this scenario.