### PR TITLE
Remove unused navigation properties

### DIFF
--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -15,8 +15,6 @@ public class ImageDeliveryChannel
     /// The image id for the attached asset
     /// </summary>
     public AssetId ImageId { get; set; }
-    
-    public Asset Asset { get; set; }
 
     /// <summary>
     /// The channel this policy applies to

--- a/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicy.cs
+++ b/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicy.cs
@@ -54,11 +54,6 @@ public class DeliveryChannelPolicy
     /// The custom policy 
     /// </summary>
     public string PolicyData { get; set; }
-    
-    /// <summary>
-    /// List of delivery channels attached to the image
-    /// </summary>
-    public List<ImageDeliveryChannel> ImageDeliveryChannels { get; set; }
 }
 
 public static class KnownDeliveryChannelPolicies

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -667,7 +667,7 @@ public partial class DlcsContext : DbContext
                     aId => aId.ToString(),
                     id => AssetId.FromString(id));
 
-            entity.HasOne(e => e.Asset)
+            entity.HasOne<Asset>()
                 .WithMany(e => e.ImageDeliveryChannels)
                 .HasForeignKey(e => e.ImageId);
         });


### PR DESCRIPTION
Primarily removed to avoid serialisation issue but they are reduntant. We likely want a more robust converter than this but it solves the immediate issue.

It's unlikely that we'd want to load a `DeliveryChannelPolicy` and from there see all `ImageDeliveryChannels` associated with it (could lead to a huge object graph). Similarly it's unlikely that we'd want to start with `ImageDeliveryChannel` and get associated `Asset` - all queries would start with `Asset`.

Verified that no migrations is required after making change to context.