### PR TITLE
Update Orchestrator `PathRewriteTransformer` to set correct `max-age` header values with 404 responses

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/PathRewriteTransformerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/PathRewriteTransformerTests.cs
@@ -166,6 +166,8 @@ public class PathRewriteTransformerTests
     [InlineData(HttpStatusCode.BadGateway)]
     [InlineData(HttpStatusCode.ServiceUnavailable)]
     [InlineData(HttpStatusCode.GatewayTimeout)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.BadRequest)]
     public async Task TransformResponseAsync_AddsSmallMaxAge_RegardlessOfDestination_IfError(HttpStatusCode statusCode)
     {
         // Arrange

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/PathRewriteTransformer.cs
@@ -61,14 +61,8 @@ public class PathRewriteTransformer : HttpTransformer
         return new ValueTask<bool>(true);
     }
 
-    private bool IsDownstreamError(HttpResponseMessage? proxyResponse)
-    {
-        var downstreamStatus = proxyResponse?.StatusCode ?? HttpStatusCode.InternalServerError;
-        return downstreamStatus is HttpStatusCode.InternalServerError
-            or HttpStatusCode.BadGateway
-            or HttpStatusCode.ServiceUnavailable
-            or HttpStatusCode.GatewayTimeout;
-    }
+    private bool IsDownstreamError(HttpResponseMessage? proxyResponse) 
+        => proxyResponse == null || !proxyResponse.IsSuccessStatusCode;
 
     private void EnsureCacheHeaders(HttpContext httpContext, bool isDownstreamError)
     {


### PR DESCRIPTION
This PR updates a bug seen in #885 where Orchestrator would not apply a `cache-control: max-age=60` header value to Orchestrator's 404 responses - previously, this was only done for 500, 502, 503 and 504. `IsDownstreamError()` has been modified to check the status code against `.IsSuccessStatusCode` instead of a list.


