### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dlcs/dlcs-developers
+* @dlcs/protagonist-developers


### PR DESCRIPTION
`dlcs-developers` has grown to include people not involved in protagonist development. `protagonist-developers` is a subset of this team