### PR TITLE
Fix issue with legacy mode responding with an error when it should pass

### DIFF
--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -61,7 +61,7 @@ public static class LegacyModeConverter
         return image;
     }
 
-    private static DeliveryChannel[] GetDeliveryChannelsForLegacyAsset<T>(T image)
+    private static DeliveryChannel[]? GetDeliveryChannelsForLegacyAsset<T>(T image)
         where T : Image
     {
         // Retrieve the name, if it is a path to a DLCS IOP/TP policy resource
@@ -153,7 +153,7 @@ public static class LegacyModeConverter
             };
         }
         
-        return Array.Empty<DeliveryChannel>();
+        return null;
     }
     
     private static string? GetPolicyValue(string? policyValue, string pathSlug)


### PR DESCRIPTION
This request:

```json
{
  "origin": "https://dlcsstage-public-test-objects.s3.eu-west-1.amazonaws.com/other-video/fish.mp4",
  "mediaType": "video/mp4",
  "deliveryChannels": [
    {
      "channel": "iiif-av",
      "policy": "default-video"
    }
  ]
}
```

causes the below response in legacy mode:

```json
{
  "@type": "Error",
  "statusCode": 400,
  "status": 400,
  "title": "Bad request",
  "detail": "'deliveryChannels' cannot be an empty array",
  "instance": "https://api.dlcs-stage.digirati.io/",
  "description": "'deliveryChannels' cannot be an empty array"
}
```

This is due to previously treating `null` and `empty` the same way when working out the delivery channels based on media type.  However, this has changed with #944  where `empty` is treated as a `400`.  As such, this PR modifies the response of the `LegacyConverter` to correctly respond with `null`, rather than `empty` when the delivery channels cannot be worked out directly