### PR TITLE
Prevent duplicate customer 'name' or 'displayName'

### DIFF
--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -238,6 +238,9 @@ public partial class DlcsContext : DbContext
             entity.Property(e => e.Name)
                 .IsRequired()
                 .HasMaxLength(500);
+
+            entity.HasIndex(c => c.Name).IsUnique();
+            entity.HasIndex(c => c.DisplayName).IsUnique();
         });
 
         modelBuilder.Entity<CustomerImageServer>(entity =>

--- a/src/protagonist/DLCS.Repository/Exceptions/DbError.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbError.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.EntityFrameworkCore;
 
 namespace DLCS.Repository.Exceptions;
 

--- a/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
@@ -45,4 +46,9 @@ public record UniqueConstraintError(
         
         return new UniqueConstraintError(columnNames, tableName, constraintName, postgresException);
     }
+    
+    /// <summary>
+    /// Check if error is for specified columnt
+    /// </summary>
+    public bool ForColumn(string columnName) => ColumnNames.Contains(columnName);
 }

--- a/src/protagonist/DLCS.Repository/Exceptions/DbUpdateExceptionX.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbUpdateExceptionX.cs
@@ -11,11 +11,11 @@ namespace DLCS.Repository.Exceptions;
 public static class DbUpdateExceptionX
 {
     /// <summary>
-    /// Retrieves a <see cref="DatabaseError"/> with database specific error 
+    /// Retrieves a <see cref="DbError"/> with database specific error 
     /// information from the <see cref="DbUpdateException"/> thrown by EF Core. 
     /// </summary>
     /// <param name="exception">The <see cref="DbUpdateException"/> thrown.</param>
-    /// <returns>A <see cref="DatabaseError"/> or derived class if the inner 
+    /// <returns>A <see cref="DbError"/> or derived class if the inner 
     /// exception matches one of the supported types. Otherwise returns null.</returns>
     public static DbError? GetDatabaseError(this DbUpdateException exception)
     {

--- a/src/protagonist/DLCS.Repository/Migrations/20250131154626_Customer uniqueconstraint.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250131154626_Customer uniqueconstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20250131154626_Customer uniqueconstraint")]
+    partial class Customeruniqueconstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20250131154626_Customer uniqueconstraint.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20250131154626_Customer uniqueconstraint.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class Customeruniqueconstraint : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Customers_DisplayName",
+                table: "Customers",
+                column: "DisplayName",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Customers_Name",
+                table: "Customers",
+                column: "Name",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Customers_DisplayName",
+                table: "Customers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Customers_Name",
+                table: "Customers");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #943 

Add unique constraint for `Customer.Name` and `Customer.DisplayName` and handling for when this is thrown, resulting in a 409.