### PR TITLE
Handle NQ 'batch' parameter

### DIFF
--- a/src/protagonist/DLCS.Core/Strings/StringX.cs
+++ b/src/protagonist/DLCS.Core/Strings/StringX.cs
@@ -132,7 +132,7 @@ public static class StringX
     /// <param name="str">String to split</param>
     /// <param name="separator">String to split by.</param>
     /// <returns>String split, or empty list.</returns>
-    public static IEnumerable<string> SplitSeparatedString(this string str, string separator)
+    public static IEnumerable<string> SplitSeparatedString(this string? str, string separator)
         => str?.Trim().Split(separator, StringSplitOptions.RemoveEmptyEntries) ?? Enumerable.Empty<string>();
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
+++ b/src/protagonist/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
@@ -55,6 +55,11 @@ public class ParsedNamedQuery
     public long? Number3 { get; set; }
     
     /// <summary>
+    /// Value of "batches" after parsing
+    /// </summary>
+    public int[]? Batches { get; set; } 
+    
+    /// <summary>
     /// The name of the namedQuery this object was parsed from.
     /// </summary>
     public string NamedQueryName { get; set; }
@@ -99,7 +104,8 @@ public class ParsedNamedQuery
         String3,
         Number1,
         Number2,
-        Number3
+        Number3,
+        Batch,
     }
 
     public enum OrderDirection

--- a/src/protagonist/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
+++ b/src/protagonist/DLCS.Model/Assets/NamedQueries/ParsedNamedQuery.cs
@@ -10,7 +10,7 @@ namespace DLCS.Model.Assets.NamedQueries;
 public class ParsedNamedQuery
 {
     /// <summary>
-    /// Collection of OrderBy clauses to apply to assets.
+    /// Collection of OrderBy clauses to apply to assets
     /// </summary>
     public List<QueryOrder> AssetOrdering { get; set; } = new() { new QueryOrder(QueryMapping.Unset) };
     
@@ -105,7 +105,6 @@ public class ParsedNamedQuery
         Number1,
         Number2,
         Number3,
-        Batch,
     }
 
     public enum OrderDirection

--- a/src/protagonist/DLCS.Repository.Tests/NamedQueries/NamedQueryRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/NamedQueries/NamedQueryRepositoryTests.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
-using DLCS.Core.Caching;
+﻿using DLCS.Core.Caching;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
 using DLCS.Repository.Assets;
 using LazyCache.Mocks;
@@ -14,12 +14,11 @@ namespace DLCS.Repository.Tests.NamedQueries;
 [Collection(DatabaseCollection.CollectionName)]
 public class NamedQueryRepositoryTests
 {
-    private readonly DlcsContext dbContext;
     private readonly NamedQueryRepository sut;
 
     public NamedQueryRepositoryTests(DlcsDatabaseFixture dbFixture)
     {
-        dbContext = dbFixture.DbContext;
+        var dbContext = dbFixture.DbContext;
         sut = new NamedQueryRepository(dbFixture.DbContext, new MockCachingService(),
             Options.Create(new CacheSettings()));
 
@@ -38,6 +37,26 @@ public class NamedQueryRepositoryTests
         dbContext.Images.AddTestAsset(AssetId.FromString("99/1/7"), space: 2);
         dbContext.Images.AddTestAsset(AssetId.FromString("99/1/8"), ref1: "foo", ref2: "bar", ref3: "baz", num1: 5,
             num2: 10, num3: 20);
+        
+        // Batch records - first with 3 and second with 2. 1 asset is in both
+        var batchedAsset1 = AssetId.FromString("99/2/1");
+        var batchedAsset2 = AssetId.FromString("99/2/2");
+        var batchedAsset3 = AssetId.FromString("99/2/3");
+        var batchedAsset4 = AssetId.FromString("99/2/4");
+        const int batchId1 = 101010;
+        const int batchId2 = 101011;
+        dbContext.Images.AddTestAsset(batchedAsset1, space: 2);
+        dbContext.Images.AddTestAsset(batchedAsset2, space: 2, num3: 1);
+        dbContext.Images.AddTestAsset(batchedAsset3, space: 2, num3: 1);
+        dbContext.Images.AddTestAsset(batchedAsset4, space: 2, num3: 1);
+        var batch = dbContext.Batches.AddTestBatch(batchId1).Result;
+        batch.Entity
+            .AddBatchAsset(batchedAsset1)
+            .AddBatchAsset(batchedAsset2, BatchAssetStatus.Completed)
+            .AddBatchAsset(batchedAsset3, BatchAssetStatus.Error);
+        
+        var batch2 = dbContext.Batches.AddTestBatch(batchId2).Result;
+        batch2.Entity.AddBatchAsset(batchedAsset1).AddBatchAsset(batchedAsset4);
         dbContext.SaveChanges();
     }
 
@@ -119,7 +138,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Count().Should().Be(8);
+        result.Should().HaveCount(12);
     }
 
     [Fact]
@@ -135,7 +154,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/1"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/1"));
     }
     
     [Fact]
@@ -151,7 +170,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/2"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/2"));
     }
     
     [Fact]
@@ -167,7 +186,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/3"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/3"));
     }
     
     [Fact]
@@ -183,7 +202,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/4"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/4"));
     }
     
     [Fact]
@@ -199,7 +218,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/5"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/5"));
     }
     
     [Fact]
@@ -215,7 +234,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/6"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/6"));
     }
     
     [Fact]
@@ -231,7 +250,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Count().Should().Be(7);
+        result.Should().HaveCount(7);
     }
     
     [Fact]
@@ -247,7 +266,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Count().Should().Be(7);
+        result.Should().HaveCount(7);
     }
     
     [Fact]
@@ -263,7 +282,7 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Count().Should().Be(7);
+        result.Should().HaveCount(7);
     }
     
     [Fact]
@@ -280,6 +299,54 @@ public class NamedQueryRepositoryTests
         var result = await sut.GetNamedQueryResults(query).ToListAsync();
 
         // Assert
-        result.Single().Id.Should().Be(AssetId.FromString("99/1/8"));
+        result.Should().ContainSingle(r => r.Id == AssetId.FromString("99/1/8"));
+    }
+    
+    [Fact]
+    public async Task GetNamedQueryResults_FilterBySingleBatch()
+    {
+        // Arrange
+        var query = new ParsedNamedQuery(99)
+        {
+            Batches = new[] { 101010 }
+        };
+
+        // Act
+        var result = await sut.GetNamedQueryResults(query).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(3);
+    }
+    
+    [Fact]
+    public async Task GetNamedQueryResults_FilterByMultipleBatch()
+    {
+        // Arrange
+        var query = new ParsedNamedQuery(99)
+        {
+            Batches = new[] { 101010, 101011 }
+        };
+
+        // Act
+        var result = await sut.GetNamedQueryResults(query).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(4);
+    }
+    
+    [Fact]
+    public async Task GetNamedQueryResults_FilterByMultipleBatch_AndOtherCriteria()
+    {
+        // Arrange
+        var query = new ParsedNamedQuery(99)
+        {
+            Batches = new[] { 101010, 101011 }, Number3 = 1 
+        };
+
+        // Act
+        var result = await sut.GetNamedQueryResults(query).ToListAsync();
+
+        // Assert
+        result.Should().HaveCount(3);
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/NamedQueries/Parsing/IIIFNamedQueryParserTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/NamedQueries/Parsing/IIIFNamedQueryParserTests.cs
@@ -81,6 +81,9 @@ public class IIIFNamedQueryParserTests
     [Theory]
     [InlineData("n1=p1", "not-an-int")]
     [InlineData("n1=p1&#=not-an-int", "")]
+    [InlineData("batch=p1", "not-an-int")]
+    [InlineData("batch=p1", "1|2|3")]
+    [InlineData("batch=p1&#=not-an-int", "")]
     public void GenerateParsedNamedQueryFromRequest_ReturnsFaultParsedNQ_IfNonNumberPassedForNumberArg(
         string template,
         string args)
@@ -127,6 +130,12 @@ public class IIIFNamedQueryParserTests
         },
         new object[]
         {
+            "batch=p1&#=10", "",
+            new IIIFParsedNamedQuery(Customer) { Batches = new[] { 10 }, NamedQueryName = "my-query" },
+            "Single batch from template"
+        },
+        new object[]
+        {
             "manifest=s1&spacename=p1", "10",
             new IIIFParsedNamedQuery(Customer)
                 { SpaceName = "10", Manifest = ParsedNamedQuery.QueryMapping.String1, NamedQueryName = "my-query" },
@@ -138,7 +147,7 @@ public class IIIFNamedQueryParserTests
             new IIIFParsedNamedQuery(Customer)
             {
                 String1 = "string-1", Number1 = 40, Space = 1, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
                 NamedQueryName = "my-query"
             },
             "All params"
@@ -149,7 +158,7 @@ public class IIIFNamedQueryParserTests
             new IIIFParsedNamedQuery(Customer)
             {
                 String1 = "string-1", Number1 = 40, Space = 10, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
                 NamedQueryName = "my-query"
             },
             "Extra args are ignored"
@@ -160,10 +169,21 @@ public class IIIFNamedQueryParserTests
             new IIIFParsedNamedQuery(Customer)
             {
                 String1 = "string-1", Number1 = 40, Space = 1, Manifest = ParsedNamedQuery.QueryMapping.String1,
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
                 NamedQueryName = "my-query"
             },
             "Incorrect template pairs are ignored"
         },
+        new object[]
+        {
+            "manifest=s1&canvas=n2&s1=p1&n1=p2&batch=p3&space=p4&#=1", "string-1/40/10,20,30",
+            new IIIFParsedNamedQuery(Customer)
+            {
+                String1 = "string-1", Number1 = 40, Space = 1, Manifest = ParsedNamedQuery.QueryMapping.String1,
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
+                NamedQueryName = "my-query", Batches = new[] { 10, 20, 30 }
+            },
+            "All params including multi Batch"
+        }
     };
 }

--- a/src/protagonist/DLCS.Repository.Tests/NamedQueries/Parsing/PdfNamedQueryParserTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/NamedQueries/Parsing/PdfNamedQueryParserTests.cs
@@ -159,11 +159,20 @@ public class PdfNamedQueryParserTests
         },
         new object[]
         {
+            "batch=p1", "10,20,40",
+            new PdfParsedNamedQuery(99)
+            {
+                NamedQueryName = "my-query", Batches = new[] { 10, 20, 40 }, Args = new List<string> { "10,20,40" }
+            },
+            "Batch from template"
+        },
+        new object[]
+        {
             "redactedmessage=you cannot view&canvas=s1&s1=p1&n1=p2&space=p3&#=1", "string-1/40",
             new PdfParsedNamedQuery(99)
             {
                 String1 = "string-1", Number1 = 40, Space = 1, RedactedMessage = "you cannot view",
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.String1)}, 
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.String1) },
                 Args = new List<string> { "string-1", "40", "1" }, NamedQueryName = "my-query",
             },
             "All params except format"
@@ -174,7 +183,7 @@ public class PdfNamedQueryParserTests
             new PdfParsedNamedQuery(99)
             {
                 String1 = "string-1", Number1 = 40, Space = 10,
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
                 Args = new List<string> { "string-1", "40", "10", "100", "1" }, NamedQueryName = "my-query",
             },
             "Extra args are ignored"
@@ -184,8 +193,8 @@ public class PdfNamedQueryParserTests
             "manifest=s1&&n3=&canvas=n2&=10&s1=p1&n1=p2&space=p3&#=1", "string-1/40",
             new PdfParsedNamedQuery(99)
             {
-                String1 = "string-1", Number1 = 40, Space = 1, 
-                AssetOrdering = new List<ParsedNamedQuery.QueryOrder>{new(ParsedNamedQuery.QueryMapping.Number2)},
+                String1 = "string-1", Number1 = 40, Space = 1,
+                AssetOrdering = new List<ParsedNamedQuery.QueryOrder> { new(ParsedNamedQuery.QueryMapping.Number2) },
                 Args = new List<string> { "string-1", "40", "1" }, NamedQueryName = "my-query",
             },
             "Incorrect template pairs are ignored"

--- a/src/protagonist/DLCS.Repository/Assets/NamedQueryRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/NamedQueryRepository.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Caching;
+using DLCS.Core.Collections;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.NamedQueries;
@@ -99,6 +100,11 @@ public class NamedQueryRepository : INamedQueryRepository
                     })
                 .Where(arg => arg.SpaceName == query.SpaceName)
                 .Select(arg => arg.Image);
+        }
+
+        if (!query.Batches.IsNullOrEmpty())
+        {
+            imageFilter = imageFilter.Where(i => i.BatchAssets.Any(ba => query.Batches.Contains(ba.BatchId)));
         }
 
         return imageFilter;

--- a/src/protagonist/DLCS.Repository/NamedQueries/Parsing/BaseNamedQueryParser.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Parsing/BaseNamedQueryParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
 using DLCS.Core.Guard;
+using DLCS.Core.Strings;
 using DLCS.Model.Assets.NamedQueries;
 using Microsoft.Extensions.Logging;
 using QueryMapping = DLCS.Model.Assets.NamedQueries.ParsedNamedQuery.QueryMapping;
@@ -12,7 +13,13 @@ using QueryOrder = DLCS.Model.Assets.NamedQueries.ParsedNamedQuery.QueryOrder;
 namespace DLCS.Repository.NamedQueries.Parsing;
 
 /// <summary>
-/// Basic NQ parser, supporting the following arguments: s1, s2, s3, n1, n2, n3, space, spacename, canvas, # and p*
+/// Basic NQ parser; supporting the following arguments:
+/// metadata-fields:   s1, s2, s3, n1, n2, n3
+/// space-fields:      space, spacename
+/// ordering-fields:   assetOrder, canvas
+/// batch:             batch
+/// auto-added-values: #
+/// parameter-values:  p*
 /// </summary>
 public abstract class BaseNamedQueryParser<T> : INamedQueryParser
     where T : ParsedNamedQuery
@@ -35,6 +42,7 @@ public abstract class BaseNamedQueryParser<T> : INamedQueryParser
     protected const string String3 = "s3";
     protected const string AssetOrdering = "assetOrder";
     protected const string PathReplacement = "%2F";
+    protected const string Batch = "batch";
     
     public BaseNamedQueryParser(ILogger logger)
     {
@@ -73,9 +81,7 @@ public abstract class BaseNamedQueryParser<T> : INamedQueryParser
     private static List<string> GetQueryArgsList(string? namedQueryArgs, string[] templatePairing)
     {
         // Get any arguments passed to the NQ from URL
-        var queryArgs = namedQueryArgs.IsNullOrEmpty()
-            ? new List<string>()
-            : namedQueryArgs!.Split("/", StringSplitOptions.RemoveEmptyEntries).ToList();
+        var queryArgs = namedQueryArgs.SplitSeparatedString("/").ToList();
 
         // Iterate through any pairs that start with '#', as these are treated as additional args
         foreach (var additionalArg in templatePairing.Where(p => p.StartsWith(AdditionalArgMarker)))
@@ -127,12 +133,16 @@ public abstract class BaseNamedQueryParser<T> : INamedQueryParser
                             ConvertToLongQueryArg(GetQueryArgumentFromTemplateElement(queryArgs, elements[1]));
                         break;
                     case Number2:
-                        assetQuery.Number2 = 
+                        assetQuery.Number2 =
                             ConvertToLongQueryArg(GetQueryArgumentFromTemplateElement(queryArgs, elements[1]));
                         break;
                     case Number3:
-                        assetQuery.Number3 = 
+                        assetQuery.Number3 =
                             ConvertToLongQueryArg(GetQueryArgumentFromTemplateElement(queryArgs, elements[1]));
+                        break;
+                    case Batch:
+                        assetQuery.Batches =
+                            ConvertToIntArrayQueryArg(GetQueryArgumentFromTemplateElement(queryArgs, elements[1]));
                         break;
                 }
 
@@ -148,15 +158,11 @@ public abstract class BaseNamedQueryParser<T> : INamedQueryParser
         return assetQuery;
     }
 
-    private long? ConvertToLongQueryArg(string? argToConvert)
-    {
-        if (argToConvert.IsNullOrEmpty())
-        {
-            return null;
-        }
+    private static long? ConvertToLongQueryArg(string? argToConvert) 
+        => argToConvert.IsNullOrEmpty() ? null : long.Parse(argToConvert);
 
-        return long.Parse(argToConvert);
-    }
+    private static int[]? ConvertToIntArrayQueryArg(string? argToConvert)
+        => argToConvert.IsNullOrEmpty() ? null : argToConvert.SplitSeparatedString(",").Select(int.Parse).ToArray();
 
     /// <summary>
     /// Adds handling for any custom key/value pairs, in addition to the core s1, s2, p1 etc

--- a/src/protagonist/DLCS.Repository/NamedQueries/Parsing/StoredNamedQueryParser.cs
+++ b/src/protagonist/DLCS.Repository/NamedQueries/Parsing/StoredNamedQueryParser.cs
@@ -36,7 +36,7 @@ public abstract class StoredNamedQueryParser<T> : BaseNamedQueryParser<T>
     }
 
     /// <summary>
-    /// Get the template to use from specified <see cref="NamedQuerySettings"/> object.
+    /// Get the template to use from specified <see cref="NamedQueryTemplateSettings"/> object.
     /// </summary>
     /// <returns>Template to use containing {customer}, {queryname} + {args} replacements.</returns>
     protected abstract string GetTemplateFromSettings(NamedQueryTemplateSettings namedQuerySettings);


### PR DESCRIPTION
Resolves #930

This introduces a new NQ parameter, `batch`. This uses the `BatchAssets` table only (so won't pull images from batches created before the introduction of `BatchAssets`).

`batch` can be a single integer, or multiple comma delimited values. e.g. the NQ "batch-test" with template `batch=p1&assetOrder=n1;n2&s1=p2&space=p3`

can be called with the following:
* `/iiif-resource/{cust}/batch-test/1234/string1-val/99`
* `/iiif-resource/{cust}/batch-test/1234,9999,2222/string1-val/99`

It's likely this is just for internal use but I've included it in the base parser so the parameter is available to all NQ projections (IIIF, zip and PDF).