### PR TITLE
Reinstate INSERT to migrateImageDeliveryChannels script

### DIFF
--- a/scripts/DeliveryChannels/0002-migrateImageDeliveryChannels.sql
+++ b/scripts/DeliveryChannels/0002-migrateImageDeliveryChannels.sql
@@ -32,6 +32,7 @@ WHERE i."Family" = 'I'
   AND i."NotForDelivery" = false;
 
 -- convert timebased
+INSERT INTO "ImageDeliveryChannels" ("ImageId", "Channel", "DeliveryChannelPolicyId")
 SELECT i."Id",
        'iiif-av',
        CASE


### PR DESCRIPTION
#818 simplified the migration scripts but had missed the `INSERT` for timebased, meaning that this was just running a `SELECT` only.