### PR TITLE
Create default storagePolicy on setup

### DIFF
--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -17,7 +17,9 @@
   "DLCS": {
     "ApiRoot": "https://api.dlcs.digirati.io",
     "ResourceRoot": "https://dlcs.digirati.io",
-    "EngineRoot": "http://engine.dlcs.digirati.io"
+    "EngineRoot": "http://engine.dlcs.digirati.io",
+    "DefaultPolicyMaxNumber": -99,
+    "DefaultPolicyMaxSize": -99
   },
   "PageSize": 100,
   "ApiSalt": "this-is-a-salt",

--- a/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
+++ b/src/protagonist/DLCS.Core/Settings/DlcsSettings.cs
@@ -47,4 +47,16 @@ public class DlcsSettings
     /// List of valid issuers of JWT for authentication
     /// </summary>
     public string[] JwtValidIssuers { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Max number of stored items for "default" storage policy 
+    /// </summary>
+    /// <remarks>These are used during 1 off setup only</remarks>
+    public long DefaultPolicyMaxNumber { get; set; } = 1000000000;
+    
+    /// <summary>
+    /// Max number of stored bytes for "default" storage policy
+    /// </summary>
+    /// <remarks>These are used during 1 off setup only</remarks>
+    public long DefaultPolicyMaxSize { get; set; } = 1000000000000000;
 }

--- a/src/protagonist/DLCS.Model/Storage/StoragePolicy.cs
+++ b/src/protagonist/DLCS.Model/Storage/StoragePolicy.cs
@@ -5,9 +5,11 @@ using System.Diagnostics;
 namespace DLCS.Model.Storage;
 
 [DebuggerDisplay("{Id}")]
-public partial class StoragePolicy
+public class StoragePolicy
 {
     public string Id { get; set; }
     public long MaximumNumberOfStoredImages { get; set; }
     public long MaximumTotalSizeOfStoredImages { get; set; }
+    
+    public const string DefaultStoragePolicyName = "default";
 }

--- a/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
+++ b/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
@@ -45,7 +45,7 @@ public class CustomerStorageRepository : IStorageRepository
                 
         if (spaceId == 0)
         {
-            storageForSpace.StoragePolicy = "default"; // this isn't set on Customer
+            storageForSpace.StoragePolicy = StoragePolicy.DefaultStoragePolicyName; // this isn't set on Customer
             // This space0 row isn't created when a customer is created, either - but should it?
         }
 


### PR DESCRIPTION
Default values are pulled from config, without this step storagePolicy needs to be configured manually to avoid issues.

Reworked `DlcsDatabaseFixture` to inherit from new class `DlcsDefaultDatabaseFixture`. The former creates customer etc, the latter is an empty db with migrations applied.