### PR TITLE
Check database before deleting derivatives

### DIFF
--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -64,7 +64,7 @@ public class AssetDeletedHandler : IMessageHandler
 
         logger.LogDebug("Processing delete notification for {AssetId}", request.Asset.Id);
         
-        // if the itme exists in the db, assume the asset has been reingested after delete
+        // if the item exists in the db, assume the asset has been reingested after delete
         if (await assetRepository.CheckExists(request.Asset.Id))
         {
             logger.LogInformation("asset {Asset} can be found in the database, so will not be deleted", request.Asset.Id);

--- a/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetDeletedHandler.cs
@@ -65,7 +65,11 @@ public class AssetDeletedHandler : IMessageHandler
         logger.LogDebug("Processing delete notification for {AssetId}", request.Asset.Id);
         
         // if the itme exists in the db, assume the asset has been reingested after delete
-        if (await assetRepository.CheckExists(request.Asset.Id)) return true;
+        if (await assetRepository.CheckExists(request.Asset.Id))
+        {
+            logger.LogInformation("asset {Asset} can be found in the database, so will not be deleted", request.Asset.Id);
+            return true;
+        }
 
         await DeleteThumbnails(request.Asset.Id);
         await DeleteTileOptimised(request.Asset.Id);
@@ -77,7 +81,7 @@ public class AssetDeletedHandler : IMessageHandler
             return await InvalidateContentDeliveryNetwork(request.Asset, request.CustomerPathElement.Name);
         }
 
-        Log.Debug("cdn invalidation not specified for {Asset}", request.Asset.Id);
+        logger.LogDebug("cdn invalidation not specified for {Asset}", request.Asset.Id);
         return true;
     }
 

--- a/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/CleanupHandlerAssetRepository.cs
@@ -19,4 +19,9 @@ public class CleanupHandlerAssetRepository : ICleanupHandlerAssetRepository
     {
         return await dbContext.Images.IncludeDeliveryChannelsWithPolicy().SingleOrDefaultAsync(x => x.Id == assetId);
     }
+
+    public async Task<bool> CheckExists(AssetId assetId)
+    {
+        return await dbContext.Images.AnyAsync(x => x.Id == assetId);
+    }
 }

--- a/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
+++ b/src/protagonist/CleanupHandler/Repository/ICleanupHandlerAssetRepository.cs
@@ -11,4 +11,9 @@ public interface ICleanupHandlerAssetRepository
     /// <param name="assetId">The asset id to retrieve details for</param>
     /// <returns>an asset</returns>
     Task<Asset?> RetrieveAssetWithDeliveryChannels(AssetId assetId);
+
+    /// <summary>
+    /// Check whether an asset exists in the database
+    /// </summary>
+    Task<bool> CheckExists(AssetId assetId);
 }


### PR DESCRIPTION
resolves #940

This PR updates the `CleanupHandler` to check that a database record exists before deleting, which helps avoid issues with a deleted asset being ingested again before the `CleanupHandler` runs, causing an asset which should be there to have it's derivatives removed