### PR TITLE
Allow SFTP origins containing spaces

### DIFF
--- a/src/protagonist/DLCS.Repository.Tests/Strategy/SftpOriginStrategyTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Strategy/SftpOriginStrategyTests.cs
@@ -123,15 +123,15 @@ public class SftpOriginStrategyTests
         result.ContentLength.Should().Be(stream.Length);
     }
     
-    [Fact]
-    public async Task LoadAssetFromOrigin_ReturnsExpectedResponseWithSpace_OnSuccess()
+    [Theory]
+    [InlineData("sftp://www.someuri.com/public_ftp/some folder/someId")]
+    [InlineData("sftp://www.someuri.com/public_ftp/some%20folder/someId")]
+    public async Task LoadAssetFromOrigin_ReturnsExpectedResponseWithSpace_OnSuccess(string originUri)
     {
         // Arrange
         var content = "this is a test";
 
         var stream = content.ToMemoryStream();
-        
-        const string originUri = "sftp://www.someuri.com/public_ftp/some folder/someId";
 
         var basicCredentials = new BasicCredentials()
         {

--- a/src/protagonist/DLCS.Repository.Tests/Strategy/SftpOriginStrategyTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Strategy/SftpOriginStrategyTests.cs
@@ -124,6 +124,58 @@ public class SftpOriginStrategyTests
     }
     
     [Fact]
+    public async Task LoadAssetFromOrigin_ReturnsExpectedResponseWithSpace_OnSuccess()
+    {
+        // Arrange
+        var content = "this is a test";
+
+        var stream = content.ToMemoryStream();
+        
+        const string originUri = "sftp://www.someuri.com/public_ftp/some folder/someId";
+
+        var basicCredentials = new BasicCredentials()
+        {
+            User = "correctTest",
+            Password = "correctPassword"
+        };
+        
+        var customerOriginStrategy = new CustomerOriginStrategy
+        {
+            Strategy = OriginStrategyType.SFTP,
+            Id = "correctResponse"
+        };
+
+        A.CallTo(() =>
+                credentialsRepository.GetBasicCredentialsForOriginStrategy(
+                    A<CustomerOriginStrategy>.That.Matches(a => a.Id == "correctResponse")))
+            .Returns(basicCredentials);
+        
+        A.CallTo(() =>
+                sftpReader.RetrieveFile(
+                    A<ConnectionInfo>.That.Matches(a => a.Username == basicCredentials.User), 
+                    A<string>._,
+                    A<CancellationToken>._))
+            .Returns(stream);
+
+        // Act
+        var result = await sut.LoadAssetFromOrigin(assetId, originUri, customerOriginStrategy);
+        
+        // Assert
+        A.CallTo(() =>
+                credentialsRepository.GetBasicCredentialsForOriginStrategy(
+                    A<CustomerOriginStrategy>.That.Matches(a => a.Id == "correctResponse")))
+            .MustHaveHappened();
+        A.CallTo(() =>
+                sftpReader.RetrieveFile(
+                    A<ConnectionInfo>.That.Matches(a => a.Username == basicCredentials.User), 
+                    A<string>.That.Matches(a => a == "/public_ftp/some folder/someId"),
+                    A<CancellationToken>._))
+            .MustHaveHappened();
+        result.Stream.Should().NotBeNull().And.Subject.Should().NotBeSameAs(Stream.Null);
+        result.ContentLength.Should().Be(stream.Length);
+    }
+    
+    [Fact]
     public async Task LoadAssetFromOrigin_ReturnsNull_IfCallFailsToFindCredentials()
     {
         // Arrange

--- a/src/protagonist/DLCS.Repository/SFTP/SftpReader.cs
+++ b/src/protagonist/DLCS.Repository/SFTP/SftpReader.cs
@@ -40,7 +40,7 @@ public class SftpReader : ISftpReader
                 outputStream.Close();
             }
             
-            logger.LogError(ex, "Error downloading SFTP file");
+            logger.LogError(ex, "Error downloading SFTP file from Host: {Hostname}, Path: {Path}", connectionInfo.Host, path);
             throw;
         }
 

--- a/src/protagonist/DLCS.Repository/Strategy/SftpOriginStrategy.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/SftpOriginStrategy.cs
@@ -52,8 +52,7 @@ public class SftpOriginStrategy : IOriginStrategy
 
         try
         {
-            var originPath = Uri.UnescapeDataString(originUri.AbsolutePath);
-            var outputStream = await sftpReader.RetrieveFile(connectionInfo, originPath, cancellationToken);
+            var outputStream = await sftpReader.RetrieveFile(connectionInfo, originUri.LocalPath, cancellationToken);
             return new OriginResponse(outputStream).WithContentLength(outputStream.Length);
         }
         catch (Exception ex)

--- a/src/protagonist/DLCS.Repository/Strategy/SftpOriginStrategy.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/SftpOriginStrategy.cs
@@ -51,8 +51,9 @@ public class SftpOriginStrategy : IOriginStrategy
         ConnectionInfo connectionInfo = GetConnectionInfo(originUri, port, basicCredentials);
 
         try
-        { 
-            var outputStream = await sftpReader.RetrieveFile(connectionInfo, originUri.AbsolutePath, cancellationToken);
+        {
+            var originPath = Uri.UnescapeDataString(originUri.AbsolutePath);
+            var outputStream = await sftpReader.RetrieveFile(connectionInfo, originPath, cancellationToken);
             return new OriginResponse(outputStream).WithContentLength(outputStream.Length);
         }
         catch (Exception ex)


### PR DESCRIPTION
Resolves DLCS-865 and https://github.com/dlcs/protagonist/issues/880

This PR fixes a bug which prevented Engine from being able to retrieve files from SFTP origins containing spaces - `originUri.AbsolutePath` would cause it to try and retrieve the image with an escaped version of the path. `originUri.LocalPath` preserves these characters while turning any escaped ones into their unescaped counterparts.