### PR TITLE
Allow batch with empty 'members' in legacy mode

### DIFF
--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -4,6 +4,7 @@ using DLCS.Core.Collections;
 using DLCS.HydraModel;
 using DLCS.Model.Assets;
 using Hydra;
+using Microsoft.Extensions.Logging;
 using AssetFamily = DLCS.HydraModel.AssetFamily;
 
 namespace API.Converters;
@@ -14,13 +15,16 @@ namespace API.Converters;
 public static class LegacyModeConverter
 {
     private const string DefaultMediaType = "image/unknown";
+
+    internal static void LogLegacyUsage(this ILogger logger, string message, params object?[] args)
+        => logger.LogWarning("LEGACY USE:" + message, args);
     
     /// <summary>
     /// Converts from legacy format to new format
     /// </summary>
     /// <param name="image">The image to convert should be emulated and translated into delivery channels</param>
     /// <returns>A converted image</returns>
-    public static T VerifyAndConvertToModernFormat<T>(T image)
+    public static T VerifyAndConvertToModernFormat<T>(T image, ILogger? logger = null)
         where T : Image
     {
         if (image.Origin.IsNullOrEmpty())
@@ -30,6 +34,7 @@ public static class LegacyModeConverter
         
         if (image.MediaType.IsNullOrEmpty())
         {
+            logger?.LogLegacyUsage("Null or empty media type");
             var contentType = image.Origin?.Split('.').Last() ?? string.Empty;
          
             image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ?? DefaultMediaType;
@@ -43,6 +48,7 @@ public static class LegacyModeConverter
 
         if (image.MaxUnauthorised is null or 0 && image.Roles.IsNullOrEmpty())
         {
+            logger?.LogLegacyUsage("MaxUnauthorised");
             image.MaxUnauthorised = -1;
         }
         

--- a/src/protagonist/API/Features/Queues/Requests/CreateEmptyBatch.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateEmptyBatch.cs
@@ -1,0 +1,35 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Core;
+using DLCS.Model.Assets;
+using MediatR;
+
+namespace API.Features.Queues.Requests;
+
+/// <summary>
+/// Handler that creates an empty batch of 0 images
+/// </summary>
+public class CreateEmptyBatch : IRequest<ModifyEntityResult<Batch>>
+{
+    public int CustomerId { get; }
+    
+    public CreateEmptyBatch(int customerId)
+    {
+        CustomerId = customerId;
+    }
+}
+
+public class CreateEmptyBatchHandler : IRequestHandler<CreateEmptyBatch, ModifyEntityResult<Batch>>
+{
+    private readonly IBatchRepository batchRepository;
+
+    public CreateEmptyBatchHandler(IBatchRepository batchRepository)
+    {
+        this.batchRepository = batchRepository;
+    }
+    
+    public async Task<ModifyEntityResult<Batch>> Handle(CreateEmptyBatch request, CancellationToken cancellationToken)
+    {
+        var batch = await batchRepository.CreateBatch(request.CustomerId, Array.Empty<Asset>(), cancellationToken);
+        return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);
+    }
+}

--- a/src/protagonist/DLCS.Core.Tests/Collections/CollectionXTests.cs
+++ b/src/protagonist/DLCS.Core.Tests/Collections/CollectionXTests.cs
@@ -54,6 +54,30 @@ public class CollectionXTests
 
         coll.IsNullOrEmpty().Should().BeFalse();
     }
+    
+    [Fact]
+    public void IsEmpty_List_False_IfNull()
+    {
+        List<int> coll = null;
+
+        coll.IsEmpty().Should().BeFalse();
+    }
+    
+    [Fact]
+    public void IsEmpty_List_True_IfEmpty()
+    {
+        var coll = new List<int>();
+
+        coll.IsEmpty().Should().BeTrue();
+    }
+    
+    [Fact]
+    public void IsEmpty_List_False_IfHasValues()
+    {
+        var coll = new List<int> {2};
+
+        coll.IsEmpty().Should().BeFalse();
+    }
 
     [Fact]
     public void AsList_ReturnsExpected()

--- a/src/protagonist/DLCS.Core/Collections/CollectionX.cs
+++ b/src/protagonist/DLCS.Core/Collections/CollectionX.cs
@@ -20,6 +20,13 @@ public static class CollectionX
     /// <returns>true if null or empty, else false</returns>
     public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IList<T>? collection)
         => collection == null || collection.Count == 0;
+    
+    /// <summary>
+    /// Check if IList is empty - this explicitly checks for Empty only, list could still be null
+    /// </summary>
+    /// <returns>true if empty, else false</returns>
+    public static bool IsEmpty<T>(this IList<T>? collection)
+        => collection?.Count == 0;
 
     /// <summary>
     /// Check if list contains single specified item


### PR DESCRIPTION
If customer has LegacyMode enabled and we receive empty members then we will create an empty batch. To simplify processing a new handler was created solely for creating the batch, saves any complication of `CreateBatchOfImages` and makes removing simpler when LegacyMode is disabled.

Note that `null` members will still result in a 400 exception.