### PR TITLE
Add JWT-based Auth option for API requests

### DIFF
--- a/src/protagonist/.editorconfig
+++ b/src/protagonist/.editorconfig
@@ -1,2 +1,3 @@
 [*.cs]
 csharp_style_namespace_declarations=file_scoped:warning
+csharp_prefer_braces = true:suggestion

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -23,6 +23,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.5" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.2" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 

--- a/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
+++ b/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
@@ -38,7 +38,7 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
     private readonly DlcsApiAuth dlcsApiAuth;
     private readonly JwtAuthHelper authHelper;
 
-    private readonly JsonWebTokenHandler jwtHandler = new();
+    private static readonly JsonWebTokenHandler JwtHandler = new();
 
     /// <summary>
     /// Deduces the caller's claims
@@ -207,7 +207,7 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         if (token is null)
             return new FailedCaller("JWT missing");
 
-        var result = await jwtHandler.ValidateTokenAsync(token, new()
+        var result = await JwtHandler.ValidateTokenAsync(token, new()
         {
             IssuerSigningKey = signingKey,
             ValidateAudience = false,

--- a/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
+++ b/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 namespace API.Auth;
 
@@ -22,7 +23,7 @@ namespace API.Auth;
 ///    to an anonymous user. Another example: https://api.dlcs.io/originStrategies
 ///  - An admin API key is allowed to make any valid API call.
 ///  - A customer path is one that starts /customers/n/, where n is the customer id.
-///    Customer-specific resources such as images, auth services, etc live under these paths.
+///    Customer-specific resources such as images, auth services, etc. live under these paths.
 ///  - Only an admin key or a key belonging to that customer can call these paths.
 ///  - A customer path is never anonymous.
 /// 
@@ -35,6 +36,9 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
 {
     private readonly ICustomerRepository customerRepository;
     private readonly DlcsApiAuth dlcsApiAuth;
+    private readonly JwtAuthHelper authHelper;
+
+    private readonly JsonWebTokenHandler jwtHandler = new();
 
     /// <summary>
     /// Deduces the caller's claims
@@ -50,11 +54,13 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         UrlEncoder encoder,
         ISystemClock clock,
         ICustomerRepository customerRepository,
-        DlcsApiAuth dlcsApiAuth)
+        DlcsApiAuth dlcsApiAuth,
+        JwtAuthHelper authHelper)
         : base(options, logger, encoder, clock)
     {
         this.customerRepository = customerRepository;
         this.dlcsApiAuth = dlcsApiAuth;
+        this.authHelper = authHelper;
     }
 
     /// <summary>
@@ -67,12 +73,13 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         var endpoint = Context.GetEndpoint();
         if (endpoint?.Metadata.GetMetadata<IAllowAnonymous>() != null)
             return AuthenticateResult.NoResult();
-        
+
         // ...but any not marked must have the auth header
         if (!Request.Headers.ContainsKey("Authorization"))
             return AuthenticateResult.Fail("Missing Authorization Header in request");
 
-        var headerValue = Request.GetAuthHeaderValue(AuthenticationHeaderUtils.BasicScheme);
+        var headerValue = Request.GetAuthHeaderValue(AuthenticationHeaderUtils.BasicScheme)
+                          ?? Request.GetAuthHeaderValue(AuthenticationHeaderUtils.BearerTokenScheme);
         if (headerValue == null)
         {
             return AuthenticateResult.Fail("Missing Authorization Header in request");
@@ -88,21 +95,29 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
                 resourceCustomerId = result;
             }
         }
-        var apiCaller = GetApiCaller(headerValue);
-        if (apiCaller == null)
-        {
-            return AuthenticateResult.Fail("Invalid credentials");
-        }
-        
-        var customerForKey = await customerRepository.GetCustomerForKey(apiCaller.Key, resourceCustomerId);
-        if (customerForKey == null)
-        {
-            return AuthenticateResult.Fail("No customer found for this key that is permitted to access this resource");
-        }
 
-        if (apiCaller.Secret != dlcsApiAuth.GetApiSecret(customerForKey, Options.Salt, apiCaller.Key))
+        switch (await GetApiCaller(headerValue, resourceCustomerId))
         {
-            return AuthenticateResult.Fail("Invalid credentials");
+            case null:
+                return AuthenticateResult.Fail("Invalid credentials");
+            case FailedCaller fail:
+                return AuthenticateResult.Fail(fail.Message);
+
+            // Success:
+            case ApiCaller apiCaller:
+                return AuthenticateApiCaller(apiCaller, resourceCustomerId);
+
+            default:
+                throw new InvalidOperationException();
+        }
+    }
+
+    private AuthenticateResult AuthenticateApiCaller(ApiCaller apiCaller, int? resourceCustomerId)
+    {
+        if (apiCaller.Customer is not { } customer)
+        {
+            Logger.LogError("A non-fail ApiCaller returned with null Customer field");
+            return AuthenticateResult.Fail("Unexpected error");
         }
 
         // We still have some checks to do before authenticating this user.
@@ -110,13 +125,14 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         if (resourceCustomerId.HasValue)
         {
             // the request is for a particular customer's resource (e.g., an asset)
-            if (customerForKey.Id != resourceCustomerId.Value)
+            if (customer.Id != resourceCustomerId.Value)
             {
                 // ... but the requester is not this customer. Only proceed if they are admin.
-                if (!customerForKey.Administrator)
+                if (!customer.Administrator)
                 {
                     return AuthenticateResult.Fail("Only admin user may access this customer's resource.");
                 }
+
                 Logger.LogDebug("Admin key accessing a customer's resource");
             }
         }
@@ -124,13 +140,14 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         {
             // The request isn't for a customer resource (i.e., under the path /customers/n/).
             // Only proceed if they are admin.
-            if (!customerForKey.Administrator)
+            if (!customer.Administrator)
             {
                 return AuthenticateResult.Fail("Only admin user may access this shared resource");
             }
+
             Logger.LogDebug("Admin key accessing a shared resource");
         }
-        
+
         // At this point our *authentication* has passed.
         // Downstream handlers may still refuse to *authorise* the request for other reasons
         // (it can still end up a 401)
@@ -138,42 +155,100 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
 
         var claims = new List<Claim>
         {
-            new (ClaimTypes.Name, customerForKey.Name), // TODO - should these be the other way round?
-            new (ClaimTypes.NameIdentifier, apiCaller.Key), // ^^^
-            new (ClaimsPrincipalUtils.Claims.Customer, customerForKey.Id.ToString()),
-            new (ClaimTypes.Role, ClaimsPrincipalUtils.Roles.Customer),
+            new(ClaimTypes.Name, customer.Name), // TODO - should these be the other way round?
+            new(ClaimTypes.NameIdentifier, apiCaller.Key), // ^^^
+            new(ClaimsPrincipalUtils.Claims.Customer, customer.Id.ToString()),
+            new(ClaimTypes.Role, ClaimsPrincipalUtils.Roles.Customer),
         };
-        if (customerForKey.Administrator)
+        if (customer.Administrator)
         {
-            claims.Add(new Claim(ClaimTypes.Role, ClaimsPrincipalUtils.Roles.Admin));
+            claims.Add(new(ClaimTypes.Role, ClaimsPrincipalUtils.Roles.Admin));
         }
+
         var identity = new ClaimsIdentity(claims, Scheme.Name);
         var principal = new ClaimsPrincipal(identity);
         var ticket = new AuthenticationTicket(principal, Scheme.Name);
         return AuthenticateResult.Success(ticket);
     }
 
-    private ApiCaller? GetApiCaller(AuthenticationHeaderValue headerValue)
+    private async Task<IApiCaller?> GetApiCaller(AuthenticationHeaderValue headerValue, int? customerIdHint)
     {
-        try
+        switch (headerValue.Scheme)
         {
-            if (headerValue.Parameter == null) return null;
-            
-            var authHeader = headerValue.Parameter.DecodeBase64();
-            string[] keyAndSecret = authHeader.Split(':');
-            var apiCaller = new ApiCaller(keyAndSecret[0], keyAndSecret[1]);
-            if (apiCaller.Key.HasText() && apiCaller.Secret.HasText())
-            {
-                return apiCaller;
-            }
+            case AuthenticationHeaderUtils.BasicScheme:
+                return await GetApiCallerFromBasic(headerValue.Parameter, customerIdHint);
+            case AuthenticationHeaderUtils.BearerTokenScheme:
+                return await GetApiCallerFromJwt(headerValue.Parameter);
+        }
 
-            return null;
-        }
-        catch
-        {
-            Logger.LogError("Could not parse auth header");
-        }
+        Logger.LogError("Could not parse auth header");
         return null;
+    }
+
+    private async Task<IApiCaller?> GetApiCallerFromBasic(string? headerValueParameter, int? customerIdHint)
+    {
+        if (headerValueParameter?.DecodeBase64().Split(':') is not
+            [{Length: > 0} key, {Length: > 0} secret]) return null;
+
+        var customerForKey = await customerRepository.GetCustomerForKey(key, customerIdHint);
+        if (customerForKey == null)
+        {
+            return new FailedCaller("No customer found for this key that is permitted to access this resource");
+        }
+
+        if (secret != dlcsApiAuth.GetApiSecret(customerForKey, Options.Salt, key))
+        {
+            return new FailedCaller("Invalid credentials");
+        }
+
+        return new ApiCaller(key, customerForKey);
+    }
+
+    private async Task<IApiCaller?> GetApiCallerFromJwt(string? token)
+    {
+        if (authHelper.SigningCredentials?.Key is not { } signingKey)
+            return new FailedCaller("JWT not enabled");
+
+        if (token is null)
+            return new FailedCaller("JWT missing");
+
+        var result = await jwtHandler.ValidateTokenAsync(token, new()
+        {
+            IssuerSigningKey = signingKey,
+            ValidateAudience = false,
+            ValidateIssuer = true,
+            ValidIssuers = authHelper.ValidIssuers
+        });
+
+        if (!result.IsValid)
+        {
+            return new FailedCaller("Invalid JWT used");
+        }
+
+        if (!result.Claims.TryGetValue(JwtRegisteredClaimNames.Sub, out var subUrnObj) ||
+            subUrnObj is not string subUrn)
+        {
+            return new FailedCaller("JWT missing sub field");
+        }
+
+        if (subUrn.Split(':') is not [_, var nid, var nss, var id, ..])
+        {
+            return new FailedCaller("JWT sub in incorrect urn format");
+        }
+
+        // Future integration: nid/nss/id can be used for granular permissions
+        // For now, we have 1 customer, the Customer Portal, so "hardcode" the
+        // verification.
+
+        // We only support the following subjects: urn:dlcs:user:<customerId>
+        if (!"dlcs".Equals(nid) || !"user".Equals(nss))
+            return new FailedCaller("Unsupported/unauthorised token data");
+
+        var customer = await customerRepository.GetCustomer(id);
+        if (customer is null)
+            return new FailedCaller("Customer not found");
+
+        return new ApiCaller(customer.Keys.First(), customer);
     }
 
     /// <summary>
@@ -187,16 +262,21 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
 }
 
 /// <summary>
+/// Can be <see cref="ApiCaller"/> or <see cref="FailedCaller"/>
+/// </summary>
+public interface IApiCaller;
+
+/// <summary>
 /// Represents the credentials in the API request, the basic auth key:secret pair.
 /// </summary>
-public class ApiCaller
+public class ApiCaller(string key, Customer? customer) : IApiCaller
 {
-    public ApiCaller(string key, string secret)
-    {
-        Key = key;
-        Secret = secret;
-    }
+    public string Key { get; set; } = key;
 
-    public string Key { get; set; }
-    public string Secret { get; set; }
+    public Customer? Customer { get; } = customer;
+}
+
+public class FailedCaller(string message) : IApiCaller
+{
+    public string Message { get; } = message;
 }

--- a/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
+++ b/src/protagonist/API/Auth/DlcsBasicAuthenticationHandler.cs
@@ -239,7 +239,10 @@ public class DlcsBasicAuthenticationHandler : AuthenticationHandler<BasicAuthent
         if (!"dlcs".Equals(nid) || !"user".Equals(nss))
             return new FailedCaller("Unsupported/unauthorised token data");
 
-        var customer = await customerRepository.GetCustomer(id);
+        if (!int.TryParse(id, out var customerId))
+            return new FailedCaller("Invalid customer id format");
+        
+        var customer = await customerRepository.GetCustomer(customerId);
         if (customer is null)
             return new FailedCaller("Customer not found");
 

--- a/src/protagonist/API/Auth/JwtAuthHelper.cs
+++ b/src/protagonist/API/Auth/JwtAuthHelper.cs
@@ -1,0 +1,16 @@
+﻿using DLCS.Core.Settings;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace API.Auth;
+
+public class JwtAuthHelper(IOptions<DlcsSettings> dlcsSettings)
+{
+    public SigningCredentials? SigningCredentials { get; } = dlcsSettings.Value.JwtKey is {Length: > 0} key
+        ? new(
+            new SymmetricSecurityKey(Convert.FromBase64String(key)),
+            SecurityAlgorithms.HmacSha256Signature)
+        : null;
+
+    public string[] ValidIssuers { get; } = dlcsSettings.Value.JwtValidIssuers.ToArray();
+}

--- a/src/protagonist/API/Auth/JwtAuthHelper.cs
+++ b/src/protagonist/API/Auth/JwtAuthHelper.cs
@@ -4,13 +4,19 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace API.Auth;
 
-public class JwtAuthHelper(IOptions<DlcsSettings> dlcsSettings)
+public class JwtAuthHelper
 {
-    public SigningCredentials? SigningCredentials { get; } = dlcsSettings.Value.JwtKey is {Length: > 0} key
-        ? new(
-            new SymmetricSecurityKey(Convert.FromBase64String(key)),
-            SecurityAlgorithms.HmacSha256Signature)
-        : null;
+    public JwtAuthHelper(IOptions<DlcsSettings> dlcsSettings)
+    {
+        SigningCredentials = dlcsSettings.Value.JwtKey is {Length: > 0} key
+            ? new(
+                new SymmetricSecurityKey(Convert.FromBase64String(key)),
+                SecurityAlgorithms.HmacSha256Signature)
+            : null;
+        ValidIssuers = dlcsSettings.Value.JwtValidIssuers.ToArray();
+    }
 
-    public string[] ValidIssuers { get; } = dlcsSettings.Value.JwtValidIssuers.ToArray();
+    public SigningCredentials? SigningCredentials { get; }
+
+    public string[] ValidIssuers { get; }
 }

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -68,6 +68,7 @@ public class Startup
             .AddSingleton<CredentialsExporter>()
             .AddSingleton<ApiKeyGenerator>()
             .AddSingleton<IEncryption, SHA256>()
+            .AddSingleton<JwtAuthHelper>()
             .AddSingleton<DlcsApiAuth>()
             .AddTransient<ClaimsPrincipal>(s => s.GetRequiredService<IHttpContextAccessor>().HttpContext.User)
             .AddCaching(cacheSettings)

--- a/src/protagonist/API/appsettings-Development-Example.json
+++ b/src/protagonist/API/appsettings-Development-Example.json
@@ -32,6 +32,7 @@
   },
   "PathBase": "",
   "Salt": "********",
+  "ApiSalt": "********",
   "PageSize": 100,
   "DefaultLegacySupport": true,
   "CustomerOverrides": {

--- a/src/protagonist/DLCS.Core.Tests/DLCS.Core.Tests.csproj
+++ b/src/protagonist/DLCS.Core.Tests/DLCS.Core.Tests.csproj
@@ -5,7 +5,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DLCS.Core/DLCS.Core.csproj
+++ b/src/protagonist/DLCS.Core/DLCS.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
+++ b/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
@@ -46,5 +46,5 @@ public class DlcsSettings
     /// <summary>
     /// List of valid issuers of JWT for authentication
     /// </summary>
-    public ICollection<string> JwtValidIssuers { get; set; } = [];
+    public ICollection<string> JwtValidIssuers { get; set; } = Array.Empty<string>();
 }

--- a/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
+++ b/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
@@ -37,4 +37,14 @@ public class DlcsSettings
     /// URL format for generating manifests for single assets
     /// </summary>
     public string SingleAssetManifestTemplate { get; set; }
+    
+    /// <summary>
+    /// 256bit or longer, Base64 encoded, JWT secret
+    /// </summary>
+    public string? JwtKey { get; set; }
+
+    /// <summary>
+    /// List of valid issuers of JWT for authentication
+    /// </summary>
+    public ICollection<string> JwtValidIssuers { get; set; } = [];
 }

--- a/src/protagonist/DLCS.Model.Tests/DLCS.Model.Tests.csproj
+++ b/src/protagonist/DLCS.Model.Tests/DLCS.Model.Tests.csproj
@@ -5,7 +5,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DLCS.Model/DLCS.Model.csproj
+++ b/src/protagonist/DLCS.Model/DLCS.Model.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protagonist/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
+++ b/src/protagonist/DLCS.Repository.Tests/DLCS.Repository.Tests.csproj
@@ -5,7 +5,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protagonist/DLCS.Web.Tests/DLCS.Web.Tests.csproj
+++ b/src/protagonist/DLCS.Web.Tests/DLCS.Web.Tests.csproj
@@ -5,7 +5,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/protagonist/Portal.Tests/Portal.Tests.csproj
+++ b/src/protagonist/Portal.Tests/Portal.Tests.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
 
-        <LangVersion>default</LangVersion>
+        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/protagonist/Thumbs/Thumbs.csproj
+++ b/src/protagonist/Thumbs/Thumbs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <Nullable>enable</Nullable>
-    <LangVersion>default</LangVersion>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I tried to balance the non-invasive, limited change with doing it at least semi-properly.

I think it should be fine, I ran it locally and it behaved as expected.

Note: this by default will be disabled, config needs to be provided for it to work:

```
  "DLCS": {
    ...,
    "JwtKey": "iy/umankHwi8fWcUOv0skf4b3vmWip9VhTWxneHokwI=",
    "JwtValidIssuers": [
      "urn:caspian:site:default"
    ]
  }
```
_don't worry, this key is made up for this PR note only_

of course key can be any Base64 encoded data, e.g.:
```
var key = new byte[32];
var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
rng.GetBytes(key);

Convert.ToBase64String(key); // returns the value for config
```

I opted NOT to include default because it'd surely end up being the actual key in prod deployments at some point down the line ;)

The `DLCS:JwtValidIssuers:#` should be `urn:caspian:site:default`, which is the default value used by Portal, though the final term (here `default`) can be whatever, configurable per env (so even if key reuse happens we still can limit (or allow) cross-env calls.

---

This will split off the existing path into its own method, do JWT things and if it's indeed a `DLCS Customer Id` claim, correctly signed, will load the customer from repo by that id and use the _first key from the list_ for this customer, before returning to the usual flow.

I split the code into respective flows, but I really didn't want to throw exceptions for flow control in sth that's ran on every request, exposed to the world, as it can create spurious overheads. So to keep it hopefully light it just returns a wrapped string (`FailedCaller`) in case of auth failure, which gets turned into `AuthenticationResult`.

The code could be nicer I'm sure, but I'd prob have to refactor much, much more, and I really, really don't want to break stuff, so make your judgement ;)