### PR TITLE
Do not finish batch if already finished

### DIFF
--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -193,6 +193,7 @@ FROM (SELECT ""BatchId""                                     as batch_id,
       GROUP BY ""BatchId"") ba
 WHERE b.""Id"" = ba.batch_id
 AND b.""Id"" = @batchId
+AND b.""Finished"" IS NULL
 RETURNING b.*;
 ";
 }


### PR DESCRIPTION
Fixes #973 

Reingested assets don't remove batchId, which can lead to batch finish date refreshing and completed notification being re-raised.

Adding `AND b."Finished" IS NULL` to query will ignore already finished batches, which means completed notification won't be raised. This seemed a safer option than changing PUT/reingest behaviour to remove batchId.