### PR TITLE
Allow ActivityTimeout to be set per destination

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1215,6 +1215,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.Should().ContainKey("Set-Cookie");
         response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+        proxyResponse.ActivityTimeout.Should().BeCloseTo(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(2));
     }
     
     [Theory]
@@ -1464,6 +1465,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.Headers.CacheControl.MaxAge.Should().Be(TimeSpan.FromDays(28));
         response.Headers.Should().ContainKey("x-test-key").WhoseValue.Should().BeEquivalentTo("foo bar");
         response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+        proxyResponse.ActivityTimeout.Should().BeCloseTo(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(2));
     }
     
     [Theory]

--- a/src/protagonist/Orchestrator.Tests/Integration/Infrastructure/TestProxyHttpClientFactory.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/Infrastructure/TestProxyHttpClientFactory.cs
@@ -60,7 +60,7 @@ public class TestProxyForwarder : IHttpForwarder
         await transformer.TransformResponseAsync(context, proxyResponse);
 
         // Write request parameters into response
-        await context.Response.WriteAsJsonAsync(new ProxyResponse(requestMessage));
+        await context.Response.WriteAsJsonAsync(new ProxyResponse(requestMessage, requestConfig.ActivityTimeout));
         return ForwarderError.None;
     }
 }
@@ -72,13 +72,15 @@ public class ProxyResponse
 {
     public Uri Uri { get; set; }
     public HttpMethod Method { get; set;}
+    public TimeSpan? ActivityTimeout { get; set; }
 
     public ProxyResponse()
     {
     }
 
-    public ProxyResponse(HttpRequestMessage request)
+    public ProxyResponse(HttpRequestMessage request, TimeSpan? activityTimeout = null)
     {
+        ActivityTimeout = activityTimeout;
         Uri = request.RequestUri;
         Method = request.Method;
     }

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -71,6 +71,9 @@
           "cantaloupe/one": {
             "Address": "http://image-server"
           }
+        },
+        "HttpRequest": {
+          "ActivityTimeout": "00:00:10"
         }
       },
       "specialserver": {

--- a/src/protagonist/Orchestrator/Features/Files/FileRouteHandlers.cs
+++ b/src/protagonist/Orchestrator/Features/Files/FileRouteHandlers.cs
@@ -87,7 +87,7 @@ public static class FileRouteHandlers
 
         if (error != ForwarderError.None)
         {
-            error.HandleProxyError(httpContext, logger);
+            error.HandleProxyError(httpContext, RequestOptions, logger);
         }
     }
 }

--- a/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRouteHandlers.cs
+++ b/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRouteHandlers.cs
@@ -21,7 +21,6 @@ public static class TimeBasedRouteHandlers
 
     static TimeBasedRouteHandlers()
     {
-        // TODO - should this be shared by AV + Image handling?
         HttpClient = new HttpMessageInvoker(new SocketsHttpHandler
         {
             UseProxy = false,
@@ -87,7 +86,7 @@ public static class TimeBasedRouteHandlers
         // Check if the proxy operation was successful
         if (error != ForwarderError.None)
         {
-            error.HandleProxyError(httpContext, logger);
+            error.HandleProxyError(httpContext, RequestOptions, logger);
         }
     }
 }

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 using DLCS.Core.Collections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -34,14 +34,14 @@ public class DownstreamDestinationSelector
         this.proxyStateLookup = proxyStateLookup;
         this.orchestratorSettings = orchestratorSettings;
     }
-    
+
     /// <summary>
     /// Attempt to get <see cref="ClusterState"/> object for specified <see cref="ProxyDestination"/>
     /// </summary>
     /// <param name="destination">Destination to get ClusterState for</param>
     /// <param name="clusterState">ClusterState, if found</param>
     /// <returns>true if ClusterState found, else false</returns>
-    public bool TryGetCluster(ProxyDestination destination, out ClusterState? clusterState)
+    public bool TryGetCluster(ProxyDestination destination, [NotNullWhen(true)] out ClusterState? clusterState)
     {
         clusterState = null;
         if (destination is ProxyDestination.S3 or ProxyDestination.Unknown)

--- a/src/protagonist/Orchestrator/appsettings.json
+++ b/src/protagonist/Orchestrator/appsettings.json
@@ -71,6 +71,13 @@
     }
   },
   "ReverseProxy": {
+    "Clusters": {
+      "cantaloupe": {
+        "HttpRequest": {
+          "ActivityTimeout": "00:00:30"
+        }
+      }
+    },
     "Routes": {
       "thumbs": {
         "ClusterId": "thumbs",


### PR DESCRIPTION
Resolves #805 

Yarp has an `HttpRequest` config parameter that can be set per destination. We currently don't use this as we use DirectForwarding, however this PR adds support for reading `HttpRequest` setting and using it's value, if set, as `ForwarderRequestConfig` parameter sent to transformer. If not set we fallback to default `ForwarderRequestConfig`, which has a timeout of 60s.

Also set default for Cantaloupe to 30s.