### PR TITLE
Raise notification on customer creation

### DIFF
--- a/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/AssetNotificationSender.cs
@@ -62,7 +62,7 @@ public class AssetNotificationSender : IAssetNotificationSender
                     attributes.Add("engineNotified", "True");
                 }
 
-                changes.Add(new AssetModifiedNotification(serialisedNotification!, attributes));
+                changes.Add(new AssetModifiedNotification(serialisedNotification, attributes));
             }
         }
 

--- a/src/protagonist/API/Infrastructure/Messaging/CustomerNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/CustomerNotificationSender.cs
@@ -1,0 +1,25 @@
+using DLCS.AWS.SNS;
+using DLCS.Model.Customers;
+using Microsoft.Extensions.Logging;
+
+namespace API.Infrastructure.Messaging;
+
+public class CustomerNotificationSender : ICustomerNotificationSender
+{
+    private readonly ITopicPublisher topicPublisher;
+    private readonly ILogger<CustomerNotificationSender> logger;
+
+    public CustomerNotificationSender(ITopicPublisher topicPublisher, ILogger<CustomerNotificationSender> logger)
+    {
+        this.logger = logger;
+        this.topicPublisher = topicPublisher;
+    }
+
+    public async Task SendCustomerCreatedMessage(Customer newCustomer, CancellationToken cancellationToken = default)
+    {
+        logger.LogDebug("Sending notification of creation of customer {CustomerId}", newCustomer.Id);
+        
+        var createdCustomer = new CustomerCreatedNotification(newCustomer);
+        await topicPublisher.PublishToCustomerCreatedTopic(createdCustomer, cancellationToken);
+    }
+}

--- a/src/protagonist/API/Infrastructure/Messaging/ICustomerNotificationSender.cs
+++ b/src/protagonist/API/Infrastructure/Messaging/ICustomerNotificationSender.cs
@@ -1,0 +1,11 @@
+using DLCS.Model.Customers;
+
+namespace API.Infrastructure.Messaging;
+
+public interface ICustomerNotificationSender
+{
+    /// <summary>
+    /// Broadcast customer creation notification
+    /// </summary>
+    Task SendCustomerCreatedMessage(Customer newCustomer, CancellationToken cancellationToken = default);
+}

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -75,6 +75,7 @@ public class Startup
             .AddDataAccess(configuration)
             .AddScoped<IIngestNotificationSender, IngestNotificationSender>()
             .AddScoped<IAssetNotificationSender, AssetNotificationSender>()
+            .AddScoped<ICustomerNotificationSender, CustomerNotificationSender>()
             .AddScoped<AssetProcessor>()
             .AddScoped<DeliveryChannelProcessor>()
             .AddTransient<TimingHandler>()

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -204,7 +204,7 @@ public class TopicPublisherTests
     }
 
     [Fact]
-    public async Task PublishToCustomerCreatedTopic_ReturnsTrue_IfNoArn()
+    public async Task PublishToCustomerCreatedTopic_ReturnsFalse_IfNoArn()
     {
         // Arrange
         var notification = new CustomerCreatedNotification(new Customer());

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using DLCS.AWS.Settings;
 using DLCS.AWS.SNS;
+using DLCS.Model.Customers;
 using DLCS.Model.Messaging;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,10 +19,14 @@ public class TopicPublisherTests
     public TopicPublisherTests()
     {
         snsClient = A.Fake<IAmazonSimpleNotificationService>();
-        
+
         var settings = Options.Create(new AWSSettings
         {
-            SNS = new SNSSettings { AssetModifiedNotificationTopicArn = "arn:aws:sns:us-east-1:000000000000:knownTopic" }
+            SNS = new SNSSettings
+            {
+                AssetModifiedNotificationTopicArn = "arn:aws:sns:us-east-1:000000000000:assetModified",
+                CustomerCreatedTopicArn = "arn:aws:sns:us-east-1:000000000000:customerCreated",
+            }
         });
 
         sut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
@@ -196,6 +201,55 @@ public class TopicPublisherTests
                                                              r.MessageAttributes["engineNotified"].StringValue == "True") &&
                                                          b.PublishBatchRequestEntries.Count == 2),
                 A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task PublishToCustomerCreatedTopic_ReturnsTrue_IfNoArn()
+    {
+        // Arrange
+        var notification = new CustomerCreatedNotification(new Customer());
+        var settings = Options.Create(new AWSSettings { SNS = new SNSSettings() });
+        var noArnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+        
+        // Act
+        var result = await noArnSut.PublishToCustomerCreatedTopic(notification, CancellationToken.None);
+        
+        // Assert
+        result.Should().BeFalse("Missing Arn should result in failure");
+    }
+    
+    [Fact]
+    public async Task PublishToCustomerCreatedTopic_PublishesMessage()
+    {
+        // Arrange
+        var notification = new CustomerCreatedNotification(new Customer { Id = 1, Name = "Test" });
+        var expectedMessage = "{\"name\":\"Test\",\"id\":1}";
+        
+        // Act
+        await sut.PublishToCustomerCreatedTopic(notification, CancellationToken.None);
+        
+        // Assert
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>.That.Matches(r => r.Message == expectedMessage),
+            A<CancellationToken>._)).MustHaveHappened();
+    }
+    
+    [Theory]
+    [InlineData(HttpStatusCode.Accepted, true)]
+    [InlineData(HttpStatusCode.OK, true)]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    public async Task PublishToCustomerCreatedTopic_ReturnsSuccessDependentOnStatusCode(HttpStatusCode statusCode, bool expected)
+    {
+        // Arrange
+        var notification = new CustomerCreatedNotification(new Customer { Id = 1, Name = "Test" });
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
+            .Returns(new PublishResponse { HttpStatusCode = statusCode });
+
+        // Act
+        var result = await sut.PublishToCustomerCreatedTopic(notification, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
     }
     
     private Dictionary<string, string> GetAttributes(ChangeType changeType, bool engineNotified)

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -1,4 +1,4 @@
-﻿using DLCS.Model.Messaging;
+﻿using DLCS.Model.Customers;
 
 namespace DLCS.AWS.SNS;
 
@@ -12,9 +12,32 @@ public interface ITopicPublisher
     /// <returns>Boolean representing the overall success/failure status of all requests</returns>
     public Task<bool> PublishToAssetModifiedTopic(IReadOnlyList<AssetModifiedNotification> messages,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Asynchronously publishes a message to Customer created topic
+    /// </summary>
+    /// <returns>Boolean representing the overall success/failure status of request</returns>
+    public Task<bool> PublishToCustomerCreatedTopic(CustomerCreatedNotification message,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
 /// Represents the contents + type of change for Asset modified notification
 /// </summary>
 public record AssetModifiedNotification(string MessageContents, Dictionary<string, string> Attributes);
+
+/// <summary>
+/// Represents contents of CustomerCreation notification
+/// </summary>
+public class CustomerCreatedNotification
+{
+    public string Name { get; private set; }
+
+    public int Id { get; private set; }
+    
+    public CustomerCreatedNotification(Customer customer)
+    {
+        Id = customer.Id;
+        Name = customer.Name;
+    }
+};

--- a/src/protagonist/DLCS.AWS/Settings/SNSSettings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/SNSSettings.cs
@@ -8,6 +8,11 @@ public class SNSSettings
     public string? AssetModifiedNotificationTopicArn { get; set; }
     
     /// <summary>
+    /// Name of the SNS topic for notifying that customers have been created
+    /// </summary>
+    public string? CustomerCreatedTopicArn { get; set; }
+    
+    /// <summary>
     /// Service root for SNS. Only used if running LocalStack
     /// </summary>
     public string ServiceUrl { get; set; } = "http://localhost:4566/";


### PR DESCRIPTION
When a customer is created, the API will publish to an SNS topic for notifying any downstream subscribers. The message is simply `{"name": "new-name", "id": 1234}`

`CustomerNotificationSender` seems superfluous but I've left it in as it follows the same model as raising asset-modified notifications and gives us a hook to enrich the notification should we need to.

Failure to raise this notification will _not_ prevent customer creation or result in a 500 but instead log a warning which will need to be picked up and dealt with.

> [!IMPORTANT]
> Requires a new SNS notification to be setup for API to publish to