### PR TITLE
Remove image services from asset manifest if not available

### DIFF
--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
@@ -108,4 +108,35 @@ public class AssetDeliveryChannelsTests
         
         asset.HasSingleDeliveryChannel(channel).Should().BeTrue();
     }
+    
+    [Theory]
+    [InlineData(AssetDeliveryChannels.File)]
+    [InlineData(AssetDeliveryChannels.Image)]
+    [InlineData(AssetDeliveryChannels.Timebased)]
+    public void HasAnyDeliveryChannel_True(string channel)
+    {
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = channel,
+            }
+        } };
+        
+        asset.HasAnyDeliveryChannel(AssetDeliveryChannels.All).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void HasAnyDeliveryChannel_False()
+    {
+        var asset = new Asset { ImageDeliveryChannels = new List<ImageDeliveryChannel>()
+        {
+            new()
+            {
+                Channel = "not-a-channel",
+            }
+        } };
+
+        asset.HasAnyDeliveryChannel(AssetDeliveryChannels.All).Should().BeFalse();
+    }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -44,12 +44,21 @@ public static class AssetDeliveryChannels
         => asset.ImageDeliveryChannels != null &&
            asset.ImageDeliveryChannels.Count == 1 && 
            asset.HasDeliveryChannel(deliveryChannel);
-    
+
     /// <summary>
     /// Checks if an asset has any delivery channel specified in a list
     /// </summary>
     public static bool HasAnyDeliveryChannel(this Asset asset, params string[] deliveryChannels)
-        => deliveryChannels.Any(asset.HasDeliveryChannel);
+    {
+        if (asset.ImageDeliveryChannels.IsNullOrEmpty() || deliveryChannels.IsNullOrEmpty()) return false;
+        if (deliveryChannels.Any(dc => !All.Contains(dc)))
+        {
+            throw new ArgumentOutOfRangeException(nameof(deliveryChannels), deliveryChannels,
+                $"Acceptable delivery-channels are: {AllString}");
+        }
+        
+        return asset.ImageDeliveryChannels.Any(dc => deliveryChannels.Contains(dc.Channel));
+    }
 
     /// <summary>
     /// Checks if string is a valid delivery channel

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -21,30 +21,7 @@ public static class AssetDeliveryChannels
     /// All possible delivery channels as a comma-delimited string
     /// </summary>
     public static readonly string AllString = string.Join(',', All);
-
-    /// <summary>
-    /// Check if asset has specified deliveryChannel
-    /// </summary>
-    public static bool HasDeliveryChannel(this Asset asset, string deliveryChannel)
-    {
-        if (asset.ImageDeliveryChannels.IsNullOrEmpty()) return false;
-        if (!All.Contains(deliveryChannel))
-        {
-            throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
-                $"Acceptable delivery-channels are: {AllString}");
-        }
-
-        return asset.ImageDeliveryChannels.Any(i => i.Channel == deliveryChannel);
-    }
-
-    /// <summary>
-    /// Checks if asset has specified deliveryChannel only (e.g. 1 channel and it matches specified value
-    /// </summary>
-    public static bool HasSingleDeliveryChannel(this Asset asset, string deliveryChannel)
-        => asset.ImageDeliveryChannels != null &&
-           asset.ImageDeliveryChannels.Count == 1 && 
-           asset.HasDeliveryChannel(deliveryChannel);
-
+    
     /// <summary>
     /// Checks if an asset has any delivery channel specified in a list
     /// </summary>
@@ -59,7 +36,21 @@ public static class AssetDeliveryChannels
         
         return asset.ImageDeliveryChannels.Any(dc => deliveryChannels.Contains(dc.Channel));
     }
-
+    
+    /// <summary>
+    /// Check if asset has specified deliveryChannel
+    /// </summary>
+    public static bool HasDeliveryChannel(this Asset asset, string deliveryChannel)
+        => HasAnyDeliveryChannel(asset, deliveryChannel);
+        
+    /// <summary>
+    /// Checks if asset has specified deliveryChannel only (e.g. 1 channel and it matches specified value
+    /// </summary>
+    public static bool HasSingleDeliveryChannel(this Asset asset, string deliveryChannel)
+        => asset.ImageDeliveryChannels != null &&
+           asset.ImageDeliveryChannels.Count == 1 && 
+           asset.HasDeliveryChannel(deliveryChannel);
+    
     /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -46,6 +46,12 @@ public static class AssetDeliveryChannels
            asset.HasDeliveryChannel(deliveryChannel);
     
     /// <summary>
+    /// Checks if an asset has any delivery channel specified in a list
+    /// </summary>
+    public static bool HasAnyDeliveryChannel(this Asset asset, params string[] deliveryChannels)
+        => deliveryChannels.Any(asset.HasDeliveryChannel);
+
+    /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
     public static bool IsValidChannel(string? deliveryChannel)

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -387,7 +387,9 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").WithTestThumbnailMetadata();
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
+            .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/{id}";

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -268,7 +268,9 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin").WithTestThumbnailMetadata();
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
+            .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -51,15 +51,8 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
                 
         var thumbsPolicy = dbFixture.DbContext.DeliveryChannelPolicies.Single(d =>
             d.Channel == AssetDeliveryChannels.Thumbnails && d.Customer == 99);
-        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-1"), num1: 2, ref1: "my-ref",
-            imageDeliveryChannels: new List<ImageDeliveryChannel>
-            {
-                new()
-                {
-                    Channel = AssetDeliveryChannels.Thumbnails,
-                    DeliveryChannelPolicyId = thumbsPolicy.Id,
-                }
-            });
+        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-1"), num1: 2, ref1: "my-ref")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Thumbnails, thumbsPolicy.Id);
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-2"), num1: 1, ref1: "my-ref")
             .WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
@@ -68,10 +61,15 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
             notForDelivery: true).WithTestThumbnailMetadata();
 
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/auth-1"), num1: 2, ref1: "auth-ref",
-            roles: "clickthrough").WithTestThumbnailMetadata();
+            roles: "clickthrough")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
+            .WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/auth-2"), num1: 1, ref1: "auth-ref",
-            roles: "clickthrough").WithTestThumbnailMetadata();
+            roles: "clickthrough")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
+            .WithTestThumbnailMetadata();
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("100/1/no-auth"), num1: 3, ref1: "auth-ref")
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
             .WithTestThumbnailMetadata();
 
         dbFixture.DbContext.SaveChanges();

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -66,10 +66,11 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
             .IncludeDataForThumbs()
             .FirstOrDefaultAsync(a => a.Id == assetId, cancellationToken);
         
-        if (!asset.HasDeliveryChannel(AssetDeliveryChannels.Image) && 
-            !asset.HasDeliveryChannel(AssetDeliveryChannels.Thumbnails))
+        if (asset == null || asset.NotForDelivery ||
+            !asset.HasAnyDeliveryChannel(AssetDeliveryChannels.Image, AssetDeliveryChannels.Thumbnails))
         {
-            logger.LogDebug("Attempted to request an iiif-manifest for {AssetId}, but it is unavailable on any image delivery channel.", assetId);
+            logger.LogDebug("Attempted to request an iiif-manifest for {AssetId}, but it was not found or is unavailable on any image delivery channel.",
+                assetId);
             return DescriptionResourceResponse.Empty;
         }    
 

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -140,14 +140,16 @@ public class IIIFCanvasFactory
                 {
                     Id = string.Concat(fullyQualifiedImageId, "/imageanno/0"),
                     On = canvasId,
-                    Resource = new IIIF2.ImageResource
-                    {
-                        Id = GetFullQualifiedImagePath(asset, customerPathElement,
-                            thumbnailSizes.MaxDerivativeSize, false),
-                        Width = thumbnailSizes.MaxDerivativeSize.Width,
-                        Height = thumbnailSizes.MaxDerivativeSize.Height,
-                        Service = GetImageServices(asset, customerPathElement, null)
-                    },
+                    Resource = asset.HasDeliveryChannel(AssetDeliveryChannels.Image) 
+                        ? new IIIF2.ImageResource
+                            {
+                                Id = GetFullQualifiedImagePath(asset, customerPathElement,
+                                    thumbnailSizes.MaxDerivativeSize, false),
+                                Width = thumbnailSizes.MaxDerivativeSize.Width,
+                                Height = thumbnailSizes.MaxDerivativeSize.Height,
+                                Service = GetImageServices(asset, customerPathElement, null)
+                            }
+                        : null,
                 }.AsList()
             };
 

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -77,15 +77,17 @@ public class IIIFCanvasFactory
                     {
                         Target = new IIIF3.Canvas { Id = canvasId },
                         Id = $"{canvasId}/page/image",
-                        Body = new Image
-                        {
-                            Id = GetFullQualifiedImagePath(asset, customerPathElement,
-                                thumbnailSizes.MaxDerivativeSize, false),
-                            Format = "image/jpeg",
-                            Width = thumbnailSizes.MaxDerivativeSize.Width,
-                            Height = thumbnailSizes.MaxDerivativeSize.Height,
-                            Service = GetImageServices(asset, customerPathElement, authProbeServices)
-                        } 
+                        Body = asset.HasDeliveryChannel(AssetDeliveryChannels.Image)
+                            ? new Image
+                                {
+                                    Id = GetFullQualifiedImagePath(asset, customerPathElement,
+                                        thumbnailSizes.MaxDerivativeSize, false),
+                                    Format = "image/jpeg",
+                                    Width = thumbnailSizes.MaxDerivativeSize.Width,
+                                    Height = thumbnailSizes.MaxDerivativeSize.Height,
+                                    Service = GetImageServices(asset, customerPathElement, authProbeServices)
+                                }
+                            : null,
                     }.AsListOf<IAnnotation>()
                 }.AsList()
             };

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -16,7 +16,6 @@ using DLCS.Model.Storage;
 using DLCS.Repository.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
-using NuGet.Packaging;
 using Test.Helpers.Data;
 
 namespace Test.Helpers.Integration;
@@ -216,12 +215,6 @@ public static class DatabaseTestDataPopulation
         string deliveryChannel,
         int? policyId = null)
     {
-        if (!AssetDeliveryChannels.IsValidChannel(deliveryChannel))
-        {
-            throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
-                $"Acceptable delivery-channels are: {AssetDeliveryChannels.AllString}");
-        }
-
         asset.Result.Entity.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
         {
             Channel = deliveryChannel,
@@ -234,7 +227,7 @@ public static class DatabaseTestDataPopulation
                     : KnownDeliveryChannelPolicies.AvDefaultAudio,
                 AssetDeliveryChannels.File => KnownDeliveryChannelPolicies.FileNone,
                 _ => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
-                    "Unable to assign default delivery channel policy to asset")
+                    $"Unable to assign default delivery channel policy for channel {deliveryChannel} for asset")
             }
         });
         

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DLCS.Core;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.CustomHeaders;
@@ -9,11 +10,13 @@ using DLCS.Model.Assets.Metadata;
 using DLCS.Model.Assets.NamedQueries;
 using DLCS.Model.Customers;
 using DLCS.Model.DeliveryChannels;
+using DLCS.Model.Policies;
 using DLCS.Model.Spaces;
 using DLCS.Model.Storage;
 using DLCS.Repository.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using NuGet.Packaging;
 using Test.Helpers.Data;
 
 namespace Test.Helpers.Integration;
@@ -205,6 +208,36 @@ public static class DatabaseTestDataPopulation
         string metadataValue = "{\"a\": [], \"o\": [[769,1024],[300,400],[150,200],[75,100]]}")
     {
         asset.Result.Entity.WithTestThumbnailMetadata(metadataValue);
+        return asset;
+    }
+
+    public static ValueTask<EntityEntry<Asset>> WithTestDeliveryChannel(
+        this ValueTask<EntityEntry<Asset>> asset,
+        string deliveryChannel,
+        int? policyId = null)
+    {
+        if (!AssetDeliveryChannels.IsValidChannel(deliveryChannel))
+        {
+            throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
+                $"Acceptable delivery-channels are: {AssetDeliveryChannels.AllString}");
+        }
+
+        asset.Result.Entity.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+        {
+            Channel = deliveryChannel,
+            DeliveryChannelPolicyId = policyId ?? deliveryChannel switch
+            {
+                AssetDeliveryChannels.Image => KnownDeliveryChannelPolicies.ImageDefault,
+                AssetDeliveryChannels.Thumbnails => KnownDeliveryChannelPolicies.ThumbsDefault,
+                AssetDeliveryChannels.Timebased => MIMEHelper.IsVideo(asset.Result.Entity.Origin)
+                    ? KnownDeliveryChannelPolicies.AvDefaultVideo
+                    : KnownDeliveryChannelPolicies.AvDefaultAudio,
+                AssetDeliveryChannels.File => KnownDeliveryChannelPolicies.FileNone,
+                _ => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,
+                    "Unable to assign default delivery channel policy to asset")
+            }
+        });
+        
         return asset;
     }
 }


### PR DESCRIPTION
Resolves #824 and WDC-87

This PR removes image services from V2/V3 asset manifests for assets that do not have the `iiif-img` delivery channel. It also updates `GetManifestForAsset` to return 404 if the asset is not being served on `thumbs` or `iiif-img`.