### PR TITLE
Create asset modified cleanup handler 

### DIFF
--- a/docs/rfcs/017-asset-modified-cleanup.md
+++ b/docs/rfcs/017-asset-modified-cleanup.md
@@ -106,6 +106,8 @@ This is that the delivery channel stays the same, but the id of the policy has c
 
 - iiif-img changed
   - `info.json` needs removed
+  - If it moves to a `use-original` policy, the derivative asset can be removed
+  - If it moves away from `use-original`, then the `/original` asset can also be removed, provided there isn't a `file` channel
 - Thumbs changed
   - Thumbs need to be removed that are no longer required.
   - `s.json` and asset application metadata should be updated - `s.json` should be updated by the reingest
@@ -126,7 +128,7 @@ The policy data being updated can be found from the date that the delivery chann
 - iiif-img changed
   - `info.json` needs removed
   - If it moves to a `use-original` policy, the derivative asset can be removed
-  - If it moves awa from `use-original`, then the `/original` asset can also be removed, provided there isn't a `file` channel
+  - If it moves away from `use-original`, then the `/original` asset can also be removed, provided there isn't a `file` channel
 - Thumbs changed
   - Thumbs need to be removed that are no longer required.
   - `s.json` and asset application metadata should be updated - `s.json` should be updated by the reingest

--- a/docs/rfcs/017-asset-modified-cleanup.md
+++ b/docs/rfcs/017-asset-modified-cleanup.md
@@ -115,7 +115,7 @@ This is that the delivery channel stays the same, but the id of the policy has c
 - iiif-av changed
   - Old transcode derivative removed if the file extension is no longer required
 - File changed
-  - The asset at origin should be removed if there's an asset on the `/original` path - should only be removed if `iiif-img` is not using it
+  - do nothing
 
 #### Roles changed
 
@@ -136,7 +136,7 @@ The policy data being updated can be found from the date that the delivery chann
 - iiif-av changed
   - Old transcode derivative removed if the file extension is no longer required
 - File changed
-  - The asset at origin should be removed if there's an asset on the `/original` path - should only be removed if `iiif-img` is not using it
+  - do nothing
 
   ## General comments
 

--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetModificationRecordTests.cs
@@ -37,19 +37,22 @@ public class AssetModificationRecordTests
         notification.Before.Should().BeNull();
     }
     
-    [Fact]
-    public void Update_SetsCorrectFields()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Update_SetsCorrectFields(bool engineNotified)
     {
         // Arrange
         var before = new Asset { Id = new AssetId(1, 2, "foo") };
         var after = new Asset { Id = new AssetId(1, 2, "foo"), MaxUnauthorised = 10 };
         
         // Act
-        var notification = AssetModificationRecord.Update(before, after);
+        var notification = AssetModificationRecord.Update(before, after, engineNotified);
         
         // Assert
         notification.ChangeType.Should().Be(ChangeType.Update);
         notification.Before.Should().Be(before);
         notification.After.Should().Be(after);
+        notification.EngineNotified.Should().Be(engineNotified);
     }
 }

--- a/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
+++ b/src/protagonist/API.Tests/Infrastructure/Messaging/AssetNotificationSenderTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using API.Infrastructure.Messaging;
 using DLCS.AWS.SNS;
 using DLCS.Core.Types;
@@ -33,7 +32,7 @@ public class AssetNotificationSenderTests
     {
         // Arrange
         var assetModifiedRecord =
-            AssetModificationRecord.Update(new Asset(new AssetId(1, 2, "foo")), new Asset(new AssetId(1, 2, "bar")));
+            AssetModificationRecord.Update(new Asset(new AssetId(1, 2, "foo")), new Asset(new AssetId(1, 2, "bar")), true);
 
         // Act
         await sut.SendAssetModifiedMessage(assetModifiedRecord, CancellationToken.None);
@@ -76,7 +75,7 @@ public class AssetNotificationSenderTests
         A.CallTo(() =>
             topicPublisher.PublishToAssetModifiedTopic(
                 A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
-                    n.Single().ChangeType == ChangeType.Delete && n.Single().MessageContents.Contains(customerName)),
+                    n.Single().Attributes.Values.Contains(ChangeType.Delete.ToString()) && n.Single().MessageContents.Contains(customerName)),
                 A<CancellationToken>._)).MustHaveHappened();
     }
     
@@ -102,7 +101,7 @@ public class AssetNotificationSenderTests
             topicPublisher.PublishToAssetModifiedTopic(
                 A<IReadOnlyList<AssetModifiedNotification>>.That.Matches(n =>
                     n.Count == 2 && n.All(m =>
-                        m.ChangeType == ChangeType.Delete && m.MessageContents.Contains(customerName))),
+                        n.First().Attributes.Values.Contains(ChangeType.Delete.ToString()) && m.MessageContents.Contains(customerName))),
                 A<CancellationToken>._)).MustHaveHappened();
     }
 }

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json;
-using API.Exceptions;
+﻿using API.Exceptions;
 using API.Features.Assets;
 using API.Infrastructure.Requests;
 using API.Settings;
@@ -53,7 +52,6 @@ public class AssetProcessor
         try
         {
             var assetFromDatabase = await assetRepository.GetAsset(assetBeforeProcessing.Asset.Id, true, true);
-            var existingAsset = assetFromDatabase?.Clone();
 
             if (assetFromDatabase == null)
             {
@@ -104,7 +102,8 @@ public class AssetProcessor
                     )
                 };
             }
-
+            
+            var existingAsset = assetFromDatabase?.Clone();
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
                     settings.RestrictedAssetIdCharacters);

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -44,7 +44,6 @@ public class AssetProcessor
     /// </param>
     /// <param name="requiresReingestPreSave">Optional delegate for modifying asset prior to saving</param>
     /// <param name="cancellationToken">Current cancellation token</param>
-    /// <param name="isPriorityQueue">Whether the request is for the priority queue or not</param>
     public async Task<ProcessAssetResult> Process(AssetBeforeProcessing assetBeforeProcessing, bool mustExist, bool alwaysReingest, bool isBatchUpdate, 
         Func<Asset, Task>? requiresReingestPreSave = null, 
         CancellationToken cancellationToken = default)

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -132,7 +132,7 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         var assetModificationRecord = existingAsset == null
             ? AssetModificationRecord.Create(assetAfterSave)
-            : AssetModificationRecord.Update(existingAsset, assetAfterSave);
+            : AssetModificationRecord.Update(existingAsset, assetAfterSave, processAssetResult.RequiresEngineNotification);
 
         await assetNotificationSender.SendAssetModifiedMessage(assetModificationRecord, cancellationToken);
 

--- a/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
+++ b/src/protagonist/API/Features/Image/Requests/ReingestAsset.cs
@@ -52,7 +52,7 @@ public class ReingestAssetHandler : IRequestHandler<ReingestAsset, ModifyEntityR
         
         var asset = await MarkAssetAsIngesting(cancellationToken, existingAsset!);
 
-        await assetNotificationSender.SendAssetModifiedMessage(AssetModificationRecord.Update(existingAsset!, asset),
+        await assetNotificationSender.SendAssetModifiedMessage(AssetModificationRecord.Update(existingAsset!, asset, true),
             cancellationToken);
         var statusCode = await ingestNotificationSender.SendImmediateIngestAssetRequest(asset, cancellationToken);
         

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using API.Features.Image;
 using API.Features.Image.Ingest;
+using API.Infrastructure.Messaging;
 using API.Infrastructure.Requests;
 using DLCS.Core;
 using DLCS.Model.Assets;
@@ -37,6 +38,7 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
     private readonly IBatchRepository batchRepository;
     private readonly AssetProcessor assetProcessor;
     private readonly IIngestNotificationSender ingestNotificationSender;
+    private readonly IAssetNotificationSender assetNotificationSender;
     private readonly ILogger<CreateBatchOfImagesHandler> logger;
 
     public CreateBatchOfImagesHandler(
@@ -44,12 +46,14 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         IBatchRepository batchRepository,
         AssetProcessor assetProcessor,
         IIngestNotificationSender ingestNotificationSender,
+        IAssetNotificationSender assetNotificationSender,
         ILogger<CreateBatchOfImagesHandler> logger)
     {
         this.dlcsContext = dlcsContext;
         this.batchRepository = batchRepository;
         this.assetProcessor = assetProcessor;
         this.ingestNotificationSender = ingestNotificationSender;
+        this.assetNotificationSender = assetNotificationSender;
         this.logger = logger;
     }
 
@@ -84,7 +88,9 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         
         var batch = await batchRepository.CreateBatch(request.CustomerId, request.AssetsBeforeProcessing.Select(a => a.Asset).ToList(), cancellationToken);
 
-        var assetNotificationList = new List<Asset>(request.AssetsBeforeProcessing.Count);
+        var engineNotificationList = new List<Asset>(request.AssetsBeforeProcessing.Count);
+        var assetModifiedNotificationList = new List<AssetModificationRecord>();
+        
         try
         {
             using var logScope = logger.BeginScope("Processing batch {BatchId}", batch.Id);
@@ -106,9 +112,15 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
 
                 var savedAsset = processAssetResult.Result.Entity!;
                 
+                var existingAsset = processAssetResult.ExistingAsset;
+                var assetModificationRecord = existingAsset == null
+                    ? AssetModificationRecord.Create(savedAsset)
+                    : AssetModificationRecord.Update(existingAsset, savedAsset, processAssetResult.RequiresEngineNotification);
+                assetModifiedNotificationList.Add(assetModificationRecord);
+                
                 if (processAssetResult.RequiresEngineNotification)
                 {
-                    assetNotificationList.Add(savedAsset);
+                    engineNotificationList.Add(savedAsset);
                 }
                 else
                 {
@@ -118,6 +130,8 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
                     batch.Completed += 1;
                 }
             }
+            
+            await assetNotificationSender.SendAssetModifiedMessage(assetModifiedNotificationList, cancellationToken);
             
             if (batch.Completed > 0)
             {
@@ -151,7 +165,7 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         {
             // Raise notifications
             logger.LogDebug("Batch {BatchId} created - sending engine notifications", batch.Id);
-            await ingestNotificationSender.SendIngestAssetsRequest(assetNotificationList, request.IsPriority,
+            await ingestNotificationSender.SendIngestAssetsRequest(engineNotificationList, request.IsPriority,
                 cancellationToken);
         }
         

--- a/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetModificationRecord.cs
@@ -13,22 +13,27 @@ public class AssetModificationRecord
     public Asset? Before { get; }
     public Asset? After { get; }
     
+    public bool EngineNotified { get; }
+    
     public ImageCacheType? DeleteFrom { get; }
- 
-    private AssetModificationRecord(ChangeType changeType, Asset? before, Asset? after, ImageCacheType? deleteFrom)
+
+    private AssetModificationRecord(ChangeType changeType, Asset? before, Asset? after, ImageCacheType? deleteFrom, bool assetModifiedEngineNotified)
     {
         ChangeType = changeType;
         Before = before;
         After = after;
         DeleteFrom = deleteFrom;
+        EngineNotified = assetModifiedEngineNotified;
     }
 
-    public static AssetModificationRecord Delete(Asset before, ImageCacheType deleteFrom) 
-        => new(ChangeType.Delete, before.ThrowIfNull(nameof(before)), null, deleteFrom.ThrowIfNull(nameof(deleteFrom)));
-    
-    public static AssetModificationRecord Update(Asset before, Asset after)
-        => new(ChangeType.Update, before.ThrowIfNull(nameof(before)), after.ThrowIfNull(nameof(after)), null);
+    public static AssetModificationRecord Delete(Asset before, ImageCacheType deleteFrom)
+        => new(ChangeType.Delete, before.ThrowIfNull(nameof(before)), null, deleteFrom.ThrowIfNull(nameof(deleteFrom)),
+            false);
 
-    public static AssetModificationRecord Create(Asset after) 
-        => new(ChangeType.Create, null, after.ThrowIfNull(nameof(after)), null);
+    public static AssetModificationRecord Update(Asset before, Asset after, bool assetModifiedEngineNotified)
+        => new(ChangeType.Update, before.ThrowIfNull(nameof(before)), after.ThrowIfNull(nameof(after)), null,
+            assetModifiedEngineNotified);
+
+    public static AssetModificationRecord Create(Asset after)
+        => new(ChangeType.Create, null, after.ThrowIfNull(nameof(after)), null, false);
 }

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -54,6 +54,7 @@ public class AssetNotificationSender : IAssetNotificationSender
                 {
                     { "messageType", notification.ChangeType.ToString() }
                 };
+                
                 if (notification.EngineNotified)
                 {
                     attributes.Add("engineNotified", "True");

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -43,25 +43,27 @@ public class AssetNotificationSender : IAssetNotificationSender
     public async Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications,
         CancellationToken cancellationToken = default)
     {
-        // Iterate through AssetModifiedMessage objects and build list(s) of changes
-        var changes = new Dictionary<ChangeType, List<string>>()
-        {
-            [ChangeType.Create] = new(),
-            [ChangeType.Update] = new(),
-            [ChangeType.Delete] = new(),
-        };
+        var changes = new List<AssetModifiedNotification>();
         
         foreach (var notification in notifications)
         {
             var serialisedNotification = await GetSerialisedNotification(notification);
             if (serialisedNotification.HasText())
             {
-                changes[notification.ChangeType].Add(serialisedNotification);
+                var attributes = new Dictionary<string, string>()
+                {
+                    { "messageType", notification.ChangeType.ToString() }
+                };
+                if (notification.EngineNotified)
+                {
+                    attributes.Add("engineNotified", "True");
+                }
+
+                changes.Add(new AssetModifiedNotification(serialisedNotification!, attributes));
             }
         }
 
-        // Send notifications generated in above method
-        await SendAssetModifiedRequest(changes, cancellationToken);
+        await topicPublisher.PublishToAssetModifiedTopic(changes, cancellationToken);
     }
 
     private async Task<string?> GetSerialisedNotification(AssetModificationRecord notification)
@@ -130,17 +132,5 @@ public class AssetNotificationSender : IAssetNotificationSender
         var customerPathElement = await customerPathRepository.GetCustomerPathElement(customer.ToString());
         customerPathElements[customer] = customerPathElement;
         return customerPathElement;
-    }
-    
-    private async Task<bool> SendAssetModifiedRequest(Dictionary<ChangeType, List<string>> change, CancellationToken cancellationToken)
-    {
-        if (change.IsNullOrEmpty()) return true;
-
-        var toSend = change
-            .SelectMany(kvp => kvp.Value
-                .Select(v => new AssetModifiedNotification(v, kvp.Key)))
-            .ToList();
-        
-        return await topicPublisher.PublishToAssetModifiedTopic(toSend, cancellationToken);
     }
 }

--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -43,6 +43,8 @@ public class AssetNotificationSender : IAssetNotificationSender
     public async Task SendAssetModifiedMessage(IReadOnlyCollection<AssetModificationRecord> notifications,
         CancellationToken cancellationToken = default)
     {
+        if (notifications.IsNullOrEmpty()) return;
+        
         var changes = new List<AssetModifiedNotification>();
         
         foreach (var notification in notifications)

--- a/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
@@ -73,7 +73,7 @@ public static class ServiceCollectionX
             .AddSingleton<IStorageKeyGenerator, S3StorageKeyGenerator>()
             .AddSingleton<IQueueLookup, SqsQueueLookup>()
             .AddSingleton<IQueueSender, SqsQueueSender>()
-            .AddSingleton<ITopicPublisher, TopicPublisher>()
+            .AddScoped<ITopicPublisher, TopicPublisher>()
             .AddSingleton<IPathCustomerRepository, CustomerPathElementRepository>()
             .AddSingleton<SqsQueueUtilities>()
             .AddSingleton<IElasticTranscoderWrapper, ElasticTranscoderWrapper>()

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -73,7 +73,7 @@ public class Startup
             .AddCaching(cacheSettings)
             .AddDataAccess(configuration)
             .AddScoped<IIngestNotificationSender, IngestNotificationSender>()
-            .AddSingleton<IAssetNotificationSender, AssetNotificationSender>()
+            .AddScoped<IAssetNotificationSender, AssetNotificationSender>()
             .AddScoped<AssetProcessor>()
             .AddScoped<DeliveryChannelProcessor>()
             .AddTransient<TimingHandler>()

--- a/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
@@ -65,7 +65,7 @@ public class AssetUpdatedHandler  : IMessageHandler
         if (request?.AssetBeforeUpdate?.Id == null) return false;
 
         var assetBefore = request.AssetBeforeUpdate;
-        var assetAfter = await assetRepository.GetAsset(request.AssetBeforeUpdate.Id);
+        var assetAfter = await assetRepository.GetAsset(request.AssetBeforeUpdate.Id); // TODO: don't cache
         
         // no changes that need to be cleaned up, or the asset has been deleted before cleanup handling
         if (assetAfter == null || !message.Attributes.Keys.Contains("engineNotified") || 

--- a/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
@@ -1,0 +1,83 @@
+﻿using CleanupHandler.Infrastructure;
+using DLCS.AWS.S3;
+using DLCS.AWS.SQS;
+using DLCS.Core.FileSystem;
+using DLCS.Model.Assets;
+using DLCS.Model.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace CleanupHandler;
+
+public class AssetUpdatedHandler  : IMessageHandler
+{
+    private readonly CleanupHandlerSettings handlerSettings;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly IBucketWriter bucketWriter;
+    private readonly IFileSystem fileSystem;
+    private readonly IAssetRepository assetRepository;
+    private readonly ILogger<AssetUpdatedHandler> logger;
+    
+    
+    public AssetUpdatedHandler(
+        IStorageKeyGenerator storageKeyGenerator,
+        IBucketWriter bucketWriter,
+        IFileSystem fileSystem,
+        IAssetRepository assetRepository,
+        IOptions<CleanupHandlerSettings> handlerSettings,
+        ILogger<AssetUpdatedHandler> logger)
+    {
+        this.storageKeyGenerator = storageKeyGenerator;
+        this.bucketWriter = bucketWriter;
+        this.fileSystem = fileSystem;
+        this.handlerSettings = handlerSettings.Value;
+        this.assetRepository = assetRepository;
+        this.logger = logger;
+    }
+
+    public async Task<bool> HandleMessage(QueueMessage message, CancellationToken cancellationToken = default)
+    {
+        AssetUpdatedNotificationRequest? request;
+        try
+        {
+            request = message.GetMessageContents<AssetUpdatedNotificationRequest>();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to deserialize asset {@Message}", message);
+            return false;
+        }
+
+        if (request?.AssetBeforeUpdate?.Id == null) return false;
+
+        var assetBefore = request.AssetBeforeUpdate;
+        var assetAfter = await assetRepository.GetAsset(request.AssetBeforeUpdate.Id);
+        
+        // no changes that need to be cleaned up, or the asset has been deleted before cleanup handling
+        if (assetAfter == null || !message.Attributes.Keys.Contains("engineNotified") || 
+            (assetBefore.Roles ?? string.Empty) != (assetAfter.Roles ?? string.Empty) || assetAfter.Ingesting == true)
+        {
+            return true;
+        }
+
+        var modifiedOrAdded =
+            assetAfter.ImageDeliveryChannels.IntersectBy(assetBefore.ImageDeliveryChannels.Select(x => x.Id),
+                x => x.Id);
+        var removed = assetBefore.ImageDeliveryChannels.IntersectBy(assetAfter.ImageDeliveryChannels.Select(x => x.Id),
+            x => x.Id);
+
+        if (!modifiedOrAdded.Any() || !removed.Any())
+        {
+            return true;
+        }
+        
+        // still ingesting, so just put it back on the queue
+        if (assetAfter.Ingesting == true || assetBefore.Finished > assetAfter.Finished)
+        {
+            return false;
+        }
+        
+        
+        return true;
+    }
+}

--- a/src/protagonist/CleanupHandler/CleanupHandler.csproj
+++ b/src/protagonist/CleanupHandler/CleanupHandler.csproj
@@ -9,6 +9,8 @@
 
     <ItemGroup>
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
+      <PackageReference Include="LazyCache" Version="2.4.0" />
+      <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
       <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
       <PackageReference Include="Serilog" Version="2.10.0" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
@@ -18,6 +20,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\DLCS.AWS\DLCS.AWS.csproj" />
+      <ProjectReference Include="..\DLCS.Repository\DLCS.Repository.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/CleanupHandler/CleanupHandler.csproj
+++ b/src/protagonist/CleanupHandler/CleanupHandler.csproj
@@ -21,6 +21,7 @@
     <ItemGroup>
       <ProjectReference Include="..\DLCS.AWS\DLCS.AWS.csproj" />
       <ProjectReference Include="..\DLCS.Repository\DLCS.Repository.csproj" />
+      <ProjectReference Include="..\DLCS.Web\DLCS.Web.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/CleanupHandler/CleanupHandler.csproj
+++ b/src/protagonist/CleanupHandler/CleanupHandler.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+      <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/CleanupHandler/Infrastructure/AssetQueueType.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/AssetQueueType.cs
@@ -1,0 +1,7 @@
+﻿namespace CleanupHandler.Infrastructure;
+
+public enum AssetQueueType
+{
+    Delete,
+    Update
+}

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -15,6 +15,9 @@ public class CleanupHandlerSettings
     /// </summary>
     public AWSSettings AWS { get; set; }
 
+    /// <summary>
+    /// Asset modified settings
+    /// </summary>
     public AssetModifiedSettings AssetModifiedSettings { get; set; }
 }
 

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -29,21 +29,7 @@ public class AssetModifiedSettings
     public bool DryRun { get; set; } = false;
     
     /// <summary>
-    /// Which image-server is handling downstream tile requests
-    /// </summary>
-    /// <remarks>
-    /// Ideally the Orchestrator should be agnostic to this but, for now at least, the downstream image server will
-    /// be useful to know for toggling some functionality
-    /// </remarks>
-    public ImageServer ImageServer { get; set; } = ImageServer.Cantaloupe;
-    
-    /// <summary>
     /// Root URL of the engine
     /// </summary>
     public Uri EngineRoot { get; set; }
-
-    /// <summary>
-    /// indicates asset is on a timebased path
-    /// </summary>
-    public string TimebasedKeyIndicator = "full/full/max/max/0";
 }

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -13,4 +13,11 @@ public class CleanupHandlerSettings
     /// AWS config
     /// </summary>
     public AWSSettings AWS { get; set; }
+
+    public AssetModifiedSettings AssetModifiedSettings { get; set; }
+}
+
+public class AssetModifiedSettings
+{
+    
 }

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -38,4 +38,9 @@ public class AssetModifiedSettings
     /// Root URL of the engine
     /// </summary>
     public Uri EngineRoot { get; set; }
+
+    /// <summary>
+    /// indicates asset is on a timebased path
+    /// </summary>
+    public string TimebasedKeyIndicator = "full/full/max/max/0";
 }

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -35,7 +35,7 @@ public class AssetModifiedSettings
     public ImageServer ImageServer { get; set; } = ImageServer.Cantaloupe;
     
     /// <summary>
-    /// A list of thumbnails that will be added to every asset regardless of the thumbnail policy
+    /// Root URL of the engine
     /// </summary>
-    public List<string> DefaultThumbs { get; set; } = new();
+    public Uri EngineRoot { get; set; }
 }

--- a/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/CleanupHandlerSettings.cs
@@ -1,4 +1,5 @@
 ﻿using DLCS.AWS.Settings;
+using DLCS.Core.Settings;
 
 namespace CleanupHandler.Infrastructure;
 
@@ -19,5 +20,22 @@ public class CleanupHandlerSettings
 
 public class AssetModifiedSettings
 {
+    /// <summary>
+    /// Whether the removal of data will actually be removed, or only logged
+    /// </summary>
+    public bool DryRun { get; set; } = false;
     
+    /// <summary>
+    /// Which image-server is handling downstream tile requests
+    /// </summary>
+    /// <remarks>
+    /// Ideally the Orchestrator should be agnostic to this but, for now at least, the downstream image server will
+    /// be useful to know for toggling some functionality
+    /// </remarks>
+    public ImageServer ImageServer { get; set; } = ImageServer.Cantaloupe;
+    
+    /// <summary>
+    /// A list of thumbnails that will be added to every asset regardless of the thumbnail policy
+    /// </summary>
+    public List<string> DefaultThumbs { get; set; } = new();
 }

--- a/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
@@ -63,7 +63,7 @@ public static class ServiceCollectionX
             .AddHostedService<CleanupHandlerQueueMonitor>();
 
     /// <summary>
-    /// Add all dataaccess dependencies, including repositories and DLCS context 
+    /// Add all data access dependencies, including repositories and DLCS context 
     /// </summary>
     public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration, 
         CleanupHandlerSettings cleanupHandlerSettings)

--- a/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionX
     {
         services
             .AddSingleton<IBucketWriter, S3BucketWriter>()
+            .AddSingleton<IBucketReader, S3BucketReader>()
             .AddSingleton<IStorageKeyGenerator, S3StorageKeyGenerator>()
             .AddSingleton<SqsListenerManager>()
             .AddTransient(typeof(SqsListener<>))
@@ -60,6 +61,7 @@ public static class ServiceCollectionX
         => services
             .AddSingleton<IAssetRepository, DapperAssetRepository>()
             .AddScoped<IAssetApplicationMetadataRepository, AssetApplicationMetadataRepository>()
+            .AddSingleton<IThumbRepository, ThumbRepository>()
             .AddSingleton<AssetCachingHelper>()
             .AddDlcsContext(configuration);
     

--- a/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
@@ -1,7 +1,6 @@
 ﻿using CleanupHandler.Repository;
 using DLCS.AWS.Cloudfront;
 using DLCS.AWS.Configuration;
-using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;
 using DLCS.AWS.SQS;
 using DLCS.Core.Caching;
@@ -39,8 +38,7 @@ public static class ServiceCollectionX
             .SetupAWS(configuration, hostEnvironment)
             .WithAmazonS3()
             .WithAmazonCloudfront()
-            .WithAmazonSQS()
-            .WithAmazonElasticTranscoder();
+            .WithAmazonSQS();
 
         return services;
     }
@@ -68,10 +66,8 @@ public static class ServiceCollectionX
         CleanupHandlerSettings cleanupHandlerSettings)
     {
         services
-            .AddSingleton<IAssetRepository, DapperAssetRepository>()
             .AddScoped<IAssetApplicationMetadataRepository, AssetApplicationMetadataRepository>()
             .AddSingleton<IThumbRepository, ThumbRepository>()
-            .AddSingleton<AssetCachingHelper>()
             .AddTransient<TimingHandler>()
             .AddScoped<ICleanupHandlerAssetRepository, CleanupHandlerAssetRepository>()
             .AddDlcsContext(configuration);

--- a/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
@@ -35,7 +35,6 @@ public static class ServiceCollectionX
             .AddSingleton<SqsListenerManager>()
             .AddTransient(typeof(SqsListener<>))
             .AddSingleton<ICacheInvalidator, CloudfrontInvalidator>()
-            .AddSingleton<IElasticTranscoderWrapper, ElasticTranscoderWrapper>()
             .AddSingleton<SqsQueueUtilities>()
             .SetupAWS(configuration, hostEnvironment)
             .WithAmazonS3()

--- a/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/CleanupHandler/Infrastructure/ServiceCollectionX.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.AWS.Cloudfront;
+﻿using CleanupHandler.Repository;
+using DLCS.AWS.Cloudfront;
 using DLCS.AWS.Configuration;
 using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;
@@ -73,6 +74,7 @@ public static class ServiceCollectionX
             .AddSingleton<IThumbRepository, ThumbRepository>()
             .AddSingleton<AssetCachingHelper>()
             .AddTransient<TimingHandler>()
+            .AddScoped<ICleanupHandlerAssetRepository, CleanupHandlerAssetRepository>()
             .AddDlcsContext(configuration);
 
         services.AddHttpClient<IEngineClient, EngineClient>(client =>

--- a/src/protagonist/CleanupHandler/Program.cs
+++ b/src/protagonist/CleanupHandler/Program.cs
@@ -1,5 +1,7 @@
 ﻿using CleanupHandler.Infrastructure;
 using DLCS.AWS.SSM;
+using DLCS.Core.Caching;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -36,6 +38,8 @@ public class Program
                 services
                     .Configure<CleanupHandlerSettings>(hostContext.Configuration)
                     .AddAws(hostContext.Configuration, hostContext.HostingEnvironment)
+                    .AddDataAccess(hostContext.Configuration)
+                    .AddCaching(hostContext.Configuration.GetSection("Caching").Get<CacheSettings>())
                     .AddQueueMonitoring();
             })
             .UseSerilog((hostingContext, loggerConfiguration)

--- a/src/protagonist/CleanupHandler/Program.cs
+++ b/src/protagonist/CleanupHandler/Program.cs
@@ -38,7 +38,7 @@ public class Program
                 services
                     .Configure<CleanupHandlerSettings>(hostContext.Configuration)
                     .AddAws(hostContext.Configuration, hostContext.HostingEnvironment)
-                    .AddDataAccess(hostContext.Configuration)
+                    .AddDataAccess(hostContext.Configuration, hostContext.Configuration.Get<CleanupHandlerSettings>())
                     .AddCaching(hostContext.Configuration.GetSection("Caching").Get<CacheSettings>())
                     .AddQueueMonitoring();
             })

--- a/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
@@ -2,6 +2,7 @@
 using DLCS.Model.Assets;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
+using Microsoft.EntityFrameworkCore;
 
 namespace CleanupHandler.Repository;
 
@@ -14,8 +15,8 @@ public class CleanupHandlerAssetRepository : ICleanupHandlerAssetRepository
         this.dbContext = dbContext;
     }
     
-    public Asset? RetrieveAssetWithDeliveryChannels(AssetId assetId)
+    public async Task<Asset?> RetrieveAssetWithDeliveryChannels(AssetId assetId)
     {
-        return dbContext.Images.IncludeDeliveryChannelsWithPolicy().SingleOrDefault(x => x.Id == assetId);
+        return await dbContext.Images.IncludeDeliveryChannelsWithPolicy().SingleOrDefaultAsync(x => x.Id == assetId);
     }
 }

--- a/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
@@ -1,0 +1,21 @@
+﻿using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Repository;
+using DLCS.Repository.Assets;
+
+namespace CleanupHandler.Repository;
+
+public class CleanupHandlerAssetRepository : ICleanupHandlerAssetRepository
+{
+    private readonly DlcsContext dbContext;
+    
+    public CleanupHandlerAssetRepository(DlcsContext dbContext)
+    {
+        this.dbContext = dbContext;
+    }
+    
+    public Asset? RetrieveAssetWithDeliveryChannels(AssetId assetId)
+    {
+        return dbContext.Images.IncludeDeliveryChannelsWithPolicy().SingleOrDefault(x => x.Id == assetId);
+    }
+}

--- a/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
@@ -1,0 +1,14 @@
+﻿using DLCS.Core.Types;
+using DLCS.Model.Assets;
+
+namespace CleanupHandler.Repository;
+
+public interface ICleanupHandlerAssetRepository
+{
+    /// <summary>
+    /// Retrieves an asset from the database with attached delivery channel policies
+    /// </summary>
+    /// <param name="assetId">The asset id to retrieve details for</param>
+    /// <returns>an asset</returns>
+    Asset? RetrieveAssetWithDeliveryChannels(AssetId assetId);
+}

--- a/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
@@ -10,5 +10,5 @@ public interface ICleanupHandlerAssetRepository
     /// </summary>
     /// <param name="assetId">The asset id to retrieve details for</param>
     /// <returns>an asset</returns>
-    Asset? RetrieveAssetWithDeliveryChannels(AssetId assetId);
+    Task<Asset?> RetrieveAssetWithDeliveryChannels(AssetId assetId);
 }

--- a/src/protagonist/CleanupHandler/appsettings-Development-Example.json
+++ b/src/protagonist/CleanupHandler/appsettings-Development-Example.json
@@ -6,7 +6,8 @@
             "StorageBucket": "storage-bucket"
         },
         "SQS": {
-            "DeleteNotificationQueueName": "dlcsspinup-delete-notification"
+            "DeleteNotificationQueueName": "dlcsspinup-delete-notification",
+            "UpdateNotificationQueueName": "dlcsspinup-update-notification"
         }
     },
     "ImageFolderTemplate": "/nas/{customer}/{space}/{image-dir}/{image}.jp2"

--- a/src/protagonist/CleanupHandler/appsettings.json
+++ b/src/protagonist/CleanupHandler/appsettings.json
@@ -18,5 +18,14 @@
     "Properties": {
       "ApplicationName": "CleanupHandler"
     }
+  },
+  "Caching": {
+    "TimeToLive": {
+      "Memory": {
+        "ShortTtlSecs": 60,
+        "DefaultTtlSecs": 600,
+        "LongTtlSecs": 1800
+      }
+    }
   }
 }

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -13,6 +13,7 @@ using DLCS.Model.Assets;
 using DLCS.Model.Assets.Metadata;
 using DLCS.Model.Messaging;
 using DLCS.Model.PathElements;
+using DLCS.Model.Policies;
 using DLCS.Repository.Messaging;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -34,6 +35,47 @@ public class AssetUpdatedHandlerTests
     private readonly ICleanupHandlerAssetRepository cleanupHandlerAssetRepository;
     private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
 
+    private readonly ImageDeliveryChannel imageDeliveryChannelUseOriginalImage = new()
+    {
+        Id = 999,
+        Channel = AssetDeliveryChannels.Image,
+        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        {
+            Id = KnownDeliveryChannelPolicies.ImageUseOriginal,
+            Channel = AssetDeliveryChannels.Image,
+            Modified = DateTime.MinValue,
+            Created = DateTime.MinValue
+        },
+        DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ImageUseOriginal
+    };
+    
+    private readonly ImageDeliveryChannel imageDeliveryChannelFile = new()
+    {
+        Id = KnownDeliveryChannelPolicies.FileNone,
+        Channel = AssetDeliveryChannels.File,
+        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        {
+            Id = KnownDeliveryChannelPolicies.ImageUseOriginal,
+            Channel = AssetDeliveryChannels.File,
+            Modified = DateTime.MinValue,
+            Created = DateTime.MinValue
+        },
+        DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.FileNone
+    };
+    
+    private readonly ImageDeliveryChannel imageDeliveryChannelThumbnail = new()
+    {
+        Channel = AssetDeliveryChannels.Thumbnails,
+        Id = KnownDeliveryChannelPolicies.ThumbsDefault,
+        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        {
+            Channel = AssetDeliveryChannels.Thumbnails,
+            Created = DateTime.MinValue,
+            Modified = DateTime.MinValue
+        },
+        DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ThumbsDefault
+    };
+
     public AssetUpdatedHandlerTests()
     {
         handlerSettings = new CleanupHandlerSettings
@@ -47,7 +89,11 @@ public class AssetUpdatedHandlerTests
                     OriginBucket = LocalStackFixture.OriginBucketName
                 }
             },
-            ImageFolderTemplate = "/nas/{customer}/{space}/{image-dir}/{image}.jp2"
+            ImageFolderTemplate = "/nas/{customer}/{space}/{image-dir}/{image}.jp2",
+            AssetModifiedSettings = new AssetModifiedSettings()
+            {
+                DryRun = false
+            }
         };
         storageKeyGenerator = new S3StorageKeyGenerator(Options.Create(handlerSettings.AWS));
         bucketWriter = A.Fake<IBucketWriter>();
@@ -57,6 +103,27 @@ public class AssetUpdatedHandlerTests
         thumbRepository = A.Fake<IThumbRepository>();
         elasticTranscoderWrapper = A.Fake<IElasticTranscoderWrapper>();
         cleanupHandlerAssetRepository = A.Fake<ICleanupHandlerAssetRepository>();
+        
+        A.CallTo(() => thumbRepository.GetAllSizes(A<AssetId>._)).Returns(new List<int[]>()
+        {
+            new[]
+            {
+                100, 200
+
+            },
+            new[]
+            {
+                200, 400
+            },
+            new[]
+            {
+                400, 800
+            },
+            new[]
+            {
+                1024, 2048
+            }
+        });
     }
 
     private AssetUpdatedHandler GetSut()
@@ -82,29 +149,360 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
+
+    // removed
     
-    private QueueMessage CreateMinimalQueueMessage(List<ImageDeliveryChannel> imageDeliveryChannelsBefore)
+    [Fact]
+    public async Task Handle_DeletesOriginal_WhenFileChannelRemoved()
     {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelFile
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>(),
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/original")))
+            .MustHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteOriginal_WhenFileChannelRemovedWithUseOriginalPolicy()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelFile,
+            imageDeliveryChannelUseOriginalImage
+        };
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore,
+            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DeletesTimebasedAssets_WhenTimebasedChannelRemoved()
+    {
+        // Arrange
+        var currentTime = DateTime.Now;
+        
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.Timebased,
+                Id = KnownDeliveryChannelPolicies.AvDefaultVideo,
+                DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                {
+                    Channel = AssetDeliveryChannels.Timebased,
+                    Created = currentTime,
+                    Modified = currentTime
+                },
+                DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.AvDefaultVideo
+            }
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>(),
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+        
+        A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
+            .Returns(new []{ "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key" });
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/metadata")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/full/full/max/max/0/default.mp4")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(x => x.Key  == "1/99/foo/some/other/key"))))
+            .MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+     [Fact]
+    public async Task Handle_DeletesThumbnailAssets_WhenThumbnailChannelRemoved()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelThumbnail
+        };
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>(),
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+        A.CallTo(() =>
+                assetMetadataRepository.DeleteAssetApplicationMetadata(A<AssetId>._, A<string>._,
+                    A<CancellationToken>._))
+            .Returns(true);
+        A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
+            .Returns(new[]
+            {
+                "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg"
+            });
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o =>
+                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
+                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
+            .MustHaveHappened();
+        A.CallTo(() => assetMetadataRepository.DeleteAssetApplicationMetadata(A<AssetId>._, A<string>._, A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() =>
+            bucketWriter.DeleteFolder(
+                A<ObjectInBucket>.That.Matches(o =>
+                    o.Key == "1/99/foo/" && o.Bucket == handlerSettings.AWS.S3.ThumbsBucket),
+                A<bool>.That.Matches(r => r == true))).MustHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DeletesSomeThumbnailAssets_WhenThumbnailChannelRemovedWithImageChannel()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelThumbnail,
+            imageDeliveryChannelUseOriginalImage
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>() {imageDeliveryChannelUseOriginalImage},
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+        A.CallTo(() =>
+                assetMetadataRepository.DeleteAssetApplicationMetadata(A<AssetId>._, A<string>._,
+                    A<CancellationToken>._))
+            .Returns(true);
+        A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
+            .Returns(new[]
+            {
+                "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
+                "1/99/foo/stuff/2048.jpg"
+            });
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o =>
+                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
+                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o =>
+                        o[1].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
+            .MustHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DeletesValidPaths_WhenImageChannelRemoved()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelUseOriginalImage
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>(),
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o[2].Key == "1/99/foo/original")))
+            .MustHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteOriginal_WhenImageChannelRemovedWithFileLeft()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelUseOriginalImage,
+            imageDeliveryChannelFile
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>() { imageDeliveryChannelFile },
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(o => o.Key == "1/99/foo/original"))))
+            .MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_DoesNotDeleteOriginal_WhenImageChannelRemovedWithThumbnailLeft()
+    {
+        // Arrange
+        var imageDeliveryChannelsBefore = new List<ImageDeliveryChannel>
+        {
+            imageDeliveryChannelUseOriginalImage,
+            imageDeliveryChannelThumbnail
+        };
+        
+
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>() { imageDeliveryChannelThumbnail },
+            string.Empty, string.Empty);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(o => o.Key == "1/99/foo/original"))))
+            .MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+
+    // modified
+    
+    
+    // updated
+    
+    
+    // roles
+
+    
+    // helper functions
+    
+    private (QueueMessage queueMessage, Asset assetAfter) CreateMinimalRequestDetails(List<ImageDeliveryChannel> imageDeliveryChannelsBefore, 
+        List<ImageDeliveryChannel> imageDeliveryChannelsAfter, string rolesBefore, string rolesAfter)
+    {
+        var assetBefore = new Asset()
+        {
+            Id = new AssetId(1, 99, "foo"),
+            ImageDeliveryChannels = imageDeliveryChannelsBefore,
+            Roles = rolesBefore
+        };
+
+        var assetAfter = new Asset()
+        {
+            Id = new AssetId(1, 99, "foo"),
+            ImageDeliveryChannels = imageDeliveryChannelsAfter,
+            Roles = rolesAfter
+        };
+        
         var cleanupRequest = new AssetUpdatedNotificationRequest()
         {
-            AssetBeforeUpdate = new Asset()
-            {
-                Id = new AssetId(1, 99, "foo"),
-                ImageDeliveryChannels = imageDeliveryChannelsBefore
-            },
+            AssetBeforeUpdate = assetBefore,
             CustomerPathElement = new CustomerPathElement(99, "stuff"),
-            AssetAfterUpdate = new Asset()
-            {
-                Id = new AssetId(1, 99, "foo")
-            }
+            AssetAfterUpdate = assetAfter
         };
 
         var serialized = JsonSerializer.Serialize(cleanupRequest, settings);
 
         var queueMessage = new QueueMessage
         {
-            Body = JsonNode.Parse(serialized)!.AsObject()
+            Body = JsonNode.Parse(serialized)!.AsObject(),
+            Attributes = new Dictionary<string, string>()
+            {
+                { "engineNotified", "True" }
+            }
         };
-        return queueMessage;
+        return (queueMessage, assetAfter);
     }
 }

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -1,0 +1,110 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+using CleanupHandler;
+using CleanupHandler.Infrastructure;
+using CleanupHandler.Repository;
+using DLCS.AWS.ElasticTranscoder;
+using DLCS.AWS.S3;
+using DLCS.AWS.S3.Models;
+using DLCS.AWS.Settings;
+using DLCS.AWS.SQS;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Assets.Metadata;
+using DLCS.Model.Messaging;
+using DLCS.Model.PathElements;
+using DLCS.Repository.Messaging;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Test.Helpers.Integration;
+
+namespace DeleteHandlerTests;
+
+public class AssetUpdatedHandlerTests
+{
+    private readonly CleanupHandlerSettings handlerSettings;
+    private readonly IBucketWriter bucketWriter;
+    private readonly IBucketReader bucketReader;
+    private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly IAssetApplicationMetadataRepository assetMetadataRepository;
+    private readonly IEngineClient engineClient;
+    private readonly IThumbRepository thumbRepository;
+    private readonly IElasticTranscoderWrapper elasticTranscoderWrapper;
+    private readonly ICleanupHandlerAssetRepository cleanupHandlerAssetRepository;
+    private readonly JsonSerializerOptions settings = new(JsonSerializerDefaults.Web);
+
+    public AssetUpdatedHandlerTests()
+    {
+        handlerSettings = new CleanupHandlerSettings
+        {
+            AWS = new AWSSettings
+            {
+                S3 = new S3Settings
+                {
+                    StorageBucket = LocalStackFixture.StorageBucketName,
+                    ThumbsBucket = LocalStackFixture.ThumbsBucketName,
+                    OriginBucket = LocalStackFixture.OriginBucketName
+                }
+            },
+            ImageFolderTemplate = "/nas/{customer}/{space}/{image-dir}/{image}.jp2"
+        };
+        storageKeyGenerator = new S3StorageKeyGenerator(Options.Create(handlerSettings.AWS));
+        bucketWriter = A.Fake<IBucketWriter>();
+        bucketReader = A.Fake<IBucketReader>();
+        engineClient = A.Fake<IEngineClient>();
+        assetMetadataRepository = A.Fake<IAssetApplicationMetadataRepository>();
+        thumbRepository = A.Fake<IThumbRepository>();
+        elasticTranscoderWrapper = A.Fake<IElasticTranscoderWrapper>();
+        cleanupHandlerAssetRepository = A.Fake<ICleanupHandlerAssetRepository>();
+    }
+
+    private AssetUpdatedHandler GetSut()
+        => new(storageKeyGenerator, bucketWriter, bucketReader, assetMetadataRepository, thumbRepository,
+            Options.Create(handlerSettings), elasticTranscoderWrapper, engineClient, cleanupHandlerAssetRepository,
+            new NullLogger<AssetUpdatedHandler>());
+    
+    [Fact]
+    public async Task Handle_ReturnsFalse_IfInvalidFormat()
+    {
+        // Arrange
+        var queueMessage = new QueueMessage
+        {
+            Body = new JsonObject { ["not-id"] = "foo" }
+        };
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeFalse();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
+    private QueueMessage CreateMinimalQueueMessage(List<ImageDeliveryChannel> imageDeliveryChannelsBefore)
+    {
+        var cleanupRequest = new AssetUpdatedNotificationRequest()
+        {
+            AssetBeforeUpdate = new Asset()
+            {
+                Id = new AssetId(1, 99, "foo"),
+                ImageDeliveryChannels = imageDeliveryChannelsBefore
+            },
+            CustomerPathElement = new CustomerPathElement(99, "stuff"),
+            AssetAfterUpdate = new Asset()
+            {
+                Id = new AssetId(1, 99, "foo")
+            }
+        };
+
+        var serialized = JsonSerializer.Serialize(cleanupRequest, settings);
+
+        var queueMessage = new QueueMessage
+        {
+            Body = JsonNode.Parse(serialized)!.AsObject()
+        };
+        return queueMessage;
+    }
+}

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -1092,6 +1092,29 @@ public class AssetUpdatedHandlerTests
     }
     
     // roles
+    
+    [Fact]
+    public async Task Handle_DeletesInfoJson_WhenRolesChanged()
+    {
+        // Arrange
+        var requestDetails = CreateMinimalRequestDetails(
+            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage }, new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
+            string.Empty, "new role");
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
+            .MustHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
 
     
     // helper functions

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -291,12 +291,6 @@ public class AssetUpdatedHandlerTests
         
         // Assert
         response.Should().BeTrue();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o =>
-                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
-                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
-            .MustHaveHappened();
         A.CallTo(() => assetMetadataRepository.DeleteAssetApplicationMetadata(A<AssetId>._, A<string>._, A<CancellationToken>._)).MustHaveHappened();
         A.CallTo(() =>
             bucketWriter.DeleteFolder(
@@ -341,14 +335,8 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
                     A<ObjectInBucket[]>.That.Matches(o =>
-                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
-                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o =>
-                        o[1].Key == "1/99/foo/stuff/2048.jpg" &&
-                        o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
+                        o[0].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[0].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -374,11 +362,8 @@ public class AssetUpdatedHandlerTests
                 bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
             .MustHaveHappened();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o => o[2].Key == "1/99/foo/original")))
+                    A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/original")))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -407,9 +392,6 @@ public class AssetUpdatedHandlerTests
         response.Should().BeTrue();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
@@ -442,9 +424,6 @@ public class AssetUpdatedHandlerTests
         response.Should().BeTrue();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
@@ -693,20 +672,14 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
                     A<ObjectInBucket[]>.That.Matches(o =>
-                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
-                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
+                        o[0].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[0].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
                     A<ObjectInBucket[]>.That.Matches(o =>
-                        o[1].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[1].Key == "1/99/full/100,200/0/default.jpg" &&
                         o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o =>
-                        o[2].Key == "1/99/full/100,200/0/default.jpg" &&
-                        o[2].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
@@ -733,10 +706,7 @@ public class AssetUpdatedHandlerTests
         // Assert
         response.Should().BeTrue();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/original")))
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/original")))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -759,10 +729,7 @@ public class AssetUpdatedHandlerTests
         // Assert
         response.Should().BeTrue();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo")))
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -1007,20 +974,14 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
                     A<ObjectInBucket[]>.That.Matches(o =>
-                        o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json" &&
-                        o[0].Bucket == handlerSettings.AWS.S3.StorageBucket)))
+                        o[0].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[0].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
                     A<ObjectInBucket[]>.That.Matches(o =>
-                        o[1].Key == "1/99/foo/stuff/2048.jpg" &&
+                        o[1].Key == "1/99/full/100,200/0/default.jpg" &&
                         o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o =>
-                        o[2].Key == "1/99/full/100,200/0/default.jpg" &&
-                        o[2].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
@@ -1061,10 +1022,7 @@ public class AssetUpdatedHandlerTests
         // Assert
         response.Should().BeTrue();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo/original")))
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/original")))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -1101,10 +1059,7 @@ public class AssetUpdatedHandlerTests
         // Assert
         response.Should().BeTrue();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[1].Key == "1/99/foo")))
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo")))
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -1129,9 +1084,8 @@ public class AssetUpdatedHandlerTests
         // Assert
         response.Should().BeTrue();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/info/Cantaloupe/v3/info.json")))
-            .MustHaveHappened();
-        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._)).MustHaveHappened();
     }
 
     

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -453,8 +453,6 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
     
-    // TODO: tests for old style thumbs removal
-
     // modified
     
     [Fact]
@@ -683,7 +681,7 @@ public class AssetUpdatedHandlerTests
             .Returns(new[]
             {
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
-                "1/99/foo/stuff/2048.jpg"
+                "1/99/foo/stuff/2048.jpg" , "1/99/full/100,200/0/default.jpg"
             });
 
         // Act
@@ -704,6 +702,16 @@ public class AssetUpdatedHandlerTests
                         o[1].Key == "1/99/foo/stuff/2048.jpg" &&
                         o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o =>
+                        o[2].Key == "1/99/full/100,200/0/default.jpg" &&
+                        o[2].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(x => x.Key == "1/99/foo/stuff/200.jpg"))))
+            .MustNotHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
     
@@ -987,7 +995,7 @@ public class AssetUpdatedHandlerTests
             .Returns(new[]
             {
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
-                "1/99/foo/stuff/2048.jpg"
+                "1/99/foo/stuff/2048.jpg", "1/99/full/100,200/0/default.jpg"
             });
 
         // Act
@@ -1008,6 +1016,16 @@ public class AssetUpdatedHandlerTests
                         o[1].Key == "1/99/foo/stuff/2048.jpg" &&
                         o[1].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
             .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o =>
+                        o[2].Key == "1/99/full/100,200/0/default.jpg" &&
+                        o[2].Bucket == handlerSettings.AWS.S3.ThumbsBucket)))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(x => x.Key == "1/99/foo/stuff/200.jpg"))))
+            .MustNotHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
     

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -31,7 +31,7 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleMessage_IfSingleItemInBatch()
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
+        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
 
         // Act
         await sut.PublishToAssetModifiedTopic(new[] { notification });
@@ -52,7 +52,7 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SingleItemInBatch_ReturnsSuccessDependentOnStatusCode(HttpStatusCode statusCode, bool expected)
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
+        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
         A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
             .Returns(new PublishResponse { HttpStatusCode = statusCode });
 
@@ -67,8 +67,8 @@ public class TopicPublisherTests
     public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleBatch()
     {
         // Arrange
-        var notification = new AssetModifiedNotification("message", ChangeType.Delete);
-        var notification2 = new AssetModifiedNotification("message", ChangeType.Delete);
+        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
+        var notification2 = new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false));
 
         // Act
         await sut.PublishToAssetModifiedTopic(new[] { notification, notification2 });
@@ -91,7 +91,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification(x < 10 ? "message" : "next", ChangeType.Delete));
+            notifications.Add(new AssetModifiedNotification(x < 10 ? "message" : "next", GetAttributes(ChangeType.Delete, false)));
         } 
 
         // Act
@@ -123,7 +123,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification("message", ChangeType.Delete));
+            notifications.Add(new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false)));
         }
         
         A.CallTo(() => snsClient.PublishBatchAsync(A<PublishBatchRequest>._, A<CancellationToken>._))
@@ -143,7 +143,7 @@ public class TopicPublisherTests
         var notifications = new List<AssetModifiedNotification>(15);
         for (int x = 0; x < 15; x++)
         {
-            notifications.Add(new AssetModifiedNotification("message", ChangeType.Delete));
+            notifications.Add(new AssetModifiedNotification("message", GetAttributes(ChangeType.Delete, false)));
         }
 
         A.CallTo(() => snsClient.PublishBatchAsync(A<PublishBatchRequest>._, A<CancellationToken>._))
@@ -156,5 +156,59 @@ public class TopicPublisherTests
 
         // Assert
         response.Should().BeFalse();
+    }
+    
+    [Fact]
+    public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleMessageWithEngineNotified_IfEngineNotifiedTrue()
+    {
+        // Arrange
+        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
+
+        // Act
+        await sut.PublishToAssetModifiedTopic(new[] { notification });
+
+        // Assert
+        A.CallTo(() =>
+            snsClient.PublishAsync(
+                A<PublishRequest>.That.Matches(r =>
+                    r.Message == "message" && r.MessageAttributes["messageType"].StringValue == "Update" && 
+                    r.MessageAttributes["engineNotified"].StringValue == "True"),
+                A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task PublishToAssetModifiedTopicBatch_SuccessfullyPublishesSingleBatchWithEngineNotified()
+    {
+        // Arrange
+        var notification = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
+        var notification2 = new AssetModifiedNotification("message", GetAttributes(ChangeType.Update, true));
+
+        // Act
+        await sut.PublishToAssetModifiedTopic(new[] { notification, notification2 });
+
+        // Assert
+        A.CallTo(() =>
+            snsClient.PublishBatchAsync(
+                A<PublishBatchRequest>.That.Matches(b => b.PublishBatchRequestEntries.All(r =>
+                                                             r.Message == "message" &&
+                                                             r.MessageAttributes["messageType"].StringValue ==
+                                                             "Update"&& 
+                                                             r.MessageAttributes["engineNotified"].StringValue == "True") &&
+                                                         b.PublishBatchRequestEntries.Count == 2),
+                A<CancellationToken>._)).MustHaveHappened();
+    }
+    
+    private Dictionary<string, string> GetAttributes(ChangeType changeType, bool engineNotified)
+    {
+        var attributes = new Dictionary<string, string>()
+        {
+            { "messageType", changeType.ToString() }
+        };
+        if (engineNotified)
+        {
+            attributes.Add("engineNotified", "True");
+        }
+
+        return attributes;
     }
 }

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
@@ -64,6 +64,4 @@ public interface IElasticTranscoderWrapper
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Job details, if found. Else null</returns>
     Task<TranscoderJob?> GetTranscoderJob(AssetId assetId, CancellationToken cancellationToken);
-    
-    
 }

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
@@ -17,6 +17,14 @@ public interface IElasticTranscoderWrapper
     Task<Dictionary<string, string>> GetPresetIdLookup(CancellationToken token = default);
 
     /// <summary>
+    /// Gets details of a preset based on the name
+    /// </summary>
+    /// <param name="name">The name of the preset</param>
+    /// <param name="token">Cancellation token</param>
+    /// <returns>Details of a single preset</returns>
+    public Task<Preset?> GetPresetDetails(string name, CancellationToken token = default);
+
+    /// <summary>
     /// Get ElasticTranscoder Pipeline Id from name. 
     /// </summary>
     /// <param name="pipelineName">Preconfigured pipeline Id</param>

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/IElasticTranscoderWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using Amazon.ElasticTranscoder.Model;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.AWS.ElasticTranscoder.Models.Job;
 using DLCS.Core.Types;
 
@@ -14,7 +15,7 @@ public interface IElasticTranscoderWrapper
     /// </summary>
     /// <param name="token">CancellationToken</param>
     /// <returns>Dictionary of ElasticTranscoder presets</returns>
-    Task<Dictionary<string, string>> GetPresetIdLookup(CancellationToken token = default);
+    Task<Dictionary<string, TranscoderPreset>> GetPresetIdLookup(CancellationToken token = default);
 
     /// <summary>
     /// Gets details of a preset based on the name
@@ -22,7 +23,7 @@ public interface IElasticTranscoderWrapper
     /// <param name="name">The name of the preset</param>
     /// <param name="token">Cancellation token</param>
     /// <returns>Details of a single preset</returns>
-    public Task<Preset?> GetPresetDetails(string name, CancellationToken token = default);
+    public Task<TranscoderPreset?> GetPresetDetails(string name, CancellationToken token = default);
 
     /// <summary>
     /// Get ElasticTranscoder Pipeline Id from name. 
@@ -63,4 +64,6 @@ public interface IElasticTranscoderWrapper
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Job details, if found. Else null</returns>
     Task<TranscoderJob?> GetTranscoderJob(AssetId assetId, CancellationToken cancellationToken);
+    
+    
 }

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscoderPreset.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscoderPreset.cs
@@ -1,0 +1,3 @@
+﻿namespace DLCS.AWS.ElasticTranscoder.Models;
+
+public record TranscoderPreset(string Id, string Name, string Extension);

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/TranscoderTemplates.cs
@@ -37,7 +37,7 @@ public static class TranscoderTemplates
     public static string GetFinalDestinationKey(string outputKey) =>
         outputKey.Substring(outputKey.IndexOf("/", StringComparison.Ordinal) + 1);
 
-    private static string GetDestinationTemplate(string mediaType)
+    public static string GetDestinationTemplate(string mediaType)
     {
         // audio: {customer}/{space}/{image}/full/max/default.{extension} (mediatype like audio/)
         // video: {customer}/{space}/{image}/full/full/max/max/0/default.{extension} (mediatype like video/)

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -17,4 +17,4 @@ public interface ITopicPublisher
 /// <summary>
 /// Represents the contents + type of change for Asset modified notification
 /// </summary>
-public record AssetModifiedNotification(string MessageContents, ChangeType ChangeType);
+public record AssetModifiedNotification(string MessageContents, Dictionary<string, string> Attributes);

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -57,7 +57,7 @@ public class TopicPublisher : ITopicPublisher
         {
             TopicArn = snsSettings.AssetModifiedNotificationTopicArn,
             Message = message.MessageContents,
-            MessageAttributes = GetMessageAttributes(message.ChangeType)
+            MessageAttributes = GetMessageAttributes(message.Attributes)
         };
 
         try
@@ -83,7 +83,7 @@ public class TopicPublisher : ITopicPublisher
                 TopicArn = snsSettings.AssetModifiedNotificationTopicArn,
                 PublishBatchRequestEntries = chunk.Select(m => new PublishBatchRequestEntry
                 {
-                    MessageAttributes = GetMessageAttributes(m.ChangeType),
+                    MessageAttributes = GetMessageAttributes(m.Attributes),
                     Message = m.MessageContents,
                     Id = $"{batchIdPrefix}_{batchNumber}_{batchCount++}",
                 }).ToList()
@@ -99,16 +99,19 @@ public class TopicPublisher : ITopicPublisher
         }
     }
 
-    private static Dictionary<string, MessageAttributeValue> GetMessageAttributes(ChangeType changeType)
+    private static Dictionary<string, MessageAttributeValue> GetMessageAttributes(Dictionary<string, string> attributes)
     {
-        var attributeValue = new MessageAttributeValue
+        var messageAttributes = new Dictionary<string, MessageAttributeValue>();
+        foreach (var attribute in attributes)
         {
-            StringValue = changeType.ToString(),
-            DataType = "String"
-        };
-        return new Dictionary<string, MessageAttributeValue>
-        {
-            { "messageType", attributeValue }
-        };
+            messageAttributes.Add(attribute.Key,
+                new MessageAttributeValue()
+                {
+                    DataType = "String",
+                    StringValue = attribute.Value
+                });
+        }
+
+        return messageAttributes;
     }
 }

--- a/src/protagonist/DLCS.AWS/SQS/Models/QueueMessage.cs
+++ b/src/protagonist/DLCS.AWS/SQS/Models/QueueMessage.cs
@@ -16,6 +16,11 @@ public class QueueMessage
     /// <summary>
     /// Any attributes associated with message
     /// </summary>
+    public Dictionary<string, string> MessageAttributes { get; set; }
+    
+    /// <summary>
+    /// Any attributes associated with message
+    /// </summary>
     public Dictionary<string, string> Attributes { get; set; }
         
     /// <summary>

--- a/src/protagonist/DLCS.AWS/SQS/SqsListener.cs
+++ b/src/protagonist/DLCS.AWS/SQS/SqsListener.cs
@@ -155,8 +155,7 @@ public class SqsListener<TMessageType> : IQueueListener
             }
 
             var messageAttributes = message.MessageAttributes
-                .Select(x => new KeyValuePair<string, string>(x.Key, x.Value.StringValue))
-                .ToDictionary(pair => pair.Key, pair => pair.Value);
+                .ToDictionary(pair => pair.Key, pair => pair.Value.StringValue);
 
             var queueMessage = new QueueMessage
             {

--- a/src/protagonist/DLCS.AWS/SQS/SqsListener.cs
+++ b/src/protagonist/DLCS.AWS/SQS/SqsListener.cs
@@ -160,9 +160,8 @@ public class SqsListener<TMessageType> : IQueueListener
 
             var queueMessage = new QueueMessage
             {
-                Attributes = message.Attributes.Concat(messageAttributes)
-                    .ToLookup(x => x.Key, x => x.Value)
-                    .ToDictionary(x => x.Key, g => g.First()),
+                MessageAttributes = messageAttributes,
+                Attributes = message.Attributes,
                 Body = JsonNode.Parse(message.Body)!.AsObject(),
                 MessageId = message.MessageId,
                 QueueName = QueueName

--- a/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
@@ -40,6 +40,11 @@ public class SQSSettings
     public string? DeleteNotificationQueueName { get; set; }
     
     /// <summary>
+    /// Name of queue for handling notifications that assets have been updated
+    /// </summary>
+    public string? UpdateNotificationQueueName { get; set; }
+    
+    /// <summary>
     /// The duration (in seconds) for which the call waits for a message to arrive in the queue before returning
     /// </summary>
     public int WaitTimeSecs { get; set; } = 20;
@@ -53,4 +58,5 @@ public class SQSSettings
     /// Service root for SQS. Only used if running LocalStack
     /// </summary>
     public string ServiceUrl { get; set; } = "http://localhost:4566/";
+    
 }

--- a/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/SQSSettings.cs
@@ -58,5 +58,4 @@ public class SQSSettings
     /// Service root for SQS. Only used if running LocalStack
     /// </summary>
     public string ServiceUrl { get; set; } = "http://localhost:4566/";
-    
 }

--- a/src/protagonist/DLCS.Core/Settings/ImageServer.cs
+++ b/src/protagonist/DLCS.Core/Settings/ImageServer.cs
@@ -1,0 +1,17 @@
+﻿namespace DLCS.Core.Settings;
+
+/// <summary>
+/// Enum representing image server used for serving image requests
+/// </summary>
+public enum ImageServer
+{
+    /// <summary>
+    /// Cantaloupe image server
+    /// </summary>
+    Cantaloupe,
+
+    /// <summary>
+    /// IIP Image Server
+    /// </summary>
+    IIPImage
+}

--- a/src/protagonist/DLCS.Model.Tests/Policies/DeliveryChannelPolicyXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Policies/DeliveryChannelPolicyXTests.cs
@@ -35,6 +35,29 @@ public class DeliveryChannelPolicyXTests
     }
     
     [Fact]
+    public void AsTimebasedPresets_Throws_IfPolicyNotTimebased()
+    {
+        var policy = new DeliveryChannelPolicy { Channel = "iiif-img" };
+
+        Action action = () => policy.AsTimebasedPresets();
+        action.Should().ThrowExactly<InvalidOperationException>();
+    }
+    
+    [Fact]
+    public void AsTimebasedPresets_ReturnsExpected()
+    {
+        // Arrange
+        var expected = new List<string> { "foo", "bar", "foobar" };
+        var policy = new DeliveryChannelPolicy { Channel = "iiif-av", PolicyData = "[\"foo\",\"bar\",\"foobar\"]" };
+        
+        // Act
+        var actual = policy.AsTimebasedPresets();
+        
+        // Assert
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
     public void PolicyDataAs_ReturnsExpected()
     {
         // Arrange

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -11,7 +11,7 @@ namespace DLCS.Model.Assets;
 /// <summary>
 /// Represents an Asset that is stored in the DLCS database.
 /// </summary>
-public class Asset
+public class Asset : ICloneable
 {
     public AssetId Id { get; set; }
     public int Customer { get; set; }
@@ -116,4 +116,17 @@ public class Asset
         Customer = assetId.Customer;
         Space = assetId.Space;
     }
+
+    public Asset Clone()
+    {
+        var asset = (Asset)MemberwiseClone();
+
+        var deliveryChannels = new ImageDeliveryChannel[asset.ImageDeliveryChannels.Count];
+
+        asset.ImageDeliveryChannels.CopyTo(deliveryChannels, 0);
+        asset.ImageDeliveryChannels = deliveryChannels;
+
+        return asset;
+    }
+    object ICloneable.Clone() { return Clone(); }
 }

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -121,12 +121,18 @@ public class Asset : ICloneable
     {
         var asset = (Asset)MemberwiseClone();
 
-        var deliveryChannels = new ImageDeliveryChannel[asset.ImageDeliveryChannels.Count];
-
-        asset.ImageDeliveryChannels.CopyTo(deliveryChannels, 0);
+        var deliveryChannels = asset.ImageDeliveryChannels.Select(d => (ImageDeliveryChannel)d.Clone()).ToList();
         asset.ImageDeliveryChannels = deliveryChannels;
+        
+        if (asset.AssetApplicationMetadata != null)
+        {
+            var assetApplicationMetadata =
+                asset.AssetApplicationMetadata.Select(a => (AssetApplicationMetadata)a.Clone()).ToList();
+            asset.AssetApplicationMetadata = assetApplicationMetadata;
+        }
 
         return asset;
     }
+    
     object ICloneable.Clone() { return Clone(); }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -52,6 +52,12 @@ public static class AssetDeliveryChannels
            asset.HasDeliveryChannel(deliveryChannel);
     
     /// <summary>
+    /// Checks if asset does not have a specified deliveryChannel
+    /// </summary>
+    public static bool DoesNotHaveDeliveryChannel(this Asset asset, string deliveryChannel)
+        => !asset.HasDeliveryChannel(deliveryChannel);
+    
+    /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
     public static bool IsValidChannel(string? deliveryChannel)

--- a/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
@@ -6,6 +6,8 @@ namespace DLCS.Model.Assets;
 public interface IAssetRepository
 {
     public Task<Asset?> GetAsset(AssetId assetId);
+    
+    public Task<Asset?> GetAsset(AssetId assetId, bool noCache);
 
     public Task<ImageLocation?> GetImageLocation(AssetId assetId);
 }

--- a/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IAssetRepository.cs
@@ -6,8 +6,6 @@ namespace DLCS.Model.Assets;
 public interface IAssetRepository
 {
     public Task<Asset?> GetAsset(AssetId assetId);
-    
-    public Task<Asset?> GetAsset(AssetId assetId, bool noCache);
 
     public Task<ImageLocation?> GetImageLocation(AssetId assetId);
 }

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -1,12 +1,11 @@
 ﻿#nullable disable
 
 using System;
-using System.Collections.Generic;
 using DLCS.Core.Types;
 using DLCS.Model.Policies;
 namespace DLCS.Model.Assets;
 
-public class ImageDeliveryChannel
+public class ImageDeliveryChannel : ICloneable
 {
     /// <summary>
     /// Unique identifier
@@ -29,4 +28,9 @@ public class ImageDeliveryChannel
     /// The delivery channel policy id for the attached delivery channel policy
     /// </summary>
     public int DeliveryChannelPolicyId { get; set; }
+
+    public object Clone()
+    {
+        return (ImageDeliveryChannel)MemberwiseClone();
+    }
 }

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 
+using System.Collections.Generic;
 using DLCS.Core.Types;
 using DLCS.Model.Policies;
 namespace DLCS.Model.Assets;

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -29,8 +29,7 @@ public class ImageDeliveryChannel : ICloneable
     /// </summary>
     public int DeliveryChannelPolicyId { get; set; }
 
-    public object Clone()
-    {
-        return (ImageDeliveryChannel)MemberwiseClone();
-    }
+    public ImageDeliveryChannel Clone() => (ImageDeliveryChannel)MemberwiseClone();
+
+    object ICloneable.Clone() => Clone();
 }

--- a/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/Assets/ImageDeliveryChannel.cs
@@ -1,5 +1,6 @@
 ﻿#nullable disable
 
+using System;
 using System.Collections.Generic;
 using DLCS.Core.Types;
 using DLCS.Model.Policies;

--- a/src/protagonist/DLCS.Model/Assets/Metadata/AssetApplicationMetadata.cs
+++ b/src/protagonist/DLCS.Model/Assets/Metadata/AssetApplicationMetadata.cs
@@ -3,7 +3,7 @@ using DLCS.Core.Types;
 
 namespace DLCS.Model.Assets.Metadata;
 
-public class AssetApplicationMetadata
+public class AssetApplicationMetadata : ICloneable
 {
     /// <summary>
     /// The image id for the attached asset
@@ -31,4 +31,9 @@ public class AssetApplicationMetadata
     /// When the metadata was last modified
     /// </summary>
     public DateTime Modified { get; set; }
+
+    public object Clone()
+    {
+        return (AssetApplicationMetadata)MemberwiseClone();
+    }
 }

--- a/src/protagonist/DLCS.Model/Assets/Metadata/AssetApplicationMetadata.cs
+++ b/src/protagonist/DLCS.Model/Assets/Metadata/AssetApplicationMetadata.cs
@@ -32,8 +32,7 @@ public class AssetApplicationMetadata : ICloneable
     /// </summary>
     public DateTime Modified { get; set; }
 
-    public object Clone()
-    {
-        return (AssetApplicationMetadata)MemberwiseClone();
-    }
+    public AssetApplicationMetadata Clone() => (AssetApplicationMetadata)MemberwiseClone();
+
+    object ICloneable.Clone() => Clone();
 }

--- a/src/protagonist/DLCS.Model/Assets/Metadata/IAssetApplicationMetadataRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/Metadata/IAssetApplicationMetadataRepository.cs
@@ -17,4 +17,14 @@ public interface IAssetApplicationMetadataRepository
     public Task<AssetApplicationMetadata> UpsertApplicationMetadata(
         AssetId assetId, string metadataType, string metadataValue, 
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes asset application metadata from the table
+    /// </summary>
+    /// <param name="assetId">The asset id associated with the metadata</param>
+    /// <param name="metadataType">The type of metadata to delete</param>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <returns>A boolean value based on successful deletion</returns>
+    public Task<bool> DeleteAssetApplicationMetadata(AssetId assetId, string metadataType,
+        CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicyX.cs
+++ b/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicyX.cs
@@ -30,6 +30,22 @@ public static class DeliveryChannelPolicyX
     }
     
     /// <summary>
+    /// Get timebased PolicyData as a list of strings
+    /// </summary>
+    /// <param name="deliveryChannelPolicy">Current <see cref="DeliveryChannelPolicy"/></param>
+    /// <returns>Collection of strings representing timebased policies</returns>
+    /// <exception cref="InvalidOperationException">Thrown if specified policy is not for thumbs channel</exception>
+    public static List<string> AsTimebasedPresets(this DeliveryChannelPolicy deliveryChannelPolicy)
+    {
+        if (deliveryChannelPolicy.Channel != AssetDeliveryChannels.Timebased)
+        {
+            throw new InvalidOperationException("Policy is not for timebased channel");
+        }
+        
+        return deliveryChannelPolicy.PolicyDataAs<List<string>>() ?? new List<string>();
+    }
+    
+    /// <summary>
     /// Deserialise PolicyData as specified type
     /// </summary>
     public static T? PolicyDataAs<T>(this DeliveryChannelPolicy deliveryChannelPolicy)

--- a/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicyX.cs
+++ b/src/protagonist/DLCS.Model/Policies/DeliveryChannelPolicyX.cs
@@ -41,8 +41,10 @@ public static class DeliveryChannelPolicyX
         {
             throw new InvalidOperationException("Policy is not for timebased channel");
         }
+
+        var timeBasedPresets = deliveryChannelPolicy.PolicyDataAs<List<string>>();
         
-        return deliveryChannelPolicy.PolicyDataAs<List<string>>() ?? new List<string>();
+        return timeBasedPresets.ThrowIfNull(nameof(timeBasedPresets));
     }
     
     /// <summary>

--- a/src/protagonist/DLCS.Repository.Tests/Assets/AssetApplicationMetadataRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/AssetApplicationMetadataRepositoryTests.cs
@@ -86,4 +86,45 @@ public class AssetApplicationMetadataRepositoryTests
         // Assert
         await action.Should().ThrowAsync<DbUpdateException>();
     }
+    
+    [Fact]
+    public async Task DeleteAssetApplicationMetadata_DeletesMetadata_WhenCalled()
+    {
+        // Arrange
+        var assetId = AssetId.FromString("99/1/1");
+        
+        var assetApplicationMetadata = new AssetApplicationMetadata()
+        {
+            AssetId = assetId,
+            MetadataType = AssetApplicationMetadataTypes.ThumbSizes,
+            MetadataValue = "{\"a\": [], \"o\": [[75, 100], [150, 200], [300, 400], [769, 1024]]}",
+            Created = DateTime.UtcNow,
+            Modified = DateTime.UtcNow
+        };
+        await dbContext.AssetApplicationMetadata.AddAsync(assetApplicationMetadata);
+        await dbContext.SaveChangesAsync();
+        
+        // Act
+        var metadata = await sut.DeleteAssetApplicationMetadata(assetId, AssetApplicationMetadataTypes.ThumbSizes);
+
+        var metaDataFromDatabase = await dbContext.AssetApplicationMetadata.FirstOrDefaultAsync(x =>
+            x.AssetId == assetId && x.MetadataType == AssetApplicationMetadataTypes.ThumbSizes);
+        
+        // Assert
+        metadata.Should().BeTrue();
+        metaDataFromDatabase.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task DeleteAssetApplicationMetadata_DoesNotDeleteMetadata_WhenCalledWithNonexistentMetadata()
+    {
+        // Arrange
+        var assetId = AssetId.FromString("99/1/1");
+        
+        // Act
+        var metadata = await sut.DeleteAssetApplicationMetadata(assetId, AssetApplicationMetadataTypes.ThumbSizes);
+        
+        // Assert
+        metadata.Should().BeFalse();
+    }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Assets/AssetApplicationMetadataRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Assets/AssetApplicationMetadataRepositoryTests.cs
@@ -3,6 +3,7 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets.Metadata;
 using DLCS.Repository.Assets;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using Test.Helpers.Integration;
 
 namespace DLCS.Repository.Tests.Assets;
@@ -23,7 +24,7 @@ public class AssetApplicationMetadataRepositoryTests
         optionsBuilder.UseNpgsql(dbFixture.ConnectionString);
         contextForTests = new DlcsContext(optionsBuilder.Options);
         
-        sut = new AssetApplicationMetadataRepository(contextForTests);
+        sut = new AssetApplicationMetadataRepository(contextForTests, new NullLogger<AssetApplicationMetadataRepository>());
         
         dbFixture.CleanUp();
         dbContext.Images.AddTestAsset(AssetId.FromString("99/1/1"), ref1: "foobar");

--- a/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
@@ -173,11 +173,10 @@ public class EngineClientTests
     }
     
     [Fact]
-    public async Task GetAvPresets_ReturnsEmpty_IfEngineAvPolicyEndpointUnreachable()
+    public async Task GetAvPresets_ReturnsEmpty_IfEngineAvPolicyEndpointThrowsError()
     {
         // Arrange
-        HttpRequestMessage message = null;
-        httpHandler.RegisterCallback(r => message = r);
+        httpHandler.RegisterCallback(r => throw new Exception("error"));
         httpHandler.GetResponseMessage("Not found", HttpStatusCode.NotFound);
         
         // Act
@@ -185,7 +184,6 @@ public class EngineClientTests
         
         // Assert
         httpHandler.CallsMade.Should().ContainSingle().Which.Should().Be("http://engine.dlcs/av-presets");
-        message.Method.Should().Be(HttpMethod.Get);
-        returnedAvPresets.Should().BeNull();
+        returnedAvPresets.Should().BeEmpty();
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
@@ -1,16 +1,21 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.AWS.SQS;
+using DLCS.Core.Caching;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Repository.Messaging;
 using FakeItEasy;
+using LazyCache.Mocks;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Test.Helpers.Http;
 
 namespace DLCS.Repository.Tests.Messaging;
@@ -33,8 +38,9 @@ public class EngineClientTests
 
         queueLookup = A.Fake<IQueueLookup>();
         queueSender = A.Fake<IQueueSender>();
-        
-        sut = new EngineClient(queueLookup, queueSender, httpClient, new NullLogger<EngineClient>());
+
+        sut = new EngineClient(queueLookup, queueSender, httpClient, new MockCachingService(), Options.Create(new CacheSettings()),
+            new NullLogger<EngineClient>());
     }
     
     [Fact]
@@ -138,5 +144,48 @@ public class EngineClientTests
         httpHandler.CallsMade.Should().ContainSingle().Which.Should().Be("http://engine.dlcs/allowed-av");
         message.Method.Should().Be(HttpMethod.Get);
         returnedAvPolicyOptions.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task GetAvPresets_RetrievesAllowedAvPresets()
+    {
+        // Arrange
+        HttpRequestMessage message = null;
+        httpHandler.RegisterCallback(r => message = r);
+        
+        var response = JsonSerializer.Serialize(new Dictionary<string, TranscoderPreset>()
+        {
+            { "webm-policy", new("webm-policy", "some-webm-preset", "oga") },
+            { "oga-policy", new("oga-policy", "some-oga-preset", "webm") }
+        });
+        
+        httpHandler.GetResponseMessage(response, HttpStatusCode.OK);
+        
+        // Act
+        var returnedAvPresets = await sut.GetAvPresets();
+        
+        // Assert
+        httpHandler.CallsMade.Should().ContainSingle().Which.Should().Be("http://engine.dlcs/av-presets");
+        message.Method.Should().Be(HttpMethod.Get);
+        returnedAvPresets!.Count.Should().Be(2);
+        returnedAvPresets!.Keys.Should().BeEquivalentTo("webm-policy", "oga-policy");
+        returnedAvPresets!.Values.Should().Contain(new TranscoderPreset("webm-policy", "some-webm-preset", "oga"));
+    }
+    
+    [Fact]
+    public async Task GetAvPresets_ReturnsEmpty_IfEngineAvPolicyEndpointUnreachable()
+    {
+        // Arrange
+        HttpRequestMessage message = null;
+        httpHandler.RegisterCallback(r => message = r);
+        httpHandler.GetResponseMessage("Not found", HttpStatusCode.NotFound);
+        
+        // Act
+        var returnedAvPresets = await sut.GetAvPresets();
+        
+        // Assert
+        httpHandler.CallsMade.Should().ContainSingle().Which.Should().Be("http://engine.dlcs/av-presets");
+        message.Method.Should().Be(HttpMethod.Get);
+        returnedAvPresets.Should().BeNull();
     }
 }

--- a/src/protagonist/DLCS.Repository/Assets/AssetApplicationMetadataRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetApplicationMetadataRepository.cs
@@ -4,16 +4,20 @@ using System.Threading.Tasks;
 using DLCS.Core.Types;
 using DLCS.Model.Assets.Metadata;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Z.EntityFramework.Plus;
 
 namespace DLCS.Repository.Assets;
 
 public class AssetApplicationMetadataRepository : IAssetApplicationMetadataRepository
 {
     private readonly DlcsContext dlcsContext;
+    private readonly ILogger<AssetApplicationMetadataRepository> logger;
 
-    public AssetApplicationMetadataRepository(DlcsContext dlcsContext)
+    public AssetApplicationMetadataRepository(DlcsContext dlcsContext, ILogger<AssetApplicationMetadataRepository> logger)
     {
         this.dlcsContext = dlcsContext;
+        this.logger = logger;
     }
 
     /// <inheritdoc />
@@ -48,5 +52,22 @@ public class AssetApplicationMetadataRepository : IAssetApplicationMetadataRepos
         
         await dlcsContext.SaveChangesAsync(cancellationToken);
         return assetApplicationMetadata;
+    }
+
+    public async Task<bool> DeleteAssetApplicationMetadata(AssetId assetId, string metadataType,
+        CancellationToken cancellationToken = default)
+    {
+        var asset = await dlcsContext.AssetApplicationMetadata
+            .SingleOrDefaultAsync(i => i.AssetId == assetId && i.MetadataType == metadataType, cancellationToken);
+        
+        if (asset == null)
+        {
+            logger.LogDebug("Attempt to delete non-existent asset metadata {MetadataType} for {AssetId}", metadataType,
+                assetId);
+            return false;
+        }
+
+        await dlcsContext.SaveChangesAsync(cancellationToken);
+        return true;
     }
 }

--- a/src/protagonist/DLCS.Repository/Assets/AssetApplicationMetadataRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetApplicationMetadataRepository.cs
@@ -57,16 +57,17 @@ public class AssetApplicationMetadataRepository : IAssetApplicationMetadataRepos
     public async Task<bool> DeleteAssetApplicationMetadata(AssetId assetId, string metadataType,
         CancellationToken cancellationToken = default)
     {
-        var asset = await dlcsContext.AssetApplicationMetadata
+        var assetApplicationMetadata = await dlcsContext.AssetApplicationMetadata
             .SingleOrDefaultAsync(i => i.AssetId == assetId && i.MetadataType == metadataType, cancellationToken);
         
-        if (asset == null)
+        if (assetApplicationMetadata == null)
         {
             logger.LogDebug("Attempt to delete non-existent asset metadata {MetadataType} for {AssetId}", metadataType,
                 assetId);
             return false;
         }
 
+        dlcsContext.AssetApplicationMetadata.Remove(assetApplicationMetadata);
         await dlcsContext.SaveChangesAsync(cancellationToken);
         return true;
     }

--- a/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -22,7 +22,17 @@ public class DapperAssetRepository : IAssetRepository, IDapperConfigRepository
         Configuration = configuration;
         this.assetCachingHelper = assetCachingHelper;
     }
-    
+
+    public Task<Asset?> GetAsset(AssetId assetId, bool noCache)
+    {
+        if (noCache)
+        {
+            assetCachingHelper.RemoveAssetFromCache(assetId);
+        }
+
+        return GetAsset(assetId);
+    }
+
     public async Task<ImageLocation?> GetImageLocation(AssetId assetId)
         => await this.QuerySingleOrDefaultAsync<ImageLocation>(ImageLocationSql, new {Id = assetId.ToString()});
     

--- a/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/DapperAssetRepository.cs
@@ -23,16 +23,6 @@ public class DapperAssetRepository : IAssetRepository, IDapperConfigRepository
         this.assetCachingHelper = assetCachingHelper;
     }
 
-    public Task<Asset?> GetAsset(AssetId assetId, bool noCache)
-    {
-        if (noCache)
-        {
-            assetCachingHelper.RemoveAssetFromCache(assetId);
-        }
-
-        return GetAsset(assetId);
-    }
-
     public async Task<ImageLocation?> GetImageLocation(AssetId assetId)
         => await this.QuerySingleOrDefaultAsync<ImageLocation>(ImageLocationSql, new {Id = assetId.ToString()});
     

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -146,6 +146,22 @@ public class EngineClient : IEngineClient
         }
     }
     
+    public async Task<IReadOnlyDictionary<string, string>?> GetAvPresets(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await httpClient.GetAsync("av-presets", cancellationToken);
+            return await response.Content.ReadFromJsonAsync<IReadOnlyDictionary<string, string>>(
+                cancellationToken: cancellationToken);
+            
+        }
+        catch(Exception ex)
+        {
+            logger.LogError(ex, "Failed to retrieve allowed iiif-av policy options from Engine");
+            return null;
+        }
+    }
+    
     private string GetJsonString(Asset asset)
     {
         var ingestAssetRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -153,7 +153,6 @@ public class EngineClient : IEngineClient
             var response = await httpClient.GetAsync("av-presets", cancellationToken);
             return await response.Content.ReadFromJsonAsync<IReadOnlyDictionary<string, string>>(
                 cancellationToken: cancellationToken);
-            
         }
         catch(Exception ex)
         {

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -159,7 +159,7 @@ public class EngineClient : IEngineClient
     public async Task<IReadOnlyDictionary<string, TranscoderPreset>?> GetAvPresets(CancellationToken cancellationToken = default)
     {
         const string key = "avPresetList";
-        return await appCache.GetOrAddAsync(key, async entry =>
+        return await appCache.GetOrAddAsync(key, async () =>
         {
             try
             {

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.AWS.SQS;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
@@ -146,12 +147,12 @@ public class EngineClient : IEngineClient
         }
     }
     
-    public async Task<IReadOnlyDictionary<string, string>?> GetAvPresets(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyDictionary<string, TranscoderPreset>?> GetAvPresets(CancellationToken cancellationToken = default)
     {
         try
         {
             var response = await httpClient.GetAsync("av-presets", cancellationToken);
-            return await response.Content.ReadFromJsonAsync<IReadOnlyDictionary<string, string>>(
+            return await response.Content.ReadFromJsonAsync<IReadOnlyDictionary<string, TranscoderPreset>>(
                 cancellationToken: cancellationToken);
         }
         catch(Exception ex)

--- a/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
@@ -42,4 +42,11 @@ public interface IEngineClient
     /// </summary>
     /// <param name="cancellationToken">Current cancellation token</param>
     Task<IReadOnlyCollection<string>?> GetAllowedAvPolicyOptions(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves av presets
+    /// </summary>
+    /// <param name="cancellationToken">a cancellation token</param>
+    /// <returns>A dictionary of identifiers and presets</returns>
+    Task<IReadOnlyDictionary<string, string>?> GetAvPresets(CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 
@@ -48,5 +49,5 @@ public interface IEngineClient
     /// </summary>
     /// <param name="cancellationToken">a cancellation token</param>
     /// <returns>A dictionary of identifiers and presets</returns>
-    Task<IReadOnlyDictionary<string, string>?> GetAvPresets(CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<string, TranscoderPreset>?> GetAvPresets(CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/IngestControllerTests.cs
@@ -30,7 +30,7 @@ public class IngestControllerTests
     }
 
     [Fact]
-    public void ReturnAllowedAvOptions_ReturnsAvOptions_WhenCalled()
+    public void GetAllowedAvOptions_ReturnsAvOptions_WhenCalled()
     {
         // Arrange and Act
         var avReturn = sut.GetAllowedAvOptions();
@@ -46,7 +46,7 @@ public class IngestControllerTests
     }
     
     [Fact]
-    public void ReturnAllowedAvOptions_ReturnsEmptyList_WhenCalledWithDefaultSettings()
+    public void GetAllowedAvOptions_ReturnsEmptyList_WhenCalledWithDefaultSettings()
     {
         // Arrange and
         var engineSettings = new EngineSettings()
@@ -61,6 +61,46 @@ public class IngestControllerTests
         
         var options = avReturn as OkObjectResult;
         var avOptions = options.Value as List<string>;
+
+        // Assert
+        options.StatusCode.Should().Be(200);
+        avOptions.Count.Should().Be(0);
+    }
+    
+    [Fact]
+    public void GetAllowedAvPresetOptions_ReturnsAvOptions_WhenCalled()
+    {
+        // Arrange and Act
+        var avReturn = sut.GetAllowedAvPresetOptions();
+        
+        var options = avReturn as OkObjectResult;
+        var avOptions = options.Value as Dictionary<string, string>;
+
+        // Assert
+        options.StatusCode.Should().Be(200);
+        avOptions.Count.Should().Be(2);
+        avOptions.Keys.Should().Contain("somePolicy");
+        avOptions.Keys.Should().Contain("somePolicy");
+        avOptions.Values.Should().Contain("An amazon policy");
+        avOptions.Values.Should().Contain("An amazon policy 2");
+    }
+    
+    [Fact]
+    public void GetAllowedAvPresetOptions_ReturnsEmptyList_WhenCalledWithDefaultSettings()
+    {
+        // Arrange and
+        var engineSettings = new EngineSettings()
+        {
+            TimebasedIngest = new TimebasedIngestSettings()
+        };
+        
+        var ingestController = new IngestController(ingester, Options.Create(engineSettings));
+        
+        // Act
+        var avReturn = ingestController.GetAllowedAvPresetOptions();
+        
+        var options = avReturn as OkObjectResult;
+        var avOptions = options.Value as Dictionary<string, string>;
 
         // Assert
         options.StatusCode.Should().Be(200);

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/Transcode/ElasticTranscoderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Amazon.ElasticTranscoder.Model;
 using DLCS.AWS.ElasticTranscoder;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Policies;
@@ -157,11 +158,11 @@ public class ElasticTranscoderTests
             .Returns("1234567890123-abcdef");
 
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
-            .Returns(new Dictionary<string, string>()
+            .Returns(new Dictionary<string, TranscoderPreset>()
             {
-                ["Standard WebM"] = "1111111111111-aaaaaa",
-                ["Standard mp4"] = "1111111111111-aaaaab",
-                ["auto-preset"] = "9999999999999-bbbbbb"
+                ["Standard WebM"] = new ("1111111111111-aaaaaa", "Standard WebM", ""),
+                ["Standard mp4"] = new ("1111111111111-aaaaab", "Standard mp4", ""),
+                ["auto-preset"] = new ("9999999999999-bbbbbb", "auto-preset", "")
             });
 
         Dictionary<string, string>? metadata = null;
@@ -224,10 +225,10 @@ public class ElasticTranscoderTests
             .Returns("1234567890123-abcdef");
 
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
-            .Returns(new Dictionary<string, string>()
+            .Returns(new Dictionary<string, TranscoderPreset>()
             {
-                ["Standard mp4"] = "1111111111111-aaaaab",
-                ["auto-preset"] = "9999999999999-bbbbbb"
+                ["Standard mp4"] = new ("1111111111111-aaaaab", "Standard mp4", ""),
+                ["auto-preset"] = new ("9999999999999-bbbbbb", "auto-preset", "")
             });
 
         A.CallTo(() => elasticTranscoderWrapper.CreateJob(A<string>._, A<string>._,
@@ -277,10 +278,10 @@ public class ElasticTranscoderTests
             .Returns(elasticTranscoderJobId);
 
         A.CallTo(() => elasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
-            .Returns(new Dictionary<string, string>
+            .Returns(new Dictionary<string, TranscoderPreset>
             {
-                ["Standard mp4"] = "1111111111111-aaaaab",
-                ["auto-preset"] = "9999999999999-bbbbbb"
+                ["Standard mp4"] = new ("1111111111111-aaaaab", "Standard mp4", ""),
+                ["auto-preset"] = new ("9999999999999-bbbbbb", "auto-preset", "")
             });
 
         A.CallTo(() => elasticTranscoderWrapper.CreateJob(A<string>._, A<string>._,

--- a/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/TimebasedIngestTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Amazon.ElasticTranscoder.Model;
 using DLCS.AWS.ElasticTranscoder;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.AWS.S3;
 using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
@@ -71,10 +72,10 @@ public class TimebasedIngestTests : IClassFixture<ProtagonistAppFactory<Startup>
         A.CallTo(() => ElasticTranscoderWrapper.GetPipelineId("protagonist-pipeline", A<CancellationToken>._))
             .Returns("pipeline-id-1234");
         A.CallTo(() => ElasticTranscoderWrapper.GetPresetIdLookup(A<CancellationToken>._))
-            .Returns(new Dictionary<string, string>
+            .Returns(new Dictionary<string, TranscoderPreset>
             {
-                ["System preset: Generic 720p"] = "123-123",
-                ["System preset: Audio MP3 - 128k"] = "456-456"
+                ["System preset: Generic 720p"] = new ("123-123", "System preset: Generic 720p", ""),
+                ["System preset: Audio MP3 - 128k"] = new ("456-456", "System preset: Audio MP3 - 128k", "")
             });
     }
 

--- a/src/protagonist/Engine/Ingest/IngestController.cs
+++ b/src/protagonist/Engine/Ingest/IngestController.cs
@@ -46,6 +46,16 @@ public class IngestController : Controller
     {
         return Ok(timebasedIngestSettings.DeliveryChannelMappings.Keys.ToList());
     }
+    
+    /// <summary>
+    /// Retrieve av option presets
+    /// </summary>
+    [HttpGet]
+    [Route("av-presets")]
+    public IActionResult GetAllowedAvPresetOptions()
+    {
+        return Ok(timebasedIngestSettings.DeliveryChannelMappings);
+    }
 
     private IActionResult ConvertToStatusCode(object message, IngestResultStatus result)
         => result switch

--- a/src/protagonist/Engine/Ingest/IngestController.cs
+++ b/src/protagonist/Engine/Ingest/IngestController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Text.Json;
+using DLCS.AWS.ElasticTranscoder;
 using DLCS.Model.Messaging;
 using Engine.Settings;
 using Microsoft.AspNetCore.Mvc;
@@ -12,11 +13,14 @@ public class IngestController : Controller
 {
     private readonly IAssetIngester ingester;
     private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web);
+    private readonly IElasticTranscoderWrapper elasticTranscoderWrapper;
     private TimebasedIngestSettings timebasedIngestSettings;
 
-    public IngestController(IAssetIngester ingester, IOptions<EngineSettings> engineSettings)
+    public IngestController(IAssetIngester ingester, IElasticTranscoderWrapper elasticTranscoderWrapper, 
+        IOptions<EngineSettings> engineSettings)
     {
         this.ingester = ingester;
+        this.elasticTranscoderWrapper = elasticTranscoderWrapper;
         timebasedIngestSettings = engineSettings.Value.TimebasedIngest;
     }
     
@@ -52,9 +56,17 @@ public class IngestController : Controller
     /// </summary>
     [HttpGet]
     [Route("av-presets")]
-    public IActionResult GetAllowedAvPresetOptions()
+    public async Task<IActionResult> GetAllowedAvPresetOptions()
     {
-        return Ok(timebasedIngestSettings.DeliveryChannelMappings);
+        var presets = await elasticTranscoderWrapper.GetPresetIdLookup();
+
+        var allowedPresets =
+            presets.Where(x => timebasedIngestSettings.DeliveryChannelMappings.Values.Contains(x.Key))
+                .ToDictionary(
+                    pair => timebasedIngestSettings.DeliveryChannelMappings.First(x => x.Value == pair.Key)
+                        .Key, pair => pair.Value);
+        
+        return Ok(allowedPresets);
     }
 
     private IActionResult ConvertToStatusCode(object message, IngestResultStatus result)

--- a/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Transcode/ElasticTranscoder.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Amazon.ElasticTranscoder.Model;
 using DLCS.AWS.ElasticTranscoder;
+using DLCS.AWS.ElasticTranscoder.Models;
 using DLCS.Core.Guard;
 using DLCS.Model.Assets;
 using Engine.Ingest.Timebased.Models;
@@ -75,7 +76,7 @@ public class ElasticTranscoder : IMediaTranscoder
     }
 
     private List<CreateJobOutput> GetJobOutputs(IngestionContext context, string jobId,
-        TimebasedIngestSettings settings, Dictionary<string, string> presets)
+        TimebasedIngestSettings settings, Dictionary<string, TranscoderPreset> presets)
     {
         var asset = context.Asset;
         var assetId = context.AssetId;
@@ -99,7 +100,7 @@ public class ElasticTranscoder : IMediaTranscoder
             var destinationPath = TranscoderTemplates.ProcessPreset(
                 mediaType, assetId, jobId, parsedTimeBasedPolicy.Extension);
             
-            if (!presets.TryGetValue(mappedPresetName, out var presetId))
+            if (!presets.TryGetValue(mappedPresetName, out var transcoderPreset))
             {
                 logger.LogWarning("Mapping for preset '{PresetName}' not found!", mappedPresetName);
                 continue;
@@ -107,7 +108,7 @@ public class ElasticTranscoder : IMediaTranscoder
 
             outputs.Add(new CreateJobOutput
             {
-                PresetId = presetId,
+                PresetId = transcoderPreset.Id,
                 Key = destinationPath,
             });
 

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text.Json.Nodes;
 using System.Threading;
+using DLCS.Core.Settings;
 using DLCS.Core.Types;
 using DLCS.Model.Assets.CustomHeaders;
 using DLCS.Model.PathElements;

--- a/src/protagonist/Orchestrator.Tests/Settings/OrchestratorSettingsTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Settings/OrchestratorSettingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using DLCS.Core.Settings;
 using DLCS.Core.Types;
 using IIIF.ImageApi;
 using Orchestrator.Settings;

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/DownstreamDestinationSelector.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using DLCS.Core.Collections;
+using DLCS.Core.Settings;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Caching;
+using DLCS.Core.Settings;
 using DLCS.Web.Response;
 
 namespace Orchestrator.Settings;
@@ -270,22 +271,6 @@ public class CustomerOverride
     /// When serving, if a PDF contains an image that has a role on the whitelist - authentication will be required.
     /// </summary>
     public List<string> PdfRolesWhitelist { get; set; } = new();
-}
-
-/// <summary>
-/// Enum representing image server used for serving image requests
-/// </summary>
-public enum ImageServer
-{
-    /// <summary>
-    /// Cantaloupe image server
-    /// </summary>
-    Cantaloupe,
-
-    /// <summary>
-    /// IIP Image Server
-    /// </summary>
-    IIPImage
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettingsX.cs
@@ -1,4 +1,5 @@
-﻿using DLCS.Core.Types;
+﻿using DLCS.Core.Settings;
+using DLCS.Core.Types;
 using DLCS.Model.Templates;
 
 namespace Orchestrator.Settings;

--- a/src/protagonist/Test.Helpers/Http/ControllableHttpMessageHandler.cs
+++ b/src/protagonist/Test.Helpers/Http/ControllableHttpMessageHandler.cs
@@ -35,7 +35,7 @@ public class ControllableHttpMessageHandler : HttpMessageHandler
         };
         return response;
     }
-    
+
     /// <summary>
     /// Set a pre-canned response 
     /// </summary>


### PR DESCRIPTION
Resolves #430 
links [WDLS-507](https://digirati.atlassian.net/browse/WDLS-507)

This PR reimplements work done on #841 as well as implementing the work required by the asset modified cleanup handler.

It includes a new appsettings section:

```
"AssetModifiedSettings": {
  "DryRun": false,
  "EngineRoot": "https://localhost:7014"
},
```

And

```
"UpdateNotificationQueueName": "dlcsspinup-update-notification"
```

`DryRun` determines whether the application should actually remove files/db entries and is `false` by default
`EngineRoot` is used for setting the engine URI, which is used by the cleanup handler to retrieve details encoding presets from engine

Additional changes in this PR includes allowing the cleanup handler to listen to multiple SQS queues and an additional endpoint added to the engine for retrieving a dictionary of presets

`UpdateNotificationQueueName` details the name of the queue

[WDLS-507]: https://digirati.atlassian.net/browse/WDLS-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

*NOTE*: this PR has previously been approved under #856 when targeting the `develop` branch.  This PR rebases and retargets the release to `main`. 