### PR TITLE
Add /raw-resource/ endpoint to Orchestrator

### DIFF
--- a/src/protagonist/DLCS.Core/ResultMessage.cs
+++ b/src/protagonist/DLCS.Core/ResultMessage.cs
@@ -13,7 +13,7 @@ public class ResultMessage<T>
     public string Message { get; }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResultStatus{T}"/> class.
+    /// Initializes a new instance of the <see cref="ResultMessage{T}"/> class.
     /// </summary>
     /// <param name="message">A message related to the result</param>
     /// <param name="value">The value.</param>

--- a/src/protagonist/DLCS.Core/ResultStatus.cs
+++ b/src/protagonist/DLCS.Core/ResultStatus.cs
@@ -11,6 +11,11 @@ public class ResultStatus<T>
     /// The associated value.
     /// </summary>
     public T? Value { get; }
+    
+    /// <summary>
+    /// Optional code for error
+    /// </summary>
+    public int? ErrorCode { get; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ResultStatus{T}"/> class.
@@ -34,11 +39,24 @@ public class ResultStatus<T>
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="ResultStatus{T}"/> class.
+    /// </summary>
+    /// <param name="success">if set to <c>true</c> [success].</param>
+    /// <param name="value">The value.</param>
+    /// <param name="errorCode">Error code, optional for failed requests</param>
+    public ResultStatus(bool success, T value, int? errorCode)
+    {
+        Success = success;
+        Value = value;
+        ErrorCode = errorCode;
+    }
+
+    /// <summary>
     /// Creates an unsuccessful result with specified value.
     /// </summary>
     /// <param name="value">The value.</param>
-    /// <returns></returns>
-    public static ResultStatus<T> Unsuccessful(T value) => new(false, value);
+    /// <param name="errorCode">Optional error code</param>
+    public static ResultStatus<T> Unsuccessful(T value, int? errorCode = null) => new(false, value, errorCode);
 
     /// <summary>
     /// Creates a successful result with specified value

--- a/src/protagonist/DLCS.Repository/NamedQueries/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Infrastructure/ServiceCollectionX.cs
@@ -19,6 +19,7 @@ public static class ServiceCollectionX
     {
         services
             .AddScoped<PdfNamedQueryParser>()
+            .AddScoped<RawNamedQueryParser>()
             .AddScoped<INamedQueryRepository, NamedQueryRepository>()
             .AddScoped<NamedQueryConductor>()
             .AddScoped<NamedQueryStorageService>()
@@ -27,6 +28,7 @@ public static class ServiceCollectionX
                 NamedQueryType.PDF => provider.GetRequiredService<PdfNamedQueryParser>(),
                 NamedQueryType.IIIF => provider.GetRequiredService<IIIFNamedQueryParser>(),
                 NamedQueryType.Zip => provider.GetRequiredService<ZipNamedQueryParser>(),
+                NamedQueryType.Raw => provider.GetRequiredService<RawNamedQueryParser>(),
                 _ => throw new ArgumentOutOfRangeException(nameof(outputFormat), outputFormat, null)
             });
 

--- a/src/protagonist/DLCS.Repository/NamedQueries/NamedQueryType.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/NamedQueryType.cs
@@ -22,7 +22,12 @@ public enum NamedQueryType
     /// <summary>
     /// NamedQuery will be projected to ZIP archive containing images.
     /// </summary>
-    Zip
+    Zip,
+    
+    /// <summary>
+    /// NamedQuery will be projected to an array of matching assets
+    /// </summary>
+    Raw
 }
 
 public static class NamedQueryTypeDeriver
@@ -35,6 +40,7 @@ public static class NamedQueryTypeDeriver
         if (typeof(T) == typeof(IIIFParsedNamedQuery)) return NamedQueryType.IIIF;
         if (typeof(T) == typeof(PdfParsedNamedQuery)) return NamedQueryType.PDF;
         if (typeof(T) == typeof(ZipParsedNamedQuery)) return NamedQueryType.Zip;
+        if (typeof(T) == typeof(ParsedNamedQuery)) return NamedQueryType.Raw;
 
         throw new ArgumentOutOfRangeException(nameof(T), "Unable to determine NamedQueryType from result type");
     }

--- a/src/protagonist/DLCS.Repository/NamedQueries/Parsing/RawNamedQueryParser.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Parsing/RawNamedQueryParser.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using DLCS.Model.Assets.NamedQueries;
+using Microsoft.Extensions.Logging;
+
+namespace DLCS.Repository.NamedQueries.Parsing;
+
+/// <summary>
+/// Named query parser for rendering raw asset results
+/// </summary>
+public class RawNamedQueryParser : BaseNamedQueryParser<ParsedNamedQuery>
+{
+    public RawNamedQueryParser(ILogger<IIIFNamedQueryParser> logger)
+        : base(logger)
+    {
+    }
+    
+    protected override void CustomHandling(List<string> queryArgs, string key, string value, ParsedNamedQuery assetQuery)
+    {
+        // no-op
+    }
+
+    protected override ParsedNamedQuery GenerateParsedQueryObject(int customerId)
+        => new(customerId);
+}

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -21,7 +21,7 @@ namespace Orchestrator.Tests.Integration;
 
 [Trait("Category", "Integration")]
 [Collection(DatabaseCollection.CollectionName)]
-public class NamedQueryTests: IClassFixture<ProtagonistAppFactory<Startup>>
+public class NamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
 {
     private readonly DlcsDatabaseFixture dbFixture;
     private readonly HttpClient httpClient;

--- a/src/protagonist/Orchestrator.Tests/Integration/RawNamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/RawNamedQueryTests.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using DLCS.Core.Types;
+using DLCS.Model.Assets.NamedQueries;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Orchestrator.Infrastructure.IIIF;
+using Orchestrator.Tests.Integration.Infrastructure;
+using Test.Helpers.Integration;
+
+namespace Orchestrator.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class RawNamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsDatabaseFixture dbFixture;
+    private readonly HttpClient httpClient;
+
+    public RawNamedQueryTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture databaseFixture)
+    {
+        dbFixture = databaseFixture;
+        httpClient = factory
+            .WithTestServices(services =>
+            {
+                services.AddSingleton<IIIIFAuthBuilder, FakeAuth2Client>();
+            })
+            .WithConnectionString(dbFixture.ConnectionString)
+            .CreateClient();
+
+        dbFixture.CleanUp();
+
+        // Setup a basic NQ for testing
+        dbFixture.DbContext.NamedQueries.Add(new NamedQuery
+        {
+            Customer = 99, Global = false, Id = Guid.NewGuid().ToString(), Name = "test-raw-named-query",
+            Template = "assetOrdering=n1&s1=p1&space=p2"
+        });
+        
+        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-1"), num1: 2, ref1: "my-ref");
+        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-2"), num1: 1, ref1: "my-ref");
+        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
+            maxUnauthorised: 10, roles: "default");
+        dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 4, ref1: "my-ref",
+            notForDelivery: true);
+        
+        dbFixture.DbContext.SaveChanges();
+    }
+    
+    [Theory]
+    [InlineData("raw-resource/99/unknown-nq")]
+    [InlineData("raw-resource/test/unknown-nq")]
+    public async Task Options_Returns200_WithCorsHeaders(string path)
+    {
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Options, path);
+        var response = await httpClient.SendAsync(request);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Should().ContainKey("Access-Control-Allow-Origin");
+        response.Headers.Should().ContainKey("Access-Control-Allow-Headers");
+        response.Headers.Should().ContainKey("Access-Control-Allow-Methods");
+    }
+
+    [Theory]
+    [InlineData("raw-resource/99/unknown-nq")]
+    [InlineData("raw-resource/test/unknown-nq")]
+    public async Task Get_Returns404_IfNQNotFound(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData("raw-resource/98/test-raw-named-query")]
+    [InlineData("raw-resource/foo/test-raw-named-query")]
+    public async Task Get_Returns404_IfCustomerNotFound(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Theory]
+    [InlineData("raw-resource/99/test-raw-named-query/my-ref")]
+    [InlineData("raw-resource/test/test-raw-named-query/my-ref")]
+    public async Task Get_Returns200_IfNamedQueryParametersLessThanMax(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+    
+    [Theory]
+    [InlineData("raw-resource/99/test-raw-named-query")]
+    [InlineData("raw-resource/test/test-raw-named-query")]
+    public async Task Get_Returns400_IfNoNamedQueryParameters(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Theory]
+    [InlineData("raw-resource/99/test-raw-named-query/not-found-ref/1")]
+    [InlineData("raw-resource/test/test-raw-named-query/not-found-ref/1")]
+    public async Task Get_Returns404_IfNoMatchingAssets(string path)
+    {
+        // Act
+        var response = await httpClient.GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory]
+    [InlineData("raw-resource/99/test-raw-named-query/my-ref/1")]
+    [InlineData("raw-resource/test/test-raw-named-query/my-ref/1")]
+    public async Task Get_ReturnsCorrectList(string path)
+    {
+        // Arrange
+        var expectedMatches = new List<string>
+        {
+            "99/1/matching-1", "99/1/matching-2", "99/1/matching-nothumbs"
+        };
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var results = JsonConvert.DeserializeObject<List<string>>(await response.Content.ReadAsStringAsync());
+        results.Should().BeEquivalentTo(expectedMatches);
+    }
+    
+    [Fact]
+    public async Task Get_ReturnsManifestWithCorrectlyOrderedItems()
+    {
+        // Arrange
+        dbFixture.DbContext.NamedQueries.Add(new NamedQuery
+        {
+            Customer = 99, Global = false, Id = Guid.NewGuid().ToString(), Name = "raw-ordered-manifest",
+            Template = "assetOrder=n1;n2 desc;s1&s2=p1"
+        });
+
+        await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/third"), num1: 1, num2: 10, ref1: "z",
+            ref2: "grace").WithTestThumbnailMetadata();;
+        await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/first"), num1: 1, num2: 20, ref1: "c",
+            ref2: "grace").WithTestThumbnailMetadata();;
+        await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/fourth"), num1: 2, num2: 10, ref1: "a",
+            ref2: "grace").WithTestThumbnailMetadata();;
+        await dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/second"), num1: 1, num2: 10, ref1: "x",
+            ref2: "grace").WithTestThumbnailMetadata();;
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var expectedOrder = new[] { "99/1/first", "99/1/second", "99/1/third", "99/1/fourth" };
+
+        const string path = "raw-resource/99/raw-ordered-manifest/grace";
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        var results = JsonConvert.DeserializeObject<List<string>>(await response.Content.ReadAsStringAsync());
+
+        results.Should().BeEquivalentTo(expectedOrder);
+    }
+}

--- a/src/protagonist/Orchestrator/Features/Query/QueryController.cs
+++ b/src/protagonist/Orchestrator/Features/Query/QueryController.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core.Caching;
+using DLCS.Core.Collections;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Orchestrator.Features.Query.Requests;
+using Orchestrator.Infrastructure;
+
+namespace Orchestrator.Features.Query;
+
+[Route("raw-resource")]
+[ApiController]
+public class QueryController : Controller
+{
+    private readonly IMediator mediator;
+    private readonly CacheSettings cacheSettings;
+
+    public QueryController(IMediator mediator, IOptions<CacheSettings> cacheSettings)
+    {
+        this.mediator = mediator;
+        this.cacheSettings = cacheSettings.Value;
+    }
+    
+    /// <summary>
+    /// Get results of asset ids matching named query
+    /// </summary>
+    /// <returns>Matching AssetIds for results of specified named query</returns>
+    [Route("{customer}/{namedQueryName}/{**namedQueryArgs}")]
+    [HttpGet]
+    public async Task<IActionResult> Index(string customer, string namedQueryName, string? namedQueryArgs = null,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new GetNamedQueryAssetIds(customer, namedQueryName, namedQueryArgs);
+        var results = await mediator.Send(request, cancellationToken);
+
+        if (results.Success && !results.Value.IsNullOrEmpty())
+        {
+            SetCacheControlHeaders();
+            return Ok(results.Value.Select(v => v.ToString()));
+        }
+
+        if ((results.ErrorCode ?? 0) == 400) return BadRequest();
+        
+        return NotFound();
+    }
+    
+    private void SetCacheControlHeaders()
+    {
+        var maxAge = TimeSpan.FromSeconds(cacheSettings.GetTtl(CacheDuration.Default, CacheSource.Http));
+        this.SetCacheControl(false, maxAge);
+    }
+}
+

--- a/src/protagonist/Orchestrator/Features/Query/Requests/GetNamedQueryAssetIds.cs
+++ b/src/protagonist/Orchestrator/Features/Query/Requests/GetNamedQueryAssetIds.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DLCS.Core;
+using DLCS.Core.Types;
+using DLCS.Model.Assets.NamedQueries;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Orchestrator.Infrastructure.NamedQueries.Requests;
+
+namespace Orchestrator.Features.Query.Requests;
+
+/// <summary>
+/// Get asset-id of every asset matching named query 
+/// </summary>
+public class GetNamedQueryAssetIds : IBaseNamedQueryRequest, IRequest<ResultStatus<IEnumerable<AssetId>>>
+{
+    public string CustomerPathValue { get; }
+    
+    public string NamedQuery { get; }
+    
+    public string? NamedQueryArgs { get; }
+    
+    public GetNamedQueryAssetIds(string customerPathValue, string namedQuery, string? namedQueryArgs)
+    {
+        CustomerPathValue = customerPathValue;
+        NamedQuery = namedQuery;
+        NamedQueryArgs = namedQueryArgs;
+    }
+}
+
+public class GetNamedQueryResultHandler : IRequestHandler<GetNamedQueryAssetIds, ResultStatus<IEnumerable<AssetId>>>
+{
+    private readonly NamedQueryResultGenerator namedQueryResultGenerator;
+
+    public GetNamedQueryResultHandler(NamedQueryResultGenerator namedQueryResultGenerator)
+    {
+        this.namedQueryResultGenerator = namedQueryResultGenerator;
+    }
+
+    public async Task<ResultStatus<IEnumerable<AssetId>>> Handle(GetNamedQueryAssetIds request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var resultContainer = await namedQueryResultGenerator.GetNamedQueryResult<ParsedNamedQuery>(request);
+            var namedQueryResult = resultContainer.NamedQueryResult;
+
+            if (namedQueryResult.ParsedQuery == null)
+                return ResultStatus<IEnumerable<AssetId>>.Unsuccessful(Enumerable.Empty<AssetId>());
+            if (namedQueryResult.ParsedQuery is { IsFaulty: true })
+                return ResultStatus<IEnumerable<AssetId>>.Unsuccessful(Enumerable.Empty<AssetId>(), 400);
+
+            var matchingAssetIds = await namedQueryResult.Results.Select(a => a.Id).ToListAsync(cancellationToken);
+            return ResultStatus<IEnumerable<AssetId>>.Successful(matchingAssetIds);
+        }
+        catch (KeyNotFoundException)
+        {
+            return ResultStatus<IEnumerable<AssetId>>.Unsuccessful(Enumerable.Empty<AssetId>(), 404);
+        }
+    }
+}


### PR DESCRIPTION
NQ result parser, returning matching AssetIds. (Basically same behaviour has `/iiif-resource/*` but returns an array of assetIds only.