### PR TITLE
Revert "Api changes to support asset modified cleanup"

### DIFF
--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
@@ -37,22 +37,19 @@ public class AssetModificationRecordTests
         notification.Before.Should().BeNull();
     }
     
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Update_SetsCorrectFields(bool engineNotified)
+    [Fact]
+    public void Update_SetsCorrectFields()
     {
         // Arrange
         var before = new Asset { Id = new AssetId(1, 2, "foo") };
         var after = new Asset { Id = new AssetId(1, 2, "foo"), MaxUnauthorised = 10 };
         
         // Act
-        var notification = AssetModificationRecord.Update(before, after, engineNotified);
+        var notification = AssetModificationRecord.Update(before, after);
         
         // Assert
         notification.ChangeType.Should().Be(ChangeType.Update);
         notification.Before.Should().Be(before);
         notification.After.Should().Be(after);
-        notification.EngineNotified.Should().Be(engineNotified);
     }
 }

--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using API.Infrastructure.Messaging;
 using DLCS.AWS.SNS;
 using DLCS.Core.Types;
@@ -32,7 +33,7 @@ public class AssetNotificationSenderTests
     {
         // Arrange
         var assetModifiedRecord =
-            AssetModificationRecord.Update(new Asset(new AssetId(1, 2, "foo")), new Asset(new AssetId(1, 2, "bar")), true);
+            AssetModificationRecord.Update(new Asset(new AssetId(1, 2, "foo")), new Asset(new AssetId(1, 2, "bar")));
 
         // Act
         await sut.SendAssetModifiedMessage(assetModifiedRecord, CancellationToken.None);
@@ -75,7 +76,7 @@ public class AssetNotificationSenderTests
         A.CallTo(() =>
             topicPublisher.PublishToAssetModifiedTopic(
                 A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
-                    n.Single().Attributes.Values.Contains(ChangeType.Delete.ToString()) && n.Single().MessageContents.Contains(customerName)),
+                    n.Single().ChangeType == ChangeType.Delete && n.Single().MessageContents.Contains(customerName)),
                 A<CancellationToken>._)).MustHaveHappened();
     }
     
@@ -101,7 +102,7 @@ public class AssetNotificationSenderTests
             topicPublisher.PublishToAssetModifiedTopic(
                 A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
                     n.Count == 2 && n.All(m =>
-                        n.First().Attributes.Values.Contains(ChangeType.Delete.ToString()) && m.MessageContents.Contains(customerName))),
+                        m.ChangeType == ChangeType.Delete && m.MessageContents.Contains(customerName))),
                 A<CancellationToken>._)).MustHaveHappened();
     }
 }

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -132,7 +132,7 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         var assetModificationRecord = existingAsset == null
             ? AssetModificationRecord.Create(assetAfterSave)
-            : AssetModificationRecord.Update(existingAsset, assetAfterSave, processAssetResult.RequiresEngineNotification);
+            : AssetModificationRecord.Update(existingAsset, assetAfterSave);
 
         await assetNotificationSender.SendAssetModifiedMessage(assetModificationRecord, cancellationToken);
 

--- a/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
@@ -52,7 +52,7 @@ public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityR
         
         var asset = await MarkAssetAsIngesting(cancellationToken, existingAsset!);
 
-        await assetNotificationSender.SendAssetModifiedMessage(AssetModificationRecord.Update(existingAsset!, asset, true),
+        await assetNotificationSender.SendAssetModifiedMessage(AssetModificationRecord.Update(existingAsset!, asset),
             cancellationToken);
         var statusCode = await ingestNotificationSender.SendImmediateIngestAssetRequest(asset, cancellationToken);
         

--- a/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
@@ -13,25 +13,22 @@ public class AssetModificationRecord
     public Asset? Before { get; }
     public Asset? After { get; }
     
-    public bool EngineNotified { get; }
-    
     public ImageCacheType? DeleteFrom { get; }
  
-    private AssetModificationRecord(ChangeType changeType, Asset? before, Asset? after, ImageCacheType? deleteFrom, bool assetModifiedEngineNotified)
+    private AssetModificationRecord(ChangeType changeType, Asset? before, Asset? after, ImageCacheType? deleteFrom)
     {
         ChangeType = changeType;
         Before = before;
         After = after;
         DeleteFrom = deleteFrom;
-        EngineNotified = assetModifiedEngineNotified;
     }
 
     public static AssetModificationRecord Delete(Asset before, ImageCacheType deleteFrom) 
-        => new(ChangeType.Delete, before.ThrowIfNull(nameof(before)), null, deleteFrom.ThrowIfNull(nameof(deleteFrom)), false);
+        => new(ChangeType.Delete, before.ThrowIfNull(nameof(before)), null, deleteFrom.ThrowIfNull(nameof(deleteFrom)));
     
-    public static AssetModificationRecord Update(Asset before, Asset after, bool assetModifiedEngineNotified)
-        => new(ChangeType.Update, before.ThrowIfNull(nameof(before)), after.ThrowIfNull(nameof(after)), null, assetModifiedEngineNotified);
+    public static AssetModificationRecord Update(Asset before, Asset after)
+        => new(ChangeType.Update, before.ThrowIfNull(nameof(before)), after.ThrowIfNull(nameof(after)), null);
 
     public static AssetModificationRecord Create(Asset after) 
-        => new(ChangeType.Create, null, after.ThrowIfNull(nameof(after)), null, false);
+        => new(ChangeType.Create, null, after.ThrowIfNull(nameof(after)), null);
 }

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Amazon.Runtime.Internal.Transform;
 using DLCS.AWS.SNS;
 using DLCS.Core.Collections;
 using DLCS.Core.Strings;
@@ -41,31 +40,28 @@ public class AssetNotificationSender : IAssetNotificationSender
         CancellationToken cancellationToken = default)
         => SendAssetModifiedMessage(notification.AsList(), cancellationToken);
 
-    public async Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications, 
+    public async Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications,
         CancellationToken cancellationToken = default)
     {
-
-        var changes = new List<AssetModifiedNotification>();
+        // Iterate through AssetModifiedMessage objects and build list(s) of changes
+        var changes = new Dictionary<ChangeType, List<string>>()
+        {
+            [ChangeType.Create] = new(),
+            [ChangeType.Update] = new(),
+            [ChangeType.Delete] = new(),
+        };
         
         foreach (var notification in notifications)
         {
             var serialisedNotification = await GetSerialisedNotification(notification);
             if (serialisedNotification.HasText())
             {
-                var attributes = new Dictionary<string, string>()
-                {
-                    { "messageType", notification.ChangeType.ToString() }
-                };
-                if (notification.EngineNotified)
-                {
-                    attributes.Add("engineNotified", "True");
-                }
-                
-                changes.Add(new AssetModifiedNotification(serialisedNotification!, attributes));
+                changes[notification.ChangeType].Add(serialisedNotification);
             }
         }
 
-        await topicPublisher.PublishToAssetModifiedTopic(changes, cancellationToken);
+        // Send notifications generated in above method
+        await SendAssetModifiedRequest(changes, cancellationToken);
     }
 
     private async Task<string?> GetSerialisedNotification(AssetModificationRecord notification)
@@ -134,5 +130,17 @@ public class AssetNotificationSender : IAssetNotificationSender
         var customerPathElement = await customerPathRepository.GetCustomerPathElement(customer.ToString());
         customerPathElements[customer] = customerPathElement;
         return customerPathElement;
+    }
+    
+    private async Task<bool> SendAssetModifiedRequest(Dictionary<ChangeType, List<string>> change, CancellationToken cancellationToken)
+    {
+        if (change.IsNullOrEmpty()) return true;
+
+        var toSend = change
+            .SelectMany(kvp => kvp.Value
+                .Select(v => new AssetModifiedNotification(v, kvp.Key)))
+            .ToList();
+        
+        return await topicPublisher.PublishToAssetModifiedTopic(toSend, cancellationToken);
     }
 }

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -31,7 +31,7 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleMessage_IfSingleItemInBatch()
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
+        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
 
         // Act
         await sut.PublishToAssetModifiedTopic(new[] { notification });
@@ -52,7 +52,7 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SingleItemInBatch_ReturnsSuccessDependentOnStatusCode(HttpStatusCode statusCode, bool expected)
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
+        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
         A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
             .Returns(new PublishResponse { HttpStatusCode = statusCode });
 
@@ -67,8 +67,8 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleBatch()
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
-        var notification2 = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
+        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
+        var notification2 = new AssetModifiedNotification("message", ChangeType.Delete);
 
         // Act
         await sut.PublishToAssetModifiedTopic(new[] { notification, notification2 });
@@ -91,7 +91,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification(x < 10 ? "message" : "next", GetAttributes(ChangeType.Delete, false)));
+            notifications.Add(new AssetModifiedNotification(x < 10 ? "message" : "next", ChangeType.Delete));
         } 
 
         // Act
@@ -123,7 +123,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false)));
+            notifications.Add(new AssetModifiedNotification("message", ChangeType.Delete));
         }
         
         A.CallTo(() => snsClient.PublishBatchAsync(A<PublishBatchRequest>._, A<CancellationToken>._))
@@ -143,7 +143,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false)));
+            notifications.Add(new AssetModifiedNotification("message", ChangeType.Delete));
         }
 
         A.CallTo(() => snsClient.PublishBatchAsync(A<PublishBatchRequest>._, A<CancellationToken>._))
@@ -156,59 +156,5 @@ public class TopicPublisherTests
 
         // Assert
         response.Should().BeFalse();
-    }
-    
-    [Fact]
-    public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleMessageWithEngineNotified_IfEngineNotifiedTrue()
-    {
-        // Arrange
-        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
-
-        // Act
-        await sut.PublishToAssetModifiedTopic(new[] { notification });
-
-        // Assert
-        A.CallTo(() =>
-            snsClient.PublishAsync(
-                A<PublishRequest>.That.Matches(r =>
-                    r.Message == "message" && r.MessageAttributes["messageType"].StringValue == "Update" && 
-                    r.MessageAttributes["engineNotified"].StringValue == "True"),
-                A<CancellationToken>._)).MustHaveHappened();
-    }
-    
-    [Fact]
-    public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleBatchWithEngineNotified()
-    {
-        // Arrange
-        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
-        var notification2 = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
- 
-        // Act
-        await sut.PublishToAssetModifiedTopic(new[] { notification, notification2 });
-
-        // Assert
-        A.CallTo(() =>
-            snsClient.PublishBatchAsync(
-                A<PublishBatchRequest>.That.Matches(b => b.PublishBatchRequestEntries.All(r =>
-                                                             r.Message == "message" &&
-                                                             r.MessageAttributes["messageType"].StringValue ==
-                                                             "Update"&& 
-                                                             r.MessageAttributes["engineNotified"].StringValue == "True") &&
-                                                         b.PublishBatchRequestEntries.Count == 2),
-                A<CancellationToken>._)).MustHaveHappened();
-    }
-    
-    private Dictionary<string, string> GetAttributes(ChangeType changeType, bool engineNotified)
-    {
-        var attributes = new Dictionary<string, string>()
-        {
-            { "messageType", changeType.ToString() }
-        };
-        if (engineNotified)
-        {
-            attributes.Add("engineNotified", "True");
-        }
-
-        return attributes;
     }
 }

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -10,11 +10,11 @@ public interface ITopicPublisher
     /// <param name="messages">A collection of notifications to send</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Boolean representing the overall success/failure status of all requests</returns>
-    public Task<bool> PublishToAssetModifiedTopic(IReadOnlyList<AssetModifiedNotification> messages, 
+    public Task<bool> PublishToAssetModifiedTopic(IReadOnlyList<AssetModifiedNotification> messages,
         CancellationToken cancellationToken);
 }
 
 /// <summary>
 /// Represents the contents + type of change for Asset modified notification
 /// </summary>
-public record AssetModifiedNotification(string MessageContents, Dictionary<string, string> Attributes);
+public record AssetModifiedNotification(string MessageContents, ChangeType ChangeType);

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -1,8 +1,8 @@
-﻿using Amazon.Runtime.Internal.Transform;
-using Amazon.SimpleNotificationService;
+﻿using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using DLCS.AWS.Settings;
 using DLCS.Core;
+using DLCS.Model.Messaging;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -50,14 +50,14 @@ public class TopicPublisher : ITopicPublisher
         return allBatchSuccess;
     }
     
-    private async Task<bool> PublishToAssetModifiedTopic(AssetModifiedNotification message, 
+    private async Task<bool> PublishToAssetModifiedTopic(AssetModifiedNotification message,
         CancellationToken cancellationToken = default)
     {
         var request = new PublishRequest
         {
             TopicArn = snsSettings.AssetModifiedNotificationTopicArn,
             Message = message.MessageContents,
-            MessageAttributes = GetMessageAttributes(message.Attributes)
+            MessageAttributes = GetMessageAttributes(message.ChangeType)
         };
 
         try
@@ -83,7 +83,7 @@ public class TopicPublisher : ITopicPublisher
                 TopicArn = snsSettings.AssetModifiedNotificationTopicArn,
                 PublishBatchRequestEntries = chunk.Select(m => new PublishBatchRequestEntry
                 {
-                    MessageAttributes = GetMessageAttributes(m.Attributes),
+                    MessageAttributes = GetMessageAttributes(m.ChangeType),
                     Message = m.MessageContents,
                     Id = $"{batchIdPrefix}_{batchNumber}_{batchCount++}",
                 }).ToList()
@@ -98,20 +98,17 @@ public class TopicPublisher : ITopicPublisher
             return false;
         }
     }
-    
-    private static Dictionary<string, MessageAttributeValue> GetMessageAttributes(Dictionary<string, string> attributes)
+
+    private static Dictionary<string, MessageAttributeValue> GetMessageAttributes(ChangeType changeType)
     {
-        var messageAttributes = new Dictionary<string, MessageAttributeValue>();
-        foreach (var attribute in attributes)
+        var attributeValue = new MessageAttributeValue
         {
-            messageAttributes.Add(new KeyValuePair<string, MessageAttributeValue>(attribute.Key,
-                new MessageAttributeValue()
-                {
-                    DataType = "String",
-                    StringValue = attribute.Value
-                }));
-        }
-        
-        return messageAttributes;
+            StringValue = changeType.ToString(),
+            DataType = "String"
+        };
+        return new Dictionary<string, MessageAttributeValue>
+        {
+            { "messageType", attributeValue }
+        };
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Policies;
 using IIIF.Auth.V2;


### PR DESCRIPTION
Reverts dlcs/protagonist#841

Seems to be causing OOM exception in memory constrained environments, will need more thorough testing. For reference the API errors seen in Fargate instance with 0.5vCPU and 2GB memory.