### PR TITLE
Thumbs are open if they are >= to MaxUnauth size

### DIFF
--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -91,7 +91,7 @@ public class ThumbCreator : IThumbCreator
 
         foreach (var thumb in orderedThumbsToProcess)
         {
-            if (asset.MaxUnauthorised > Math.Max(thumb.Width, thumb.Height)) return new Size(thumb.Width, thumb.Height);
+            if (asset.MaxUnauthorised >= Math.Max(thumb.Width, thumb.Height)) return new Size(thumb.Width, thumb.Height);
         }
 
         return new Size(0, 0);


### PR DESCRIPTION
Update logic used when working out whether a thumb is open or auth. Thumbnails that match the maxUnauth size are open.