### PR TITLE
Add types to ProducesResponseType where possible

### DIFF
--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -8,6 +8,9 @@
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+    </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.1" />

--- a/src/protagonist/API/Features/Application/ApplicationController.cs
+++ b/src/protagonist/API/Features/Application/ApplicationController.cs
@@ -2,8 +2,10 @@
 using API.Infrastructure;
 using API.Settings;
 using DLCS.HydraModel;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -23,6 +25,8 @@ public class ApplicationController : HydraController
 
     [Route("/setup")]
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApiKey))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> SetupApplication()
     {
         var request = new SetupApplication();

--- a/src/protagonist/API/Features/CustomHeaders/CustomHeadersController.cs
+++ b/src/protagonist/API/Features/CustomHeaders/CustomHeadersController.cs
@@ -4,6 +4,8 @@ using API.Features.CustomHeaders.Validation;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.HydraModel;
+using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -29,7 +31,9 @@ public class CustomHeadersController : HydraController
     /// </summary>
     /// <returns>HydraCollection of CustomHeader</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<CustomHeader>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> GetCustomHeaders(
         [FromRoute] int customerId,
         CancellationToken cancellationToken)
@@ -59,7 +63,7 @@ public class CustomHeadersController : HydraController
     /// </remarks>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> PostCustomHeader(
         [FromRoute] int customerId,
         [FromBody] CustomHeader newCustomHeader,
@@ -86,8 +90,8 @@ public class CustomHeadersController : HydraController
     /// </summary>
     [HttpGet]
     [Route("{customHeaderId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomHeader))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetCustomHeader(
         [FromRoute] int customerId,
         [FromRoute] string customHeaderId,
@@ -119,8 +123,8 @@ public class CustomHeadersController : HydraController
     /// </remarks>
     [HttpPut]
     [Route("{customHeaderId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomHeader))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> PutCustomHeader(
         [FromRoute] int customerId,
         [FromRoute] string customHeaderId,
@@ -150,7 +154,7 @@ public class CustomHeadersController : HydraController
     [HttpDelete]
     [Route("{customHeaderId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> DeleteCustomHeader(
         [FromRoute] int customerId,
         [FromRoute] string customHeaderId)

--- a/src/protagonist/API/Features/Customer/ApiKeysController.cs
+++ b/src/protagonist/API/Features/Customer/ApiKeysController.cs
@@ -6,6 +6,7 @@ using DLCS.Core.Strings;
 using DLCS.HydraModel;
 using DLCS.Web.Requests;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -33,8 +34,8 @@ public class ApiKeysController : HydraController
     /// <returns>HydraCollection of ApiKey objects</returns>
     [HttpGet]
     [Route("{customerId}/keys")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<ApiKey>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetApiKeys(int customerId)
     {
         var dbCustomer = await Mediator.Send(new GetCustomer(customerId));
@@ -72,8 +73,8 @@ public class ApiKeysController : HydraController
     /// </remarks>
     [HttpPost]
     [Route("{customerId}/keys")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApiKey))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> CreateApiKey(int customerId)
     {
         var result = await Mediator.Send(new CreateApiKey(customerId));
@@ -92,7 +93,7 @@ public class ApiKeysController : HydraController
     /// <param name="key">Key to remove</param>
     /// <returns>No content</returns>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     [HttpDelete]
     [Route("{customerId}/keys/{key}")]
     public async Task<IActionResult> DeleteApiKey(int customerId, string key)

--- a/src/protagonist/API/Features/Customer/Converters/CustomerConverter.cs
+++ b/src/protagonist/API/Features/Customer/Converters/CustomerConverter.cs
@@ -23,6 +23,7 @@ public static class CustomerConverter
     
     /// <summary>
     /// Converts the EF model object to a simplified JObject with just @id and @type
+    /// (PK): Could this return dedicated type, e.g. a record or sth?
     /// </summary>
     public static JObject ToCollectionForm(this DLCS.Model.Customers.Customer dbCustomer, string baseUrl)
     {

--- a/src/protagonist/API/Features/Customer/CustomerController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerController.cs
@@ -7,6 +7,7 @@ using DLCS.Core.Strings;
 using DLCS.Web.Auth;
 using DLCS.Web.Requests;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -73,9 +74,9 @@ public class CustomerController : HydraController
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> CreateCustomer(
         [FromBody] DLCS.HydraModel.Customer newCustomer,
         [FromServices] HydraCustomerValidator validator)
@@ -120,8 +121,8 @@ public class CustomerController : HydraController
     /// </summary>
     [HttpGet]
     [Route("{customerId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.Customer))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetCustomer(int customerId)
     {
         var dbCustomer = await Mediator.Send(new GetCustomer(customerId));
@@ -150,8 +151,8 @@ public class CustomerController : HydraController
     /// </remarks>
     [HttpPatch]
     [Route("{customerId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.Customer))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> PatchCustomer(
         [FromRoute] int customerId,
         [FromBody] DLCS.HydraModel.Customer hydraCustomer,

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -6,6 +6,7 @@ using API.Settings;
 using DLCS.Model;
 using DLCS.Model.Assets;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -44,8 +45,8 @@ public class CustomerImagesController : HydraController
     /// </remarks>
     [HttpPost]
     [Route("allImages")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DLCS.HydraModel.Image>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> GetAllImages(
         [FromRoute] int customerId,
         [FromBody] HydraCollection<IdentifierOnly> imageIdentifiers,

--- a/src/protagonist/API/Features/Customer/PortalUsersController.cs
+++ b/src/protagonist/API/Features/Customer/PortalUsersController.cs
@@ -8,7 +8,9 @@ using DLCS.HydraModel;
 using DLCS.Model.Customers;
 using DLCS.Web.Requests;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -62,6 +64,8 @@ public class PortalUsersController : HydraController
     /// <returns></returns>
     [HttpGet]
     [Route("{customerId}/portalUsers/{userId}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PortalUser))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetPortalUser(int customerId, string userId)
     {
         var users = await Mediator.Send(new GetPortalUsers(customerId));
@@ -84,6 +88,9 @@ public class PortalUsersController : HydraController
     /// <returns></returns>
     [HttpPost]
     [Route("{customerId}/portalUsers")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> CreatePortalUser(int customerId, [FromBody] PortalUser portalUser)
     {
         var request = new CreatePortalUser
@@ -120,6 +127,8 @@ public class PortalUsersController : HydraController
     /// <returns></returns>
     [HttpPatch]
     [Route("{customerId}/portalUsers/{userId}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PortalUser))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> PatchPortalUser(int customerId, string userId, [FromBody] PortalUser portalUser)
     {
         // NB Deliverator doesn't support toggling Enabled here so we won't for now.
@@ -154,6 +163,8 @@ public class PortalUsersController : HydraController
     /// <returns></returns>
     [HttpDelete]
     [Route("{customerId}/portalUsers/{userId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> DeletePortalUser(int customerId, string userId)
     {
         var result = await Mediator.Send(new DeletePortalUser(customerId, userId));

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -4,6 +4,7 @@ using API.Features.DeliveryChannels.Validation;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.HydraModel;
+using Hydra.Collections;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +33,7 @@ public class DefaultDeliveryChannelsController : HydraController
     /// </summary>
     /// <returns>Collection of Hydra JSON-LD default delivery channel objects</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DefaultDeliveryChannel>))]
     public async Task<IActionResult> GetCustomerDefaultDeliveryChannels(
         [FromRoute] int customerId,
         CancellationToken cancellationToken,
@@ -55,7 +56,7 @@ public class DefaultDeliveryChannelsController : HydraController
     /// </summary>
     /// <returns>A Hydra JSON-LD default delivery channel object</returns>
     [HttpGet("{defaultDeliveryChannelId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DefaultDeliveryChannel))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetCustomerDefaultDeliveryChannel(
         [FromRoute] int customerId,
@@ -120,7 +121,7 @@ public class DefaultDeliveryChannelsController : HydraController
     /// </summary>
     /// <returns>A Hydra JSON-LD default delivery channel object</returns>
     [HttpPut("{defaultDeliveryChannelId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DefaultDeliveryChannel))]
     public async Task<IActionResult> UpdateCustomerDefaultDeliveryChannel(
         [FromRoute] int customerId,
         [FromBody]DefaultDeliveryChannel defaultDeliveryChannel,

--- a/src/protagonist/API/Features/DeliveryChannels/DeliveryChannelPoliciesController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DeliveryChannelPoliciesController.cs
@@ -9,6 +9,7 @@ using DLCS.Model.Assets;
 using DLCS.Web.Requests;
 using FluentValidation;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -38,7 +39,8 @@ public class DeliveryChannelPoliciesController : HydraController
     /// </summary>
     /// <returns>HydraCollection of DeliveryChannelPolicy HydraCollection</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK,
+        Type = typeof(HydraCollection<HydraNestedCollection<DeliveryChannelPolicy>>))]
     public async Task<IActionResult> GetDeliveryChannelPolicyCollections(
         [FromRoute] int customerId,
         CancellationToken cancellationToken)
@@ -65,7 +67,7 @@ public class DeliveryChannelPoliciesController : HydraController
     /// </summary>
     /// <returns>HydraCollection of DeliveryChannelPolicy</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DeliveryChannelPolicy>))]
     [Route("{deliveryChannelName}")]
     public async Task<IActionResult> GetDeliveryChannelPolicyCollection(
         [FromRoute] int customerId,
@@ -104,8 +106,8 @@ public class DeliveryChannelPoliciesController : HydraController
     [HttpPost]
     [Route("{deliveryChannelName}")]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> PostDeliveryChannelPolicy(
         [FromRoute] int customerId,
         [FromRoute] string deliveryChannelName,
@@ -138,8 +140,8 @@ public class DeliveryChannelPoliciesController : HydraController
     /// <returns>DeliveryChannelPolicy</returns>
     [HttpGet]
     [Route("{deliveryChannelName}/{deliveryChannelPolicyName}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeliveryChannelPolicy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetDeliveryChannelPolicy(
         [FromRoute] int customerId,
         [FromRoute] string deliveryChannelName,
@@ -171,10 +173,10 @@ public class DeliveryChannelPoliciesController : HydraController
     /// <returns>DeliveryChannelPolicy</returns>
     [HttpPut]
     [Route("{deliveryChannelName}/{deliveryChannelPolicyName}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeliveryChannelPolicy))]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> PutDeliveryChannelPolicy(
         [FromRoute] int customerId,
         [FromRoute] string deliveryChannelName,
@@ -219,10 +221,10 @@ public class DeliveryChannelPoliciesController : HydraController
     /// <returns>DeliveryChannelPolicy</returns>
     [HttpPatch]
     [Route("{deliveryChannelName}/{deliveryChannelPolicyName}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DeliveryChannelPolicy))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> PatchDeliveryChannelPolicy(
         [FromRoute] int customerId,
         [FromRoute] string deliveryChannelName,

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -5,6 +5,7 @@ using API.Features.Image.Requests;
 using API.Features.Image.Validation;
 using API.Infrastructure;
 using API.Settings;
+using DLCS.AWS.ElasticTranscoder.Models.Job;
 using DLCS.Core;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
@@ -258,9 +259,9 @@ public class ImageController : HydraController
     /// <summary>
     /// Get transcode metadata for Timebased assets
     /// </summary>
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TranscoderJob))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     [HttpGet]
     [Route("metadata")]
     public async Task<IActionResult> GetAssetMetadata([FromRoute] int customerId, [FromRoute] int spaceId,

--- a/src/protagonist/API/Features/NamedQueries/NamedQueriesController.cs
+++ b/src/protagonist/API/Features/NamedQueries/NamedQueriesController.cs
@@ -5,6 +5,8 @@ using API.Settings;
 using DLCS.HydraModel;
 using DLCS.Web.Auth;
 using FluentValidation;
+using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -30,7 +32,9 @@ public class NamedQueriesController : HydraController
     /// </summary>
     /// <returns>HydraCollection of NamedQuery</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<NamedQuery>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(Error))]
     public async Task<IActionResult> GetNamedQueries(
         [FromRoute] int customerId,
         CancellationToken cancellationToken)
@@ -59,9 +63,9 @@ public class NamedQueriesController : HydraController
     /// </remarks>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(Error))]
     public async Task<IActionResult> PostNamedQuery(
         [FromRoute] int customerId,
         [FromBody] NamedQuery newNamedQuery,
@@ -92,8 +96,8 @@ public class NamedQueriesController : HydraController
     /// </summary>
     [HttpGet]
     [Route("{namedQueryId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(NamedQuery))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetNamedQuery(
         [FromRoute] int customerId,
         [FromRoute] string namedQueryId,
@@ -122,10 +126,10 @@ public class NamedQueriesController : HydraController
     /// </remarks>
     [HttpPut]
     [Route("{namedQueryId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(NamedQuery))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> PutNamedQuery(
         [FromRoute] int customerId,
         [FromRoute] string namedQueryId,
@@ -156,7 +160,7 @@ public class NamedQueriesController : HydraController
     [HttpDelete]
     [Route("{namedQueryId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> DeleteNamedQuery(
         [FromRoute] int customerId,
         [FromRoute] string namedQueryId)

--- a/src/protagonist/API/Features/OriginStrategies/CustomerOriginStrategiesController.cs
+++ b/src/protagonist/API/Features/OriginStrategies/CustomerOriginStrategiesController.cs
@@ -7,6 +7,8 @@ using DLCS.Core.Enum;
 using DLCS.Core.Strings;
 using DLCS.Model.Customers;
 using FluentValidation;
+using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -36,7 +38,7 @@ public class CustomerOriginStrategiesController : HydraController
     /// </summary>
     /// <returns>HydraCollection of CustomerOriginStrategies</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<CustomerOriginStrategy>))]
     public async Task<IActionResult> GetCustomerOriginStrategies(
         [FromRoute] int customerId,
         CancellationToken cancellationToken)
@@ -68,9 +70,9 @@ public class CustomerOriginStrategiesController : HydraController
     /// </remarks>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(Error))]
     public async Task<IActionResult> PostCustomerOriginStrategy(
         [FromRoute] int customerId,
         [FromBody] CustomerOriginStrategy newStrategy,
@@ -102,8 +104,8 @@ public class CustomerOriginStrategiesController : HydraController
     /// </summary>
     [HttpGet]
     [Route("{strategyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerOriginStrategy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetCustomerOriginStrategy(
         [FromRoute] int customerId,
         [FromRoute] string strategyId,
@@ -135,10 +137,10 @@ public class CustomerOriginStrategiesController : HydraController
     /// </remarks>
     [HttpPut]
     [Route("{strategyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CustomerOriginStrategy))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> PutCustomerOriginStrategy(
         [FromRoute] int customerId,
         [FromRoute] string strategyId,
@@ -184,7 +186,7 @@ public class CustomerOriginStrategiesController : HydraController
     [HttpDelete]
     [Route("{strategyId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> DeleteCustomerOriginStrategy(
         [FromRoute] int customerId,
         [FromRoute] string strategyId)

--- a/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
+++ b/src/protagonist/API/Features/Policies/CustomerPolicyController.cs
@@ -3,6 +3,8 @@ using API.Features.Policies.Requests;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.HydraModel;
+using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -30,7 +32,7 @@ public class CustomerPolicyController : HydraController
     /// <returns>Collection of Hydra JSON-LD image optimisation policy object</returns>
     [HttpGet]
     [Route("imageOptimisationPolicies")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<ImageOptimisationPolicy>))]
     public async Task<IActionResult> GetImageOptimisationPolicies([FromRoute] int customerId,
         CancellationToken cancellationToken)
     {
@@ -51,8 +53,8 @@ public class CustomerPolicyController : HydraController
     /// <returns>Hydra JSON-LD image optimisation policy object</returns>
     [HttpGet]
     [Route("imageOptimisationPolicies/{imageOptimisationPolicyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ImageOptimisationPolicy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetImageOptimisationPolicy([FromRoute] int customerId,
         [FromRoute] string imageOptimisationPolicyId, CancellationToken cancellationToken)
     {

--- a/src/protagonist/API/Features/Policies/PolicyController.cs
+++ b/src/protagonist/API/Features/Policies/PolicyController.cs
@@ -3,6 +3,8 @@ using API.Features.Policies.Requests;
 using API.Infrastructure;
 using API.Settings;
 using DLCS.HydraModel;
+using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -30,7 +32,7 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/imageOptimisationPolicies")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<ImageOptimisationPolicy>))]
     public async Task<IActionResult> GetImageOptimisationPolicies(CancellationToken cancellationToken)
     {
         var getImageOptimisationPolicies = new GetImageOptimisationPolicies();
@@ -51,8 +53,8 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/imageOptimisationPolicies/{imageOptimisationPolicyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ImageOptimisationPolicy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetImageOptimisationPolicy([FromRoute] string imageOptimisationPolicyId, CancellationToken cancellationToken)
     {
         var getImageOptimisationPolicy = new GetImageOptimisationPolicy(imageOptimisationPolicyId);
@@ -80,7 +82,7 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/storagePolicies")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<StoragePolicy>))]
     public async Task<IActionResult> GetStoragePolicies(CancellationToken cancellationToken)
     {
         var getStoragePolicies = new GetStoragePolicies();
@@ -101,8 +103,8 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/storagePolicies/{storagePolicyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(StoragePolicy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetStoragePolicy([FromRoute] string storagePolicyId, CancellationToken cancellationToken)
     {
         var getStoragePolicy = new GetStoragePolicy(storagePolicyId);
@@ -130,7 +132,7 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/thumbnailPolicies")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<ThumbnailPolicy>))]
     public async Task<IActionResult> GetThumbnailPolicies(CancellationToken cancellationToken)
     {
         var getThumbnailPolicies = new GetThumbnailPolicies();
@@ -150,8 +152,8 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/thumbnailPolicies/{thumbnailPolicyId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ThumbnailPolicy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetThumbnailPolicy([FromRoute] string thumbnailPolicyId, 
         CancellationToken cancellationToken)
     {
@@ -180,7 +182,7 @@ public class PolicyController : HydraController
     [HttpGet]
     [AllowAnonymous]
     [Route("/originStrategies")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<OriginStrategy>))]
     public async Task<IActionResult> GetOriginStrategies(CancellationToken cancellationToken)
     {
         var getOriginStrategies = new GetOriginStrategies();
@@ -199,8 +201,8 @@ public class PolicyController : HydraController
     /// <param name="originStrategyId"></param>
     /// <param name="cancellationToken"></param>
     /// <returns>Hydra JSON-LD origin strategy object</returns>
-    /// [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OriginStrategy))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     [HttpGet]
     [AllowAnonymous]
     [Route("/originStrategies/{originStrategyId}")]

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -13,6 +13,7 @@ using DLCS.HydraModel;
 using DLCS.Model.Assets;
 using DLCS.Model.Processing;
 using Hydra.Collections;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -39,7 +40,7 @@ public class CustomerQueueController : HydraController
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.CustomerQueue))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetCustomerQueue([FromRoute] int customerId, CancellationToken cancellationToken)
     {
@@ -142,7 +143,7 @@ public class CustomerQueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [Route("priority")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.CustomerQueue))]
     public async Task<IActionResult> GetCustomerPriorityQueue([FromRoute] int customerId, 
         CancellationToken cancellationToken)
     {
@@ -165,8 +166,8 @@ public class CustomerQueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [Route("batches/{batchId}")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.CustomerQueue))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetBatch([FromRoute] int customerId, [FromRoute] int batchId, 
         CancellationToken cancellationToken)
     {
@@ -204,8 +205,9 @@ public class CustomerQueueController : HydraController
     /// </remarks>
     [HttpGet]
     [Route("batches/{batchId}/images")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DLCS.HydraModel.Image>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
     public async Task<IActionResult> GetBatchImages([FromRoute] int customerId, [FromRoute] int batchId,
         [FromQuery] string? q = null, CancellationToken cancellationToken = default)
     {
@@ -271,7 +273,7 @@ public class CustomerQueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [Route("batches")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<Batch>))]
     public async Task<IActionResult> GetBatches([FromRoute] int customerId, CancellationToken cancellationToken)
     {
         var getBatches = new GetBatches(customerId);
@@ -293,6 +295,7 @@ public class CustomerQueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [Route("active")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<Batch>))]
     public async Task<IActionResult> GetActiveBatches([FromRoute] int customerId, CancellationToken cancellationToken)
     {
         var getActiveBatches = new GetActiveBatches(customerId);
@@ -314,6 +317,7 @@ public class CustomerQueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [Route("recent")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<Batch>))]
     public async Task<IActionResult> GetRecentBatches([FromRoute] int customerId, CancellationToken cancellationToken)
     {
         var getRecentBatches = new GetRecentBatches(customerId);

--- a/src/protagonist/API/Features/Queues/QueueController.cs
+++ b/src/protagonist/API/Features/Queues/QueueController.cs
@@ -2,8 +2,10 @@
 using API.Features.Queues.Requests;
 using API.Infrastructure;
 using API.Settings;
+using DLCS.HydraModel;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
@@ -28,6 +30,7 @@ public class QueueController : HydraController
     /// <returns>Hydra JSON-LD Queue object</returns>
     [HttpGet]
     [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(QueueSummary))]
     public async Task<IActionResult> GetQueueDetails(CancellationToken cancellationToken)
     {
         var getCustomerRequest = new GetQueueCounts();

--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -37,7 +37,7 @@ public class SpaceController : HydraController
     /// </summary>
     /// <returns>HydraCollection of Space</returns>
     [HttpGet]
-    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DLCS.HydraModel.Space>))]
     public async Task<HydraCollection<DLCS.HydraModel.Space>> GetSpaces(
         int customerId, int? page = 1, int? pageSize = -1, 
         string? orderBy = null, string? orderByDescending = null)

--- a/src/protagonist/API/Features/Storage/StorageController.cs
+++ b/src/protagonist/API/Features/Storage/StorageController.cs
@@ -2,6 +2,7 @@
 using API.Features.Storage.Requests;
 using API.Infrastructure;
 using API.Settings;
+using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -25,8 +26,8 @@ public class StorageController : HydraController
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/spaces/{spaceId}/images/{imageId}/storage")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.ImageStorage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetImageStorage(
         [FromRoute] int customerId,
         [FromRoute] int spaceId,
@@ -46,8 +47,8 @@ public class StorageController : HydraController
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/spaces/{spaceId}/storage")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.CustomerStorage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetSpaceStorage(
         [FromRoute] int customerId,
         [FromRoute] int spaceId,
@@ -66,8 +67,8 @@ public class StorageController : HydraController
     /// </summary>
     [HttpGet]
     [Route("/customers/{customerId}/storage")]
-    [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DLCS.HydraModel.CustomerStorage))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(Error))]
     public async Task<IActionResult> GetCustomerStorage(
         [FromRoute] int customerId,
         CancellationToken cancellationToken)


### PR DESCRIPTION
This change is IMHO unlikely to cause any issues, as it should only affect the generated OpenAPI doc, not anything functional.

This is to allow autogeneration of an API client that helps ensure compatibility between API and client application(s). 