### PR TITLE
Respect JsonPropertyName attributes in generated swagger

### DIFF
--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -27,7 +27,7 @@
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
-      <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.3" />
+      <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.3.1 " />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/API/API.csproj
+++ b/src/protagonist/API/API.csproj
@@ -27,6 +27,7 @@
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.22" />
       <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+      <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -115,6 +115,8 @@ public class Startup
                 options.SerializerSettings.ApplyHydraSerializationSettings();
             });
 
+        services.AddSwaggerGenNewtonsoftSupport();
+
         services
             .AddHealthChecks()
             .AddDbContextCheck<DlcsContext>("DLCS-DB");


### PR DESCRIPTION
The swagger is currently generated using Swashbuckle, which only supports System.Text.Json attributes out of the box.

Resolves https://github.com/dlcs/protagonist/issues/898.