### PR TITLE
Adding abilty to use a stickiness cookie when generating thumbs through cantaloupe

### DIFF
--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
@@ -311,9 +311,9 @@ public class CantaloupeThumbsClientTests
         var response = new HttpResponseMessage(HttpStatusCode.OK);
         response.Headers.Add("Set-Cookie", new List<string?>()
         {
-            "AWSALBAPP-0=_remove_; Expires=Tue, 25 Jun 2024 10:56:45 GMT; Path=/",
-            "AWSALBAPP-1=_remove_; Expires=Tue, 25 Jun 2024 10:56:45 GMT; Path=/",
-            "AWSALBAPP-2=_remove_; Expires=Tue, 25 Jun 2024 10:56:45 GMT; Path=/"
+            "AWSALBAPP-0=_remove_; Path=/",
+            "AWSALBAPP-1=_remove_; Path=/",
+            "AWSALBAPP-2=_remove_; Path=/"
         });
         httpHandler.SetResponse(response);
         context.Asset.Width = 2000;

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using DLCS.Core.Exceptions;
 using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
@@ -10,9 +9,11 @@ using Engine.Ingest.Image.ImageServer.Measuring;
 using Engine.Settings;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Net.Http.Headers;
 using Test.Helpers.Data;
 using Test.Helpers.Http;
 using Test.Helpers.Settings;
+using CookieHeaderValue = System.Net.Http.Headers.CookieHeaderValue;
 
 namespace Engine.Tests.Ingest.Image.ImageServer.Clients;
 
@@ -321,7 +322,7 @@ public class CantaloupeThumbsClientTests
         var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
 
         var response = new HttpResponseMessage(HttpStatusCode.OK);
-        response.Headers.Add("Set-Cookie", new List<string?>()
+        response.Headers.Add(HeaderNames.SetCookie, new List<string?>()
         {
             "AWSALB=_remove_; Path=/",
             "AWSALBCORS=_remove_; Path=/"
@@ -360,7 +361,7 @@ public class CantaloupeThumbsClientTests
         var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
 
         var response = new HttpResponseMessage(HttpStatusCode.OK);
-        response.Headers.Add("Set-Cookie", new List<string?>()
+        response.Headers.Add(HeaderNames.SetCookie, new List<string?>()
         {
             "SOMECOOKIE=_remove_; Path=/",
             "SOMECOOKIE2=_remove_; Path=/"

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClientTests.cs
@@ -337,6 +337,31 @@ public class CantaloupeThumbsClientTests
         cookies[2].Cookies[0].Name.Should().Be("AWSALBAPP-2");
     }
 
+    [Fact]
+    public async Task GenerateThumbnails_UpdatesHandlerWithNoCookiesSet()
+    {
+        // Arrange
+        var assetId = new AssetId(2, 1, nameof(GenerateThumbnails_ReturnsThumbForSuccessfulResponse));
+        var context = IngestionContextFactory.GetIngestionContext(assetId: assetId.ToString());
+
+        httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK));
+        context.Asset.Width = 2000;
+        context.Asset.Height = 2000;
+
+        context.WithLocation(new ImageLocation
+        {
+            S3 = "//some/location/with/s3"
+        });
+        
+        // Act
+        await sut.GenerateThumbnails(context, defaultThumbs, ThumbsRoot);
+
+        var cookies = httpClient.DefaultRequestHeaders.GetCookies();
+
+        // Assert
+        cookies.Count.Should().Be(0);
+    }
+
     public class ImageOnDiskResults
     {
         public ImageOnDisk ReturnedFromImageServer { get; }

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using DLCS.AWS.Configuration;
 using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;
@@ -102,13 +103,13 @@ public static class ServiceCollectionX
             services.AddTransient<TimingHandler>();
             services.AddScoped<IImageProcessor, ImageServerClient>()
                 .AddScoped<IImageMeasurer, ImageSharpMeasurer>();
-                
+
             services.AddHttpClient<IAppetiserClient, AppetiserClient>(client =>
                 {
                     client.BaseAddress = engineSettings.ImageIngest.ImageProcessorUrl;
                     client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
                 }).AddHttpMessageHandler<TimingHandler>();
-            
+
             services.AddHttpClient<IThumbsClient, CantaloupeThumbsClient>(client =>
             {
                 client.BaseAddress = engineSettings.ImageIngest.ThumbsProcessorUrl;

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using DLCS.AWS.Configuration;
 using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;

--- a/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Engine/Infrastructure/ServiceCollectionX.cs
@@ -110,10 +110,11 @@ public static class ServiceCollectionX
                 }).AddHttpMessageHandler<TimingHandler>();
 
             services.AddHttpClient<IThumbsClient, CantaloupeThumbsClient>(client =>
-            {
-                client.BaseAddress = engineSettings.ImageIngest.ThumbsProcessorUrl;
-                client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
-            }).AddHttpMessageHandler<TimingHandler>();
+                {
+                    client.BaseAddress = engineSettings.ImageIngest.ThumbsProcessorUrl;
+                    client.Timeout = TimeSpan.FromMilliseconds(engineSettings.ImageIngest.ImageProcessorTimeoutMs);
+                }).ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler() { UseCookies = false })
+                .AddHttpMessageHandler<TimingHandler>();
 
             services.AddHttpClient<IOrchestratorClient, InfoJsonOrchestratorClient>(client =>
             {

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -114,7 +114,7 @@ public class CantaloupeThumbsClient : IThumbsClient
             foreach (var cookie in cookies!)
             {
                 if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
-                        cookie.Split(';').Any(h => h.Trim(' ').StartsWith(c))))
+                        cookie.Split(';').Any(h => h.Trim(' ').StartsWith($"{c}="))))
                 {
                     loadBalancerCookies.Add(cookie);
                 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -107,7 +107,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private void AttemptToAddStickinessCookie(HttpResponseMessage response)
     {
-        if (!cantaloupeClient.DefaultRequestHeaders.Contains("Cookie"))
+        if (!loadBalancerCookies.Any())
         {
             var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
             if (hasCookie)

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using DLCS.Core.Exceptions;
 using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
@@ -107,16 +106,18 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private void AttemptToAddStickinessCookie(HttpResponseMessage response)
     {
-        var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
-        if (hasCookie)
+        if (!loadBalancerCookies.Any())
         {
-            loadBalancerCookies = new List<string>();
-            foreach (var cookie in cookies!)
+            var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
+            if (hasCookie)
             {
-                if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
-                        cookie.Split(';').Any(h => h.Trim(' ').StartsWith($"{c}="))))
+                foreach (var cookie in cookies!)
                 {
-                    loadBalancerCookies.Add(cookie);
+                    if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
+                            cookie.Split(';').Any(h => h.Trim(' ').StartsWith($"{c}="))))
+                    {
+                        loadBalancerCookies.Add(cookie);
+                    }
                 }
             }
         }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -7,6 +7,7 @@ using Engine.Settings;
 using IIIF;
 using IIIF.ImageApi;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 
 namespace Engine.Ingest.Image.ImageServer.Clients;
 
@@ -98,7 +99,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
         if (loadBalancerCookies.Any())
         {
-            request.Headers.Add("Cookie", loadBalancerCookies);
+            request.Headers.Add(HeaderNames.Cookie, loadBalancerCookies);
         }
 
         return request;
@@ -106,7 +107,7 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private void AttemptToAddStickinessCookie(HttpResponseMessage response)
     {
-        var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        var hasCookie = response.Headers.TryGetValues(HeaderNames.SetCookie, out var cookies);
         if (hasCookie)
         {
             loadBalancerCookies = new List<string>();

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -20,7 +20,7 @@ public class CantaloupeThumbsClient : IThumbsClient
     private readonly IFileSystem fileSystem;
     private readonly IImageMeasurer imageMeasurer;
     private readonly ILogger<CantaloupeThumbsClient> logger;
-    private readonly List<string> loadBalancerCookies = new();
+    private List<string> loadBalancerCookies = new();
     private readonly EngineSettings engineSettings;
 
     public CantaloupeThumbsClient(
@@ -107,18 +107,16 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private void AttemptToAddStickinessCookie(HttpResponseMessage response)
     {
-        if (!loadBalancerCookies.Any())
+        var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        if (hasCookie)
         {
-            var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
-            if (hasCookie)
+            loadBalancerCookies = new List<string>();
+            foreach (var cookie in cookies!)
             {
-                foreach (var cookie in cookies!)
+                if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
+                        cookie.Split(';').Any(h => h.Trim(' ').StartsWith(c))))
                 {
-                    if (CookieHeaderValue.TryParse(cookie, out var parsedCookie) && parsedCookie.Cookies.Any(x =>
-                            engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Contains(x.Name)))
-                    {
-                        loadBalancerCookies.Add(cookie);
-                    }
+                    loadBalancerCookies.Add(cookie);
                 }
             }
         }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/Clients/CantaloupeThumbsClient.cs
@@ -106,18 +106,16 @@ public class CantaloupeThumbsClient : IThumbsClient
 
     private void AttemptToAddStickinessCookie(HttpResponseMessage response)
     {
-        if (!loadBalancerCookies.Any())
+        var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
+        if (hasCookie)
         {
-            var hasCookie = response.Headers.TryGetValues("Set-Cookie", out var cookies);
-            if (hasCookie)
+            loadBalancerCookies = new List<string>();
+            foreach (var cookie in cookies!)
             {
-                foreach (var cookie in cookies!)
+                if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
+                        cookie.Split(';').Any(h => h.Trim(' ').StartsWith($"{c}="))))
                 {
-                    if (engineSettings.ImageIngest!.LoadBalancerStickinessCookieNames.Any(c =>
-                            cookie.Split(';').Any(h => h.Trim(' ').StartsWith($"{c}="))))
-                    {
-                        loadBalancerCookies.Add(cookie);
-                    }
+                    loadBalancerCookies.Add(cookie);
                 }
             }
         }

--- a/src/protagonist/Engine/Settings/EngineSettings.cs
+++ b/src/protagonist/Engine/Settings/EngineSettings.cs
@@ -115,6 +115,15 @@ public class ImageIngestSettings
     public List<string> DefaultThumbs { get; set; } = new();
 
     /// <summary>
+    /// A set of cookie names used by the load balancer to indicate stickiness
+    /// </summary>
+    public List<string> LoadBalancerStickinessCookieNames { get; set; } = new()
+    {
+        "AWSALB",
+        "AWSALBCORS"
+    };
+
+    /// <summary>
     /// Get the root folder, if forImageProcessor will ensure that it is compatible with needs of image-processor
     /// sidecar.
     /// </summary>


### PR DESCRIPTION
Links DLCS-846

This PR implements handling a stickiness cookie coming from AWS which allows all thumbs requests to go through the same cantaloupe when using a load balancer with multiple cantaloupe instances.

It does this by attaching a cookie to requests made to cantaloupe for an instance of the `HttpClient`, after the first thumbs response.  This cookie comes from the AWS "stickiness" attribute and is entirely managed by AWS