### PR TITLE
DLCS.Repository + explicit EFCore.Relational pkg 

### DIFF
--- a/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
+++ b/src/protagonist/DLCS.Repository/DLCS.Repository.csproj
@@ -12,6 +12,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder"/>
         <PackageReference Include="Microsoft.Extensions.Http"/>


### PR DESCRIPTION
`DLCS.Repository` relies on `Microsoft.EntityFrameworkCore.Relational` but gets it via `Npgsql.EntityFrameworkCore.PostgreSQL` dependency.

`Npgsql...` `9.0.4` pkg uses a range `[9.0.1,10.0.0)` for EFCore packages, causing apps dependant on `DLCS.Repository`to resolve `Microsoft.EntityFrameworkCore.Relational` in lowest `9.0.1` version causing runtime exception.

Explicitly stating the dependency of `DLCS.Repository` on `Microsoft.EntityFrameworkCore.Relational` fixes the discrepancy between version built against and version available in app environment.