### PR TITLE
Resolve bug where NQ stored projections always used Open thumbs

### DIFF
--- a/src/protagonist/API.Tests/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidatorTests.cs
@@ -100,7 +100,7 @@ public class DeliveryChannelPolicyDataValidatorTests
         // Assert
         result.Should().BeFalse();
     }
-    
+
     [Theory]
     [InlineData("max", false)]
     [InlineData("^max", false)]
@@ -114,7 +114,8 @@ public class DeliveryChannelPolicyDataValidatorTests
     [InlineData("^10,10", false)]
     [InlineData("!10,10", true)]
     [InlineData("^!10,10", true)]
-    public async Task PolicyDataValidator_ReturnsExpectedResult_ForThumbsPolicy_FromIIIFDocs(string sizeParam, bool expectedResult)
+    public async Task PolicyDataValidator_ReturnsExpectedResult_ForThumbsPolicySizeParameter(string sizeParam,
+        bool expectedResult)
     {
         // Arrange and Act
         var policyData = $"[\"{sizeParam}\"]";

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -39,7 +39,6 @@ public class DefaultDeliveryChannelsController : HydraController
         CancellationToken cancellationToken,
         [FromRoute] int space = 0)
     {
-
         var getCustomerDefaultDeliveryChannels = new GetDefaultDeliveryChannels(customerId, space);
 
         return await HandlePagedFetch<DLCS.Model.DeliveryChannels.DefaultDeliveryChannel, GetDefaultDeliveryChannels,

--- a/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Validation/DeliveryChannelPolicyDataValidator.cs
@@ -3,6 +3,7 @@ using API.Exceptions;
 using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Model.DeliveryChannels;
+using DLCS.Model.IIIF;
 using IIIF.ImageApi;
 
 namespace API.Features.DeliveryChannels.Validation;
@@ -54,7 +55,7 @@ public class DeliveryChannelPolicyDataValidator
         {
             try
             {
-                if (!IsValidThumbnailParameter(SizeParameter.Parse(sizeValue)))
+                if (!SizeParameter.Parse(sizeValue).IsValidThumbnailParameter())
                 {
                     return false;
                 }
@@ -67,16 +68,6 @@ public class DeliveryChannelPolicyDataValidator
 
         return true;
     }
-
-    private bool IsValidThumbnailParameter(SizeParameter param) => param switch
-        {
-            { Max: true } => false,
-            { PercentScale: not null } => false,
-            { Confined: false, Width: not null, Height: not null } => false,
-            { Confined: true } and ({ Width: null } or { Height : null }) => false,
-            { Width: null, Height: null } => false,
-            _ => true,
-        };
 
     private async Task<bool> ValidateTimeBasedPolicyData(string policyDataJson)
     {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -15,177 +15,119 @@ public class AssetXTests
         SizeParameter.Parse("!200,200"),
         SizeParameter.Parse("!100,100"),
     };
+    
+    [Fact]
+    public void GetAvailableThumbSizes_Correct_MaxUnauthorisedNoRoles()
+    {
+        // Arrange
+        var asset = new Asset { Width = 5000, Height = 2500, MaxUnauthorised = 500 };
 
-    [Fact]
-    public void GetAvailableThumbSizes_IncludeUnavailable_Correct_MaxUnauthorisedNoRoles()
-    {
-        // Arrange
-        var asset = new Asset {Width = 5000, Height = 2500, MaxUnauthorised = 500};
-
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions, true);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
         
         // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
+        sizes.Open.Should().BeEquivalentTo(new List<int[]>
         {
-            new(800, 400),
-            new(400, 200),
-            new(200, 100),
-            new(100, 50),
+            new[] { 400, 200 },
+            new[] { 200, 100 },
+            new[] { 100, 50 },
         });
-        maxDimensions.maxBoundedSize.Should().Be(400);
-        maxDimensions.maxAvailableWidth.Should().Be(400);
-        maxDimensions.maxAvailableHeight.Should().Be(200);
+        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 800, 400 },
+        });
+    }
+    
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void GetAvailableThumbSizes_Correct_IfRolesNoMaxUnauthorised(int maxUnauthorised)
+    {
+        // Arrange
+        var asset = new Asset { Width = 5000, Height = 2500, Roles = "GoodGuys", MaxUnauthorised = maxUnauthorised };
+        
+        // Act
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
+        
+        // Assert
+        sizes.Open.Should().BeEmpty();
+        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 800, 400 },
+            new[] { 400, 200 },
+            new[] { 200, 100 },
+            new[] { 100, 50 },
+        });
     }
     
     [Fact]
-    public void GetAvailableThumbSizes_NotIncludeUnavailable_Correct_MaxUnauthorisedNoRoles()
+    public void GetAvailableThumbSizes_Correct_IfRolesMaxUnauthorised()
     {
         // Arrange
-        var asset = new Asset { Width = 5000, Height = 2500, MaxUnauthorised = 500};
+        var asset = new Asset { Width = 2500, Height = 5000, Roles = "GoodGuys", MaxUnauthorised = 399 };
         
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions, false);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
         
         // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
+        sizes.Open.Should().BeEquivalentTo(new List<int[]>
         {
-            new(400, 200),
-            new(200, 100),
-            new(100, 50),
+            new[] { 200, 100 },
+            new[] { 100, 50 },
         });
-        maxDimensions.maxBoundedSize.Should().Be(400);
-        maxDimensions.maxAvailableWidth.Should().Be(400);
-        maxDimensions.maxAvailableHeight.Should().Be(200);
+        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 800, 400 },
+            new[] { 400, 200 },
+        });
     }
     
     [Fact]
-    public void GetAvailableThumbSizes_IncludeUnavailable_Correct_IfRolesNoMaxUnauthorised()
+    public void GetAvailableThumbSizes_DoesNotReturnDuplicates_IfImageSmallerThanThumbnail()
     {
         // Arrange
-        var asset = new Asset {Width = 5000, Height = 2500, Roles = "GoodGuys", MaxUnauthorised = -1};
+        var asset = new Asset { Width = 300, Height = 150 };
         
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions, true);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
         
         // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
+        sizes.Open.Should().BeEquivalentTo(new List<int[]>
         {
-            new(800, 400),
-            new(400, 200),
-            new(200, 100),
-            new(100, 50),
+            new[] { 300, 150 },
+            new[] { 200, 100 },
+            new[] { 100, 50 },
         });
-        maxDimensions.maxBoundedSize.Should().Be(0);
-        maxDimensions.maxAvailableWidth.Should().Be(0);
-        maxDimensions.maxAvailableHeight.Should().Be(0);
+        sizes.Auth.Should().BeEmpty();
     }
     
     [Fact]
-    public void GetAvailableThumbSizes_NotIncludeUnavailable_Correct_IfRolesNoMaxUnauthorised()
+    public void GetAvailableThumbSizes_HandlesNonConfinedSizeParameters_ExcludingDuplicates()
     {
         // Arrange
-        var asset = new Asset {Width = 5000, Height = 2500, Roles = "GoodGuys", MaxUnauthorised = -1};
-        
-        // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters,out var maxDimensions, false);
-        
-        // Assert
-        sizes.Should().BeNullOrEmpty();
-        maxDimensions.maxBoundedSize.Should().Be(0);
-        maxDimensions.maxAvailableWidth.Should().Be(0);
-        maxDimensions.maxAvailableHeight.Should().Be(0);
-    }
-
-    [Fact]
-    public void GetAvailableThumbSizes_RestrictsAvailableSizes_IfHasRolesAndMaxUnauthorised()
-    {
-        // Arrange
-        var asset = new Asset {Width = 2500, Height = 5000, Roles = "GoodGuys", MaxUnauthorised = 399};
-        
-        // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions);
-        
-        // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
-        {
-            new(100, 200),
-            new(50, 100),
-        });
-        maxDimensions.maxBoundedSize.Should().Be(200);
-        maxDimensions.maxAvailableWidth.Should().Be(100);
-        maxDimensions.maxAvailableHeight.Should().Be(200);
-    }
-    
-    [Fact]
-    public void GetAvailableThumbSizes_ReturnsAvailableAndUnavailableSizes_ButReturnsMaxDimensionsOfAvailableOnly_IfIncludeUnavailable()
-    {
-        // Arrange
-        var asset = new Asset {Width = 2500, Height = 5000, Roles = "GoodGuys", MaxUnauthorised = 399};
-        
-        // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions, true);
-        
-        // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
-        {
-            new(400, 800),
-            new(200, 400),
-            new(100, 200),
-            new(50, 100),
-        });
-        maxDimensions.maxBoundedSize.Should().Be(200);
-        maxDimensions.maxAvailableWidth.Should().Be(100);
-        maxDimensions.maxAvailableHeight.Should().Be(200);
-    }
-    
-    [Fact]
-    public void GetAvailableThumbSizes_HandlesImageBeingSmallerThanThumbnail()
-    {
-        // Arrange
-        var asset = new Asset { Width = 300, Height = 150};
-        
-        // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters, out var maxDimensions, true);
-        
-        // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
-        {
-            new(300, 150),
-            new(200, 100),
-            new(100, 50),
-        });
-        maxDimensions.maxBoundedSize.Should().Be(300);
-        maxDimensions.maxAvailableWidth.Should().Be(300);
-        maxDimensions.maxAvailableHeight.Should().Be(150);
-    }
-    
-    [Fact]
-    public void GetAvailableThumbSizes_Ignores_NonConfinedSizeParameters()
-    {
-        // Arrange
-        var asset = new Asset {Width = 5000, Height = 2500, MaxUnauthorised = 500};
+        var asset = new Asset { Width = 5000, Height = 2500, MaxUnauthorised = 500 };
         var sizeParametersWithNotConfined = new List<SizeParameter>
         {
-            SizeParameter.Parse("800,800"),
-            SizeParameter.Parse("400,400"),
-            SizeParameter.Parse("!200,200"),
-            SizeParameter.Parse("100,100"),
+            SizeParameter.Parse("800,"), // == 800,400
+            SizeParameter.Parse(",400"), // == 800,400
+            SizeParameter.Parse("!800,800"), // == 800,400
+            SizeParameter.Parse("400,"), // == 400,200
         };
 
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined, out var maxDimensions, true);
+        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined);
         
         // Assert
-        sizes.Should().BeEquivalentTo(new List<Size>
+        sizes.Open.Should().BeEquivalentTo(new List<int[]>
         {
-            new(200, 100),
+            new[] { 400, 200 },
         });
-        maxDimensions.maxBoundedSize.Should().Be(200);
-        maxDimensions.maxAvailableWidth.Should().Be(200);
-        maxDimensions.maxAvailableHeight.Should().Be(100);
+        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 800, 400 },
+        });
     }
-
+    
     [Fact]
     public void SetFieldsForIngestion_ClearsFields()
     {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -128,6 +128,41 @@ public class AssetXTests
         });
     }
     
+    [Theory]
+    [InlineData(250, 500, "100,", true, "Ignore width for portrait")]
+    [InlineData(500, 250, "100,", false, "Width okay for landscape")]
+    [InlineData(250, 250, "100,", false, "Width okay for square")]
+    [InlineData(250, 500, "^100,", true, "Ignore confined width for portrait")]
+    [InlineData(500, 250, "^100,", false, "Upscale width okay for landscape")]
+    [InlineData(250, 250, "^100,", false, "Upscale width okay for square")]
+    [InlineData(500, 250, ",100", true, "Ignore height for landscape")]
+    [InlineData(250, 500, ",100", false, "Height okay for portrait")]
+    [InlineData(250, 250, ",100", false, "Height okay for square")]
+    [InlineData(500, 250, "^,100", true, "Ignore height for landscape")]
+    [InlineData(250, 500, "^,100", false, "Upscale height okay for portrait")]
+    [InlineData(250, 250, "^,100", false, "Upscale height okay for square")]
+    [InlineData(500, 250, "!100,100", false, "Confined okay for landscape")]
+    [InlineData(250, 500, "!100,100", false, "Confined okay for portrait")]
+    [InlineData(250, 250, "!100,100", false, "Confined okay for square")]
+    [InlineData(500, 250, "^!100,100", false, "Upscale confined okay for landscape")]
+    [InlineData(250, 500, "^!100,100", false, "Upscale confined okay for portrait")]
+    [InlineData(250, 250, "^!100,100", false, "Upscale confined okay for square")]
+    public void GetAvailableThumbSizes_IgnoresWidthOnlyForPortrait(int w, int h, string sizeParam, bool ignored, string reason)
+    {
+        // Arrange
+        var asset = new Asset { Width = w, Height = h, };
+        var sizeParametersWithNotConfined = new List<SizeParameter>
+        {
+            SizeParameter.Parse(sizeParam)
+        };
+
+        // Act
+        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined);
+        
+        // Assert
+        sizes.IsEmpty().Should().Be(ignored, reason);
+    }
+    
     [Fact]
     public void SetFieldsForIngestion_ClearsFields()
     {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -147,7 +147,7 @@ public class AssetXTests
     [InlineData(500, 250, "^!100,100", false, "Upscale confined okay for landscape")]
     [InlineData(250, 500, "^!100,100", false, "Upscale confined okay for portrait")]
     [InlineData(250, 250, "^!100,100", false, "Upscale confined okay for square")]
-    public void GetAvailableThumbSizes_IgnoresWidthOnlyForPortrait(int w, int h, string sizeParam, bool ignored, string reason)
+    public void GetAvailableThumbSizes_Ignores_IfMaxDimensionMayVary(int w, int h, string sizeParam, bool ignored, string reason)
     {
         // Arrange
         var asset = new Asset { Width = w, Height = h, };

--- a/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailSizesTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ThumbnailSizesTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using DLCS.Model.Assets;
+
+namespace DLCS.Model.Tests.Assets;
+
+public class ThumbnailSizesTests
+{
+    [Fact]
+    public void Empty_InitialisesSizes()
+    {
+        ThumbnailSizes.Empty.Auth.Should().BeEmpty();
+        ThumbnailSizes.Empty.Open.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Empty_GetAllSizes_Empty()
+    {
+        ThumbnailSizes.Empty.GetAllSizes().Should().BeEmpty();
+        ThumbnailSizes.Empty.IsEmpty().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CtorWithLists_Count_OpenAndAuth()
+    {
+        var actual = new ThumbnailSizes(
+            new List<int[]> { new[] { 100, 200 }, new[] { 75, 150 }, },
+            new List<int[]> { new[] { 500, 1000 }, });
+
+        actual.Count.Should().Be(3);
+    }
+    
+    [Fact]
+    public void CtorWithLists_Count_OpenOnly()
+    {
+        var actual = new ThumbnailSizes(
+            new List<int[]> { new[] { 100, 200 }, new[] { 75, 150 }, },
+            new List<int[]>());
+
+        actual.Count.Should().Be(2);
+    }
+    
+    [Fact]
+    public void CtorWithLists_Count_AuthOnly()
+    {
+        var actual = new ThumbnailSizes(
+            new List<int[]>(),
+            new List<int[]> { new[] { 500, 1000 }, new[] { 200, 400 }, });
+
+        actual.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public void SizeClosestTo_Throws_IfEmpty()
+    {
+        Action action = () => ThumbnailSizes.Empty.SizeClosestTo(200, out _);
+        action.Should()
+            .ThrowExactly<InvalidOperationException>()
+            .WithMessage("Cannot find closest size as ThumbnailSizes empty");
+    }
+
+    [Fact]
+    public void SizeClosestTo_Returns_CorrectOpen()
+    {
+        var sizes = new ThumbnailSizes(
+            new List<int[]> { new[] { 100, 200 }, new[] { 75, 150 }, },
+            new List<int[]> { new[] { 500, 1000 }, });
+
+        var closest = sizes.SizeClosestTo(350, out var isOpen);
+
+        closest.Width.Should().Be(100);
+        closest.Height.Should().Be(200);
+        isOpen.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void SizeClosestTo_Returns_CorrectAuth()
+    {
+        var sizes = new ThumbnailSizes(
+            new List<int[]> { new[] { 100, 200 }, new[] { 75, 150 }, },
+            new List<int[]> { new[] { 500, 1000 }, });
+
+        var closest = sizes.SizeClosestTo(900, out var isOpen);
+
+        closest.Width.Should().Be(500);
+        closest.Height.Should().Be(1000);
+        isOpen.Should().BeFalse();
+    }
+}

--- a/src/protagonist/DLCS.Model/Assets/AssetX.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetX.cs
@@ -32,6 +32,8 @@ public static class AssetX
 
         foreach (var sizeParameter in sizeParameters)
         {
+            if (!IsValidForCalculation(assetSize, sizeParameter)) continue;
+            
             var resized = sizeParameter.ResizeIfSupported(assetSize);
             var maxDimension = resized.MaxDimension;
             
@@ -52,6 +54,23 @@ public static class AssetX
         }
 
         return thumbnailSizes;
+    }
+
+    private static bool IsValidForCalculation(Size imageSize, SizeParameter sizeParameter)
+    {
+        // /!w,h/ is applicable for calculating as we will use the max, which will be the confined value
+        if (sizeParameter.Confined) return true;
+
+        var imageShape = imageSize.GetShape();
+        
+        // /w,/ is applicable for Landscape or Square images as width will be fixed as it's longest edge
+        if (sizeParameter.Width.HasValue && imageShape != ImageShape.Portrait) return true;
+        
+        // /,h/ is applicable for Portait or Square images as width will be fixed as it's longest edge
+        if (sizeParameter.Height.HasValue && imageShape != ImageShape.Landscape) return true;
+
+        // any other combination is invalid as we store thumbs by longest so rounding error could affect finding image 
+        return false;
     }
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
+++ b/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
@@ -29,11 +29,11 @@ public class ThumbnailSizes
     public int Count { get; private set; }
 
     [JsonConstructor]
-    public ThumbnailSizes(List<int[]> open, List<int[]> auth)
+    public ThumbnailSizes(List<int[]>? open, List<int[]>? auth)
     {
-        Open = open;
-        Auth = auth;
-        Count = open.Count + auth.Count;
+        Open = open ?? new List<int[]>();
+        Auth = auth ?? new List<int[]>();
+        Count = Open.Count + Auth.Count;
     }
     
     public ThumbnailSizes(int sizesCount)

--- a/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
+++ b/src/protagonist/DLCS.Model/Assets/ThumbnailSizes.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using DLCS.Core.Collections;
+using DLCS.Model.IIIF;
 using IIIF;
 using Newtonsoft.Json;
 
@@ -11,6 +14,11 @@ namespace DLCS.Model.Assets;
 /// <remarks>This is saved as s.json in s3 and ThumbsSizes metadata in DB.</remarks>
 public class ThumbnailSizes
 {
+    /// <summary>
+    /// Default empty thumbnail sizes element
+    /// </summary>
+    public static readonly ThumbnailSizes Empty = new(0);
+    
     [JsonProperty("o")]
     public List<int[]> Open { get; }
         
@@ -25,6 +33,7 @@ public class ThumbnailSizes
     {
         Open = open;
         Auth = auth;
+        Count = open.Count + auth.Count;
     }
     
     public ThumbnailSizes(int sizesCount)
@@ -53,4 +62,31 @@ public static class ThumbnailSizesX
     /// </summary>
     public static IEnumerable<int[]> GetAllSizes(this ThumbnailSizes sizes)
         => sizes.Auth.Union(sizes.Open);
+
+    /// <summary>
+    /// Get boolean representing whether this instance is empty (ie contains no thumbs)
+    /// </summary>
+    public static bool IsEmpty(this ThumbnailSizes sizes) => sizes.Count == 0;
+
+    /// <summary>
+    /// Get the thumbnail size that is closest to specified targetSize.
+    /// </summary>
+    /// <param name="sizes">Current <see cref="ThumbnailSizes"/> object</param>
+    /// <param name="targetSize"></param>
+    /// <param name="isOpen">true if thumbnail is open, false if requires auth</param>
+    /// <returns>Closest size</returns>
+    /// <exception cref="NotImplementedException">Thrown if there are no open or auth thumbs</exception>
+    public static Size SizeClosestTo(this ThumbnailSizes sizes, int targetSize, out bool isOpen)
+    {
+        if (sizes.IsEmpty())
+        {
+            throw new InvalidOperationException($"Cannot find closest size as {nameof(ThumbnailSizes)} empty");
+        }
+
+        var closestSize = sizes.GetAllSizes()
+            .Select(Size.FromArray)
+            .SizeClosestTo(targetSize);
+        isOpen = sizes.Open.Any(wh => wh[0] == closestSize.Width && wh[1] == closestSize.Height);
+        return closestSize;
+    }
 }

--- a/src/protagonist/DLCS.Model/DLCS.Model.csproj
+++ b/src/protagonist/DLCS.Model/DLCS.Model.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.2.6" />
+    <PackageReference Include="iiif-net" Version="0.2.7" />
   </ItemGroup>
 
 </Project>

--- a/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
+++ b/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
@@ -34,4 +34,19 @@ public static class IIIFX
                 Math.Abs(x.MaxDimension - targetSize) < Math.Abs(y.MaxDimension - targetSize) ? x : y);
         return closestSize;
     }
+    
+    /// <summary>
+    /// Validate whether <see cref="SizeParameter"/> is valid as a thumbnail policy
+    ///
+    /// We do not support: max, pct or non-confining w,h (ie /w,h/ or /^w,h/)
+    /// </summary>
+    public static bool IsValidThumbnailParameter(this SizeParameter param) => param switch
+    {
+        { Max: true } => false,
+        { PercentScale: not null } => false,
+        { Confined: false, Width: not null, Height: not null } => false,
+        { Confined: true } and ({ Width: null } or { Height : null }) => false,
+        { Width: null, Height: null } => false,
+        _ => true,
+    };
 }

--- a/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
+++ b/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using IIIF;
@@ -13,11 +12,21 @@ namespace DLCS.Model.IIIF;
 public static class IIIFX
 {
     /// <summary>
-    /// Get the maximum dimension (width or height) for size parameter
+    /// Use <see cref="SizeParameter"/> values to resize <see cref="Size"/> object.
+    ///
+    /// Note that this isn't an exhaustive method - it'll only support the allowed sizeParam values, as reflected in
+    /// <see cref="IsValidThumbnailParameter"/>
     /// </summary>
-    public static int GetMaxDimension(this SizeParameter sizeParameter)
-        => Math.Max(sizeParameter.Width ?? 0, sizeParameter.Height ?? 0);
+    public static Size ResizeIfSupported(this SizeParameter sizeParameter, Size assetSize)
+    {
+        if (!sizeParameter.IsValidThumbnailParameter())
+        {
+            throw new InvalidOperationException($"Attempt to resize using unsupported SizeParameter: {sizeParameter}");
+        }
 
+        return sizeParameter.Resize(assetSize, InvalidUpscaleBehaviour.ReturnOriginal);
+    }
+    
     /// <summary>
     /// From provided sizes, return the Size that has MaxDimension closest to specified targetSize
     ///

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="6.0.5" />
-    <PackageReference Include="Npgsql" Version="6.0.10" />
+    <PackageReference Include="Npgsql" Version="6.0.11" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
     <PackageReference Include="SSH.NET" Version="2020.0.2" />
     <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="6.20.1" />

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="iiif-net" Version="0.2.6" />
+    <PackageReference Include="iiif-net" Version="0.2.7" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="iiif-net" Version="0.2.6" />
+    <PackageReference Include="iiif-net" Version="0.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="iiif-net" Version="0.2.6" />
+        <PackageReference Include="iiif-net" Version="0.2.7" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />

--- a/src/protagonist/Engine/Engine.csproj
+++ b/src/protagonist/Engine/Engine.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
         <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
@@ -21,7 +21,9 @@ public class MetadataWithFallbackThumbSizeProviderTests
     {
         policyRepository = A.Fake<IPolicyRepository>();
 
-        var orchestratorSettings = Options.Create(new OrchestratorSettings());
+        var settings = new OrchestratorSettings();
+        settings.ImageIngest.DefaultThumbs = new List<string> { "!400,400" };
+        var orchestratorSettings = Options.Create(settings);
         sut = new MetadataWithFallbackThumbSizeProvider(policyRepository, orchestratorSettings,
             new NullLogger<MetadataWithFallbackThumbSizeProvider>());
     }
@@ -86,7 +88,7 @@ public class MetadataWithFallbackThumbSizeProviderTests
         
         var policy = new DeliveryChannelPolicy
         {
-            PolicyData = "[\"!1000,1000\", \"!400,400\", \"!200,200\", \"75,\"]",
+            PolicyData = "[\"!1000,1000\", \"!400,400\", \"!200,200\", \",150\"]",
             Channel = "thumbs",
             Id = DeliveryChannelPolicyId,
         };

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
@@ -88,7 +88,7 @@ public class MetadataWithFallbackThumbSizeProviderTests
         
         var policy = new DeliveryChannelPolicy
         {
-            PolicyData = "[\"!1000,1000\", \"!400,400\", \"!200,200\", \",150\"]",
+            PolicyData = "[\"!1000,1000\", \"!200,200\", \",150\"]", //"!400,400" is included from defaults
             Channel = "thumbs",
             Id = DeliveryChannelPolicyId,
         };

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
@@ -12,7 +12,6 @@ using DLCS.AWS.Settings;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
-using FakeItEasy;
 using FizzWare.NBuilder;
 using IIIF;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -187,7 +186,7 @@ public class FireballPdfCreatorTests
                     A<string>._, A<string>._, A<CancellationToken>._))
             .MustHaveHappened(2, Times.Exactly);
     }
-    
+
     [Fact]
     public async Task CreatePdf_RedactsNotWhitelistedRoles()
     {
@@ -205,25 +204,25 @@ public class FireballPdfCreatorTests
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = 0
             },
-            new ()
+            new()
             {
                 Roles = "whitelist,notwhitelist",
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = 0
             },
-            new ()
+            new()
             {
                 Roles = "notwhitelist",
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = 0
             },
-            new ()
+            new()
             {
                 Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
                 MaxUnauthorised = -1
             },
-            new ()
+            new()
             {
                 Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
@@ -231,8 +230,8 @@ public class FireballPdfCreatorTests
             }
         };
 
-        A.CallTo(() => thumbSizeProvider.GetThumbSizesForImage(A<Asset>._, false))
-            .Returns(new List<Size> { new(500, 500) });
+        A.CallTo(() => thumbSizeProvider.GetThumbSizesForImage(A<Asset>._))
+            .Returns(new ThumbnailSizes(new List<int[]>{ new[] { 500, 500 } }, new List<int[]>()));
 
         var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
         responseMessage.Content =

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFCanvasFactory.cs
@@ -171,16 +171,17 @@ public class IIIFCanvasFactory
     
     private async Task<ImageSizeDetails?> RetrieveThumbnails(Asset asset)
     {
-        var thumbnailSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, true);
+        var allThumbSizes = await thumbSizeProvider.GetThumbSizesForImage(asset);
+        var openThumbnails = allThumbSizes.Open.Select(Size.FromArray).ToList();
 
-        var maxDerivativeSize = thumbnailSizes.IsNullOrEmpty()
+        var maxDerivativeSize = openThumbnails.IsNullOrEmpty()
             ? Size.Confine(orchestratorSettings.TargetThumbnailSize, new Size(asset.Width ?? 0, asset.Height ?? 0))
-            : thumbnailSizes.MaxBy(s => s.MaxDimension)!;
+            : openThumbnails.MaxBy(s => s.MaxDimension)!;
         
         return new ImageSizeDetails
         {
             MaxDerivativeSize = maxDerivativeSize,
-            OpenThumbnails = thumbnailSizes,
+            OpenThumbnails = openThumbnails,
         };
     }
     

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
 using DLCS.Core.Guard;
@@ -92,6 +93,13 @@ public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
         var sizeParameters = thumbnailPolicyFromDb
             .ThrowIfNull(nameof(thumbnailPolicyFromDb))
             .ThumbsDataAsSizeParameters();
+
+        if (!orchestratorSettings.ImageIngest.DefaultThumbs.IsNullOrEmpty())
+        {
+            var defaultThumbs = orchestratorSettings.ImageIngest.DefaultThumbs.Select(ImageApi.SizeParameter.Parse);
+            sizeParameters = sizeParameters.Union(defaultThumbs).ToList();
+        }
+        
         thumbnailPolicies[thumbnailDeliveryChannel.DeliveryChannelPolicyId] = sizeParameters;
         return sizeParameters;
     }

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
@@ -120,17 +120,18 @@ public class FireballPdfCreator : BaseProjectionCreator<PdfParsedNamedQuery>
 
     private async Task<ObjectInBucket?> GetThumbnailLocation(Asset asset)
     {
-        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, false);
+        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset);
 
-        if (availableSizes.IsNullOrEmpty())
+        if (availableSizes.IsEmpty())
         {
             Logger.LogInformation("Unable to find thumbnail for {AssetId}, excluding from PDF", asset.Id);
             return null;
         }
         
-        var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize);
-        Logger.LogTrace("Using thumbnail {ThumbnailSize} for asset {AssetId}", selectedSize, asset.Id);
-        return StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension);
+        var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize, out var isOpen);
+        Logger.LogTrace("Using thumbnail {ThumbnailSize} for asset {AssetId}. IsOpen: {ThumbnailOpen}", selectedSize,
+            asset.Id, isOpen);
+        return StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension, isOpen);
     }
 
     private CustomerOverride GetCustomerOverride(PdfParsedNamedQuery parsedNamedQuery) 

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
@@ -138,13 +138,14 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
     
     private async Task<Stream?> GetThumbnailStream(Asset asset)
     {
-        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset, false);
+        var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset);
         
-        if (availableSizes.IsNullOrEmpty()) return null;
+        if (availableSizes.IsEmpty()) return null;
         
-        var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize);
-        Logger.LogTrace("Using thumbnail {ThumbnailSize} for asset {AssetId}", selectedSize, asset.Id);
-        var thumbnailLocation = StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension);
+        var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize, out var isOpen);
+        Logger.LogTrace("Using thumbnail {ThumbnailSize} for asset {AssetId}. IsOpen: {ThumbnailOpen}", selectedSize,
+            asset.Id, isOpen);
+        var thumbnailLocation = StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension, isOpen);
         
         var thumbStream = await BucketReader.GetObjectContentFromBucket(thumbnailLocation);
         return thumbStream;

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -183,8 +183,8 @@ public class ImageIngestSettings
     /// A list of thumbnails that will be added to every asset regardless of the thumbnail policy
     /// </summary>
     /// <remarks>
-    /// This is an Engine concern and ideally wouldn't be in Orchestrator but Orchestrator needs to be aware when
-    /// calculating sizes of images for 
+    /// This is an Engine concern and ideally shouldn't be in Orchestrator but Orchestrator needs to be aware when
+    /// calculating sizes of images for when AssetApplicationMetadata doesn't exist
     /// </remarks>
     public List<string> DefaultThumbs { get; set; } = new();
 }

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -99,6 +99,8 @@ public class OrchestratorSettings
     public AuthSettings Auth { get; set; } = new();
 
     public NamedQuerySettings NamedQuery { get; set; } = new();
+
+    public ImageIngestSettings ImageIngest { get; set; } = new();
 }
 
 public class ProxySettings
@@ -173,6 +175,18 @@ public class ThumbUpscaleConfig
     /// The maximum % size difference for upscaling.
     /// </summary>
     public int UpscaleThreshold { get; set; }
+}
+
+public class ImageIngestSettings
+{
+    /// <summary>
+    /// A list of thumbnails that will be added to every asset regardless of the thumbnail policy
+    /// </summary>
+    /// <remarks>
+    /// This is an Engine concern and ideally wouldn't be in Orchestrator but Orchestrator needs to be aware when
+    /// calculating sizes of images for 
+    /// </remarks>
+    public List<string> DefaultThumbs { get; set; } = new();
 }
 
 public class AuthSettings

--- a/src/protagonist/Orchestrator/appSettings-Development-Example.json
+++ b/src/protagonist/Orchestrator/appSettings-Development-Example.json
@@ -57,6 +57,11 @@
       "my-proxy.com": "/{prefix}/{assetPath}"
     }
   },
+  "ImageIngest": {
+    "DefaultThumbs": [
+      "!100,100", "!200,200", "!400,400", "!1024,1024"
+    ]
+  },
   "Caching": {
     "TimeToLive": {
       "Memory": {

--- a/src/protagonist/Portal/Portal.csproj
+++ b/src/protagonist/Portal/Portal.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
       <PackageReference Include="CsvHelper" Version="30.0.1" />
       <PackageReference Include="Destructurama.Attributed" Version="2.0.0" />
-      <PackageReference Include="iiif-net" Version="0.2.6" />
+      <PackageReference Include="iiif-net" Version="0.2.7" />
       <PackageReference Include="MediatR" Version="10.0.1" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.5" />

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.150" />
-    <PackageReference Include="iiif-net" Version="0.2.6" />
+    <PackageReference Include="iiif-net" Version="0.2.7" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />


### PR DESCRIPTION
Fixes #892 

## Overview

Overall process is for `MetadataWithFallbackThumbSizeProvider` to return a `ThumbnailSizes` object containing both open and auth sizes, rather than returning a single list of `Size` objects as we are then unable to tell what's open or not. The consumer can then decide how best to query the open/auth thumbs.

Added default thumbnail sizes to Orchestrator as these are required when calculating available sizes if `AssetApplicationMetadata` isn't available.

`FireballPdfCreator`, `ImageThumbZipCreator` and `IIIFCanvasFactory` were updated to use `ThumbnailSizes` object, from this it can determine if the thumbnail is open or not and request the appropriate thumbnail location.

## Details

Moved DeliveryChannel thumbnail policy (ie `SizeParameter`) validation to `IIIFX.IsValidThumbnailParameter()` to allow it to be reused.

`AssetX.GetAvailableThumbSizes()` was simplified to return a `ThumbnailSizes` object always, rather than optionally including unavailable. Previously this rejected non-confined sizes but this was updated to use `SizeParameter.Resize()` method introduced in https://github.com/digirati-co-uk/iiif-net/pull/47. Prior to calling this we validate using above `IsValidThumbnailParameter()` as a safety check. This method will only use attempt to recalculate sizes for images that we can be sure of the longest dimension (ie any confined, `w,` for landscape or square images, `.h` for portrait or square images - other combinations would involve calculating the longest edge and potentially being out by 1, meaning thumbnail wouldn't be found)

Added some helpers around `ThumbnailSizes` for finding closest size and determining if open or auth. The intention of this object was only for serialisation/deserialisation but usage fit here.

## Settings Change

Note that this requires a new AppSetting, `ImageIngest_DefaultThumbs`, which is the same as previous setting used in Engine.