### PR TITLE
Introduce "BatchAssets"

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -903,7 +903,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         hydraBatch.Count.Should().Be(3);
         var batchId = hydraBatch.GetLastPathElementAsInt()!.Value;
         
-        // Db batch exists (unnecessary?)
+        // Db batch exists
         var dbBatch = await dbContext.Batches
             .Include(b => b.BatchAssets)
             .SingleAsync(i => i.Id == batchId);

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -96,7 +96,7 @@ public class AssetProcessor
                 return new ProcessAssetResult
                 {
                     Result = ModifyEntityResult<Asset>.Failure(
-                        "Delivery channels are required when updating an existing Asset via PUT",
+                        "Delivery channels are required when updating an existing Asset",
                         WriteResult.BadRequest
                     )
                 };

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -56,29 +56,15 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         this.assetNotificationSender = assetNotificationSender;
         this.logger = logger;
     }
-
+    
     public async Task<ModifyEntityResult<Batch>> Handle(CreateBatchOfImages request,
         CancellationToken cancellationToken)
     {
-        // TODO - we may need to support non-Image assets here 
-        if (request.IsPriority)
-        {
-            if (request.AssetsBeforeProcessing.Any(a =>
-                    a.Asset.Family != AssetFamily.Image && !a.Asset.HasDeliveryChannel(AssetDeliveryChannels.Image) &&
-                    !MIMEHelper.IsImage(a.Asset.MediaType)))
-            {
-                return ModifyEntityResult<Batch>.Failure("Priority queue only supports image assets",
-                    WriteResult.FailedValidation);
-            }
-        }
+        var priorityValidation = ValidatePriorityQueueRequest(request);
+        if (priorityValidation != null) return priorityValidation;
         
-        var (exists, missing) = await DoAllSpacesExist(request.CustomerId, request.AssetsBeforeProcessing.Select(a => a.Asset), cancellationToken);
-        if (!exists)
-        {
-            var spaceList = string.Join(", ", missing);
-            return ModifyEntityResult<Batch>.Failure($"The following space(s) could not be found: {spaceList}",
-                WriteResult.FailedValidation);
-        }
+        var spaceValidation = await ValidateAllSpaces(request, cancellationToken);
+        if (spaceValidation != null) return spaceValidation; 
 
         bool updateFailed = false;
         var failureMessage = string.Empty;
@@ -112,22 +98,21 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
                 }
 
                 var savedAsset = processAssetResult.Result.Entity!;
-                
-                var existingAsset = processAssetResult.ExistingAsset;
-                var assetModificationRecord = existingAsset == null
-                    ? AssetModificationRecord.Create(savedAsset)
-                    : AssetModificationRecord.Update(existingAsset, savedAsset, processAssetResult.RequiresEngineNotification);
-                assetModifiedNotificationList.Add(assetModificationRecord);
+                assetModifiedNotificationList.Add(GetAssetModificationRecord(processAssetResult, savedAsset));
                 
                 if (processAssetResult.RequiresEngineNotification)
                 {
                     engineNotificationList.Add(savedAsset);
+                    batch.AddBatchAsset(assetId);
                 }
                 else
                 {
+                    // NOTE(DG) - I think this code block is no longer accessible as alwaysReingest:true is sent to
+                    // the assetProcessor
                     logger.LogDebug(
                         "Asset {AssetId} of Batch {BatchId} does not require engine notification. Marking as complete",
                         assetId, batch.Id);
+                    batch.AddBatchAsset(assetId, BatchAssetStatus.Completed);
                     batch.Completed += 1;
                 }
             }
@@ -172,6 +157,32 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
         return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);
     }
 
+    private ModifyEntityResult<Batch>? ValidatePriorityQueueRequest(CreateBatchOfImages request)
+    {
+        if (!request.IsPriority) return null;
+
+        if (request.AssetsBeforeProcessing.Any(a =>
+                a.Asset.Family != AssetFamily.Image && !a.Asset.HasDeliveryChannel(AssetDeliveryChannels.Image) &&
+                !MIMEHelper.IsImage(a.Asset.MediaType)))
+        {
+            return ModifyEntityResult<Batch>.Failure("Priority queue only supports image assets",
+                WriteResult.FailedValidation);
+        }
+
+        return null;
+    }
+
+    private async Task<ModifyEntityResult<Batch>?> ValidateAllSpaces(CreateBatchOfImages request,
+        CancellationToken cancellationToken)
+    {
+        var (exists, missing) = await DoAllSpacesExist(request.CustomerId, request.AssetsBeforeProcessing.Select(a => a.Asset), cancellationToken);
+        if (exists) return null;
+
+        var spaceList = string.Join(", ", missing);
+        return ModifyEntityResult<Batch>.Failure($"The following space(s) could not be found: {spaceList}",
+            WriteResult.FailedValidation);
+    }
+
     private async Task<(bool Exists, IEnumerable<int> NonExistant)> DoAllSpacesExist(int customer,
         IEnumerable<Asset> assets, CancellationToken cancellationToken)
     {
@@ -188,5 +199,15 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
 
         var missing = uniqueSpaceIds.Except(matchingIds);
         return (false, missing);
+    }
+    
+    private static AssetModificationRecord GetAssetModificationRecord(ProcessAssetResult processAssetResult,
+        Asset savedAsset)
+    {
+        var existingAsset = processAssetResult.ExistingAsset;
+        var assetModificationRecord = existingAsset == null
+            ? AssetModificationRecord.Create(savedAsset)
+            : AssetModificationRecord.Update(existingAsset, savedAsset, processAssetResult.RequiresEngineNotification);
+        return assetModificationRecord;
     }
 }

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -116,11 +116,8 @@ public class CreateBatchOfImagesHandler : IRequestHandler<CreateBatchOfImages, M
                     batch.Completed += 1;
                 }
             }
-            
-            if (batch.Completed > 0)
-            {
-                await dlcsContext.SaveChangesAsync(cancellationToken);
-            }
+
+            await dlcsContext.SaveChangesAsync(cancellationToken);
 
             if (!updateFailed)
             {

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchAssets.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchAssets.cs
@@ -43,9 +43,12 @@ public class GetBatchAssetsHandler : GetBatchAssetsBase<GetBatchAssets>
     }
     
     protected override IQueryable<Asset> GetBatchAssets(DlcsContext dlcsContext, GetBatchAssets request)
-        => dlcsContext.Images
+        => dlcsContext.BatchAssets
             .AsNoTracking()
-            .IncludeDeliveryChannelsWithPolicy()
-            .Where(a => a.Customer == request.CustomerId)
-            .Include(a => a.BatchAssets.Where(ba => ba.BatchId == request.BatchId)); 
+            .Include(ba => ba.Batch)
+            .Include(ba => ba.Asset)
+            .ThenInclude(a => a.ImageDeliveryChannels.OrderBy(idc => idc.Channel))
+            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .Where(ba => ba.Batch.Id == request.BatchId && ba.Batch.Customer == request.CustomerId)
+            .Select(ba => ba.Asset);
 }

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchAssets.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchAssets.cs
@@ -1,0 +1,51 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Model.Assets;
+using DLCS.Model.Page;
+using DLCS.Repository;
+using DLCS.Repository.Assets;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Queues.Requests;
+
+/// <summary>
+/// Get details of images within batch. This uses BatchAssets table to get historical data, not just current data 
+/// </summary>
+public class GetBatchAssets : IRequest<FetchEntityResult<PageOf<Asset>>>, IPagedRequest, IOrderableRequest,
+    IAssetFilterableRequest
+{
+    public int CustomerId { get; }
+
+    public int BatchId { get; }
+
+    public AssetFilter? AssetFilter { get; }
+
+    public int Page { get; set; }
+
+    public int PageSize { get; set; }
+
+    public string? Field { get; set; }
+
+    public bool Descending { get; set; }
+
+    public GetBatchAssets(int customerId, int batchId, AssetFilter? assetFilter)
+    {
+        CustomerId = customerId;
+        BatchId = batchId;
+        AssetFilter = assetFilter;
+    }
+}
+
+public class GetBatchAssetsHandler : GetBatchAssetsBase<GetBatchAssets>
+{
+    public GetBatchAssetsHandler(DlcsContext dlcsContext) : base(dlcsContext)
+    {
+    }
+    
+    protected override IQueryable<Asset> GetBatchAssets(DlcsContext dlcsContext, GetBatchAssets request)
+        => dlcsContext.Images
+            .AsNoTracking()
+            .IncludeDeliveryChannelsWithPolicy()
+            .Where(a => a.Customer == request.CustomerId)
+            .Include(a => a.BatchAssets.Where(ba => ba.BatchId == request.BatchId)); 
+}

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchAssetsBase.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchAssetsBase.cs
@@ -1,0 +1,49 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Model.Assets;
+using DLCS.Model.Page;
+using DLCS.Repository;
+using DLCS.Repository.Assets;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Queues.Requests;
+
+public abstract class GetBatchAssetsBase<T> : IRequestHandler<T, FetchEntityResult<PageOf<Asset>>>
+    where T : GetBatchAssets
+{
+    private readonly DlcsContext dlcsContext;
+
+    protected GetBatchAssetsBase(DlcsContext dlcsContext)
+    {
+        this.dlcsContext = dlcsContext;
+    }
+
+    protected abstract IQueryable<Asset> GetBatchAssets(DlcsContext dlcsContext, T request);
+
+    public async Task<FetchEntityResult<PageOf<Asset>>> Handle(
+        T request, CancellationToken cancellationToken)
+    {
+        var result = await GetBatchAssets(dlcsContext, request).CreatePagedResult(
+            request,
+            i => i
+                .ApplyAssetFilter(request.AssetFilter, true)
+                .AsSplitQuery(),
+            images => images.AsOrderedAssetQuery(request),
+            cancellationToken);
+
+        // Any empty result set could be the result of an applied asset filter - check if batch exists
+        if (result.Total == 0 && !await DoesBatchExist(request, cancellationToken))
+        {
+            return FetchEntityResult<PageOf<Asset>>.NotFound();
+        }
+
+        return FetchEntityResult<PageOf<Asset>>.Success(result);
+    }
+
+    private async Task<bool> DoesBatchExist(T request, CancellationToken cancellationToken)
+    {
+        var batchExists = await dlcsContext.Batches.AsNoTracking()
+            .AnyAsync(b => b.Customer == request.CustomerId && b.Id == request.BatchId, cancellationToken);
+        return batchExists;
+    }
+}

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchImages.cs
@@ -1,74 +1,34 @@
-﻿using API.Infrastructure.Requests;
-using DLCS.Model.Assets;
-using DLCS.Model.Page;
+﻿using DLCS.Model.Assets;
 using DLCS.Repository;
 using DLCS.Repository.Assets;
-using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 namespace API.Features.Queues.Requests;
 
 /// <summary>
-/// Get details of images within batch
+/// Get details of images within batch. This will include images currently in that batch only
 /// </summary>
-public class GetBatchImages : IRequest<FetchEntityResult<PageOf<Asset>>>, IPagedRequest, IOrderableRequest, IAssetFilterableRequest
+/// <remarks>
+/// Although the behaviour is slightly different, this has been superseded by <see cref="GetBatchAssets"/>, which
+/// returns historical data as well as current batch data
+/// </remarks>
+public class GetBatchImages : GetBatchAssets
 {
-    public int CustomerId { get; }
-    
-    public int BatchId { get; }
-    
-    public AssetFilter? AssetFilter { get; }
-
-    public int Page { get; set; }
-    
-    public int PageSize { get; set; }
-
-    public string? Field { get; set; }
-
-    public bool Descending { get; set; }
-
     public GetBatchImages(int customerId, int batchId, AssetFilter? assetFilter)
+        : base(customerId, batchId, assetFilter)
     {
-        CustomerId = customerId;
-        BatchId = batchId;
-        AssetFilter = assetFilter;
     }
 }
 
-public class GetBatchImagesHandler : IRequestHandler<GetBatchImages, FetchEntityResult<PageOf<Asset>>>
+public class GetBatchImagesHandler : GetBatchAssetsBase<GetBatchImages>
 {
-    private readonly DlcsContext dlcsContext;
-
-    public GetBatchImagesHandler(DlcsContext dlcsContext)
+    public GetBatchImagesHandler(DlcsContext dlcsContext) : base(dlcsContext)
     {
-        this.dlcsContext = dlcsContext;
-    }
-    
-    public async Task<FetchEntityResult<PageOf<Asset>>> Handle(GetBatchImages request, CancellationToken cancellationToken)
-    {
-        var result = await dlcsContext.Images.AsNoTracking().CreatePagedResult(
-            request,
-            i => i
-                .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId)
-                .ApplyAssetFilter(request.AssetFilter, true)
-                .IncludeDeliveryChannelsWithPolicy()
-                .AsSplitQuery(),
-            images => images.AsOrderedAssetQuery(request),
-            cancellationToken);
-
-        // Any empty result set could be the result of an applied asset filter - check if batch exists
-        if (result.Total == 0 && !await DoesBatchExist(request, cancellationToken))
-        {
-            return FetchEntityResult<PageOf<Asset>>.NotFound();
-        }
-
-        return FetchEntityResult<PageOf<Asset>>.Success(result);
     }
 
-    private async Task<bool> DoesBatchExist(GetBatchImages request, CancellationToken cancellationToken)
-    {
-        var batchExists = await dlcsContext.Batches.AsNoTracking()
-            .AnyAsync(b => b.Customer == request.CustomerId && b.Id == request.BatchId, cancellationToken);
-        return batchExists;
-    }
+    protected override IQueryable<Asset> GetBatchAssets(DlcsContext dlcsContext, GetBatchImages request)
+        => dlcsContext.Images
+            .AsNoTracking()
+            .IncludeDeliveryChannelsWithPolicy()
+            .Where(a => a.Customer == request.CustomerId && a.Batch == request.BatchId);
 }

--- a/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/Model/TranscodedNotificationTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/ElasticTranscoder/Model/TranscodedNotificationTests.cs
@@ -59,4 +59,59 @@ public class TranscodedNotificationTests
         // Assert
         result.Should().BeEquivalentTo(expected);
     }
+    
+    [Fact]
+    public void GetBatchId_Null_IfNotFound()
+    {
+        // Arrange
+        var notification = new TranscodedNotification { UserMetadata = new Dictionary<string, string>() };
+        
+        // Act
+        var result = notification.GetBatchId();
+        
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("invalid-id")]
+    public void GetBatchId_Null_IfEmptyOrInvalid(string metadataValue)
+    {
+        // Arrange
+        var notification = new TranscodedNotification
+        {
+            UserMetadata = new Dictionary<string, string>
+            {
+                ["batchId"] = metadataValue
+            }
+        };
+        
+        // Act
+        var result = notification.GetBatchId();
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
+    [Fact]
+    public void GetBatchId_ReturnsId_IfFound()
+    {
+        // Arrange
+        var expected = 1888;
+        var notification = new TranscodedNotification
+        {
+            UserMetadata = new Dictionary<string, string>
+            {
+                ["batchId"] = expected.ToString()
+            }
+        };
+        
+        // Act
+        var result = notification.GetBatchId();
+        
+        // Assert
+        result.Should().Be(expected);
+    }
 }

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscodedNotification.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/Models/TranscodedNotification.cs
@@ -56,7 +56,6 @@ public class TranscodedNotification
     /// <summary>
     /// Get the AssetId for this job from user metadata
     /// </summary>
-    /// <returns></returns>
     public AssetId? GetAssetId()
     {
         try
@@ -69,5 +68,15 @@ public class TranscodedNotification
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Get the BatchId, if found, for this job from user metadata
+    /// </summary>
+    public int? GetBatchId()
+    {
+        if (!UserMetadata.TryGetValue(UserMetadataKeys.BatchId, out var rawBatchId)) return null;
+
+        return int.TryParse(rawBatchId, out var batchId) ? batchId : null;
     }
 }

--- a/src/protagonist/DLCS.AWS/ElasticTranscoder/UserMetadataKeys.cs
+++ b/src/protagonist/DLCS.AWS/ElasticTranscoder/UserMetadataKeys.cs
@@ -24,4 +24,9 @@ public static class UserMetadataKeys
     /// Key for the size of origin file saved in DLCS (may be 0)
     /// </summary>
     public const string OriginSize = "storedOriginSize";
+
+    /// <summary>
+    /// Key for the BatchId this asset is part of
+    /// </summary>
+    public const string BatchId = "batchId";
 }

--- a/src/protagonist/DLCS.Model.Tests/Assets/BatchXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/BatchXTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+
+namespace DLCS.Model.Tests.Assets;
+
+public class BatchXTests
+{
+    [Fact]
+    public void AddBatchAsset_Adds_IfBatchAssetsNull()
+    {
+        var batch = new Batch { BatchAssets = null };
+        var assetId = new AssetId(99, 100, "hi");
+        
+        batch.AddBatchAsset(assetId);
+
+        var ba = batch.BatchAssets.Single();
+        ba.Finished.Should().BeNull();
+        ba.Status.Should().Be(BatchAssetStatus.Waiting);
+    }
+    
+    [Theory]
+    [InlineData(BatchAssetStatus.Waiting)]
+    [InlineData(BatchAssetStatus.Error)]
+    [InlineData(BatchAssetStatus.Completed)]
+    public void AddBatchAsset_Adds_WithSpecifiedStatus(BatchAssetStatus status)
+    {
+        var batch = new Batch { BatchAssets = null };
+        var assetId = new AssetId(99, 100, "hi");
+        
+        batch.AddBatchAsset(assetId, status);
+
+        var ba = batch.BatchAssets.Single();
+        ba.Finished.Should().BeNull();
+        ba.Status.Should().Be(status);
+    }
+}

--- a/src/protagonist/DLCS.Model.Tests/Messaging/IngestAssetRequestTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Messaging/IngestAssetRequestTests.cs
@@ -1,0 +1,18 @@
+﻿using DLCS.Core.Types;
+using DLCS.Model.Messaging;
+
+namespace DLCS.Model.Tests.Messaging;
+
+public class IngestAssetRequestTests
+{
+    [Theory]
+    [InlineData(123, 123)]
+    [InlineData(0, null)]
+    [InlineData(null, null)]
+    public void Ctor_SetsBatchIdCorrectly(int? input, int? expected)
+    {
+        var request = new IngestAssetRequest(new AssetId(1, 2, "foo"), null, input);
+        
+        request.BatchId.Should().Be(expected);
+    }
+}

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -105,6 +105,11 @@ public class Asset : ICloneable
     /// A list of metadata attached to this asset
     /// </summary>
     public ICollection<AssetApplicationMetadata>? AssetApplicationMetadata { get; set; }
+    
+    /// <summary>
+    /// A list of batch assets attached to this asset
+    /// </summary>
+    public List<BatchAsset>? BatchAssets { get; set; }
 
     public Asset()
     {

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -70,13 +70,14 @@ public static class AssetPreparer
     /// be saved as this effectively drops validation.
     /// </param>
     /// <param name="isBatchUpdate">True if this is part of batch creation - allows Batch value to be set.</param>
+    /// <param name="disallowedCharacters">List of characters that are not allowed to be used in AssetId</param>
     /// <returns>A validation result</returns>
     public static AssetPreparationResult PrepareAssetForUpsert(
         Asset? existingAsset,
         Asset updateAsset,
         bool allowNonApiUpdates,
         bool isBatchUpdate,
-        char[]? disallowedCharacters)
+        char[] disallowedCharacters)
     {
         bool requiresReingest = existingAsset == null;
         
@@ -150,7 +151,7 @@ public static class AssetPreparer
     }
 
     private static AssetPreparationResult? ValidateRequests(Asset? existingAsset, Asset updateAsset,
-        bool allowNonApiUpdates, bool isBatchUpdate, char[]? disallowedCharacters)
+        bool allowNonApiUpdates, bool isBatchUpdate, char[] disallowedCharacters)
     {
         if (existingAsset == null)
         {

--- a/src/protagonist/DLCS.Model/Assets/Batch.cs
+++ b/src/protagonist/DLCS.Model/Assets/Batch.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using DLCS.Core.Types;
 
 namespace DLCS.Model.Assets;
 
@@ -20,5 +22,19 @@ public class Batch
     /// </summary>
     public bool Superseded { get; set; }
     
+    public List<BatchAsset>? BatchAssets { get; set; }
+    
     private string DebuggerDisplay => $"{Id}, Cust:{Customer}, {Count} item(s)";
+}
+
+public static class BatchX
+{
+    /// <summary>
+    /// Add a new <see cref="BatchAsset"/> to <see cref="Batch"/>
+    /// </summary>
+    public static Batch AddBatchAsset(this Batch batch, AssetId assetId, BatchAssetStatus status = BatchAssetStatus.Waiting)
+    {
+        (batch.BatchAssets ??= new List<BatchAsset>()).Add(new BatchAsset { AssetId = assetId, Status = status });
+        return batch;
+    }
 }

--- a/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
+++ b/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
@@ -8,7 +8,6 @@ namespace DLCS.Model.Assets;
 /// </summary>
 public class BatchAsset
 {
-    public int Id { get; set; }
     public int BatchId { get; set; }
     public AssetId AssetId { get; set; } = null!;
     public BatchAssetStatus Status { get; set; } = BatchAssetStatus.Waiting;

--- a/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
+++ b/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
@@ -1,0 +1,38 @@
+using System;
+using DLCS.Core.Types;
+
+namespace DLCS.Model.Assets;
+
+/// <summary>
+/// A record of all images that were part of a batch
+/// </summary>
+public class BatchAsset
+{
+    public int Id { get; set; }
+    public int BatchId { get; set; }
+    public AssetId AssetId { get; set; } = null!;
+    public BatchAssetStatus Status { get; set; } = BatchAssetStatus.Waiting;
+    public string? Error { get; set; }
+    public DateTime? Finished { get; set; }
+    
+    public Batch Batch { get; set; } = null!;
+    public Asset Asset { get; set; } = null!;
+}
+
+public enum BatchAssetStatus
+{
+    /// <summary>
+    /// Asset is waiting to be picked up or is in-flight
+    /// </summary>
+    Waiting,
+    
+    /// <summary>
+    /// Asset failed to ingest
+    /// </summary>
+    Error,
+    
+    /// <summary>
+    /// Asset completed successfully
+    /// </summary>
+    Completed,
+}

--- a/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
+++ b/src/protagonist/DLCS.Model/Assets/BatchAsset.cs
@@ -22,17 +22,22 @@ public class BatchAsset
 public enum BatchAssetStatus
 {
     /// <summary>
+    /// Placeholder
+    /// </summary>
+    Unknown = 0,
+    
+    /// <summary>
     /// Asset is waiting to be picked up or is in-flight
     /// </summary>
-    Waiting,
+    Waiting = 1,
     
     /// <summary>
     /// Asset failed to ingest
     /// </summary>
-    Error,
+    Error = 2,
     
     /// <summary>
     /// Asset completed successfully
     /// </summary>
-    Completed,
+    Completed = 3,
 }

--- a/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
@@ -8,6 +9,7 @@ namespace DLCS.Model.Messaging;
 /// <summary>
 /// Represents a request to ingest an asset.
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class IngestAssetRequest
 {
     /// <summary>
@@ -33,8 +35,10 @@ public class IngestAssetRequest
     {
         Id = id;
         Created = created;
-        BatchId = batchId;
+        
+        // 0 batchId represents no batch. It's cleaner if we catch that here so that engine only sees null
+        BatchId = batchId is > 0 ? batchId : null;
     }
 
-    public override string ToString() => $"IngestAssetRequest at {Created} for Asset {Id}";
+    private string DebuggerDisplay => $"IngestAssetRequest at {Created} for Asset {Id}";
 }

--- a/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
+++ b/src/protagonist/DLCS.Model/Messaging/IngestAssetRequest.cs
@@ -16,19 +16,25 @@ public class IngestAssetRequest
     public DateTime? Created { get; }
     
     /// <summary>
-    /// Get Asset to be ingested.
+    /// AssetId to be ingested.
     /// </summary>
     public AssetId Id { get; }
+    
+    /// <summary>
+    /// BatchId this ingestion operation is for
+    /// </summary>
+    /// <remarks>
+    /// When we fetch the Asset we can fetch the latest Batch it's associated with but that might be wrong
+    /// </remarks>
+    public int? BatchId { get; }
 
     [JsonConstructor]
-    public IngestAssetRequest(AssetId id, DateTime? created)
+    public IngestAssetRequest(AssetId id, DateTime? created, int? batchId)
     {
         Id = id;
         Created = created;
+        BatchId = batchId;
     }
 
-    public override string ToString()
-    {
-        return $"IngestAssetRequest at {Created} for Asset {Id}";
-    }
+    public override string ToString() => $"IngestAssetRequest at {Created} for Asset {Id}";
 }

--- a/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Messaging/EngineClientTests.cs
@@ -55,7 +55,7 @@ public class EngineClientTests
             NumberReference1 = 1234
         };
         
-        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow, null);
         HttpRequestMessage message = null;
         httpHandler.RegisterCallback(r => message = r);
         httpHandler.GetResponseMessage("{ \"engine\": \"hello\" }", HttpStatusCode.OK);
@@ -90,7 +90,7 @@ public class EngineClientTests
             NumberReference1 = 1234
         };
         
-        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
+        var ingestRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow, null);
        
         var jsonString = string.Empty;
         A.CallTo(() => queueLookup.GetQueueNameForFamily(AssetFamily.Image, false)).Returns("test-queue");

--- a/src/protagonist/DLCS.Repository/AssetIdConverter.cs
+++ b/src/protagonist/DLCS.Repository/AssetIdConverter.cs
@@ -1,0 +1,18 @@
+﻿#nullable disable
+using DLCS.Core.Types;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace DLCS.Repository;
+
+/// <summary>
+/// <see cref="ValueConverter{TModel,TProvider}"/> for converting <see cref="AssetId"/> to/from string in db
+/// </summary>
+internal class AssetIdConverter : ValueConverter<AssetId, string>
+{
+    public AssetIdConverter()
+        : base(
+            assetId => assetId.ToString(),
+            db => AssetId.FromString(db))
+    {
+    }
+}

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -29,7 +29,8 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
             Customer = customerId,
             Errors = 0,
             Submitted = DateTime.UtcNow,
-            Superseded = false
+            Superseded = false,
+            BatchAssets = new List<BatchAsset>(assets.Count),
         };
         
         postCreate?.Invoke(batch);

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -79,8 +79,16 @@ public partial class DlcsContext : DbContext
     public virtual DbSet<ImageDeliveryChannel> ImageDeliveryChannels { get; set; }
     public virtual DbSet<DefaultDeliveryChannel> DefaultDeliveryChannels { get; set; }
     public virtual DbSet<AssetApplicationMetadata> AssetApplicationMetadata { get; set; }
+    //public virtual DbSet<BatchAsset> BatchAssets { get; set; }
 
     public virtual DbSet<SignupLink> SignupLinks { get; set; }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        configurationBuilder
+            .Properties<AssetId>()
+            .HaveConversion<AssetIdConverter>();
+    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -302,10 +310,7 @@ public partial class DlcsContext : DbContext
             entity.HasIndex(e => new { e.Customer, e.Space }, "IX_ImagesBySpace");
 
             entity.Property(e => e.Id)
-                .HasMaxLength(500)
-                .HasConversion(
-                    aId => aId.ToString(),
-                    id => AssetId.FromString(id));
+                .HasMaxLength(500);
 
             entity.Property(e => e.Created)
                 .IsRequired()
@@ -395,10 +400,7 @@ public partial class DlcsContext : DbContext
             entity.ToTable("ImageLocation");
 
             entity.Property(e => e.Id)
-                .HasMaxLength(500)
-                .HasConversion(
-                    aId => aId.ToString(),
-                    id => AssetId.FromString(id));;
+                .HasMaxLength(500);
 
             entity.Property(e => e.Nas)
                 .IsRequired()
@@ -444,10 +446,7 @@ public partial class DlcsContext : DbContext
             entity.HasIndex(e => new { e.Customer, e.Space, e.Id }, "IX_ImageStorageByCustomerSpace");
 
             entity.Property(e => e.Id)
-                .HasMaxLength(500)
-                .HasConversion(
-                    aId => aId.ToString(),
-                    id => AssetId.FromString(id));;
+                .HasMaxLength(500);
 
             entity.Property(e => e.LastChecked).HasColumnType("timestamp with time zone");
         });
@@ -660,12 +659,8 @@ public partial class DlcsContext : DbContext
             entity.Property(e => e.Id).HasMaxLength(100);
 
             entity.Property(e => e.Channel).IsRequired();
-            
-            entity.Property(e => e.ImageId)
-                .IsRequired()
-                .HasConversion(
-                    aId => aId.ToString(),
-                    id => AssetId.FromString(id));
+
+            entity.Property(e => e.ImageId).IsRequired();
 
             entity.HasOne<Asset>()
                 .WithMany(e => e.ImageDeliveryChannels)
@@ -685,11 +680,7 @@ public partial class DlcsContext : DbContext
         modelBuilder.Entity<AssetApplicationMetadata>(entity =>
         {
             entity.HasKey(e => new { e.AssetId, e.MetadataType });
-            entity.Property(e => e.AssetId).IsRequired().HasConversion(
-                aId => aId.ToString(),
-                id => AssetId.FromString(id));
-            entity.Property(e => e.MetadataType).IsRequired();
-            entity.Property(e => e.MetadataValue).IsRequired().HasColumnType("jsonb");
+            entity.Property(e => e.MetadataValue).HasColumnType("jsonb");
             
             entity.HasOne(e => e.Asset)
                 .WithMany(e => e.AssetApplicationMetadata)

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -79,7 +79,7 @@ public partial class DlcsContext : DbContext
     public virtual DbSet<ImageDeliveryChannel> ImageDeliveryChannels { get; set; }
     public virtual DbSet<DefaultDeliveryChannel> DefaultDeliveryChannels { get; set; }
     public virtual DbSet<AssetApplicationMetadata> AssetApplicationMetadata { get; set; }
-    //public virtual DbSet<BatchAsset> BatchAssets { get; set; }
+    public virtual DbSet<BatchAsset> BatchAssets { get; set; }
 
     public virtual DbSet<SignupLink> SignupLinks { get; set; }
 

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -687,6 +687,11 @@ public partial class DlcsContext : DbContext
                 .HasForeignKey(e => e.AssetId);
         });
 
+        modelBuilder.Entity<BatchAsset>(entity =>
+        {
+            entity.HasKey(ba => new { ba.BatchId, ba.AssetId, });
+        });
+
         OnModelCreatingPartial(modelBuilder);
     }
 

--- a/src/protagonist/DLCS.Repository/DlcsContextConfiguration.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContextConfiguration.cs
@@ -49,6 +49,14 @@ public static class DlcsContextConfiguration
     public static DlcsContext GetNewDbContext(IConfiguration configuration)
         => new(GetOptionsBuilder(configuration).Options);
 
+    /// <summary>
+    /// Setup <see cref="DbContextOptionsBuilder"/> specific to DLCS
+    /// </summary>
+    /// <remarks>This is a single place to setup options for both running app and testing</remarks>
+    public static T SetupDlcsContextOptions<T>(this T optionsBuilder, string connectionString)
+        where T : DbContextOptionsBuilder
+        => (T)optionsBuilder.UseNpgsql(connectionString, builder => builder.SetPostgresVersion(13, 0));
+
     private static DbContextOptionsBuilder<DlcsContext> GetOptionsBuilder(IConfiguration configuration)
     {
         var optionsBuilder = new DbContextOptionsBuilder<DlcsContext>();
@@ -56,8 +64,6 @@ public static class DlcsContextConfiguration
         return optionsBuilder;
     }
 
-    private static void SetupOptions(IConfiguration configuration,
-        DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseNpgsql(configuration.GetConnectionString(ConnectionStringKey), builder => builder.SetPostgresVersion(13, 0));
-
+    private static void SetupOptions(IConfiguration configuration, DbContextOptionsBuilder optionsBuilder)
+        => optionsBuilder.SetupDlcsContextOptions(configuration.GetConnectionString(ConnectionStringKey));
 }

--- a/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/EngineClient.cs
@@ -179,9 +179,9 @@ public class EngineClient : IEngineClient
         }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long));
     }
     
-    private string GetJsonString(Asset asset)
+    private static string GetJsonString(Asset asset)
     {
-        var ingestAssetRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow);
+        var ingestAssetRequest = new IngestAssetRequest(asset.Id, DateTime.UtcNow, asset.Batch);
         var jsonString = JsonSerializer.Serialize(ingestAssetRequest, SerializerOptions);
         return jsonString;
     }

--- a/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
+++ b/src/protagonist/DLCS.Repository/Messaging/IEngineClient.cs
@@ -15,7 +15,6 @@ public interface IEngineClient
     /// This shouldn't be used frequently as it can be relatively long running.
     /// </summary>
     /// <param name="asset">The asset the request is for</param>
-    /// <param name="derivativesOnly">If true, only derivatives will be generated</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>HttpStatusCode returned from engine.</returns>
     Task<HttpStatusCode> SynchronousIngest(Asset asset,  CancellationToken cancellationToken = default);

--- a/src/protagonist/DLCS.Repository/Migrations/20250107145354_Add BatchAssets.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250107145354_Add BatchAssets.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20250107145354_Add BatchAssets")]
+    partial class AddBatchAssets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20250107145354_Add BatchAssets.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250107145354_Add BatchAssets.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class AddBatchAssets : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "BatchAssets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    BatchId = table.Column<int>(type: "integer", nullable: false),
+                    AssetId = table.Column<string>(type: "character varying(500)", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Error = table.Column<string>(type: "text", nullable: true),
+                    Finished = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_BatchAssets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_BatchAssets_Batches_BatchId",
+                        column: x => x.BatchId,
+                        principalTable: "Batches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_BatchAssets_Images_AssetId",
+                        column: x => x.AssetId,
+                        principalTable: "Images",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BatchAssets_AssetId",
+                table: "BatchAssets",
+                column: "AssetId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BatchAssets_BatchId",
+                table: "BatchAssets",
+                column: "BatchId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "BatchAssets");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Migrations/20250109145229_Add BatchAssets.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250109145229_Add BatchAssets.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    [Migration("20250107145354_Add BatchAssets")]
+    [Migration("20250109145229_Add BatchAssets")]
     partial class AddBatchAssets
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -221,18 +221,11 @@ namespace DLCS.Repository.Migrations
 
             modelBuilder.Entity("DLCS.Model.Assets.BatchAsset", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("AssetId")
-                        .IsRequired()
-                        .HasColumnType("character varying(500)");
-
                     b.Property<int>("BatchId")
                         .HasColumnType("integer");
+
+                    b.Property<string>("AssetId")
+                        .HasColumnType("character varying(500)");
 
                     b.Property<string>("Error")
                         .HasColumnType("text");
@@ -243,11 +236,9 @@ namespace DLCS.Repository.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 
-                    b.HasKey("Id");
+                    b.HasKey("BatchId", "AssetId");
 
                     b.HasIndex("AssetId");
-
-                    b.HasIndex("BatchId");
 
                     b.ToTable("BatchAssets");
                 });
@@ -1093,7 +1084,7 @@ namespace DLCS.Repository.Migrations
             modelBuilder.Entity("DLCS.Model.Assets.BatchAsset", b =>
                 {
                     b.HasOne("DLCS.Model.Assets.Asset", "Asset")
-                        .WithMany()
+                        .WithMany("BatchAssets")
                         .HasForeignKey("AssetId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -1151,6 +1142,8 @@ namespace DLCS.Repository.Migrations
             modelBuilder.Entity("DLCS.Model.Assets.Asset", b =>
                 {
                     b.Navigation("AssetApplicationMetadata");
+
+                    b.Navigation("BatchAssets");
 
                     b.Navigation("ImageDeliveryChannels");
                 });

--- a/src/protagonist/DLCS.Repository/Migrations/20250109145229_Add BatchAssets.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250109145229_Add BatchAssets.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
@@ -14,8 +13,6 @@ namespace DLCS.Repository.Migrations
                 name: "BatchAssets",
                 columns: table => new
                 {
-                    Id = table.Column<int>(type: "integer", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     BatchId = table.Column<int>(type: "integer", nullable: false),
                     AssetId = table.Column<string>(type: "character varying(500)", nullable: false),
                     Status = table.Column<int>(type: "integer", nullable: false),
@@ -24,7 +21,7 @@ namespace DLCS.Repository.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_BatchAssets", x => x.Id);
+                    table.PrimaryKey("PK_BatchAssets", x => new { x.BatchId, x.AssetId });
                     table.ForeignKey(
                         name: "FK_BatchAssets_Batches_BatchId",
                         column: x => x.BatchId,
@@ -43,11 +40,6 @@ namespace DLCS.Repository.Migrations
                 name: "IX_BatchAssets_AssetId",
                 table: "BatchAssets",
                 column: "AssetId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_BatchAssets_BatchId",
-                table: "BatchAssets",
-                column: "BatchId");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
@@ -219,18 +219,11 @@ namespace DLCS.Repository.Migrations
 
             modelBuilder.Entity("DLCS.Model.Assets.BatchAsset", b =>
                 {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("AssetId")
-                        .IsRequired()
-                        .HasColumnType("character varying(500)");
-
                     b.Property<int>("BatchId")
                         .HasColumnType("integer");
+
+                    b.Property<string>("AssetId")
+                        .HasColumnType("character varying(500)");
 
                     b.Property<string>("Error")
                         .HasColumnType("text");
@@ -241,11 +234,9 @@ namespace DLCS.Repository.Migrations
                     b.Property<int>("Status")
                         .HasColumnType("integer");
 
-                    b.HasKey("Id");
+                    b.HasKey("BatchId", "AssetId");
 
                     b.HasIndex("AssetId");
-
-                    b.HasIndex("BatchId");
 
                     b.ToTable("BatchAssets");
                 });
@@ -1091,7 +1082,7 @@ namespace DLCS.Repository.Migrations
             modelBuilder.Entity("DLCS.Model.Assets.BatchAsset", b =>
                 {
                     b.HasOne("DLCS.Model.Assets.Asset", "Asset")
-                        .WithMany()
+                        .WithMany("BatchAssets")
                         .HasForeignKey("AssetId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -1149,6 +1140,8 @@ namespace DLCS.Repository.Migrations
             modelBuilder.Entity("DLCS.Model.Assets.Asset", b =>
                 {
                     b.Navigation("AssetApplicationMetadata");
+
+                    b.Navigation("BatchAssets");
 
                     b.Navigation("ImageDeliveryChannels");
                 });

--- a/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
@@ -214,7 +214,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasIndex(new[] { "Customer", "Superseded", "Submitted" }, "IX_BatchTest");
 
-                    b.ToTable("Batches");
+                    b.ToTable("Batches", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.CustomHeaders.CustomHeader", b =>
@@ -249,7 +249,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasIndex(new[] { "Customer", "Space" }, "IX_CustomHeaders_ByCustomerSpace");
 
-                    b.ToTable("CustomHeaders");
+                    b.ToTable("CustomHeaders", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.ImageDeliveryChannel", b =>
@@ -278,7 +278,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasIndex("ImageId");
 
-                    b.ToTable("ImageDeliveryChannels");
+                    b.ToTable("ImageDeliveryChannels", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.ImageLocation", b =>
@@ -353,7 +353,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("AssetId", "MetadataType");
 
-                    b.ToTable("AssetApplicationMetadata");
+                    b.ToTable("AssetApplicationMetadata", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.NamedQueries.NamedQuery", b =>
@@ -380,7 +380,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("NamedQueries");
+                    b.ToTable("NamedQueries", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Auth.Entities.AuthService", b =>
@@ -436,7 +436,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id", "Customer");
 
-                    b.ToTable("AuthServices");
+                    b.ToTable("AuthServices", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Auth.Entities.Role", b =>
@@ -464,7 +464,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id", "Customer");
 
-                    b.ToTable("Roles");
+                    b.ToTable("Roles", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Auth.Entities.RoleProvider", b =>
@@ -491,7 +491,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("RoleProviders");
+                    b.ToTable("RoleProviders", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Customers.Customer", b =>
@@ -525,7 +525,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Customers");
+                    b.ToTable("Customers", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Customers.CustomerOriginStrategy", b =>
@@ -560,7 +560,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("CustomerOriginStrategies");
+                    b.ToTable("CustomerOriginStrategies", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Customers.SignupLink", b =>
@@ -582,7 +582,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("SignupLinks");
+                    b.ToTable("SignupLinks", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Customers.User", b =>
@@ -617,7 +617,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("Users");
+                    b.ToTable("Users", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.DeliveryChannels.DefaultDeliveryChannel", b =>
@@ -647,7 +647,7 @@ namespace DLCS.Repository.Migrations
                     b.HasIndex("Customer", "Space", "MediaType", "DeliveryChannelPolicyId")
                         .IsUnique();
 
-                    b.ToTable("DefaultDeliveryChannels");
+                    b.ToTable("DefaultDeliveryChannels", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Policies.DeliveryChannelPolicy", b =>
@@ -691,7 +691,7 @@ namespace DLCS.Repository.Migrations
                     b.HasIndex("Customer", "Name", "Channel")
                         .IsUnique();
 
-                    b.ToTable("DeliveryChannelPolicies");
+                    b.ToTable("DeliveryChannelPolicies", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Policies.ImageOptimisationPolicy", b =>
@@ -718,7 +718,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id", "Customer");
 
-                    b.ToTable("ImageOptimisationPolicies");
+                    b.ToTable("ImageOptimisationPolicies", (string)null);
 
                     b.HasData(
                         new
@@ -750,7 +750,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("OriginStrategies");
+                    b.ToTable("OriginStrategies", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Policies.ThumbnailPolicy", b =>
@@ -771,7 +771,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("ThumbnailPolicies");
+                    b.ToTable("ThumbnailPolicies", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Processing.Queue", b =>
@@ -790,7 +790,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Customer", "Name");
 
-                    b.ToTable("Queues");
+                    b.ToTable("Queues", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Spaces.Space", b =>
@@ -836,7 +836,7 @@ namespace DLCS.Repository.Migrations
                     b.HasKey("Id", "Customer")
                         .HasName("Spaces_pkey");
 
-                    b.ToTable("Spaces");
+                    b.ToTable("Spaces", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Storage.CustomerStorage", b =>
@@ -882,7 +882,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("StoragePolicies");
+                    b.ToTable("StoragePolicies", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Auth.AuthToken", b =>
@@ -928,7 +928,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasIndex(new[] { "CookieId" }, "IX_AuthTokens_CookieId");
 
-                    b.ToTable("AuthTokens");
+                    b.ToTable("AuthTokens", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Auth.SessionUser", b =>
@@ -946,7 +946,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("SessionUsers");
+                    b.ToTable("SessionUsers", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.ActivityGroup", b =>
@@ -964,7 +964,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Group");
 
-                    b.ToTable("ActivityGroups");
+                    b.ToTable("ActivityGroups", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.CustomerImageServer", b =>
@@ -979,7 +979,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Customer");
 
-                    b.ToTable("CustomerImageServers");
+                    b.ToTable("CustomerImageServers", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.EntityCounter", b =>
@@ -1000,7 +1000,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Type", "Scope", "Customer");
 
-                    b.ToTable("EntityCounters");
+                    b.ToTable("EntityCounters", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.ImageServer", b =>
@@ -1015,7 +1015,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("ImageServers");
+                    b.ToTable("ImageServers", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.InfoJsonTemplate", b =>
@@ -1031,7 +1031,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("InfoJsonTemplates");
+                    b.ToTable("InfoJsonTemplates", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Repository.Entities.MetricThreshold", b =>
@@ -1052,7 +1052,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasKey("Name", "Metric");
 
-                    b.ToTable("MetricThresholds");
+                    b.ToTable("MetricThresholds", (string)null);
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.ImageDeliveryChannel", b =>

--- a/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
+++ b/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
@@ -32,6 +32,59 @@ public class EngineAssetRepositoryTests
         contextForTests = new DlcsContext(optionsBuilder.Options);
         sut = new EngineAssetRepository(contextForTests, batchCompletedNotificationSender,
             new NullLogger<EngineAssetRepository>());
+        dbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task GetAsset_Null_IfNotFound()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+        var asset = await sut.GetAsset(assetId, null);
+        asset.Should().BeNull("Asset was not found");
+    }
+
+    [Fact]
+    public async Task GetAsset_ReturnsAssetWithDeliveryChannels()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId).WithTestDeliveryChannel("iiif-img");
+        await dbContext.SaveChangesAsync();
+        
+        var asset = await sut.GetAsset(assetId, null);
+        asset.ImageDeliveryChannels.Should().NotBeNullOrEmpty("DeliveryChannels are loaded");
+        asset.BatchAssets.Should().BeNull("No batch Id specified");
+    }
+    
+    [Fact]
+    public async Task GetAsset_Returns_IfBatchIdSpecifiedButNoAssetBatchRecordsFound()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId).WithTestDeliveryChannel("iiif-img");
+        await dbContext.SaveChangesAsync();
+        
+        var asset = await sut.GetAsset(assetId, -101);
+        asset.ImageDeliveryChannels.Should().NotBeNullOrEmpty("DeliveryChannels are loaded");
+        asset.BatchAssets.Should().BeNullOrEmpty("Batch Id specified but not found");
+    }
+    
+    [Fact]
+    public async Task GetAsset_Returns_BatchAssets_ForSpecifiedBatch_IfBatchIdSpecified()
+    {
+        // Simulate asset belonging to multiple batches, ensure only the specified one is returned 
+        var assetId = AssetIdGenerator.GetAssetId();
+        const int batchId = 4004;
+        const int otherBatchId = 4005;
+        await dbContext.Batches.AddTestBatch(batchId);
+        await dbContext.Batches.AddTestBatch(otherBatchId);
+        await dbContext.BatchAssets.AddTestBatchAsset(batchId, assetId);
+        await dbContext.BatchAssets.AddTestBatchAsset(otherBatchId, assetId);
+        await dbContext.Images.AddTestAsset(assetId, batch: batchId * 10).WithTestDeliveryChannel("iiif-img");
+        
+        await dbContext.SaveChangesAsync();
+        
+        var asset = await sut.GetAsset(assetId, batchId);
+        asset.ImageDeliveryChannels.Should().NotBeNullOrEmpty("DeliveryChannels are loaded");
+        asset.BatchAssets.Should().ContainSingle(ba => ba.BatchId == batchId, "Only specified batch is returned");
     }
     
     [Fact]
@@ -50,7 +103,7 @@ public class EngineAssetRepositoryTests
         var success = await sut.UpdateIngestedAsset(newAsset, null, null, true);
         
         // Assert
-        success.Should().BeFalse();
+        success.Should().BeFalse("No rows were updated but ingest is finished");
         var updatedItem = await dbContext.Images.SingleAsync(a => a.Id == assetId);
         updatedItem.Width.Should().Be(existingAsset.Width);
         updatedItem.Height.Should().Be(existingAsset.Height);
@@ -77,6 +130,7 @@ public class EngineAssetRepositoryTests
         existingAsset.Height = 1000;
         existingAsset.Duration = 99;
         existingAsset.Error = "broken state";
+        
         // Assert
         success.Should().BeTrue();
         
@@ -131,43 +185,6 @@ public class EngineAssetRepositoryTests
                     A<CancellationToken>._))
             .MustNotHaveHappened();
     }
-    
-    [Fact]
-    public async Task UpdateIngestedAsset_ModifiedExistingAsset_IncludingMediaType_NoBatch_Location_OrStorage()
-    {
-        // Arrange
-        var assetId = AssetIdGenerator.GetAssetId();
-        var entry = await dbContext.Images.AddTestAsset(assetId, width: 0, height: 0, duration: 0,
-            ingesting: true, ref1: "foo", roles: "secret");
-        var existingAsset = entry.Entity;
-        await dbContext.SaveChangesAsync();
-        
-        contextForTests.Images.Attach(existingAsset);
-
-        existingAsset.Width = 999;
-        existingAsset.Height = 1000;
-        existingAsset.Duration = 99;
-        existingAsset.Error = "broken state";
-
-        // Act
-        var success = await sut.UpdateIngestedAsset(existingAsset, null, null, true);
-        
-        // Assert
-        success.Should().BeTrue();
-
-        var updatedItem = await dbContext.Images.AsNoTracking().SingleAsync(a => a.Id == assetId);
-        updatedItem.Width.Should().Be(999);
-        updatedItem.Height.Should().Be(1000);
-        updatedItem.Duration.Should().Be(99);
-        updatedItem.Error.Should().Be("broken state");
-        updatedItem.Ingesting.Should().BeFalse();
-        updatedItem.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
-        A.CallTo(() =>
-                batchCompletedNotificationSender.SendBatchCompletedMessage(
-                    A<Batch>._,
-                    A<CancellationToken>._))
-            .MustNotHaveHappened();
-    }
 
     [Fact]
     public async Task UpdateIngestedAsset_ModifiedExistingAsset_NoBatch_WithLocationAndStorage_NoExistingLocationOrStorage()
@@ -214,23 +231,23 @@ public class EngineAssetRepositoryTests
         await dbContext.ImageStorages.AddTestImageStorage(assetId);
         await dbContext.CustomerStorages.AddTestCustomerStorage(sizeOfStored: 500, sizeOfThumbs: 800);
         await dbContext.SaveChangesAsync();
-        
+
         var imageLocation = new ImageLocation { Id = assetId, S3 = "union-card", Nas = "wedding-coat" };
         var imageStorage = new ImageStorage
         {
             Id = assetId, Customer = 99, Space = 1, Size = 1010, CheckingInProgress = false,
             LastChecked = DateTime.UtcNow, ThumbnailSize = 2020
         };
-        
+
         // Act
         var success = await sut.UpdateIngestedAsset(existingAsset, imageLocation, imageStorage, true);
-        
+
         // Assert
         success.Should().BeTrue();
-        
+
         var dbImageLocation = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);
         dbImageLocation.Should().BeEquivalentTo(imageLocation);
-        
+
         var dbImageStorage = await dbContext.ImageStorages.SingleAsync(a => a.Id == assetId);
         dbImageStorage.Should().BeEquivalentTo(imageStorage, opts => opts.Excluding(s => s.LastChecked));
         dbImageStorage.LastChecked.Should().BeCloseTo(imageStorage.LastChecked, TimeSpan.FromMinutes(1));
@@ -244,106 +261,59 @@ public class EngineAssetRepositoryTests
                     A<CancellationToken>._))
             .MustNotHaveHappened();
     }
-    
+
     [Fact]
     public async Task UpdateIngestedAsset_UpdatesBatch_IfError()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
+        var waiting = AssetIdGenerator.GetAssetId(assetPostfix: "waiting");
+        var failing = AssetIdGenerator.GetAssetId(assetPostfix: "fail");
+        var complete = AssetIdGenerator.GetAssetId(assetPostfix: "complete");
+
         const int batchId = -10;
-        await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 1);
+
+        var batch = await dbContext.Batches.AddTestBatch(batchId, count: 4, errors: 1, completed: 1);
+        batch.Entity
+            .AddBatchAsset(assetId)
+            .AddBatchAsset(waiting)
+            .AddBatchAsset(failing, BatchAssetStatus.Error)
+            .AddBatchAsset(complete, BatchAssetStatus.Completed);
         await dbContext.Images.AddTestAsset(assetId, batch: batchId);
+        await dbContext.Images.AddTestAsset(waiting, batch: batchId);
+        await dbContext.Images.AddTestAsset(failing, batch: batchId);
+        await dbContext.Images.AddTestAsset(complete, batch: batchId);
         await dbContext.SaveChangesAsync();
 
+        var batchAsset = batch.Entity.BatchAssets.Single(b => b.AssetId == assetId);
         var newAsset = new Asset
         {
             Id = assetId, Reference1 = "bar", Ingesting = true, Width = 999, Height = 1000,
             Duration = 99, Batch = batchId, Customer = 99, Space = 1, Created = new DateTime(2021, 1, 1),
-            Error = "broken state"
+            Error = "broken state", BatchAssets = new List<BatchAsset> { batchAsset },
         };
-        
         contextForTests.Images.Attach(newAsset);
+        contextForTests.BatchAssets.Attach(batchAsset);
 
         // Act
         var success = await sut.UpdateIngestedAsset(newAsset, null, null, true);
-        
+
         // Assert
         success.Should().BeTrue();
-        
-        var updatedItem = await dbContext.Batches.SingleAsync(b => b.Id == batchId);
+
+        var updatedItem = await dbContext.Batches
+            .Include(b => b.BatchAssets)
+            .SingleAsync(b => b.Id == batchId);
         updatedItem.Errors.Should().Be(2);
         updatedItem.Completed.Should().Be(1);
         updatedItem.Finished.Should().BeNull();
+
+        updatedItem.BatchAssets.Single(ba => ba.AssetId == assetId).Status.Should().Be(BatchAssetStatus.Error);
         A.CallTo(() =>
                 batchCompletedNotificationSender.SendBatchCompletedMessage(
                     A<Batch>._,
                     A<CancellationToken>._))
             .MustNotHaveHappened();
-    }
-    
-    [Trait("Category", "Manual")]
-    [Fact]
-    public async Task UpdateIngestedAsset_UpdatesBatch_HandlesExistingTransaction()
-    {
-        // Arrange
-        var assetId = AssetIdGenerator.GetAssetId();
-        const int batchId = -10;
-        await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 1);
-        var entity = await dbContext.Images.AddTestAsset(assetId, batch: batchId);
-        var existingAsset = entity.Entity;
-        await dbContext.SaveChangesAsync();
-        
-        existingAsset.Width = 999;
-        existingAsset.Height = 1000;
-        existingAsset.Duration = 99;
-        existingAsset.Error = "broken state";
-        
-        contextForTests.Images.Attach(existingAsset);
-        
-        // Act
-        await using var transaction = await contextForTests.Database.BeginTransactionAsync();
-        var success = await sut.UpdateIngestedAsset(existingAsset, null, null, true);
-        await transaction.CommitAsync();
-        
-        // Assert
-        success.Should().BeTrue();
-        var updatedItem = await dbContext.Batches.SingleAsync(b => b.Id == batchId);
-        updatedItem.Errors.Should().Be(2);
-        updatedItem.Completed.Should().Be(1);
-        updatedItem.Finished.Should().BeNull();
-    }
-    
-    [Trait("Category", "Manual")]
-    [Fact]
-    public async Task UpdateIngestedAsset_UpdatesBatch_HandlesExistingTransactionRollback()
-    {
-        // Arrange
-        var assetId = AssetIdGenerator.GetAssetId();
-        const int batchId = -10;
-        await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 1);
-        var entity = await dbContext.Images.AddTestAsset(assetId, batch: batchId);
-        var existingAsset = entity.Entity;
-        await dbContext.SaveChangesAsync();
-        
-        existingAsset.Width = 999;
-        existingAsset.Height = 1000;
-        existingAsset.Duration = 99;
-        existingAsset.Error = "broken state";
-        
-        contextForTests.Images.Attach(existingAsset);
-
-        // Act
-        await using var transaction = await contextForTests.Database.BeginTransactionAsync();
-        var success = await sut.UpdateIngestedAsset(existingAsset, null, null, true);
-        await transaction.RollbackAsync();
-        
-        // Assert
-        success.Should().BeTrue();
-        
-        var updatedItem = await dbContext.Batches.SingleAsync(b => b.Id == batchId);
-        updatedItem.Errors.Should().Be(1);
-        updatedItem.Completed.Should().Be(1);
-        updatedItem.Finished.Should().BeNull();
     }
     
     [Fact]
@@ -354,15 +324,15 @@ public class EngineAssetRepositoryTests
         var waiting = AssetIdGenerator.GetAssetId(assetPostfix: "waiting");
         var failing = AssetIdGenerator.GetAssetId(assetPostfix: "fail");
         var complete = AssetIdGenerator.GetAssetId(assetPostfix: "complete");
-        
-        const int batchId = -11;
+
+        const int batchId = -22;
         var batch = await dbContext.Batches.AddTestBatch(batchId, count: 4, errors: 1, completed: 1);
         batch.Entity
             .AddBatchAsset(assetId)
             .AddBatchAsset(waiting)
             .AddBatchAsset(failing, BatchAssetStatus.Error)
             .AddBatchAsset(complete, BatchAssetStatus.Completed);
-        
+
         var entity = await dbContext.Images.AddTestAsset(assetId, batch: batchId);
         await dbContext.Images.AddTestAsset(waiting, batch: batchId);
         await dbContext.Images.AddTestAsset(failing, batch: batchId);
@@ -375,13 +345,13 @@ public class EngineAssetRepositoryTests
         existingAsset.Duration = 99;
 
         contextForTests.Images.Attach(existingAsset);
-        
+
         // Act
         var success = await sut.UpdateIngestedAsset(existingAsset, null, null, true);
-        
+
         // Assert
         success.Should().BeTrue();
-        
+
         var updatedItem = await dbContext.Batches
             .Include(b => b.BatchAssets)
             .SingleAsync(b => b.Id == batchId);
@@ -396,36 +366,47 @@ public class EngineAssetRepositoryTests
                     A<CancellationToken>._))
             .MustNotHaveHappened();
     }
-    
+
     [Fact]
     public async Task UpdateIngestedAsset_DoesNotUpdateBatch_IfIngestNotFinished()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
+        var waiting = AssetIdGenerator.GetAssetId(assetPostfix: "waiting");
+        var failing = AssetIdGenerator.GetAssetId(assetPostfix: "fail");
         const int batchId = -111;
-        await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 1);
+        var batch = await dbContext.Batches.AddTestBatch(batchId, count: 3, errors: 1, completed: 0);
+        batch.Entity
+            .AddBatchAsset(assetId)
+            .AddBatchAsset(waiting)
+            .AddBatchAsset(failing, BatchAssetStatus.Error);
         var entity = await dbContext.Images.AddTestAsset(assetId, batch: batchId);
+        await dbContext.Images.AddTestAsset(waiting, batch: batchId);
+        await dbContext.Images.AddTestAsset(failing, batch: batchId);
         var existingAsset = entity.Entity;
         await dbContext.SaveChangesAsync();
 
         contextForTests.Images.Attach(existingAsset);
-        
+
         existingAsset.Width = 999;
         existingAsset.Height = 1000;
         existingAsset.Duration = 99;
         existingAsset.Ingesting = true;
-        
+
         // Act
         var success = await sut.UpdateIngestedAsset(existingAsset, null, null, false);
-        
+
         // Assert
         success.Should().BeTrue();
-        
-        var updatedBatch = await dbContext.Batches.SingleAsync(b => b.Id == batchId);
+
+        var updatedBatch = await dbContext.Batches
+            .Include(b => b.BatchAssets)
+            .SingleAsync(b => b.Id == batchId);
         updatedBatch.Errors.Should().Be(1);
-        updatedBatch.Completed.Should().Be(1);
+        updatedBatch.Completed.Should().Be(0);
         updatedBatch.Finished.Should().BeNull();
-        
+        updatedBatch.BatchAssets.Single(ba => ba.AssetId == assetId).Status.Should().Be(BatchAssetStatus.Waiting);
+
         var updatedImage = await dbContext.Images.SingleAsync(i => i.Id == assetId);
         updatedImage.Finished.Should().BeNull();
         updatedImage.Ingesting.Should().BeTrue();
@@ -435,7 +416,7 @@ public class EngineAssetRepositoryTests
                     A<CancellationToken>._))
             .MustNotHaveHappened();
     }
-    
+
     [Theory]
     [InlineData(-12, "" )]
     [InlineData(-13, "error")]
@@ -443,24 +424,36 @@ public class EngineAssetRepositoryTests
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId(assetPostfix: batchId.ToString());
-        await dbContext.Batches.AddTestBatch(batchId, count: 10, errors: 1, completed: 8);
+        var failing = AssetIdGenerator.GetAssetId(assetPostfix: $"{batchId}fail");
+        var complete = AssetIdGenerator.GetAssetId(assetPostfix: $"{batchId}complete");
+        
+        var batch = await dbContext.Batches.AddTestBatch(batchId, count: 3, errors: 1, completed: 1);
+        batch.Entity
+            .AddBatchAsset(assetId)
+            .AddBatchAsset(failing, BatchAssetStatus.Error)
+            .AddBatchAsset(complete, BatchAssetStatus.Completed);
+        
         var entity = await dbContext.Images.AddTestAsset(assetId, batch: batchId);
+        await dbContext.Images.AddTestAsset(failing, batch: batchId);
+        await dbContext.Images.AddTestAsset(complete, batch: batchId);
+        
         var existingAsset = entity.Entity;
         await dbContext.SaveChangesAsync();
-        
+
         contextForTests.Images.Attach(existingAsset);
-        
+
         existingAsset.Width = 999;
         existingAsset.Height = 1000;
         existingAsset.Duration = 99;
         existingAsset.Ingesting = true;
-        
+        existingAsset.Error = error;
+
         // Act
         var success = await sut.UpdateIngestedAsset(existingAsset, null, null, true);
-        
+
         // Assert
         success.Should().BeTrue();
-        
+
         var updatedItem = await dbContext.Batches.SingleAsync(b => b.Id == batchId);
         updatedItem.Finished.Should().NotBeNull();
         A.CallTo(() =>

--- a/src/protagonist/Engine.Tests/Engine.Tests.csproj
+++ b/src/protagonist/Engine.Tests/Engine.Tests.csproj
@@ -36,12 +36,16 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Content Include="Samples\ElasticTranscoderNotificationBatch.json" />
       <None Remove="Samples\ElasticTranscoderNotification.json" />
       <Content Include="Samples\ElasticTranscoderNotification.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
       <None Remove="Samples\ElasticTranscoderErrorNotification.json" />
       <Content Include="Samples\ElasticTranscoderErrorNotification.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Update="Samples\ElasticTranscoderNotificationBatch.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/TranscodeCompleteHandlerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/TranscodeCompleteHandlerTests.cs
@@ -86,6 +86,34 @@ public class TranscodeCompleteHandlerTests
             .MustHaveHappened();
     }
     
+    [Fact]
+    public async Task Handle_PassesDeserialisedObject_AssetInBatch_ToCompleteIngest()
+    {
+        // Arrange
+        const string fileName = "ElasticTranscoderNotificationBatch.json";
+        var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Samples", fileName);
+
+        var queueMessage = new QueueMessage
+        {
+            Body = JsonObject.Parse(System.IO.File.OpenRead(filePath)).AsObject()
+        };
+        var cancellationToken = CancellationToken.None;
+
+        // Act
+        await sut.HandleMessage(queueMessage, cancellationToken);
+            
+        // Assert
+        A.CallTo(() => completion.CompleteSuccessfulIngest(new AssetId(2, 1, "engine_vid_1"),
+                123,
+                A<TranscodeResult>.That.Matches(result =>
+                    result.InputKey == "2/1/engine_vid_1/9912" &&
+                    result.Outputs.Count == 2 &&
+                    result.Outputs[0].Key == "random-guid/2/1/engine_vid_1/full/full/max/max/0/default.mp4" &&
+                    result.Outputs[1].Key == "random-guid/2/1/engine_vid_1/full/full/max/max/0/default.webm"),
+                cancellationToken))
+            .MustHaveHappened();
+    }
+    
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/src/protagonist/Engine.Tests/Ingest/Timebased/TranscodeCompleteHandlerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Timebased/TranscodeCompleteHandlerTests.cs
@@ -76,6 +76,7 @@ public class TranscodeCompleteHandlerTests
             
         // Assert
         A.CallTo(() => completion.CompleteSuccessfulIngest(new AssetId(2, 1, "engine_vid_1"),
+                null,
                 A<TranscodeResult>.That.Matches(result =>
                     result.InputKey == "2/1/engine_vid_1/9912" &&
                     result.Outputs.Count == 2 &&
@@ -101,7 +102,7 @@ public class TranscodeCompleteHandlerTests
         var cancellationToken = CancellationToken.None;
 
         A.CallTo(() =>
-            completion.CompleteSuccessfulIngest(new AssetId(2, 1, "engine_vid_1"), A<TranscodeResult>._,
+            completion.CompleteSuccessfulIngest(new AssetId(2, 1, "engine_vid_1"), null, A<TranscodeResult>._,
                 cancellationToken)).Returns(success);
 
         // Act

--- a/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/ImageIngestTests.cs
@@ -40,8 +40,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
     private readonly DlcsContext dbContext;
     private static readonly TestBucketWriter BucketWriter = new();
     private readonly ApiStub apiStub;
-    private readonly IImageMeasurer imageMeasurer;
-    
+
     private readonly List<ImageDeliveryChannel> imageDeliveryChannels = new()
     {
         new ImageDeliveryChannel
@@ -71,7 +70,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         dbContext = engineFixture.DbFixture.DbContext;
         apiStub = engineFixture.ApiStub;
-        imageMeasurer = A.Fake<IImageMeasurer>();
+        var imageMeasurer = A.Fake<IImageMeasurer>();
         httpClient = appFactory
             .WithTestServices(services =>
             {
@@ -122,7 +121,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         using var image = new Image<Rgba32>(1024, 1024);
 
-        //draw a useless line for some data
+        // draw a useless line for some data
         image.Mutate(imageContext =>
         {
             // draw background
@@ -130,8 +129,8 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageContext.BackgroundColor(bgColor);
         });
         
-        //Convert to byte array
-        MemoryStream memoryStream = new MemoryStream();
+        // Convert to byte array
+        using MemoryStream memoryStream = new MemoryStream();
         byte[] jpegData;
 
         using (memoryStream)
@@ -237,8 +236,7 @@ public class ImageIngestTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var updatedBatch = await dbContext.Batches.Include(b => b.BatchAssets).SingleAsync(b => b.Id == batchId);
         updatedBatch.BatchAssets.Should()
-            .HaveCount(1)
-            .And.OnlyContain(b => b.Status == BatchAssetStatus.Completed);
+            .ContainSingle(b => b.Status == BatchAssetStatus.Completed);
 
         var location = await dbContext.ImageLocations.SingleAsync(a => a.Id == assetId);
         location.Nas.Should().BeEmpty();

--- a/src/protagonist/Engine.Tests/Integration/IngestResponseTests.cs
+++ b/src/protagonist/Engine.Tests/Integration/IngestResponseTests.cs
@@ -42,7 +42,7 @@ public class IngestResponseTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = AssetId.FromString($"1/2/{ingestResult}");
-        var message = new IngestAssetRequest(assetId, DateTime.UtcNow);
+        var message = new IngestAssetRequest(assetId, DateTime.UtcNow, null);
         A.CallTo(() =>
             assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
                 A<CancellationToken>._)).Returns(new IngestResult(null, ingestResult));
@@ -65,7 +65,7 @@ public class IngestResponseTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = AssetId.FromString($"1/2/{ingestResult}");
-        var message = new IngestAssetRequest(assetId, DateTime.UtcNow);
+        var message = new IngestAssetRequest(assetId, DateTime.UtcNow, null);
         A.CallTo(() =>
             assetIngester.Ingest(A<IngestAssetRequest>.That.Matches(r => r.Id == assetId),
                 A<CancellationToken>._)).Returns(new IngestResult(null, ingestResult));

--- a/src/protagonist/Engine.Tests/Samples/ElasticTranscoderNotificationBatch.json
+++ b/src/protagonist/Engine.Tests/Samples/ElasticTranscoderNotificationBatch.json
@@ -1,0 +1,12 @@
+{
+  "Type": "Notification",
+  "MessageId": "bf2dc336-5276-5ceb-b1c9-948911b8e8b5",
+  "TopicArn": "arn:aws:sns:eu-west-1:111222333444:sns-test-notification",
+  "Subject": "Amazon Elastic Transcoder has finished transcoding job 1598374269794-x3aftt.",
+  "Message": "{\n  \"state\" : \"COMPLETED\",\n  \"version\" : \"2012-09-25\",\n  \"jobId\" : \"1598374269794-x3aftt\",\n  \"pipelineId\" : \"1598364121543-wusy52\",\n  \"input\" : {\n    \"key\" : \"2/1/engine_vid_1/9912\",\n    \"frameRate\" : \"auto\",\n    \"resolution\" : \"auto\",\n    \"aspectRatio\" : \"auto\",\n    \"interlaced\" : \"auto\",\n    \"container\" : \"auto\"\n  },\n  \"inputCount\" : 1,\n  \"outputs\" : [ {\n    \"id\" : \"1\",\n    \"presetId\" : \"1351620000001-100070\",\n    \"key\" : \"random-guid/2/1/engine_vid_1/full/full/max/max/0/default.mp4\",\n    \"status\" : \"Complete\",\n    \"duration\" : 14,\n    \"width\" : 640,\n    \"height\" : 480\n  }, {\n    \"id\" : \"2\",\n    \"presetId\" : \"1351620000001-100240\",\n    \"key\" : \"random-guid/2/1/engine_vid_1/full/full/max/max/0/default.webm\",\n    \"status\" : \"Complete\",\n    \"duration\" : 15,\n    \"width\" : 640,\n    \"height\" : 480\n  } ],\n  \"userMetadata\" : {\n    \"jobId\" : \"2a9e35a9-078c-4a43-b311-b14f2e74ddf4\",\n    \"dlcsId\" : \"2/1/engine_vid_1\",\n    \"batchId\" : \"123\",\n    \"startTime\" : \"1659095486\"\n  }\n}",
+  "Timestamp": "2022-07-29T11:51:26.616Z",
+  "SignatureVersion": "1",
+  "Signature": "_ignored_",
+  "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-aaabbcdb4e1f29c941702d737128f7b6.pem",
+  "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:111222333444:sns-test-notification:c24f06ac-f817-4755-9998-8d5924532874"
+}

--- a/src/protagonist/Engine/Data/IEngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/IEngineAssetRepository.cs
@@ -23,7 +23,7 @@ public interface IEngineAssetRepository
     /// <summary>
     /// Get Asset with specified Id
     /// </summary>
-    ValueTask<Asset?> GetAsset(AssetId assetId, CancellationToken cancellationToken = default);
+    ValueTask<Asset?> GetAsset(AssetId assetId, int? batchId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the size of an image from the database, or null if the image is not found

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -48,7 +48,7 @@ public class AssetIngester : IAssetIngester
     /// <returns>Result of ingest operations</returns>
     public async Task<IngestResult> Ingest(IngestAssetRequest request, CancellationToken cancellationToken = default)
     {
-        var asset = await engineAssetRepository.GetAsset(request.Id, cancellationToken);
+        var asset = await engineAssetRepository.GetAsset(request.Id, request.BatchId, cancellationToken);
 
         if (asset == null)
         {

--- a/src/protagonist/Engine/Ingest/AssetIngester.cs
+++ b/src/protagonist/Engine/Ingest/AssetIngester.cs
@@ -1,10 +1,7 @@
 ﻿using DLCS.Core.Types;
-using DLCS.Model.Assets;
 using DLCS.Model.Customers;
 using DLCS.Model.Messaging;
-using DLCS.Model.Policies;
 using Engine.Data;
-using Engine.Ingest.Models;
 
 namespace Engine.Ingest;
 
@@ -25,17 +22,14 @@ public class AssetIngester : IAssetIngester
     private readonly IngestExecutor executor;
     private readonly ILogger<AssetIngester> logger;
     private readonly ICustomerOriginStrategyRepository customerOriginRepository;
-    private readonly IPolicyRepository policyRepository;
     private readonly IEngineAssetRepository engineAssetRepository;
 
     public AssetIngester(
-        IPolicyRepository policyRepository, 
         ICustomerOriginStrategyRepository customerOriginRepository,
         ILogger<AssetIngester> logger,
         IngestExecutor executor,
         IEngineAssetRepository engineAssetRepository)
     {
-        this.policyRepository = policyRepository;
         this.customerOriginRepository = customerOriginRepository;
         this.logger = logger;
         this.executor = executor;

--- a/src/protagonist/Engine/Ingest/IngestController.cs
+++ b/src/protagonist/Engine/Ingest/IngestController.cs
@@ -31,7 +31,6 @@ public class IngestController : Controller
     [Route("asset-ingest")]
     public async Task<IActionResult> IngestAsset(CancellationToken cancellationToken)
     {
-        // TODO - throw if this is a 'T' request
         var message =
             await JsonSerializer.DeserializeAsync<IngestAssetRequest>(Request.Body,
                 JsonSerializerOptions, cancellationToken);

--- a/src/protagonist/Engine/Ingest/Timebased/Completion/ITimebasedIngestorCompletion.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Completion/ITimebasedIngestorCompletion.cs
@@ -11,7 +11,7 @@ public interface ITimebasedIngestorCompletion
     /// <param name="assetId">Id of asset running completion operations for</param>
     /// <param name="batchId">The id of batch this ingest operation is for</param>
     /// <param name="transcodeResult">Result of transcode operation</param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="cancellationToken">Current cancellation token</param>
     /// <returns>Value representing success</returns>
     Task<bool> CompleteSuccessfulIngest(AssetId assetId, int? batchId, TranscodeResult transcodeResult,
         CancellationToken cancellationToken = default);

--- a/src/protagonist/Engine/Ingest/Timebased/Completion/ITimebasedIngestorCompletion.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Completion/ITimebasedIngestorCompletion.cs
@@ -9,8 +9,10 @@ public interface ITimebasedIngestorCompletion
     /// Mark asset as completed in database. Move assets from Transcode output to main storage location.
     /// </summary>
     /// <param name="assetId">Id of asset running completion operations for</param>
+    /// <param name="batchId">The id of batch this ingest operation is for</param>
     /// <param name="transcodeResult">Result of transcode operation</param>
+    /// <param name="cancellationToken"></param>
     /// <returns>Value representing success</returns>
-    Task<bool> CompleteSuccessfulIngest(AssetId assetId, TranscodeResult transcodeResult,
+    Task<bool> CompleteSuccessfulIngest(AssetId assetId, int? batchId, TranscodeResult transcodeResult,
         CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Engine/Ingest/Timebased/Completion/TimebasedIngestorCompletion.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/Completion/TimebasedIngestorCompletion.cs
@@ -26,10 +26,10 @@ public class TimebasedIngestorCompletion : ITimebasedIngestorCompletion
         this.logger = logger;
     }
 
-    public async Task<bool> CompleteSuccessfulIngest(AssetId assetId, TranscodeResult transcodeResult,
+    public async Task<bool> CompleteSuccessfulIngest(AssetId assetId, int? batchId, TranscodeResult transcodeResult,
         CancellationToken cancellationToken = default)
     {
-        var asset = await assetRepository.GetAsset(assetId, cancellationToken);
+        var asset = await assetRepository.GetAsset(assetId, batchId, cancellationToken);
 
         if (asset == null)
         {

--- a/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
@@ -1,5 +1,6 @@
 ﻿using DLCS.AWS.ElasticTranscoder;
 using DLCS.AWS.S3;
+using DLCS.Core.Collections;
 using DLCS.Model.Customers;
 using Engine.Ingest.Persistence;
 using Engine.Ingest.Timebased.Transcode;
@@ -72,8 +73,11 @@ public class TimebasedIngesterWorker : IAssetIngesterWorker
         {
             [UserMetadataKeys.DlcsId] = ingestionContext.AssetId.ToString(),
             [UserMetadataKeys.OriginSize] = (TryGetStoredOriginFileSize(ingestionContext) ?? 0).ToString(),
-            [UserMetadataKeys.BatchId] = ingestionContext.Asset.Batch?.ToString() ?? string.Empty,
+            [UserMetadataKeys.BatchId] = ingestionContext.Asset.BatchAssets.IsNullOrEmpty()
+                ? string.Empty
+                : ingestionContext.Asset.BatchAssets.Single().BatchId.ToString()
         };
+        
         return jobMetadata;
     }
 

--- a/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
@@ -71,7 +71,8 @@ public class TimebasedIngesterWorker : IAssetIngesterWorker
         var jobMetadata = new Dictionary<string, string>
         {
             [UserMetadataKeys.DlcsId] = ingestionContext.AssetId.ToString(),
-            [UserMetadataKeys.OriginSize] = (TryGetStoredOriginFileSize(ingestionContext) ?? 0).ToString()
+            [UserMetadataKeys.OriginSize] = (TryGetStoredOriginFileSize(ingestionContext) ?? 0).ToString(),
+            [UserMetadataKeys.BatchId] = ingestionContext.Asset.Batch?.ToString() ?? string.Empty,
         };
         return jobMetadata;
     }

--- a/src/protagonist/Engine/Ingest/Timebased/TranscodeCompleteHandler.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TranscodeCompleteHandler.cs
@@ -40,13 +40,16 @@ public class TranscodeCompleteHandler : IMessageHandler
             logger.LogWarning("Unable to find DlcsId in message for ET job {JobId}", elasticTranscoderMessage.JobId);
             return false;
         }
+        
+        var batchId = elasticTranscoderMessage.GetBatchId();
 
-        logger.LogTrace("Received Message {MessageId} for {AssetId}", message.MessageId, assetId);
+        logger.LogTrace("Received Message {MessageId} for {AssetId}, batch {BatchId}", message.MessageId, assetId,
+            batchId ?? 0);
 
         var transcodeResult = new TranscodeResult(elasticTranscoderMessage);
 
         var success =
-            await timebasedIngestorCompletion.CompleteSuccessfulIngest(assetId, transcodeResult, cancellationToken);
+            await timebasedIngestorCompletion.CompleteSuccessfulIngest(assetId, batchId, transcodeResult, cancellationToken);
 
         logger.LogInformation("Message {MessageId} handled for {AssetId} with result {IngestResult}", message.MessageId,
             assetId, success);

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -249,4 +249,7 @@ public static class DatabaseTestDataPopulation
         
         return asset;
     }
+
+    public static ValueTask<EntityEntry<BatchAsset>> AddTestBatchAsset(this DbSet<BatchAsset> batchAssets, int batchId,
+        AssetId assetId) => batchAssets.AddAsync(new BatchAsset { AssetId = assetId, BatchId = batchId });
 }

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -220,10 +220,10 @@ public class DlcsDefaultDatabaseFixture : IAsyncLifetime
         ConnectionString = postgresContainer.ConnectionString;
 
         // Create new DlcsContext using connection string for Postgres container
-        DbContext = new DlcsContext(
-            new DbContextOptionsBuilder<DlcsContext>()
-                .UseNpgsql(postgresContainer.ConnectionString, builder => builder.SetPostgresVersion(13, 0)).Options
-        );
+        var dbContextOptions = new DbContextOptionsBuilder<DlcsContext>()
+            .SetupDlcsContextOptions(postgresContainer.ConnectionString)
+            .EnableSensitiveDataLogging();
+        DbContext = new DlcsContext(dbContextOptions.Options);
         DbContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
     }
 }


### PR DESCRIPTION
Resolves #491 

Adds a new table to database, `BatchAssets`, which tracks which assets have been in each batch over time.

The main points of change were:
* API - when processing a batch, save a `BatchAsset` record for every item in batch. 
* API now includes the batchId in notifications sent to Engine, both for sync and async ingests. Previously we read the value from DB but this isn't necessarily the batch this ingest is related to. Similarly, ET metadata now includes batchId. Batch is `0` rather than `null` for historical reasons but rewrite `0` -> `null` at API boundary to simplify Engine.
* Refactored when asset modified message is sent as discovered a bug where notifications could be raised when data is will not be persisted to DB - could have happened if 1 asset in a batch caused a failure in API.
* API - new endpoint `/customers/{customer}/queue/batches/{batchId}/assets` which returns details of all assets in specified batch.
* Engine - largest changes were in `EngineAssetRepository`. We now calculate the `Batches` totals based in `BatchAsset` records, this simplified the implementation and removed the need to Transactions. We can now use the EF transaction as part of `.SaveChanges()` once records are saved we can run the update script to set the `Batches` totals independently on a new connection - ensures we're always using current state of table.

> [!IMPORTANT]  
> This PR contains a migration
> When deployed, any in-flight ingest operations (particularly AV) may not be handled correctly, leading to batch totals being inaccurate.