### PR TITLE
Create batch asset when using PUT for a timebased asset

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -1901,7 +1901,17 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
             nameof(Patch_TimebasedAsset_Updates_Asset_AndEnqueuesMessage_IfReingestRequired));
 
         var testAsset = await dbContext.Images.AddTestAsset(assetId, family: AssetFamily.Timebased,
-            ref1: "I am string 1", origin: $"https://example.org/{assetId.Asset}.mp4", mediaType: "video/mp4");
+            ref1: "I am string 1", 
+            origin: $"https://example.org/{assetId.Asset}.mp4", 
+            mediaType: "video/mp4", 
+            imageDeliveryChannels: new List<ImageDeliveryChannel>
+            {
+                new()
+                {
+                    Channel = AssetDeliveryChannels.Timebased,
+                    DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.AvDefaultVideo
+                }
+            });
         
         await dbContext.SaveChangesAsync();
         

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -42,10 +42,8 @@ public class AssetProcessor
     /// <param name="isBatchUpdate">
     /// If true, this operation is part of a batch save. Allows Batch property to be set
     /// </param>
-    /// <param name="requiresReingestPreSave">Optional delegate for modifying asset prior to saving</param>
     /// <param name="cancellationToken">Current cancellation token</param>
     public async Task<ProcessAssetResult> Process(AssetBeforeProcessing assetBeforeProcessing, bool mustExist, bool alwaysReingest, bool isBatchUpdate, 
-        Func<Asset, Task>? requiresReingestPreSave = null, 
         CancellationToken cancellationToken = default)
     {
         try
@@ -129,11 +127,6 @@ public class AssetProcessor
             if (requiresEngineNotification)
             {
                 updatedAsset.SetFieldsForIngestion();
-
-                if (requiresReingestPreSave != null)
-                {
-                    await requiresReingestPreSave(updatedAsset);
-                }
             }
             else
             {

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Data;
 using System.Net;
 using API.Exceptions;
@@ -8,7 +7,6 @@ using API.Infrastructure.Messaging;
 using API.Infrastructure.Requests;
 using DLCS.Core;
 using DLCS.Core.Collections;
-using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Model.Spaces;

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -109,8 +109,10 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
             if (modifyEntityResult.Entity!.Family == AssetFamily.Timebased)
             {
                 await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
-                    modifyEntityResult.Entity.AsList(), cancellationToken);
-                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
+                    modifyEntityResult.Entity.AsList(), postCreate: b =>
+                    {
+                        b.AddBatchAsset(modifyEntityResult.Entity!.Id);
+                    }, cancellationToken: cancellationToken);
             }
             
             await transaction.CommitAsync(cancellationToken);

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -99,23 +99,17 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
             request.AssetMustExist,
             request.AlwaysReingest,
             false,
-            async updatedAsset =>
-            {
-                if (updatedAsset.Family == AssetFamily.Timebased)
-                {
-                    // Timebased asset - create a Batch record in DB and populate Batch property in Asset
-                    await batchRepository.CreateBatch(updatedAsset.Customer, updatedAsset.AsList(), cancellationToken);
-                }
-            },
-            cancellationToken
+            cancellationToken: cancellationToken
         );
         
         var modifyEntityResult = processAssetResult.Result;
 
         if (modifyEntityResult.IsSuccess)
         {
-            if (modifyEntityResult.Entity!.HasSingleDeliveryChannel(AssetDeliveryChannels.Timebased))
+            if (modifyEntityResult.Entity!.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
             {
+                await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
+                    modifyEntityResult.Entity.AsList(), cancellationToken);
                 await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
             }
             

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Data;
 using System.Net;
 using API.Exceptions;
@@ -7,6 +8,7 @@ using API.Infrastructure.Messaging;
 using API.Infrastructure.Requests;
 using DLCS.Core;
 using DLCS.Core.Collections;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Model.Spaces;
@@ -114,6 +116,11 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         if (modifyEntityResult.IsSuccess)
         {
+            if (modifyEntityResult.Entity!.HasSingleDeliveryChannel(AssetDeliveryChannels.Timebased))
+            {
+                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
+            }
+            
             await transaction.CommitAsync(cancellationToken);
         }
         else

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -106,7 +106,7 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         if (modifyEntityResult.IsSuccess)
         {
-            if (modifyEntityResult.Entity!.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
+            if (modifyEntityResult.Entity!.Family == AssetFamily.Timebased)
             {
                 var batch = await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
                     modifyEntityResult.Entity.AsList(), cancellationToken);

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -108,9 +108,9 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
         {
             if (modifyEntityResult.Entity!.Family == AssetFamily.Timebased)
             {
-                var batch = await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
+                await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
                     modifyEntityResult.Entity.AsList(), cancellationToken);
-                batch.AddBatchAsset(modifyEntityResult.Entity!.Id);
+                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
             }
             
             await transaction.CommitAsync(cancellationToken);

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -108,9 +108,9 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
         {
             if (modifyEntityResult.Entity!.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
             {
-                await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
+                var batch = await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
                     modifyEntityResult.Entity.AsList(), cancellationToken);
-                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
+                batch.AddBatchAsset(modifyEntityResult.Entity!.Id);
             }
             
             await transaction.CommitAsync(cancellationToken);

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -106,10 +106,11 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         if (modifyEntityResult.IsSuccess)
         {
-            if (modifyEntityResult.Entity!.Family == AssetFamily.Timebased)
+            if (modifyEntityResult.Entity!.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
             {
                 await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
                     modifyEntityResult.Entity.AsList(), cancellationToken);
+                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
             }
             
             await transaction.CommitAsync(cancellationToken);

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -106,11 +106,10 @@ public class CreateOrUpdateImageHandler : IRequestHandler<CreateOrUpdateImage, M
 
         if (modifyEntityResult.IsSuccess)
         {
-            if (modifyEntityResult.Entity!.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
+            if (modifyEntityResult.Entity!.Family == AssetFamily.Timebased)
             {
                 await batchRepository.CreateBatch(modifyEntityResult.Entity.Customer,
                     modifyEntityResult.Entity.AsList(), cancellationToken);
-                await batchRepository.CreateBatchAsset(modifyEntityResult.Entity!, cancellationToken);
             }
             
             await transaction.CommitAsync(cancellationToken);

--- a/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
@@ -22,12 +22,4 @@ public interface IBatchRepository
     /// <returns>Created Batch object</returns>
     Task<Batch> CreateBatch(int customerId, IReadOnlyList<Asset> assets, CancellationToken cancellationToken,
         Action<Batch>? postCreate = null);
-
-    /// <summary>
-    /// Create batch assets for a batch in the DB
-    /// </summary>
-    /// <param name="asset">The asset to create batch assets for</param>
-    /// <param name="cancellationToken">The current cancellation token</param>
-    /// <returns>Created batch assets</returns>
-    public Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core.Types;
 
 namespace DLCS.Model.Assets;
 
@@ -22,12 +21,4 @@ public interface IBatchRepository
     /// <returns>Created Batch object</returns>
     Task<Batch> CreateBatch(int customerId, IReadOnlyList<Asset> assets, CancellationToken cancellationToken,
         Action<Batch>? postCreate = null);
-
-    /// <summary>
-    /// Create batch assets for a batch in the DB
-    /// </summary>
-    /// <param name="asset">The asset to create batch assets for</param>
-    /// <param name="cancellationToken">The current cancellation token</param>
-    /// <returns>Created batch assets</returns>
-    public Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core.Types;
 
 namespace DLCS.Model.Assets;
 
@@ -21,4 +22,12 @@ public interface IBatchRepository
     /// <returns>Created Batch object</returns>
     Task<Batch> CreateBatch(int customerId, IReadOnlyList<Asset> assets, CancellationToken cancellationToken,
         Action<Batch>? postCreate = null);
+
+    /// <summary>
+    /// Create batch assets for a batch in the DB
+    /// </summary>
+    /// <param name="asset">The asset to create batch assets for</param>
+    /// <param name="cancellationToken">The current cancellation token</param>
+    /// <returns>Created batch assets</returns>
+    public Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
+++ b/src/protagonist/DLCS.Model/Assets/IBatchRepository.cs
@@ -22,4 +22,12 @@ public interface IBatchRepository
     /// <returns>Created Batch object</returns>
     Task<Batch> CreateBatch(int customerId, IReadOnlyList<Asset> assets, CancellationToken cancellationToken,
         Action<Batch>? postCreate = null);
+
+    /// <summary>
+    /// Create batch assets for a batch in the DB
+    /// </summary>
+    /// <param name="asset">The asset to create batch assets for</param>
+    /// <param name="cancellationToken">The current cancellation token</param>
+    /// <returns>Created batch assets</returns>
+    public Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core.Guard;
 using DLCS.Model.Assets;
 
 namespace DLCS.Repository.Assets;
@@ -44,24 +43,5 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
         }
 
         return batch;
-    }
-    
-    /// <inheritdoc />
-    public async Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken)
-    {
-        asset.Batch.ThrowIfNull(nameof(asset.Batch));
-        
-        var batchAsset = new BatchAsset
-        {
-            AssetId = asset.Id,
-            BatchId = asset.Batch!.Value,
-            Status = BatchAssetStatus.Waiting
-        };
-        
-       var batchAssets = await DlcsContext.BatchAssets.AddAsync(batchAsset, cancellationToken);
-
-        await DlcsContext.SaveChangesAsync(cancellationToken);
-        
-        return batchAssets.Entity;
     }
 }

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -45,23 +45,4 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
 
         return batch;
     }
-    
-    /// <inheritdoc />
-    public async Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken)
-    {
-        asset.Batch.ThrowIfNull(nameof(asset.Batch));
-        
-        var batchAsset = new BatchAsset
-        {
-            AssetId = asset.Id,
-            BatchId = asset.Batch!.Value,
-            Status = BatchAssetStatus.Waiting
-        };
-        
-       var batchAssets = await DlcsContext.BatchAssets.AddAsync(batchAsset, cancellationToken);
-
-        await DlcsContext.SaveChangesAsync(cancellationToken);
-        
-        return batchAssets.Entity;
-    }
 }

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -49,12 +49,12 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
     /// <inheritdoc />
     public async Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken)
     {
-        asset.Batch.ThrowIfNull("Saving a batch asset requires a batch");
+        asset.Batch.ThrowIfNull(nameof(asset.Batch));
         
         var batchAsset = new BatchAsset
         {
             AssetId = asset.Id,
-            BatchId = asset.Batch.Value,
+            BatchId = asset.Batch!.Value,
             Status = BatchAssetStatus.Waiting
         };
         

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -33,6 +33,11 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
             Superseded = false,
             BatchAssets = new List<BatchAsset>(assets.Count)
         };
+
+        foreach (var asset in assets)
+        {
+            batch.AddBatchAsset(asset.Id);
+        }
         
         postCreate?.Invoke(batch);
         DlcsContext.Batches.Add(batch);
@@ -44,24 +49,5 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
         }
 
         return batch;
-    }
-    
-    /// <inheritdoc />
-    public async Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken)
-    {
-        asset.Batch.ThrowIfNull(nameof(asset.Batch));
-        
-        var batchAsset = new BatchAsset
-        {
-            AssetId = asset.Id,
-            BatchId = asset.Batch!.Value,
-            Status = BatchAssetStatus.Waiting
-        };
-        
-       var batchAssets = await DlcsContext.BatchAssets.AddAsync(batchAsset, cancellationToken);
-
-        await DlcsContext.SaveChangesAsync(cancellationToken);
-        
-        return batchAssets.Entity;
     }
 }

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -45,4 +45,23 @@ public class BatchRepository : IDapperContextRepository, IBatchRepository
 
         return batch;
     }
+    
+    /// <inheritdoc />
+    public async Task<BatchAsset> CreateBatchAsset(Asset asset, CancellationToken cancellationToken)
+    {
+        asset.Batch.ThrowIfNull(nameof(asset.Batch));
+        
+        var batchAsset = new BatchAsset
+        {
+            AssetId = asset.Id,
+            BatchId = asset.Batch!.Value,
+            Status = BatchAssetStatus.Waiting
+        };
+        
+       var batchAssets = await DlcsContext.BatchAssets.AddAsync(batchAsset, cancellationToken);
+
+        await DlcsContext.SaveChangesAsync(cancellationToken);
+        
+        return batchAssets.Entity;
+    }
 }

--- a/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
+++ b/src/protagonist/DLCS.Repository/Assets/BatchRepository.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Guard;
-using DLCS.Core.Types;
 using DLCS.Model.Assets;
 
 namespace DLCS.Repository.Assets;


### PR DESCRIPTION
Resolves #937

This PR adds a call to create a batch asset record when ingesting timebased assets via PUT. 