### PR TITLE
Use AssetIdGenerator for ImageHandlingTests

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -202,8 +202,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_Correct_ViaDisplayName()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}");
-        var namedId = $"test/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}";
+        var id = AssetIdGenerator.GetAssetId();
+        var namedId = $"test/1/{id.Asset}";
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -239,8 +239,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_Correct_IgnoresQueryParamOnRequestUri()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_Correct_IgnoresQueryParamOnRequestUri)}");
-        var namedId = $"test/1/{nameof(GetInfoJson_Correct_IgnoresQueryParamOnRequestUri)}";
+        var id = AssetIdGenerator.GetAssetId();
+        var namedId = $"test/1/{id.Asset}";
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -317,7 +317,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_RestrictedImage_NoRole_HasMaxWidthSet()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_RestrictedImage_NoRole_HasMaxWidthSet)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -346,7 +346,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_NoRole_HasMaxWidthSet()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_NoRole_HasMaxWidthSet)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -376,7 +376,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_ReturnsImageServerSizes_IfS3GetFails()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_ReturnsImageServerSizes_IfS3GetFails)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -414,7 +414,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3_CustomPathRules)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -462,7 +462,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -501,7 +501,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_AlreadyInS3_CustomPathRules)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -543,7 +543,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV2_Correct_ViaConneg()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaConneg)}");
+        var id = AssetIdGenerator.GetAssetId();
         const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/image/2/context.json\"";
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
@@ -576,7 +576,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV3_RedirectsToCanonical()
     {
         // Arrange
-        var id = $"99/1/{nameof(GetInfoJsonV3_RedirectsToCanonical)}";
+        var id = AssetIdGenerator.GetAssetId();
 
         // Act
         var response = await httpClient.GetAsync($"iiif-img/v3/{id}/info.json");
@@ -590,7 +590,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV3_Correct_ViaConneg_CustomPathRules()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg_CustomPathRules)}"); 
+        var id = AssetIdGenerator.GetAssetId();
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/image/3/context.json\"";
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
@@ -627,7 +627,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJsonV3_Correct_ViaConneg()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV3_Correct_ViaConneg)}");
+        var id = AssetIdGenerator.GetAssetId();
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/image/3/context.json\"";
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
@@ -659,7 +659,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_OpenImage_Correct()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OpenImage_Correct)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -686,7 +686,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_OrchestratesImage_IfServedFromS3()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OrchestratesImage_IfServedFromS3)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -717,7 +717,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // the imageserver to serve but this isn't caught in these tests 
         
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_DoesNotOrchestratesImage_IfServedFromImageServer)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -739,7 +739,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_DoesNotOrchestratesImage_IfQueryParamPassed()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_DoesNotOrchestratesImage_IfQueryParamPassed)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -761,7 +761,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_OpenImage_ForwardedFor_Correct()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_OpenImage_ForwardedFor_Correct)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -791,7 +791,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_Correct()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_Correct)}");
+        var id = AssetIdGenerator.GetAssetId();
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
         const string logoutServiceName = "my-logout-service";
@@ -840,7 +840,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_Correct_CustomPathRules()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_Correct_CustomPathRules)}");
+        var id = AssetIdGenerator.GetAssetId();
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
         const string logoutServiceName = "my-logout-service";
@@ -894,7 +894,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_NoRole_HasNoService()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(GetInfoJson_RestrictedImage_NoRole_HasNoService)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -925,8 +925,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_WithUnknownRole_Returns401WithoutServices()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401WithoutServices)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "unknown-role", maxUnauthorised: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
 
@@ -956,8 +955,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfNoBearerTokenProvided()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfNoBearerTokenProvided)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
@@ -985,8 +983,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfUnknownBearerTokenProvided()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfUnknownBearerTokenProvided)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1016,8 +1013,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfExpiredBearerTokenProvided()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns401_IfExpiredBearerTokenProvided)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
@@ -1052,8 +1048,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task GetInfoJson_RestrictedImage_WithUnknownRole_Returns200_AndRefreshesToken_IfValidBearerTokenProvided()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(GetInfoJson_RestrictedImage_WithUnknownRole_Returns200_AndRefreshesToken_IfValidBearerTokenProvided)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
@@ -1148,7 +1143,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_Returns401_IfNoCookie(string path, string type)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/test-auth-nocook{type}");
+        var id = AssetIdGenerator.GetAssetId(asset: "test-auth-nocook", assetPostfix: type);
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1168,7 +1163,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_Returns401_IfInvalidCookie(string path, string type)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/test-auth-invalidcook{type}");
+        var id = AssetIdGenerator.GetAssetId(asset: "test-auth-invalidcook", assetPostfix: type);
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1190,7 +1185,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_Returns401_IfExpiredCookie(string path, string type)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/test-auth-expcook{type}");
+        var id = AssetIdGenerator.GetAssetId(asset: "test-auth-expcook", assetPostfix: type);
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1217,7 +1212,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_RedirectsToImageServer_AndSetsCookie_IfCookieProvided_TileRequest(string path, string type)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/test-auth-cook-tile{type}");
+        var id = AssetIdGenerator.GetAssetId(asset: "test-auth-cook-tile", assetPostfix: type);
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1255,7 +1250,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_ImageRequiresAuth_RedirectsToImageServer_AndSetsCookie_IfCookieProvided_FullRequest(string path, string type)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/test-auth-cook{type}");
+        var id = AssetIdGenerator.GetAssetId(asset: "test-auth-cook", assetPostfix: type);
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1297,7 +1292,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": [[200,200]]}",
         });
 
-        var id = AssetId.FromString("99/1/known-thumb");
+        var id = AssetIdGenerator.GetAssetId(asset: "known-thumb");
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1317,7 +1312,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_FullRegion_LargerThumbExists_RedirectsToResizeThumbs()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_FullRegion_LargerThumbExists_RedirectsToResizeThumbs)}");
+        var id = AssetIdGenerator.GetAssetId();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1344,8 +1339,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/{nameof(Get_FullRegion_SmallerThumbExists_NoMatchingUpscaleConfig_RedirectsToSpecialServer)}");
+        var id = AssetIdGenerator.GetAssetId();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1371,7 +1365,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_FullRegion_NoOpenThumbs_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_FullRegion_NoOpenThumbs_RedirectsToSpecialServer)}");
+        var id = AssetIdGenerator.GetAssetId();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1398,8 +1392,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToSpecialServer()
     {
         // Arrange
-        var id = AssetId.FromString(
-            $"99/1/upscale{nameof(Get_FullRegion_HasSmallerThumb_MatchesUpscaleRegex_ThresholdTooLarge_RedirectsToSpecialServer)}");
+        var id = AssetIdGenerator.GetAssetId();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1478,7 +1471,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": []}",
         });
 
-        var id = AssetId.FromString($"99/1/{imageName}");
+        var id = AssetIdGenerator.GetAssetId(asset: imageName);
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1512,7 +1505,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             ContentBody = "{\"o\": []}",
         });
 
-        var id = AssetId.FromString($"99/1/{imageName}");
+        var id = AssetIdGenerator.GetAssetId(asset: imageName);
         await dbFixture.DbContext.Images.AddTestAsset(id, origin: "/test/space", width: 1000, height: 1000,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
@@ -1536,7 +1529,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_RedirectsSpecialServer_ForTileRequests_IfRegionEquivalentToFull_WithNoMatchingThumbs()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_RedirectsSpecialServer_ForTileRequests_IfRegionEquivalentToFull_WithNoMatchingThumbs)}");
+        var id = AssetIdGenerator.GetAssetId();
         
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1568,7 +1561,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_Returns404_IfRedirectsImageServer_ButOrchestratorNotFound()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfRedirectsImageServer_ButOrchestratorNotFound)}");
+        var id = AssetIdGenerator.GetAssetId();
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1597,7 +1590,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_Returns500_IfRedirectsImageServer_ButOrchestratorError()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_Returns500_IfRedirectsImageServer_ButOrchestratorError)}");
+        var id = AssetIdGenerator.GetAssetId();
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -1629,7 +1622,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_404_IfNotForDelivery(string path)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_404_IfNotForDelivery)}");
+        var id = AssetIdGenerator.GetAssetId();
 
         // test runs 3 times so only add on first run
         if (await dbFixture.DbContext.Images.FindAsync(id) == null)
@@ -1653,7 +1646,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Get_404_IfNotForImageDeliveryChannel(string path)
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_404_IfNotForImageDeliveryChannel)}");
+        var id = AssetIdGenerator.GetAssetId();
 
         // test runs 3 times so only add on first run
         if (await dbFixture.DbContext.Images.FindAsync(id) == null)


### PR DESCRIPTION
Attempt to resolve issue with flaky tests. Prefer using `AssetIdGenerator` over `nameof` to avoid potential collisions as former uses `[CallerMemberName]`

The following test used the wrong `nameof(`
```cs
public async Task GetInfoJson_Correct_ViaDisplayName()
{ 
    var id = AssetId.FromString($"99/1/{nameof(GetInfoJsonV2_Correct_ViaDirectPath_NotInS3)}");
```

`GetInfoJsonV2_Correct_ViaDirectPath_NotInS3` test used `AssetIdGenerator` so there could be collisions, depending on timing/order of tests.