### PR TITLE
For the overload of GetSpace, use noCache: true

### DIFF
--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -67,7 +67,7 @@ public class SpaceRepository : ISpaceRepository
     
     public async Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken)
     {
-        return await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: false);
+        return await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: true);
     }
 
     public async Task<Space> CreateSpace(int customer, string name, string? imageBucket, 


### PR DESCRIPTION
When checking for space name collision, cache is currently used, causing inconsistent and often incorrect responses, leading to invalid database state (multiple Spaces with same name for given customer), causing exception, rather than triggering predefined checks and returns.

The overload in question is used only for those state-changing commands, hence the change should have no unintended consequences.
![image](https://github.com/user-attachments/assets/e149e746-57c6-46b1-b7c6-b4fc0c825d2a)
