### PR TITLE
Add additional validation rule to provide a bad request when more than just the default channel

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -128,6 +128,25 @@ public class HydraImageValidatorTests
     }
     
     [Fact]
+    public void DeliveryChannel_ValidationError_WhenDefaultAndMoreDeliveryChannels()
+    {
+        var sut = GetSut();
+        var model = new Image { DeliveryChannels = new[]
+        {
+            new DeliveryChannel()
+            {
+                Channel = "default"
+            },
+            new DeliveryChannel()
+            {
+                Channel = "file"
+            }
+        } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
+    }
+    
+    [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsWithNoNone()
     {
         var sut = GetSut();

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -218,6 +218,34 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_NewImageAsset_BadRequest_WithMultipleSingleOnlyDeliveryChannel()
+    {
+        var customerAndSpace = await CreateCustomerAndSpace();
+
+        var assetId = new AssetId(customerAndSpace.customer, customerAndSpace.space, nameof(Put_NewImageAsset_Creates_Asset_WithDeliveryChannelsSetToDefault));
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+            {{
+                ""channel"": ""default""
+            }},
+            {{
+                ""channel"": ""none""
+            }}]
+        }}";
+
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
     public async Task Put_NewImageAsset_Creates_Asset_WithCustomDefaultDeliveryChannel()
     {
         var customerAndSpace = await CreateCustomerAndSpace();

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -190,6 +190,34 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_NewImageAsset_BadRequest_WithDefaultDeliveryChannelPlusOther()
+    {
+        var customerAndSpace = await CreateCustomerAndSpace();
+
+        var assetId = new AssetId(customerAndSpace.customer, customerAndSpace.space, nameof(Put_NewImageAsset_Creates_Asset_WithDeliveryChannelsSetToDefault));
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+            {{
+                ""channel"": ""default""
+            }},
+            {{
+                ""channel"": ""iiif-img""
+            }}]
+        }}";
+
+        // act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
     public async Task Put_NewImageAsset_Creates_Asset_WithCustomDefaultDeliveryChannel()
     {
         var customerAndSpace = await CreateCustomerAndSpace();

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -51,6 +51,11 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.None))
             .When(a => a.DeliveryChannels!.Length > 1)
             .WithMessage("If 'none' is the specified channel, then no other delivery channels are allowed");
+        
+        RuleFor(a => a.DeliveryChannels)
+            .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.Default))
+            .When(a => a.DeliveryChannels!.Length > 1)
+            .WithMessage("If 'default' is a specified channel, then no other delivery channels are allowed");
 
         RuleForEach(a => a.DeliveryChannels)
             .Must(c => !string.IsNullOrEmpty(c.Channel))

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -46,16 +46,11 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleForEach(a => a.DeliveryChannels)
             .Must(dc => AssetDeliveryChannels.IsValidChannel(dc.Channel))
             .WithMessage($"DeliveryChannel must be one of {AssetDeliveryChannels.AllString}");
-
-        RuleFor(a => a.DeliveryChannels)
-            .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.None))
-            .When(a => a.DeliveryChannels!.Length > 1)
-            .WithMessage("If 'none' is the specified channel, then no other delivery channels are allowed");
         
         RuleFor(a => a.DeliveryChannels)
-            .Must(d => d.All(d => d.Channel != AssetDeliveryChannels.Default))
+            .Must(dl => dl.All(d => !AssetDeliveryChannels.SingleOnly.Contains(d.Channel)))
             .When(a => a.DeliveryChannels!.Length > 1)
-            .WithMessage("If 'default' is a specified channel, then no other delivery channels are allowed");
+            .WithMessage(d => $"If one of '{AssetDeliveryChannels.SingleOnlyString}' is a specified channel, then no other delivery channels are allowed");
 
         RuleForEach(a => a.DeliveryChannels)
             .Must(c => !string.IsNullOrEmpty(c.Channel))

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -17,11 +17,21 @@ public static class AssetDeliveryChannels
     /// All possible delivery channels
     /// </summary>
     public static string[] All { get; } = { File, Timebased, Image, Thumbnails, None, Default };
+    
+    /// <summary>
+    /// All possible delivery channels that can only be used by themselves
+    /// </summary>
+    public static string[] SingleOnly { get; } = { Default, None };
 
     /// <summary>
     /// All possible delivery channels as a comma-delimited string
     /// </summary>
     public static readonly string AllString = string.Join(',', All);
+    
+    /// <summary>
+    /// All single only delivery channels as a comma-delimited string
+    /// </summary>
+    public static readonly string SingleOnlyString = string.Join(',', SingleOnly);
     
     /// <summary>
     /// Checks if an asset has any delivery channel specified in a list


### PR DESCRIPTION
This PR simply adds an additional hydra validator that will stop allowing the `default` channel to be specified with other channels, mimicking the behaviour of the `none` channel