### PR TITLE
Do not include ImageService3 on v2 manifests

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -238,6 +238,29 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     }
     
     [Fact]
+    public async Task Get_ManifestForImage_V2_ReturnsManifest_WithoutIIIFImage3Services()
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.SaveChangesAsync();
+            
+        var path = $"iiif-manifest/v2/{id}";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        var json = await response.Content.ReadAsStringAsync();
+        json.Should().NotContain("ImageService3");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+        response.Headers.CacheControl.Public.Should().BeTrue();
+        response.Headers.CacheControl.MaxAge.Should().BeGreaterThan(TimeSpan.FromSeconds(2));
+    }
+    
+    [Fact]
     public async Task Get_V2ManifestForImage_ReturnsManifest_FromMetadata()
     {
         // Arrange

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -193,6 +192,25 @@ public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
         response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
         var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
         jsonResponse["@id"].ToString().Should().Be($"http://localhost/{path}");
+    }
+    
+    [Fact]
+    public async Task Get_ReturnsV2Manifest_WithoutImageService3Services()
+    {
+        // Arrange
+        const string path = "iiif-resource/v2/99/test-named-query/my-ref/1";
+        const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
+        
+        // Act
+        var response = await httpClient.GetAsync($"{path}?foo=bar");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif2);
+
+        var json = await response.Content.ReadAsStringAsync();
+        json.Should().NotContain("ImageService3");
     }
     
     [Fact]


### PR DESCRIPTION
Both `ImageService2` and `ImageService3` services were included on both V2 and V3 manifests.

This changes that logic to only include both for Presentation3 manifests, Presentation2 manifests only include `ImageService2` services.

The `[ObjectIfSingle]` attribute on `Service` in iiif-net lib ensures this is serialised properly (see https://github.com/digirati-co-uk/iiif-net/blob/main/src/IIIF/IIIF/Presentation/V2/Resource.cs#L13-L14)