### PR TITLE
Use unique directory names for `ImageServerClient` output images

### DIFF
--- a/src/protagonist/Engine.Tests/Ingest/Image/Completion/ImageIngestPostProcessingTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Completion/ImageIngestPostProcessingTests.cs
@@ -133,11 +133,15 @@ public class ImageIngestPostProcessingTests
         var assetId = AssetId.FromString("2/1/avalon");
         var asset = new Asset(assetId);
         var sut = GetSut(true);
-
+        var context = new IngestionContext(asset);
+        
         // Act
-        await sut.CompleteIngestion(new IngestionContext(asset), success);
+        await sut.CompleteIngestion(context, success);
         
         // Assert
-        fileSystem.DeletedDirectories.Should().Contain("2_1_avalon");
+        var expectedWorkingFolder = $"scratch/{context.IngestId}/";
+        fileSystem.DeletedDirectories.Should().Contain(d => 
+            // Account for backslashes being used to separate directories when running on Windows
+            d.Replace("\\", "/") == expectedWorkingFolder);
     }
 }

--- a/src/protagonist/Engine.Tests/Ingest/Image/Completion/ImageIngestPostProcessingTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/Completion/ImageIngestPostProcessingTests.cs
@@ -37,7 +37,8 @@ public class ImageIngestPostProcessingTests
             ImageIngest = new ImageIngestSettings
             {
                 SourceTemplate = "{customer}_{space}_{image}",
-                OrchestrateImageAfterIngest = orchestrateAfterIngest
+                OrchestrateImageAfterIngest = orchestrateAfterIngest,
+                ScratchRoot = "scratch/"
             },
         };
         var optionsMonitor = OptionsHelpers.GetOptionsMonitor(engineSettings);

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
@@ -91,7 +91,7 @@ public class ImageServerClientTests
         await sut.ProcessImage(context);
 
         // Assert
-        A.CallTo(() => fileSystem.CreateDirectory( "scratch/1/2/some_id_/output")).MustHaveHappenedOnceExactly();
+        A.CallTo(() => fileSystem.CreateDirectory( $"scratch/{context.IngestId}1/2/some_id_/output")).MustHaveHappenedOnceExactly();
         A.CallTo(() => fileSystem.DeleteDirectory(A<string>._, true, true)).MustHaveHappenedTwiceExactly();
     }
 
@@ -178,13 +178,13 @@ public class ImageServerClientTests
     {
         // Arrange
         var imageProcessorResponse = new AppetiserResponseModel();
-
+        var context = IngestionContextFactory.GetIngestionContext("/1/2/test");
+        
         A.CallTo(() => appetiserClient.GenerateJP2(A<IngestionContext>._, A<AssetId>._, A<CancellationToken>._))
             .Returns(Task.FromResult(imageProcessorResponse as IAppetiserResponse));
-        A.CallTo(() => appetiserClient.GetJP2FilePath(A<AssetId>._, A<bool>._))
-            .Returns("scratch/1/2/test/outputtest.jp2");
-
-        var context = IngestionContextFactory.GetIngestionContext("/1/2/test");
+        A.CallTo(() => appetiserClient.GetJP2FilePath(A<AssetId>._, context.IngestId, A<bool>._))
+            .Returns($"scratch/{context.IngestId}/1/2/test/outputtest.jp2");
+        
         context.AssetFromOrigin.CustomerOriginStrategy = new CustomerOriginStrategy
         {
             Optimised = optimised,
@@ -201,7 +201,7 @@ public class ImageServerClientTests
         // Assert
         bucketWriter
             .ShouldHaveKey("1/2/test")
-            .WithFilePath("scratch/1/2/test/outputtest.jp2")
+            .WithFilePath($"scratch/{context.IngestId}/1/2/test/outputtest.jp2")
             .WithContentType("image/jp2");
         context.ImageLocation.S3.Should().Be(expected);
         context.StoredObjects.Should().NotBeEmpty();

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/ImageServerClientTests.cs
@@ -91,10 +91,13 @@ public class ImageServerClientTests
         await sut.ProcessImage(context);
 
         // Assert
-        A.CallTo(() => fileSystem.CreateDirectory( $"scratch/{context.IngestId}1/2/some_id_/output")).MustHaveHappenedOnceExactly();
+        var expectedDirectory = $"scratch/{context.IngestId}/1/2/some_id_/output";
+        A.CallTo(() => fileSystem.CreateDirectory( 
+            // Account for backslashes being used to separate directories when running on Windows
+            A<string>.That.Matches(x => x.Replace("\\", "/") == expectedDirectory ))).MustHaveHappenedOnceExactly();
         A.CallTo(() => fileSystem.DeleteDirectory(A<string>._, true, true)).MustHaveHappenedTwiceExactly();
     }
-
+    
     [Fact]
     public async Task ProcessImage_False_IfImageProcessorCallFails()
     {

--- a/src/protagonist/Engine.Tests/Ingest/Workers/ImageIngesterWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Workers/ImageIngesterWorkerTests.cs
@@ -28,7 +28,8 @@ public class ImageIngesterWorkerTests
             ImageIngest = new ImageIngestSettings
             {
                 SourceTemplate = "{root}",
-                OrchestrateImageAfterIngest = true
+                OrchestrateImageAfterIngest = true,
+                ScratchRoot = "scratch/"
             },
         };
         var optionsMonitor = OptionsHelpers.GetOptionsMonitor(engineSettings);

--- a/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestPostProcessing.cs
+++ b/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestPostProcessing.cs
@@ -86,7 +86,7 @@ public class ImageIngestPostProcessing : IImageIngestPostProcessing
 
     private void DeleteWorkingFolder(IngestionContext ingestionContext)
     {
-        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(ingestionContext.Asset, ingestionContext.IngestId, engineSettings);
+        var sourceTemplate = ImageIngestionHelpers.GetWorkingFolder(ingestionContext.IngestId, engineSettings.ImageIngest);
         fileSystem.DeleteDirectory(sourceTemplate, true);
     }
 }

--- a/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestPostProcessing.cs
+++ b/src/protagonist/Engine/Ingest/Image/Completion/ImageIngestPostProcessing.cs
@@ -86,7 +86,7 @@ public class ImageIngestPostProcessing : IImageIngestPostProcessing
 
     private void DeleteWorkingFolder(IngestionContext ingestionContext)
     {
-        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(ingestionContext.Asset, engineSettings);
+        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(ingestionContext.Asset, ingestionContext.IngestId, engineSettings);
         fileSystem.DeleteDirectory(sourceTemplate, true);
     }
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
@@ -44,7 +44,7 @@ public class ImageIngesterWorker : IAssetIngesterWorker, IAssetIngesterPostProce
     {
         bool ingestSuccess;
         var asset = ingestionContext.Asset;
-        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(asset, ingestionContext.IngestId, engineSettings);
+        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(ingestionContext, engineSettings);
 
         try
         {

--- a/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngesterWorker.cs
@@ -44,7 +44,7 @@ public class ImageIngesterWorker : IAssetIngesterWorker, IAssetIngesterPostProce
     {
         bool ingestSuccess;
         var asset = ingestionContext.Asset;
-        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(asset, engineSettings);
+        var sourceTemplate = ImageIngestionHelpers.GetSourceFolder(asset, ingestionContext.IngestId, engineSettings);
 
         try
         {

--- a/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
@@ -10,10 +10,10 @@ internal static class ImageIngestionHelpers
     /// <summary>
     /// Get folder location where working assets are to be saved to
     /// </summary>
-    public static string GetSourceFolder(Asset asset, EngineSettings engineSettings)
+    public static string GetSourceFolder(Asset asset, string ingestId, EngineSettings engineSettings)
     {
         var imageIngest = engineSettings.ImageIngest;
-        var root = imageIngest.GetRoot();
+        var root = Path.Combine(imageIngest.GetRoot(), ingestId);
             
         // source is the main folder for storing downloaded image
         var assetId = new AssetId(asset.Id.Customer, asset.Id.Space,

--- a/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
@@ -18,14 +18,14 @@ internal static class ImageIngestionHelpers
     /// <summary>
     /// Get folder location where working assets are to be saved to
     /// </summary>
-    public static string GetSourceFolder(Asset asset, string ingestId, EngineSettings engineSettings)
+    public static string GetSourceFolder(IngestionContext ingestionContext, EngineSettings engineSettings)
     {
         var imageIngest = engineSettings.ImageIngest;
-        var workingFolder = GetWorkingFolder(ingestId, imageIngest);
+        var workingFolder = GetWorkingFolder(ingestionContext.IngestId, imageIngest);
         
         // source is the main folder for storing downloaded image
-        var assetId = new AssetId(asset.Id.Customer, asset.Id.Space,
-            asset.Id.Asset.Replace("(", imageIngest.OpenBracketReplacement)
+        var assetId = new AssetId(ingestionContext.AssetId.Customer, ingestionContext.AssetId.Space,
+            ingestionContext.AssetId.Asset.Replace("(", imageIngest.OpenBracketReplacement)
                 .Replace(")", imageIngest.CloseBracketReplacement));
         var source = TemplatedFolders.GenerateFolderTemplate(imageIngest.SourceTemplate, assetId, root: workingFolder);
         return source;

--- a/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageIngestionHelpers.cs
@@ -8,18 +8,26 @@ namespace Engine.Ingest.Image;
 internal static class ImageIngestionHelpers
 {
     /// <summary>
+    /// Get the top level working directory for an ingest request
+    /// </summary>
+    public static string GetWorkingFolder(string ingestId, ImageIngestSettings imageIngestSettings, bool forImageProcessor = false)
+    {
+        return $"{Path.Combine(imageIngestSettings.GetRoot(forImageProcessor), ingestId)}{Path.DirectorySeparatorChar}";
+    }
+    
+    /// <summary>
     /// Get folder location where working assets are to be saved to
     /// </summary>
     public static string GetSourceFolder(Asset asset, string ingestId, EngineSettings engineSettings)
     {
         var imageIngest = engineSettings.ImageIngest;
-        var root = Path.Combine(imageIngest.GetRoot(), ingestId);
-            
+        var workingFolder = GetWorkingFolder(ingestId, imageIngest);
+        
         // source is the main folder for storing downloaded image
         var assetId = new AssetId(asset.Id.Customer, asset.Id.Space,
             asset.Id.Asset.Replace("(", imageIngest.OpenBracketReplacement)
                 .Replace(")", imageIngest.CloseBracketReplacement));
-        var source = TemplatedFolders.GenerateFolderTemplate(imageIngest.SourceTemplate, assetId, root: root);
+        var source = TemplatedFolders.GenerateFolderTemplate(imageIngest.SourceTemplate, assetId, root: workingFolder);
         return source;
     }
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/AppetiserClient.cs
@@ -76,7 +76,8 @@ public class AppetiserClient : IAppetiserClient
         var extension = assetOnDisk.EverythingAfterLast('.');
 
         // this is to get it working nice locally as appetiser/tizer root needs to be unix + relative to it
-        var imageProcessorRoot = Path.Combine(engineSettings.ImageIngest.GetRoot(true), context.IngestId);
+        
+        var imageProcessorRoot = ImageIngestionHelpers.GetWorkingFolder(context.IngestId, engineSettings.ImageIngest, true);
         var unixPath = TemplatedFolders.GenerateTemplateForUnix(engineSettings.ImageIngest.SourceTemplate, modifiedAssetId,
             root: imageProcessorRoot);
 
@@ -90,9 +91,9 @@ public class AppetiserClient : IAppetiserClient
         // This logic allows handling when running locally on win/unix and when deployed to unix
         var destFolder = forImageProcessor
             ? TemplatedFolders.GenerateTemplateForUnix(engineSettings.ImageIngest.DestinationTemplate,
-                assetId, root: Path.Combine(engineSettings.ImageIngest.GetRoot(true), ingestId))
+                assetId, root: ImageIngestionHelpers.GetWorkingFolder(ingestId, engineSettings.ImageIngest, true))
             : TemplatedFolders.GenerateFolderTemplate(engineSettings.ImageIngest.DestinationTemplate,
-                assetId, root: Path.Combine(engineSettings.ImageIngest.GetRoot(), ingestId));
+                assetId, root: ImageIngestionHelpers.GetWorkingFolder(ingestId, engineSettings.ImageIngest));
 
         return $"{destFolder}{assetId.Asset}.jp2";
     }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/AppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/AppetiserClient.cs
@@ -23,7 +23,7 @@ public class AppetiserClient : IAppetiserClient
 
     public async Task<IAppetiserResponse> GenerateJP2(
         IngestionContext context, 
-        AssetId modifiedAssetId, 
+        AssetId modifiedAssetId,
         CancellationToken cancellationToken = default)
     {
         var requestModel = CreateModel(context, modifiedAssetId);
@@ -58,7 +58,7 @@ public class AppetiserClient : IAppetiserClient
     {
         var requestModel = new AppetiserRequestModel
         {
-            Destination = GetJP2FilePath(modifiedAssetId, true),
+            Destination = GetJP2FilePath(modifiedAssetId, context.IngestId, true),
             Operation = "image-only",
             Optimisation = "kdu_max",
             Origin = context.Asset.Origin,
@@ -76,7 +76,7 @@ public class AppetiserClient : IAppetiserClient
         var extension = assetOnDisk.EverythingAfterLast('.');
 
         // this is to get it working nice locally as appetiser/tizer root needs to be unix + relative to it
-        var imageProcessorRoot = engineSettings.ImageIngest.GetRoot(true);
+        var imageProcessorRoot = Path.Combine(engineSettings.ImageIngest.GetRoot(true), context.IngestId);
         var unixPath = TemplatedFolders.GenerateTemplateForUnix(engineSettings.ImageIngest.SourceTemplate, modifiedAssetId,
             root: imageProcessorRoot);
 
@@ -84,15 +84,15 @@ public class AppetiserClient : IAppetiserClient
         return unixPath;
     }
     
-    public string GetJP2FilePath(AssetId assetId, bool forImageProcessor)
+    public string GetJP2FilePath(AssetId assetId, string ingestId, bool forImageProcessor)
     {
         // Appetiser/Tizer want unix paths relative to mount share.
         // This logic allows handling when running locally on win/unix and when deployed to unix
         var destFolder = forImageProcessor
             ? TemplatedFolders.GenerateTemplateForUnix(engineSettings.ImageIngest.DestinationTemplate,
-                assetId, root: engineSettings.ImageIngest.GetRoot(true))
+                assetId, root: Path.Combine(engineSettings.ImageIngest.GetRoot(true), ingestId))
             : TemplatedFolders.GenerateFolderTemplate(engineSettings.ImageIngest.DestinationTemplate,
-                assetId, root: engineSettings.ImageIngest.GetRoot());
+                assetId, root: Path.Combine(engineSettings.ImageIngest.GetRoot(), ingestId));
 
         return $"{destFolder}{assetId.Asset}.jp2";
     }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/IAppetiserClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/IAppetiserClient.cs
@@ -21,7 +21,8 @@ public interface IAppetiserClient
     /// Retrieves a JP2 filepath for an image
     /// </summary>
     /// <param name="assetId">The asset id used to retrieve the JP2 filepath</param>
+    /// <param name="ingestId">The id for the ingest operation associated with this image</param>
     /// <param name="forImageProcessor">Whether this is for the image processor or not</param>
     /// <returns></returns>
-    public string GetJP2FilePath(AssetId assetId, bool forImageProcessor);
+    public string GetJP2FilePath(AssetId assetId, string ingestId, bool forImageProcessor);
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
@@ -53,11 +53,11 @@ public class ImageServerClient : IImageProcessor
         var modifiedAssetId = new AssetId(context.AssetId.Customer, context.AssetId.Space,
             context.AssetId.Asset.Replace("(", engineSettings.ImageIngest.OpenBracketReplacement)
                 .Replace(")", engineSettings.ImageIngest.CloseBracketReplacement));
-        var (dest, thumb) = CreateRequiredFolders(modifiedAssetId);
+        var (dest, thumb) = CreateRequiredFolders(modifiedAssetId, context.IngestId);
 
         try
         {
-            var flags = new ImageProcessorFlags(context, appetiserClient.GetJP2FilePath(modifiedAssetId, false));
+            var flags = new ImageProcessorFlags(context, appetiserClient.GetJP2FilePath(modifiedAssetId, context.IngestId, false));
             logger.LogDebug("Got flags '{@Flags}' for {AssetId}", flags, context.AssetId);
             var responseModel = await appetiserClient.GenerateJP2(context, modifiedAssetId);
 
@@ -89,10 +89,10 @@ public class ImageServerClient : IImageProcessor
         }
     }
 
-    private (string dest, string thumb) CreateRequiredFolders(AssetId assetId)
+    private (string dest, string thumb) CreateRequiredFolders(AssetId assetId, string ingestId)
     {
         var imageIngest = engineSettings.ImageIngest;
-        var root = imageIngest.GetRoot();
+        var root = Path.Combine(imageIngest.GetRoot(), ingestId);
 
         // dest is the folder where appetiser will copy output to
         var dest = TemplatedFolders.GenerateFolderTemplate(imageIngest.DestinationTemplate, assetId, root: root);

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/ImageServerClient.cs
@@ -92,13 +92,13 @@ public class ImageServerClient : IImageProcessor
     private (string dest, string thumb) CreateRequiredFolders(AssetId assetId, string ingestId)
     {
         var imageIngest = engineSettings.ImageIngest;
-        var root = Path.Combine(imageIngest.GetRoot(), ingestId);
+        var workingFolder = ImageIngestionHelpers.GetWorkingFolder(ingestId, imageIngest);
 
         // dest is the folder where appetiser will copy output to
-        var dest = TemplatedFolders.GenerateFolderTemplate(imageIngest.DestinationTemplate, assetId, root: root);
+        var dest = TemplatedFolders.GenerateFolderTemplate(imageIngest.DestinationTemplate, assetId, root: workingFolder);
 
         // thumb is the folder where generated thumbnails will be output to
-        var thumb = TemplatedFolders.GenerateFolderTemplate(imageIngest.ThumbsTemplate, assetId, root: root);
+        var thumb = TemplatedFolders.GenerateFolderTemplate(imageIngest.ThumbsTemplate, assetId, root: workingFolder);
 
         fileSystem.CreateDirectory(dest);
         fileSystem.CreateDirectory(thumb);

--- a/src/protagonist/Engine/Ingest/IngestExecutor.cs
+++ b/src/protagonist/Engine/Ingest/IngestExecutor.cs
@@ -34,8 +34,7 @@ public class IngestExecutor
     public async Task<IngestResult> IngestAsset(Asset asset, CustomerOriginStrategy customerOriginStrategy,
         CancellationToken cancellationToken = default)
     {
-        var ingestId = DateTime.Now.Ticks.ToString();
-        var context = new IngestionContext(asset, ingestId);
+        var context = new IngestionContext(asset);
 
         // If the asset has the `none` delivery channel specified, skip processing and mark the ingest as being complete
         if (asset.HasSingleDeliveryChannel(AssetDeliveryChannels.None))

--- a/src/protagonist/Engine/Ingest/IngestExecutor.cs
+++ b/src/protagonist/Engine/Ingest/IngestExecutor.cs
@@ -34,7 +34,8 @@ public class IngestExecutor
     public async Task<IngestResult> IngestAsset(Asset asset, CustomerOriginStrategy customerOriginStrategy,
         CancellationToken cancellationToken = default)
     {
-        var context = new IngestionContext(asset);
+        var ingestId = DateTime.Now.Ticks.ToString();
+        var context = new IngestionContext(asset, ingestId);
 
         // If the asset has the `none` delivery channel specified, skip processing and mark the ingest as being complete
         if (asset.HasSingleDeliveryChannel(AssetDeliveryChannels.None))

--- a/src/protagonist/Engine/Ingest/IngestionContext.cs
+++ b/src/protagonist/Engine/Ingest/IngestionContext.cs
@@ -31,13 +31,13 @@ public class IngestionContext
     /// </summary>
     public Dictionary<ObjectInBucket, long> StoredObjects { get; } = new();
     
-    public IngestionContext(Asset asset, string ingestId)
+    public IngestionContext(Asset asset)
     {
         Asset = asset;
         AssetId = asset.Id;
-        IngestId = ingestId;
+        IngestId = DateTime.Now.Ticks.ToString();
     }
-
+    
     public IngestionContext WithAssetFromOrigin(AssetFromOrigin assetFromOrigin)
     {
         AssetFromOrigin = assetFromOrigin;

--- a/src/protagonist/Engine/Ingest/IngestionContext.cs
+++ b/src/protagonist/Engine/Ingest/IngestionContext.cs
@@ -16,6 +16,8 @@ public class IngestionContext
     
     public AssetId AssetId { get; }
     
+    public string IngestId { get; }
+    
     public AssetFromOrigin? AssetFromOrigin { get; private set; }
         
     public ImageLocation? ImageLocation { get; private set; }
@@ -29,10 +31,11 @@ public class IngestionContext
     /// </summary>
     public Dictionary<ObjectInBucket, long> StoredObjects { get; } = new();
     
-    public IngestionContext(Asset asset)
+    public IngestionContext(Asset asset, string ingestId)
     {
         Asset = asset;
         AssetId = asset.Id;
+        IngestId = ingestId;
     }
 
     public IngestionContext WithAssetFromOrigin(AssetFromOrigin assetFromOrigin)


### PR DESCRIPTION
Resolves #839

This PR fixes a bug where simultaneous ingest requests would fail as they are attempting to process and delete the same working files.

The path to the working image directory is now prefixed with a unique identifier for that request, stored in `IngestionContext` and created from `DateTime.Now.Ticks` - e.g `.../63851993863614337227/1/5/my_image`