### PR TITLE
Simplify LegacyCustomer test setup

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -87,6 +87,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
             }
         );
         dbContext.SaveChanges();
+        LegacyModeHelpers.SetupLegacyCustomer(dbContext).Wait();
     }
 
     [Fact]
@@ -532,32 +533,25 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfLegacyModeEnabled()
     {
-        const int customerId = 15;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, 2);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
     ""@type"": ""Collection"",
     ""member"": [
-        {
+        {{
           ""id"": ""one"",
           ""family"": ""T"",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 2
-        }
+          ""space"": {LegacyModeHelpers.LegacySpace}
+        }}
     ]
-}";
+}}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
  
         // Assert
         // status code correct
@@ -567,38 +561,30 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfLegacyModeEnabledWithAtIdFieldSet()
     {
-        const int customerId = 15;
-        const int space = 200;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
     ""@type"": ""Collection"",
     ""member"": [
-        {
-          ""@id"": ""https://test/customers/15/spaces/200/images/one"",
+        {{
+          ""@id"": ""https://test/customers/{LegacyModeHelpers.LegacyCustomer}/spaces/{LegacyModeHelpers.LegacySpace}/images/one"",
           ""family"": ""T"",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 200,
-        }
+          ""space"": {LegacyModeHelpers.LegacySpace},
+        }}
     ]
-}";
+}}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
 
         // Assert
         // status code correct
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var assetInDatabase = dbContext.Images.Where(a => a.Customer == customerId && a.Space == space);
+        var assetInDatabase = dbContext.Images.Where(a => a.Customer == LegacyModeHelpers.LegacyCustomer && a.Space == LegacyModeHelpers.LegacySpace);
         assetInDatabase.Count().Should().Be(1);
         assetInDatabase.ToList()[0].Id.Asset.Should().Be("one");
     }
@@ -606,13 +592,6 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_400_WithIdEmptyString()
     {
-        const int customerId = 15;
-        const int space = 3;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
@@ -627,10 +606,10 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -639,13 +618,6 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_WithMixtureOfIdSet()
     {
-        const int customerId = 15;
-        const int space = 4;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
@@ -653,21 +625,21 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     ""member"": [
         {
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""T"",
           ""mediaType"": ""video/mp4""
         },
         {
           ""id"": """",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""T"",
           ""mediaType"": ""video/mp4""
         },
         {
           ""id"": ""someId"",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""T"",
           ""mediaType"": ""video/mp4""
         }
@@ -675,15 +647,16 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        const string path = "/customers/99/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(99).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         
-        var assetInDatabase = dbContext.Images.Where(a => a.Customer == customerId && a.Space == space);
+        var model = await response.ReadAsHydraResponseAsync<DLCS.HydraModel.CustomerQueue>();
+        var assetInDatabase = dbContext.Images.Where(a => a.Batch == model.Id.GetLastPathElementAsInt());
         assetInDatabase.Count().Should().Be(3);
         Guid.TryParse(assetInDatabase.ToList()[0].Id.Asset, out _).Should().BeTrue();
         Guid.TryParse(assetInDatabase.ToList()[1].Id.Asset, out _).Should().BeTrue();
@@ -693,13 +666,6 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_400_WithInvalidIdsSet()
     {
-        const int customerId = 15;
-        const int space = 4;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
@@ -708,14 +674,14 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         {
           ""id"": ""some\id"",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""T"",
           ""mediaType"": ""video/mp4""
         },
         {
           ""id"": ""some Id"",
           ""origin"": ""https://example.org/vid.mp4"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""T"",
           ""mediaType"": ""video/mp4""
         }
@@ -723,10 +689,10 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        const string path = "/customers/99/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(99).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -751,7 +717,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = "/customers/99/queue";
+        const string path = "/customers/99/queue";
 
         // Act
         var response = await httpClient.AsCustomer(99).PostAsync(path, content);
@@ -761,73 +727,65 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-    [Fact]
-    public async Task Post_CreateBatch_400_IfThumbnailPolicySet()
+    [Theory]
+    [InlineData("I")]
+    [InlineData("T")]
+    [InlineData("F")]
+    public async Task Post_CreateBatch_400_IfThumbnailPolicySet(string family)
     {
-        const int customerId = 15;
-        const int space = 4;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
+                {{
                   ""id"": ""one"",
                   ""origin"": ""https://example.org/vid.mp4"",
-                  ""space"": 4,
-                  ""family"": ""T"",
+                  ""space"": 1,
+                  ""family"": ""{family}"",
                   ""thumbnailPolicy"": ""some-thumbnail-policy""
                   ""mediaType"": ""video/mp4""
-                }
+                }}
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        const string path = "/customers/99/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(99).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
-    [Fact]
-    public async Task Post_CreateBatch_400_IfImageOptimisationPolicySet()
-    {
-        const int customerId = 15;
-        const int space = 4;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
+    [Theory]
+    [InlineData("I")]
+    [InlineData("T")]
+    [InlineData("F")]
+    public async Task Post_CreateBatch_400_IfImageOptimisationPolicySet(string family)
+    { 
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
+                {{
                   ""id"": ""one"",
                   ""origin"": ""https://example.org/vid.mp4"",
-                  ""space"": 4,
-                  ""family"": ""T"",
-                  ""thumbnailPolicy"": ""some-thumbnail-policy""
+                  ""space"": 1,
+                  ""family"": ""{family}"",
+                  ""imageOptimisationPolicy"": ""some-thumbnail-policy""
                   ""mediaType"": ""video/mp4""
-                }
+                }}
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        const string path = "/customers/99/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(99).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -968,31 +926,24 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreatePriorityBatch_201_IfLegacyModeEnabled()
     {
-        const int customerId = 15;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, 5);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
     ""@type"": ""Collection"",
     ""member"": [
-        {
+        {{
           ""id"": ""one"",
           ""origin"": ""https://example.org/stuff.jpg"",
-          ""space"": 5,
-        }
+          ""space"": {LegacyModeHelpers.LegacySpace},
+        }}
     ]
-}";
+}}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue/priority";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue/priority";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
 
         // Assert
         // status code correct
@@ -1002,13 +953,6 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreatePriorityBatch_201_WithMixtureOfIdSet()
     {
-        const int customerId = 15;
-        const int space = 4;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
         var hydraImageBody = @"{
     ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
@@ -1016,21 +960,21 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     ""member"": [
         {
           ""origin"": ""https://example.org/stuff.jpg"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""I"",
           ""mediaType"": ""image/jpeg""
         },
         {
           ""id"": """",
           ""origin"": ""https://example.org/stuff.jpg"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""I"",
           ""mediaType"": ""image/jpeg""
         },
         {
           ""id"": ""someId"",
           ""origin"": ""https://example.org/stuff.jpg"",
-          ""space"": 4,
+          ""space"": 1,
           ""family"": ""I"",
           ""mediaType"": ""image/jpeg""
         }
@@ -1038,15 +982,16 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
 }";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue/priority";
+        const string path = "/customers/99/queue/priority";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(99).PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         
-        var assetInDatabase = dbContext.Images.Where(a => a.Customer == customerId && a.Space == space);
+        var model = await response.ReadAsHydraResponseAsync<DLCS.HydraModel.CustomerQueue>();
+        var assetInDatabase = dbContext.Images.Where(a => a.Batch == model.Id.GetLastPathElementAsInt());
         assetInDatabase.Count().Should().Be(3);
         Guid.TryParse(assetInDatabase.ToList()[0].Id.Asset, out _).Should().BeTrue();
         Guid.TryParse(assetInDatabase.ToList()[1].Id.Asset, out _).Should().BeTrue();
@@ -1270,34 +1215,25 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfImageOptimisationPolicySetForImage_AndLegacyEnabled()
     {
-        const int customerId = 325665;
-        const int space = 201;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.DeliveryChannelPolicies.AddTestDeliveryChannelPolicies(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
-                  ""@id"": ""https://test/customers/325665/spaces/201/images/one"",
+                {{
+                  ""@id"": ""https://test/customers/{LegacyModeHelpers.LegacyCustomer}/spaces/{LegacyModeHelpers.LegacySpace}/images/one"",
                   ""origin"": ""https://example.org/my-image.png"",
                   ""imageOptimisationPolicy"": ""fast-higher"",
                   ""space"": 201,
-                },
+                }},
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
   
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -1305,7 +1241,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var image = dbContext.Images
             .Include(a => a.ImageDeliveryChannels!)
             .ThenInclude(dc => dc.DeliveryChannelPolicy)
-            .Single(i => i.Customer == customerId && i.Space == space);
+            .Single(i => i.Customer == LegacyModeHelpers.LegacyCustomer && i.Space == LegacyModeHelpers.LegacySpace);
         
         image.ImageDeliveryChannels!.Should().Satisfy(
             dc => dc.Channel == AssetDeliveryChannels.Image && 
@@ -1317,34 +1253,25 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfThumbnailPolicySetForImage_AndLegacyEnabled()
     {
-        const int customerId = 325665;
-        const int space = 201;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.DeliveryChannelPolicies.AddTestDeliveryChannelPolicies(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
-                  ""@id"": ""https://test/customers/325665/spaces/201/images/one"",
+                {{
+                  ""@id"": ""https://test/customers/{LegacyModeHelpers.LegacyCustomer}/spaces/{LegacyModeHelpers.LegacySpace}/images/one"",
                   ""origin"": ""https://example.org/my-image.png"",
                   ""thumbnailPolicy"": ""default"",
-                  ""space"": 201,
-                },
+                  ""space"": {LegacyModeHelpers.LegacySpace},
+                }},
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
   
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -1352,7 +1279,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var image = dbContext.Images
             .Include(a => a.ImageDeliveryChannels!)
             .ThenInclude(dc => dc.DeliveryChannelPolicy)
-            .Single(i => i.Customer == customerId && i.Space == space);
+            .Single(i => i.Customer == LegacyModeHelpers.LegacyCustomer && i.Space == LegacyModeHelpers.LegacySpace);
         
         image.ImageDeliveryChannels!.Should().Satisfy(
             dc => dc.Channel == AssetDeliveryChannels.Image && 
@@ -1364,35 +1291,26 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfImageOptimisationPolicySetForVideo_AndLegacyEnabled()
     {
-        const int customerId = 325665;
-        const int space = 201;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.DeliveryChannelPolicies.AddTestDeliveryChannelPolicies(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
-                  ""@id"": ""https://test/customers/325665/spaces/201/images/one"",
+                {{
+                  ""@id"": ""https://test/customers/{LegacyModeHelpers.LegacyCustomer}/spaces/{LegacyModeHelpers.LegacySpace}/images/one"",
                   ""family"": ""T"",
                   ""origin"": ""https://example.org/my-video.mp4"",
                   ""imageOptimisationPolicy"": ""video-max"",
                   ""space"": 201,
-                },
+                }},
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
   
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -1400,7 +1318,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var image = dbContext.Images
             .Include(a => a.ImageDeliveryChannels!)
             .ThenInclude(dc => dc.DeliveryChannelPolicy)
-            .Single(i => i.Customer == customerId && i.Space == space);
+            .Single(i => i.Customer == LegacyModeHelpers.LegacyCustomer && i.Space == LegacyModeHelpers.LegacySpace);
 
         image.ImageDeliveryChannels!.Should().Satisfy(
             dc => dc.Channel == AssetDeliveryChannels.Timebased &&
@@ -1410,35 +1328,26 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Post_CreateBatch_201_IfImageOptimisationPolicySetForAudio_AndLegacyEnabled()
     {
-        const int customerId = 325665;
-        const int space = 201;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, space);
-        await dbContext.DeliveryChannelPolicies.AddTestDeliveryChannelPolicies(customerId);
-        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.SaveChangesAsync();
-
         // Arrange
-        var hydraImageBody = @"{
+        var hydraImageBody = $@"{{
             ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
             ""@type"": ""Collection"",
             ""member"": [
-                {
-                  ""@id"": ""https://test/customers/325665/spaces/201/images/one"",
+                {{
+                  ""@id"": ""https://test/customers/{LegacyModeHelpers.LegacyCustomer}/spaces/{LegacyModeHelpers.LegacySpace}/images/one"",
                   ""family"": ""T"",
                   ""origin"": ""https://example.org/my-audio.mp3"",
                   ""imageOptimisationPolicy"": ""audio-max"",
                   ""space"": 201,
-                },
+                }},
             ]
-        }";
+        }}";
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/{LegacyModeHelpers.LegacyCustomer}/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PostAsync(path, content);
   
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -1446,7 +1355,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var image = dbContext.Images
             .Include(a => a.ImageDeliveryChannels!)
             .ThenInclude(dc => dc.DeliveryChannelPolicy)
-            .Single(i => i.Customer == customerId && i.Space == space);
+            .Single(i => i.Customer == LegacyModeHelpers.LegacyCustomer && i.Space == LegacyModeHelpers.LegacySpace);
 
         image.ImageDeliveryChannels!.Should().Satisfy(
             dc => dc.Channel == AssetDeliveryChannels.Timebased &&

--- a/src/protagonist/API.Tests/LegacyModeHelpers.cs
+++ b/src/protagonist/API.Tests/LegacyModeHelpers.cs
@@ -1,0 +1,26 @@
+﻿using DLCS.Repository;
+using Test.Helpers.Integration;
+
+namespace API.Tests;
+
+/// <summary>
+/// Helper methods and constants for working with LegacyMode. LegacyCustomer + Space are configured as such via
+/// appsettings.Testing.json
+/// </summary>
+public class LegacyModeHelpers
+{
+    public const int LegacyCustomer = 325665;
+    public const int LegacySpace = 201;
+    public const int NonLegacySpace = 4;
+    
+    public static async Task SetupLegacyCustomer(DlcsContext dbContext, int space = LegacySpace)
+    {
+        await dbContext.Customers.AddTestCustomer(LegacyCustomer);
+        await dbContext.Spaces.AddTestSpace(LegacyCustomer, space);
+        await dbContext.Spaces.AddTestSpace(LegacyCustomer, NonLegacySpace);
+        await dbContext.CustomerStorages.AddTestCustomerStorage(LegacyCustomer);
+        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(LegacyCustomer);
+        await dbContext.DeliveryChannelPolicies.AddTestDeliveryChannelPolicies(LegacyCustomer);
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -22,13 +22,9 @@
   "PageSize": 100,
   "ApiSalt": "this-is-a-salt",
   "CustomerOverrides": {
-    "15": {
-      "LegacySupport": true,
-      "NovelSpaces": ["1","4"]
-    },
     "325665": {
       "LegacySupport": true,
-      "NovelSpaces": ["1","4"]
+      "NovelSpaces": ["4"]
     }
   },
   "RestrictedAssetIdCharacterString": "\\ "


### PR DESCRIPTION
Introduce helper method to create customer + spaces. Use constants when using Legacy and prefer default Customer 99 where possible.
