### PR TITLE
Update Portal thumbnail viewer to request IIIF Image3 thumbnails

### DIFF
--- a/src/protagonist/Portal/Pages/Images/Index.cshtml.cs
+++ b/src/protagonist/Portal/Pages/Images/Index.cshtml.cs
@@ -57,7 +57,7 @@ public class Index : PageModel
     
     public string CreateSrc(Size size)
     {
-        return $"{Image.ThumbnailImageService}/full/{size.Width},{size.Height}/0/default.jpg";
+        return $"{dlcsSettings.ResourceRoot}thumbs/v3/{Customer}/{Image.Space}/{Image.ModelId}/full/{size.Width},{size.Height}/0/default.jpg";
     }
     
     public string CreateUniversalViewerUrl(string singleAssetManifest)


### PR DESCRIPTION
Resolves https://github.com/dlcs/protagonist/issues/876

This PR updates Portal's thumbnail viewer to always request IIIF Image API v3 when retrieving thumbnails for assets, fixing an issue where it would not work in setups configured to use v2.