### PR TITLE
Clear cache on customer creation

### DIFF
--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -1,6 +1,7 @@
-using System.Collections.Generic;
 using System.Data;
 using API.Infrastructure.Messaging;
+using API.Infrastructure.Requests;
+using DLCS.Core;
 using DLCS.Model;
 using DLCS.Model.Auth;
 using DLCS.Model.Processing;
@@ -14,7 +15,7 @@ namespace API.Features.Customer.Requests;
 /// <summary>
 /// Create a new Customer
 /// </summary>
-public class CreateCustomer : IRequest<CreateCustomerResult>
+public class CreateCustomer : IRequest<ModifyEntityResult<DLCS.Model.Customers.Customer>>
 {
     /// <summary>
     /// Customer name. Will be checked for uniqueness.
@@ -34,14 +35,7 @@ public class CreateCustomer : IRequest<CreateCustomerResult>
     }
 }
 
-public class CreateCustomerResult
-{
-    public DLCS.Model.Customers.Customer? Customer;
-    public List<string> ErrorMessages = new();
-    public bool Conflict { get; set; }
-}
-
-public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCustomerResult>
+public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEntityResult<DLCS.Model.Customers.Customer>>
 {
     private readonly DlcsContext dbContext;
     private readonly IEntityCounterRepository entityCounterRepository;
@@ -63,95 +57,76 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
         this.customerNotificationSender = customerNotificationSender;
     }
 
-    public async Task<CreateCustomerResult> Handle(CreateCustomer request, CancellationToken cancellationToken)
+    public async Task<ModifyEntityResult<DLCS.Model.Customers.Customer>> Handle(CreateCustomer request, CancellationToken cancellationToken)
     {
-        // Reproducing POST behaviour for customer in Deliverator
-        // what gets locked here?
-        var result = new CreateCustomerResult();
-        
-        await EnsureCustomerNamesNotTaken(request, result, cancellationToken);
-        if (result.ErrorMessages.Any()) return result;
-        
+        var customerNameError = await EnsureCustomerNamesNotTaken(request, cancellationToken);
+        if (customerNameError != null)
+        {
+            return ModifyEntityResult<DLCS.Model.Customers.Customer>.Failure(customerNameError, WriteResult.Conflict);
+        }
+
         await using var transaction = 
             await dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         
-        var newModelId = await GetIdForNewCustomer();
-        result.Customer = await CreateCustomer(request, cancellationToken, newModelId);
+        var customer = await CreateCustomer(request, cancellationToken);
+        var newCustomerId = customer.Id;
 
-        // create an entity counter for space IDs [CreateCustomerSpaceEntityCounterBehaviour]
-        await entityCounterRepository.Create(result.Customer.Id, KnownEntityCounters.CustomerSpaces, result.Customer.Id.ToString());
+        // create an entity counter for space IDs
+        await entityCounterRepository.Create(newCustomerId, KnownEntityCounters.CustomerSpaces, newCustomerId.ToString());
 
-        // Create a clickthrough auth service [CreateClickthroughAuthServiceBehaviour]
-        var clickThrough = authServicesRepository.CreateAuthService(
-            result.Customer.Id, string.Empty, "clickthrough", 600);
-        // Create a logout auth service [CreateLogoutAuthServiceBehaviour]
-        var logout = authServicesRepository.CreateAuthService(
-            result.Customer.Id, "http://iiif.io/api/auth/1/logout", "logout", 600);
-        clickThrough.ChildAuthService = logout.Id;
-        
-        // Make a Role for clickthrough [CreateClickthroughRoleBehaviour]
-        var clickthroughRole = authServicesRepository.CreateRole("clickthrough", result.Customer.Id, clickThrough.Id);
-        
-        // Save these [UpdateAuthServiceBehaviour x2, UpdateRoleBehaviour]
-        // Like this?
-        // authServicesRepository.SaveAuthService(clickThrough);
-        // authServicesRepository.SaveAuthService(logout);
-        // authServicesRepository.SaveRole(clickthroughRole);
-        // or like this?
-        await dbContext.AuthServices.AddAsync(clickThrough, cancellationToken);
-        await dbContext.AuthServices.AddAsync(logout, cancellationToken);
-        await dbContext.Roles.AddAsync(clickthroughRole, cancellationToken);
-        
+        await CreateAuthServices(cancellationToken, newCustomerId);
+
         // Create both a default and priority queue
         await dbContext.Queues.AddRangeAsync(
-            new Queue { Customer = result.Customer.Id, Name = QueueNames.Default, Size = 0 },
-            new Queue { Customer = result.Customer.Id, Name = QueueNames.Priority, Size = 0 }
+            new Queue { Customer = newCustomerId, Name = QueueNames.Default, Size = 0 },
+            new Queue { Customer = newCustomerId, Name = QueueNames.Priority, Size = 0 }
         );
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        var deliveryChannelPoliciesCreated = await deliveryChannelPolicyRepository.SeedDeliveryChannelsData(result.Customer.Id);
+        var deliveryChannelPoliciesCreated = await deliveryChannelPolicyRepository.SeedDeliveryChannelsData(newCustomerId);
 
         if (deliveryChannelPoliciesCreated)
         {
             await transaction.CommitAsync(cancellationToken);
-            await customerNotificationSender.SendCustomerCreatedMessage(result.Customer, cancellationToken);
-            return result;
+            await customerNotificationSender.SendCustomerCreatedMessage(customer, cancellationToken);
+            return ModifyEntityResult<DLCS.Model.Customers.Customer>.Success(customer, WriteResult.Created);
         }
         
-        result = new CreateCustomerResult()
-        {
-            ErrorMessages = new List<string>()
-            {
-                "Failed to create customer"
-            }
-        };
-        
         await transaction.RollbackAsync(cancellationToken);
-        
 
-        // [UpdateCustomerBehaviour] - customer has already been saved.
-        // The problem here is that we have had:
-        // - some direct use of dbContext
-        // - some calls to repositories that use EF (and do their own SaveChanges)
-        // - some calls to repositories that use Dapper
-        
-        return result;
+        return ModifyEntityResult<DLCS.Model.Customers.Customer>.Failure("Failed to create customer",
+            WriteResult.Error);
     }
 
-    // Does this belong on ICustomerRepository?
-    private async Task<DLCS.Model.Customers.Customer> CreateCustomer(
-        CreateCustomer request, 
-        CancellationToken cancellationToken, 
-        int newModelId)
+    private async Task CreateAuthServices(CancellationToken cancellationToken, int newCustomerId)
     {
+        // Create a clickthrough auth service
+        var clickThrough = authServicesRepository.CreateAuthService(newCustomerId, string.Empty, "clickthrough", 600);
+        // Create a logout auth service
+        var logout =
+            authServicesRepository.CreateAuthService(newCustomerId, "http://iiif.io/api/auth/1/logout", "logout", 600);
+        clickThrough.ChildAuthService = logout.Id;
+        
+        // Make a Role for clickthrough
+        var clickthroughRole = authServicesRepository.CreateRole("clickthrough", newCustomerId, clickThrough.Id);
+        
+        await dbContext.AuthServices.AddAsync(clickThrough, cancellationToken);
+        await dbContext.AuthServices.AddAsync(logout, cancellationToken);
+        await dbContext.Roles.AddAsync(clickthroughRole, cancellationToken);
+    }
+
+    private async Task<DLCS.Model.Customers.Customer> CreateCustomer(CreateCustomer request,
+        CancellationToken cancellationToken)
+    {
+        var newModelId = await GetIdForNewCustomer();
         var customer = new DLCS.Model.Customers.Customer
         {
             Id = newModelId,
             Name = request.Name,
             DisplayName = request.DisplayName,
             Administrator = false,
-            Created = DateTime.UtcNow,  
+            Created = DateTime.UtcNow,
             AcceptedAgreement = true,
             Keys = Array.Empty<string>()
         };
@@ -161,7 +136,7 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
         return customer;
     }
 
-    private async Task EnsureCustomerNamesNotTaken(CreateCustomer request, CreateCustomerResult result, CancellationToken cancellationToken)
+    private async Task<string?> EnsureCustomerNamesNotTaken(CreateCustomer request, CancellationToken cancellationToken)
     {
         // This could use customerRepository.GetCustomer(request.Name), but we want to be a bit more restrictive.
         var allCustomers = await dbContext.Customers.ToListAsync(cancellationToken);
@@ -170,17 +145,17 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer, CreateCusto
             => c.Name.Equals(request.Name, StringComparison.InvariantCultureIgnoreCase));
         if (existing != null)
         {
-            result.Conflict = true;
-            result.ErrorMessages.Add("A customer with this name (url part) already exists.");
+            return "A customer with this name (url part) already exists.";
         }
 
         existing = allCustomers.SingleOrDefault(
                 c => c.DisplayName.Equals(request.DisplayName, StringComparison.InvariantCultureIgnoreCase));
         if (existing != null)
         {
-            result.Conflict = true;
-            result.ErrorMessages.Add("A customer with this display name (label) already exists.");
+            return "A customer with this display name (label) already exists.";
         }
+
+        return null;
     }
 
     private async Task<int> GetIdForNewCustomer()

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using API.Infrastructure.Messaging;
 using API.Infrastructure.Requests;
+using API.Infrastructure.Requests.Pipelines;
 using DLCS.Core;
 using DLCS.Model;
 using DLCS.Model.Auth;
@@ -15,7 +16,7 @@ namespace API.Features.Customer.Requests;
 /// <summary>
 /// Create a new Customer
 /// </summary>
-public class CreateCustomer : IRequest<ModifyEntityResult<DLCS.Model.Customers.Customer>>
+public class CreateCustomer : IRequest<ModifyEntityResult<DLCS.Model.Customers.Customer>>, IInvalidateCaches
 {
     /// <summary>
     /// Customer name. Will be checked for uniqueness.
@@ -33,6 +34,8 @@ public class CreateCustomer : IRequest<ModifyEntityResult<DLCS.Model.Customers.C
         Name = name;
         DisplayName = displayName;
     }
+
+    public string[] InvalidatedCacheKeys => new[] { CacheKeys.CustomerIdLookup, CacheKeys.CustomerNameLookup };
 }
 
 public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEntityResult<DLCS.Model.Customers.Customer>>

--- a/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/API/Infrastructure/ServiceCollectionX.cs
@@ -26,6 +26,7 @@ using DLCS.Model.Storage;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Auth;
+using DLCS.Repository.CustomerPath;
 using DLCS.Repository.Customers;
 using DLCS.Repository.Entities;
 using DLCS.Repository.Policies;
@@ -75,7 +76,7 @@ public static class ServiceCollectionX
             .AddSingleton<IQueueLookup, SqsQueueLookup>()
             .AddSingleton<IQueueSender, SqsQueueSender>()
             .AddScoped<ITopicPublisher, TopicPublisher>()
-            .AddSingleton<IPathCustomerRepository, CustomerPathElementRepository>()
+            .AddSingleton<IPathCustomerRepository, BulkCustomerPathElementRepository>()
             .AddSingleton<SqsQueueUtilities>()
             .AddSingleton<IElasticTranscoderWrapper, ElasticTranscoderWrapper>()
             .SetupAWS(configuration, webHostEnvironment)

--- a/src/protagonist/DLCS.Repository.Tests/CustomerPath/BulkCustomerPathElementRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/CustomerPath/BulkCustomerPathElementRepositoryTests.cs
@@ -3,20 +3,21 @@ using System.Collections.Generic;
 using DLCS.Core.Caching;
 using DLCS.Model.Customers;
 using DLCS.Model.PathElements;
+using DLCS.Repository.CustomerPath;
 using FakeItEasy;
 using LazyCache.Mocks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
-namespace DLCS.Repository.Tests;
+namespace DLCS.Repository.Tests.CustomerPath;
 
-public class CustomerPathElementRepositoryTests
+public class BulkCustomerPathElementRepositoryTests
 {
-    private readonly CustomerPathElementRepository sut;
+    private readonly BulkCustomerPathElementRepository sut;
     private const int CustomerId = 3;
     private const string CustomerName = "Robert-Paulson";
     
-    public CustomerPathElementRepositoryTests()
+    public BulkCustomerPathElementRepositoryTests()
     {
         var customerRepository = A.Fake<ICustomerRepository>();
         A.CallTo(() => customerRepository.GetCustomerIdLookup())
@@ -24,8 +25,8 @@ public class CustomerPathElementRepositoryTests
         
         var appCache = new MockCachingService();
 
-        sut = new CustomerPathElementRepository(appCache, Options.Create(new CacheSettings()), customerRepository,
-            new NullLogger<CustomerPathElementRepository>());
+        sut = new BulkCustomerPathElementRepository(appCache, Options.Create(new CacheSettings()), customerRepository,
+            new NullLogger<BulkCustomerPathElementRepository>());
     }
     
     [Fact]

--- a/src/protagonist/DLCS.Repository.Tests/CustomerPath/GranularCustomerPathElementRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/CustomerPath/GranularCustomerPathElementRepositoryTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using DLCS.Core.Caching;
+using DLCS.Model.Customers;
+using DLCS.Model.PathElements;
+using DLCS.Repository.CustomerPath;
+using FakeItEasy;
+using LazyCache.Mocks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DLCS.Repository.Tests.CustomerPath;
+
+public class GranularCustomerPathElementRepositoryTests
+{
+    private readonly GranularCustomerPathElementRepository sut;
+    private readonly ICustomerRepository customerRepository;
+    private const int CustomerId = 3;
+    private const string CustomerName = "Robert-Paulson";
+    private readonly Customer customer = new() { Id = CustomerId, Name = CustomerName };
+    
+    public GranularCustomerPathElementRepositoryTests()
+    {
+        customerRepository = A.Fake<ICustomerRepository>();
+        
+        var appCache = new MockCachingService();
+
+        sut = new GranularCustomerPathElementRepository(appCache, Options.Create(new CacheSettings()), customerRepository,
+            new NullLogger<GranularCustomerPathElementRepository>());
+    }
+    
+    [Fact]
+    public async Task GetCustomerPathElement_ById_ReturnsPathElement()
+    {
+        // Arrange
+        A.CallTo(() => customerRepository.GetCustomer(CustomerId)).Returns(customer);
+        var expected = new CustomerPathElement(CustomerId, CustomerName);
+
+        // Act
+        var byId = await sut.GetCustomerPathElement(CustomerId.ToString());
+
+        // Assert
+        byId.Should().BeEquivalentTo(expected);
+    }
+    
+    [Fact]
+    public void GetCustomerPathElement_ById_ThrowsIfNotFound()
+    {
+        // Act
+        A.CallTo(() => customerRepository.GetCustomer(CustomerId.ToString())).Returns<Customer>(null);
+        Func<Task<CustomerPathElement>> action = () => sut.GetCustomerPathElement(CustomerId.ToString());
+
+        // Assert
+        action.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("Customer 3 not found");
+    }
+    
+    [Theory]
+    [InlineData("Robert-Paulson")]
+    [InlineData("robert-paulson")]
+    [InlineData("ROBERT-PAULSON")]
+    public async Task GetCustomerPathElement_ByName_AnyCase_ReturnsPathElement(string customerName)
+    {
+        // Arrange
+        A.CallTo(() => customerRepository.GetCustomer(customerName)).Returns(customer);
+        var expected = new CustomerPathElement(CustomerId, customerName);
+
+        // Act
+        var byId = await sut.GetCustomerPathElement(customerName);
+
+        // Assert
+        byId.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void GetCustomerPathElement_ByName_ThrowsIfNotFound()
+    {
+        // Act
+        A.CallTo(() => customerRepository.GetCustomer(CustomerName)).Returns<Customer>(null);
+        Func<Task<CustomerPathElement>> action = () => sut.GetCustomerPathElement(CustomerName);
+
+        // Assert
+        action.Should().ThrowAsync<KeyNotFoundException>()
+            .WithMessage("Customer Robert-Paulson not found");
+    }
+}

--- a/src/protagonist/DLCS.Repository/CacheKeys.cs
+++ b/src/protagonist/DLCS.Repository/CacheKeys.cs
@@ -7,6 +7,14 @@ public static class CacheKeys
 {
     public static string Customer(int customerId) => $"cust:{customerId}";
     
+    public static string CustomerByName(string name) => $"cbn:{name.ToLower()}";
+    
+    public static string CustomerById(int id) => $"cbi:{id}";
+
+    public static readonly string CustomerIdLookup = "CustomerIdLookup";
+    
+    public static readonly string CustomerNameLookup = "CustomerNameLookup";
+    
     public static string DefaultDeliveryChannels(int customerId) => $"defaultDeliveryChannels:{customerId}";
 
     public static string DeliveryChannelPolicies(int customerId) => $"deliveryChannelPolicies:{customerId}";

--- a/src/protagonist/DLCS.Repository/CustomerPath/BulkCustomerPathElementRepository.cs
+++ b/src/protagonist/DLCS.Repository/CustomerPath/BulkCustomerPathElementRepository.cs
@@ -4,13 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Model.Customers;
-using DLCS.Model.PathElements;
 using LazyCache;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace DLCS.Repository;
+namespace DLCS.Repository.CustomerPath;
 
 /// <summary>
 /// Class that manages looking up CustomerName to get Id, or vice versa.
@@ -20,47 +19,32 @@ namespace DLCS.Repository;
 ///  Lowercase-Name:Id - this allows us to lookup "Customer", "customer", "CUSTOMER" to get Id
 ///  Id:Name - this allows us to use Id to get name as saved in DB 
 /// </remarks>
-public class CustomerPathElementRepository : IPathCustomerRepository
+public class BulkCustomerPathElementRepository : CustomerPathElementTemplate
 {
     private readonly ICustomerRepository customerRepository;
-    private readonly ILogger<CustomerPathElementRepository> logger;
+    private readonly ILogger<BulkCustomerPathElementRepository> logger;
     private readonly CacheSettings cacheSettings;
     private readonly IAppCache appCache;
 
-    public CustomerPathElementRepository(
+    public BulkCustomerPathElementRepository(
         IAppCache appCache,
         IOptions<CacheSettings> cacheOptions,
         ICustomerRepository customerRepository,
-        ILogger<CustomerPathElementRepository> logger)
+        ILogger<BulkCustomerPathElementRepository> logger)
     {
         this.customerRepository = customerRepository;
         this.logger = logger;
         this.appCache = appCache;
         cacheSettings = cacheOptions.Value;
     }
-
-    public async Task<CustomerPathElement> GetCustomerPathElement(string customerPart)
-    {
-        // customerPart can be an int or a string name
-        if (int.TryParse(customerPart, out var customerId))
-        {
-            var customerName = await GetCustomerName(customerId);
-            return new CustomerPathElement(customerId, customerName);
-        }
-        else
-        {
-            customerId = await GetCustomerId(customerPart);
-            return new CustomerPathElement(customerId, customerPart);
-        }
-    }
-
-    private async Task<int> GetCustomerId(string customerName)
+    
+    protected override async Task<int> GetCustomerId(string customerName)
     {
         var idLookup = await GetIdLookup();
         return idLookup[customerName.ToLower()];
     }
 
-    private async Task<string> GetCustomerName(int customerId)
+    protected override async Task<string> GetCustomerName(int customerId)
     {
         var nameLookup = await GetNameLookup();
         return nameLookup[customerId];
@@ -68,29 +52,24 @@ public class CustomerPathElementRepository : IPathCustomerRepository
 
     private Task<Dictionary<string, int>> GetIdLookup()
         => GetLookupResult(
-            "CustomerIdLookup",
+            CacheKeys.CustomerIdLookup,
             customerIdLookup => customerIdLookup.ToDictionary(kvp => kvp.Key.ToLower(), kvp => kvp.Value));
 
     private Task<Dictionary<int, string>> GetNameLookup()
         => GetLookupResult(
-            "CustomerNameLookup",
+            CacheKeys.CustomerNameLookup,
             customerIdLookup => customerIdLookup.ToDictionary(kvp => kvp.Value, kvp => kvp.Key));
 
     /// <summary>
     /// Id:Name and Name:Id lookup are the same data reversed. This method takes a transform function to convert from
     /// Name:Id to relevant shape to cache 
     /// </summary>
-    /// <param name="cacheKey"></param>
-    /// <param name="transformer"></param>
-    /// <typeparam name="T"></typeparam>
     /// <returns>Transformed object</returns>
-    private Task<T> GetLookupResult<T>(string cacheKey, Func<Dictionary<string, int>, T> transformer)
-    {
-        return appCache.GetOrAddAsync(cacheKey, async () =>
+    private Task<T> GetLookupResult<T>(string cacheKey, Func<Dictionary<string, int>, T> transformer) =>
+        appCache.GetOrAddAsync(cacheKey, async () =>
         {
             logger.LogDebug("Refreshing customer lookup {CacheKey} from database", cacheKey);
             var customerIdLookup = await customerRepository.GetCustomerIdLookup();
             return transformer(customerIdLookup);
         }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long, priority: CacheItemPriority.High));
-    }
 }

--- a/src/protagonist/DLCS.Repository/CustomerPath/CustomerPathElementTemplate.cs
+++ b/src/protagonist/DLCS.Repository/CustomerPath/CustomerPathElementTemplate.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using DLCS.Model.PathElements;
+
+namespace DLCS.Repository.CustomerPath;
+
+/// <summary>
+/// Base template for <see cref="IPathCustomerRepository"/> implementations
+/// </summary>
+public abstract class CustomerPathElementTemplate : IPathCustomerRepository
+{
+    public async Task<CustomerPathElement> GetCustomerPathElement(string customerPart)
+    {
+        // customerPart can be an int or a string name
+        if (int.TryParse(customerPart, out var customerId))
+        {
+            var customerName = await GetCustomerName(customerId);
+            return new CustomerPathElement(customerId, customerName);
+        }
+        else
+        {
+            customerId = await GetCustomerId(customerPart);
+            return new CustomerPathElement(customerId, customerPart);
+        }
+    }
+
+    protected abstract Task<int> GetCustomerId(string customerName);
+    
+    protected abstract Task<string> GetCustomerName(int customerId);
+}

--- a/src/protagonist/DLCS.Repository/CustomerPath/GranularCustomerPathElementRepository.cs
+++ b/src/protagonist/DLCS.Repository/CustomerPath/GranularCustomerPathElementRepository.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DLCS.Core.Caching;
+using DLCS.Model.Customers;
+using LazyCache;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DLCS.Repository.CustomerPath;
+
+/// <summary>
+/// Class that manages looking up CustomerName to get Id, or vice versa.
+/// </summary>
+/// <remarks>
+/// Internally this is a read-through cache and has multiple cached lookups values. Customers are added as they are
+/// requested. This can result in slightly more requests to DB than <see cref="BulkCustomerPathElementRepository"/> but
+/// reduces need to invalidate when new customers are created. 
+/// </remarks>
+public class GranularCustomerPathElementRepository : CustomerPathElementTemplate
+{
+    private readonly ICustomerRepository customerRepository;
+    private readonly ILogger<GranularCustomerPathElementRepository> logger;
+    private readonly CacheSettings cacheSettings;
+    private readonly IAppCache appCache;
+
+    public GranularCustomerPathElementRepository(
+        IAppCache appCache,
+        IOptions<CacheSettings> cacheOptions,
+        ICustomerRepository customerRepository,
+        ILogger<GranularCustomerPathElementRepository> logger)
+    {
+        this.customerRepository = customerRepository;
+        this.logger = logger;
+        this.appCache = appCache;
+        cacheSettings = cacheOptions.Value;
+    }
+    
+    protected override Task<int> GetCustomerId(string customerName)
+        => GetCustomerLookup<string, int>(customerName,
+            CacheKeys.CustomerByName(customerName),
+            -99,
+            s => customerRepository.GetCustomer(s),
+            customer => customer.Id);
+
+    protected override Task<string> GetCustomerName(int customerId)
+        => GetCustomerLookup<int, string>(customerId,
+            CacheKeys.CustomerById(customerId),
+            "_nocust_",
+            i => customerRepository.GetCustomer(i),
+            customer => customer.Name);
+    
+    private async Task<TOut> GetCustomerLookup<TIn, TOut>(TIn customerLookup, string cacheKey, TOut nullValue,
+        Func<TIn, Task<Customer?>> query, Func<Customer, TOut> propertyFinder)
+    {
+        var customerProp = await appCache.GetOrAddAsync(cacheKey, async entry =>
+        {
+            logger.LogDebug("Refreshing customer lookup {CacheKey} from database", cacheKey);
+            var customer = await query(customerLookup);
+            if (customer == null)
+            {
+                entry.SetAbsoluteExpiration(TimeSpan.FromSeconds(cacheSettings.GetTtl(CacheDuration.Short)));
+                return nullValue;
+            }
+            return propertyFinder(customer);
+        }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long, priority: CacheItemPriority.High));
+
+        return customerProp == null || customerProp.Equals(nullValue)
+            ? throw new KeyNotFoundException($"Customer {customerLookup} not found")
+            : customerProp;
+    }
+}

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -14,6 +14,7 @@ using DLCS.Repository;
 using DLCS.Repository.Assets;
 using DLCS.Repository.Assets.CustomHeaders;
 using DLCS.Repository.Auth;
+using DLCS.Repository.CustomerPath;
 using DLCS.Repository.Customers;
 using DLCS.Repository.Policies;
 using DLCS.Repository.Strategy;
@@ -50,7 +51,7 @@ public static class ServiceCollectionX
     public static IServiceCollection AddDataAccess(this IServiceCollection services, IConfiguration configuration)
         => services
             .AddSingleton<ICustomerRepository, DapperCustomerRepository>()
-            .AddSingleton<IPathCustomerRepository, CustomerPathElementRepository>()
+            .AddSingleton<IPathCustomerRepository, GranularCustomerPathElementRepository>()
             .AddSingleton<AssetCachingHelper>()
             .AddSingleton<IAssetRepository, DapperAssetRepository>()
             .AddSingleton<IThumbRepository, ThumbRepository>()

--- a/src/protagonist/Thumbs/Startup.cs
+++ b/src/protagonist/Thumbs/Startup.cs
@@ -2,6 +2,7 @@ using DLCS.Core.Caching;
 using DLCS.Model.Customers;
 using DLCS.Model.PathElements;
 using DLCS.Repository;
+using DLCS.Repository.CustomerPath;
 using DLCS.Repository.Customers;
 using DLCS.Web.Configuration;
 using DLCS.Web.Logging;
@@ -49,7 +50,7 @@ public class Startup
             .AddAws(configuration, webHostEnvironment)
             .AddSingleton<AssetDeliveryPathParser>()
             .AddSingleton<ICustomerRepository, DapperCustomerRepository>()
-            .AddSingleton<IPathCustomerRepository, CustomerPathElementRepository>()
+            .AddSingleton<IPathCustomerRepository, GranularCustomerPathElementRepository>()
             .AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>();
 
         // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively


### PR DESCRIPTION
Fixes #923. Ticket was to clear API `CustomerPathElementRepository` cache, which caches a single lookup of all customers for future requests, when a new customer is created. This was done by updating `CreateCustomer` request to implement `IInvalidateCaches` and `ModifyEntityResult`.

However, `Thumbs` and `Orchestrator` also use the same `CustomerPathElementRepository` so those would need invalidate at the same time. This could be done by adding queue listeners to `Thumbs` and `Orchestrator` and invalidating on receipt of "customer-created" notification. Rather than do this I opted to create 2 `ICustomerPathElementRepository` implementations:

* `BulkCustomerPathElementRepository` - this is the same implementation as before, caching a single large lookup.
* `GranularCustomerPathElementRepository` - this is a new implementation, acting as a read through cache and caching customer values as they are requested. This will be used by `Thumbs` and `Orchestrator` to avoid needing to add queue listeners.