### PR TITLE
Use MER<> for CreateSpace and return Conflict/Created responses

### DIFF
--- a/src/protagonist/API/Features/Space/SpaceController.cs
+++ b/src/protagonist/API/Features/Space/SpaceController.cs
@@ -102,25 +102,11 @@ public class SpaceController : HydraController
             Tags = space.DefaultTags ?? Array.Empty<string>(),
             MaxUnauthorised = space.MaxUnauthorised
         };
-
-        try
-        {
-            var newDbSpace = await Mediator.Send(command, cancellationToken);
-            var newApiSpace = newDbSpace.ToHydra(GetUrlRoots().BaseUrl);
-
-            if (!newApiSpace.Id.HasText())
-            {
-                return this.HydraProblem("New space not assigned an ID", 
-                    null, 500, "Bad Request");
-            }
-
-            return this.HydraCreated(newApiSpace);
-        }
-        catch (BadRequestException badRequestException)
-        {
-            return this.HydraProblem(badRequestException.Message, 
-                null, badRequestException.StatusCode, "Bad Request");
-        }
+        
+        return await HandleUpsert(command,
+            s => s.ToHydra(GetUrlRoots().BaseUrl),
+            errorTitle: "Failed to create space",
+            cancellationToken: cancellationToken);
     }
     
     /// <summary>


### PR DESCRIPTION
Resolves #911 

The check for ID seems to not be needed:
`API.Features.Space.Converters.SpaceConverter.ToHydra`
calls
`DLCS.HydraModel.Space.Space_ctor`
calls
`DLCS.HydraModel.DlcsResource.Init`
sets:
```
Id = BaseUrl + string.Format(uriTemplate, urlParams);
```
which uses:
```
[HydraClass(typeof(SpaceClass),
       Description = (snip),
       UriTemplate = "/customers/{0}/spaces/{1}")]
[Unstable(Note = "Under active development")]
public class Space...
```