### PR TITLE
Getting image delivery channels to work with the default policy

### DIFF
--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -1151,13 +1151,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels).Single(x => x.Id == assetId);
         asset.Id.Should().Be(assetId);
         asset.MaxUnauthorised.Should().Be(-1);
-        asset.ImageDeliveryChannels.Should().HaveCount(3).And.Contain(i =>
-                i.Channel == AssetDeliveryChannels.Image &&
-                i.DeliveryChannelPolicyId == KnownDeliveryChannelPolicies.ImageDefault).And
-            .Contain(i => i.Channel == AssetDeliveryChannels.Thumbnails && i.DeliveryChannelPolicyId == thumbsPolicy.Id)
-            .And.Contain(i =>
-                i.Channel == AssetDeliveryChannels.File &&
-                i.DeliveryChannelPolicyId == KnownDeliveryChannelPolicies.FileNone);
+        asset.ImageDeliveryChannels.Should().BeEquivalentTo(deliveryChannels);
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -1233,7 +1233,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("Delivery channels are required when updating an existing Asset");
+        body.Should().Contain("'deliveryChannels' cannot be an empty array");
     }
 
     [Fact]

--- a/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
+++ b/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
@@ -12,7 +12,7 @@ public class AssetBeforeProcessing
 
     public Asset Asset { get; }
 
-    public DeliveryChannelsBeforeProcessing[]? DeliveryChannelsBeforeProcessing { get; set; }
+    public DeliveryChannelsBeforeProcessing[]? DeliveryChannelsBeforeProcessing { get; }
 }
 
 /// <summary>

--- a/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
+++ b/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
@@ -4,7 +4,7 @@ namespace API.Features.Image;
 
 public class AssetBeforeProcessing
 {
-    public AssetBeforeProcessing(Asset asset, DeliveryChannelsBeforeProcessing[] deliveryChannelsBeforeProcessing)
+    public AssetBeforeProcessing(Asset asset, DeliveryChannelsBeforeProcessing[]? deliveryChannelsBeforeProcessing)
     {
         Asset = asset;
         DeliveryChannelsBeforeProcessing = deliveryChannelsBeforeProcessing;
@@ -12,7 +12,7 @@ public class AssetBeforeProcessing
 
     public Asset Asset { get; }
 
-    public DeliveryChannelsBeforeProcessing[] DeliveryChannelsBeforeProcessing { get; }
+    public DeliveryChannelsBeforeProcessing[]? DeliveryChannelsBeforeProcessing { get; set; }
 }
 
 /// <summary>

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -288,7 +288,7 @@ public class ImageController : HydraController
         // See https://github.com/dlcs/protagonist/issues/338
         var method = hydraAsset is ImageWithFile ? "PUT" : Request.Method;
 
-        var deliveryChannelsBeforeProcessing = (hydraAsset.DeliveryChannels ?? Array.Empty<DeliveryChannel>())
+        var deliveryChannelsBeforeProcessing = hydraAsset.DeliveryChannels?
             .Select(d => new DeliveryChannelsBeforeProcessing(d.Channel, d.Policy)).ToArray();
 
         var assetBeforeProcessing = new AssetBeforeProcessing(asset, deliveryChannelsBeforeProcessing);

--- a/src/protagonist/API/Features/Image/ImagesController.cs
+++ b/src/protagonist/API/Features/Image/ImagesController.cs
@@ -125,7 +125,7 @@ public class ImagesController : HydraController
             {
                 var asset = hydraImage.ToDlcsModel(customerId, spaceId);
 
-                var deliveryChannelsBeforeProcessing = (hydraImage.DeliveryChannels ?? Array.Empty<DeliveryChannel>())
+                var deliveryChannelsBeforeProcessing = hydraImage.DeliveryChannels?
                     .Select(d => new DeliveryChannelsBeforeProcessing(d.Channel, d.Policy)).ToArray();
 
                 var assetBeforeProcessing = new AssetBeforeProcessing(asset, deliveryChannelsBeforeProcessing);

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -100,17 +100,6 @@ public class AssetProcessor
 
                 updatedDeliveryChannels = true;
             }
-            else if (assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Length == 0 && alwaysReingest)
-            {
-                return new ProcessAssetResult
-                {
-                    Result = ModifyEntityResult<Asset>.Failure(
-                        "Delivery channels are required when updating an existing Asset",
-                        WriteResult.BadRequest
-                    )
-                };
-            }
-            
             
             var existingAsset = assetFromDatabase?.Clone();
             var assetPreparationResult =

--- a/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/DeliveryChannelProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿﻿using System.Collections.Generic;
 using API.Exceptions;
 using DLCS.Core.Collections;
 using DLCS.Model.Assets;
@@ -33,16 +33,16 @@ public class DeliveryChannelProcessor
     /// </param>
     /// <param name="deliveryChannelsBeforeProcessing">List of deliveryChannels submitted in body</param>
     /// <returns>Boolean indicating whether asset requires processing Engine</returns>
-    public async Task<bool> ProcessImageDeliveryChannels(Asset? existingAsset, Asset updatedAsset,  
-        bool deliveryChannelsUpdated, DeliveryChannelsBeforeProcessing[]? deliveryChannelsBeforeProcessing)
+    public async Task<bool> ProcessImageDeliveryChannels(Asset? existingAsset, Asset updatedAsset,
+        DeliveryChannelsBeforeProcessing[]? deliveryChannelsBeforeProcessing)
     {
-        if (existingAsset == null || deliveryChannelsUpdated ||
+        if (existingAsset == null ||
             DeliveryChannelsRequireReprocessing(existingAsset, deliveryChannelsBeforeProcessing))
         {
             try
             {
                 var deliveryChannelChanged = await SetImageDeliveryChannels(updatedAsset,
-                    deliveryChannelsBeforeProcessing, existingAsset != null);
+                    deliveryChannelsBeforeProcessing ?? Array.Empty<DeliveryChannelsBeforeProcessing>(), existingAsset != null);
                 return deliveryChannelChanged;
             }
             catch (InvalidOperationException ioEx)
@@ -54,8 +54,9 @@ public class DeliveryChannelProcessor
         return false;
     }
 
-    private bool DeliveryChannelsRequireReprocessing(Asset originalAsset, DeliveryChannelsBeforeProcessing[]? deliveryChannelsBeforeProcessing)
+    private bool DeliveryChannelsRequireReprocessing(Asset originalAsset, DeliveryChannelsBeforeProcessing[] deliveryChannelsBeforeProcessing)
     {
+        // PUT prevents empty delivery channels from being passed here, but PATCH doesn't
         if (deliveryChannelsBeforeProcessing.IsNullOrEmpty()) return false;
         if (originalAsset.ImageDeliveryChannels.Count != deliveryChannelsBeforeProcessing.Length) return true;
         
@@ -72,20 +73,21 @@ public class DeliveryChannelProcessor
         return false;
     }
 
-    private async Task<bool> SetImageDeliveryChannels(Asset asset, DeliveryChannelsBeforeProcessing[]? deliveryChannelsBeforeProcessing, bool isUpdate)
+    private async Task<bool> SetImageDeliveryChannels(Asset asset, DeliveryChannelsBeforeProcessing[] deliveryChannelsBeforeProcessing, bool isUpdate)
     {
         var assetId = asset.Id;
-        var isDefaultChannel = deliveryChannelsBeforeProcessing?.Any(d => d.Channel == AssetDeliveryChannels.Default) ??
-                               false;
+        var isDefaultChannel = deliveryChannelsBeforeProcessing.Any(d => d.Channel == AssetDeliveryChannels.Default);
         
-        // if it's a new asset, or has "default" specified, figure out the delivery channels based on media type
         if (!isUpdate || isDefaultChannel)
         {
-            logger.LogTrace("Setting delivery channels for asset {AssetId}", assetId);
+            logger.LogTrace("Asset {AssetId} is new, resetting ImageDeliveryChannels", assetId);
             asset.ImageDeliveryChannels = new List<ImageDeliveryChannel>();
-
+            
+            // Only valid for creation - set image delivery channels to default values for media type
             if (deliveryChannelsBeforeProcessing.IsNullOrEmpty() || isDefaultChannel)
             {
+                logger.LogDebug("Asset {AssetId} is new, no deliveryChannels specified. Assigning defaults for mediaType",
+                    assetId);
                 await AddDeliveryChannelsForMediaType(asset);
                 return true;
             }
@@ -102,19 +104,16 @@ public class DeliveryChannelProcessor
         var changeMade = false;
         var handledChannels = new List<string>();
         var assetImageDeliveryChannels = asset.ImageDeliveryChannels;
-        
         foreach (var deliveryChannel in deliveryChannelsBeforeProcessing)
         {
             handledChannels.Add(deliveryChannel.Channel);
             var deliveryChannelPolicy = await GetDeliveryChannelPolicy(asset, deliveryChannel);
-            var currentChannel =
-                assetImageDeliveryChannels.SingleOrDefault(idc => idc.Channel == deliveryChannel.Channel);
+            var currentChannel = assetImageDeliveryChannels.SingleOrDefault(idc => idc.Channel == deliveryChannel.Channel);
 
             // No current ImageDeliveryChannel for channel so this is an addition
             if (currentChannel == null)
             {
-                logger.LogTrace(
-                    "Adding new deliveryChannel {DeliveryChannel}, Policy {PolicyName} to Asset {AssetId}",
+                logger.LogTrace("Adding new deliveryChannel {DeliveryChannel}, Policy {PolicyName} to Asset {AssetId}",
                     deliveryChannel.Channel, deliveryChannelPolicy.Name, assetId);
 
                 assetImageDeliveryChannels.Add(new ImageDeliveryChannel

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -13,13 +13,10 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
 {
     public HydraImageValidator()
     {
-        RuleSet("patch", () =>
-        {
-            RuleFor(p => p.DeliveryChannels)
-                .Must(a => a!.Any())
-                .When(a => a.DeliveryChannels != null)
-                .WithMessage("'deliveryChannels' cannot be an empty array when updating an existing asset via PATCH");
-        });
+        RuleFor(p => p.DeliveryChannels)
+            .Must(a => a!.Any())
+            .When(a => a.DeliveryChannels != null)
+            .WithMessage("'deliveryChannels' cannot be an empty array");
         
         RuleSet("create", () =>
         {

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -424,7 +424,7 @@ public class CustomerQueueController : HydraController
     {
         var assetsBeforeProcessing = images.Members!
             .Select(i => new AssetBeforeProcessing(i.ToDlcsModel(customerId),
-                (i.DeliveryChannels ?? Array.Empty<DeliveryChannel>())
+                i.DeliveryChannels?
                 .Select(d => new DeliveryChannelsBeforeProcessing(d.Channel, d.Policy)).ToArray())).ToList();
         return assetsBeforeProcessing;
     }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -11,11 +11,12 @@ public static class AssetDeliveryChannels
     public const string Timebased = "iiif-av";
     public const string File = "file";
     public const string None = "none";
+    public const string Default = "default";
 
     /// <summary>
     /// All possible delivery channels
     /// </summary>
-    public static string[] All { get; } = { File, Timebased, Image, Thumbnails, None };
+    public static string[] All { get; } = { File, Timebased, Image, Thumbnails, None, Default };
 
     /// <summary>
     /// All possible delivery channels as a comma-delimited string
@@ -72,6 +73,7 @@ public static class AssetDeliveryChannels
             Image => mediaType.StartsWith("image/"),
             Thumbnails => mediaType.StartsWith("image/"),
             Timebased => mediaType.StartsWith("video/") || mediaType.StartsWith("audio/"),
+            Default => true, // Default causes delivery channels to be selected based on media type
             File => true, // A file can be matched to any media type
             None => true, // Likewise for the 'none' channel
             _ when throwIfChannelUnknown => throw new ArgumentOutOfRangeException(nameof(deliveryChannel), deliveryChannel,


### PR DESCRIPTION
Resolves #931 

This PR implements the new `default` delivery channel which does the following:

- if `default` specified
  - if new asset, act like `null` delivery channel
  - if updated asset, ingest with customer specified default delivery channels
- if `null` specified
  - if new asset, act the same as previous behavior
  - if updated asset, reuse the previous delivery channels