### PR TITLE
Update portal date format to be 24h time

### DIFF
--- a/src/protagonist/Portal/Extensions/DateTimeX.cs
+++ b/src/protagonist/Portal/Extensions/DateTimeX.cs
@@ -4,7 +4,7 @@ namespace Portal.Extensions;
 
 public static class DateTimeX
 {
-    private const string DefaultTimeFormat = "yyyy-MM-dd hh:mm:ss";
+    private const string DefaultTimeFormat = "yyyy-MM-dd HH:mm:ss";
     private const string DateNotFoundMessage = "Date not found";
     
     /// <summary>


### PR DESCRIPTION
`hh` is "The hour, using a 12-hour clock from 01 to 12.". Replaced with `HH`, "The hour, using a 24-hour clock from 00 to 23.". Helps differentiate when items were processed without needing to add AM/PM designator