### PR TITLE
Reject `!w,` `!,h` IIIF parameters in Thumbs channel `policyData`

### DIFF
--- a/src/protagonist/API.Tests/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidatorTests.cs
@@ -24,12 +24,14 @@ public class DeliveryChannelPolicyDataValidatorTests
             .Returns(fakedAvPolicies);
         sut = new DeliveryChannelPolicyDataValidator(avChannelPolicyOptionsRepository);
     }
-
+    
     [Theory]
     [InlineData("[\"400,\",\"200,\",\"100,\"]")]
-    [InlineData("[\"!400,\",\"!200,\",\"!100,\"]")]
     [InlineData("[\",400\",\",200\",\",100\"]")]
-    [InlineData("[\"!,400\",\"!,200\",\"!,100\"]")]
+    [InlineData("[\"^400,\",\"^200,\",\"^100,\"]")]
+    [InlineData("[\"^,400\",\"^,200\",\"^,100\"]")]
+    [InlineData("[\"!400,400\",\"!200,200\",\"!100,100\"]")]
+    [InlineData("[\"^!400,400\",\"^!200,200\",\"^!100,100\"]")]
     public async Task PolicyDataValidator_ReturnsTrue_ForValidThumbParameters(string policyData)
     {
         // Arrange and Act
@@ -88,6 +90,8 @@ public class DeliveryChannelPolicyDataValidatorTests
     [InlineData("[\"^pct:41.6,7.5\"]")]
     [InlineData("[\"10,50\"]")]
     [InlineData("[\",\"]")]
+    [InlineData("[\"!10,\"]")]
+    [InlineData("[\"!,10\"]")]
     public async Task PolicyDataValidator_ReturnsFalse_ForInvalidThumbParameters(string policyData)
     {
         // Arrange and Act

--- a/src/protagonist/API.Tests/Integration/DeliveryChannelTests.cs
+++ b/src/protagonist/API.Tests/Integration/DeliveryChannelTests.cs
@@ -786,19 +786,8 @@ public class DeliveryChannelTests : IClassFixture<ProtagonistAppFactory<Startup>
         },
         new object[]
         {
-            "my-thumbs-policy-1-b",
-            @"[\""!400,\"",\""!200,\"",\""!100,\""]"
-        },
-        new object[]
-        {
             "my-thumbs-policy-1-c",
             @"[\"",400\"",\"",200\"",\"",100\""]"
-        },
-        new object[]
-        {
-            "my-thumbs-policy-1-d",
-            @"[\""!,400\"",\""!,200\"",\""!,100\""]"
-
         },
         new object[]
         {
@@ -807,18 +796,8 @@ public class DeliveryChannelTests : IClassFixture<ProtagonistAppFactory<Startup>
         },
         new object[]
         {
-            "my-thumbs-policy-1-f",
-            @"[\""^!400,\"",\""^!200,\"",\""^!100,\""]"
-        },
-        new object[]
-        {
             "my-thumbs-policy-1-g",
             @"[\""^,400\"",\""^,200\"",\""^,100\""]"
-        },
-        new object[]
-        {
-            "my-thumbs-policy-1-h",
-            @"[\""^!,400\"",\""^!,200\"",\""^!,100\""]"
         },
         new object[]
         {

--- a/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
@@ -68,10 +68,15 @@ public class DeliveryChannelPolicyDataValidator
         return true;
     }
 
-    private bool IsValidThumbnailParameter(SizeParameter param)
-        => !(param.Max || param.PercentScale.HasValue ||
-             (param.Width.HasValue && param.Height.HasValue && !param.Confined) ||
-             (!param.Width.HasValue && !param.Height.HasValue));
+    private bool IsValidThumbnailParameter(SizeParameter param) => param switch
+        {
+            { Max: true } => false,
+            { PercentScale: not null } => false,
+            { Confined: false } and { Width: not null, Height: not null } => false,
+            { Confined: true } and ({ Width: null } or { Height : null }) => false,
+            { Width: null } and { Height: null } => false,
+            _ => true,
+        };
 
     private async Task<bool> ValidateTimeBasedPolicyData(string policyDataJson)
     {

--- a/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
@@ -72,9 +72,9 @@ public class DeliveryChannelPolicyDataValidator
         {
             { Max: true } => false,
             { PercentScale: not null } => false,
-            { Confined: false } and { Width: not null, Height: not null } => false,
+            { Confined: false, Width: not null, Height: not null } => false,
             { Confined: true } and ({ Width: null } or { Height : null }) => false,
-            { Width: null } and { Height: null } => false,
+            { Width: null, Height: null } => false,
             _ => true,
         };
 


### PR DESCRIPTION
Resolves WDC-89

This PR changes `DeliveryChannelPolicyDataValidator` to refuse `!w,` and `!,h` format IIIF parameters for thumbnails.
