### PR TITLE
Implement get all images

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
@@ -511,7 +511,11 @@ public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var response = await httpClient.AsCustomer().GetAsync("/customers/99/allImages?q={\"manifests\":[\"wrong\"]}");
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        collection.Members.Should().HaveCount(0);
+        collection.TotalItems.Should().Be(0);
     }
     
     [Fact]

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -415,7 +415,7 @@ public static class AssetConverter
             assetFilter ??= new AssetFilter();
             assetFilter.NumberReference3 = number3;
         }
-        var manifests = request.GetFirstQueryParamValueAsList("manifests");
+        var manifests = request.GetFirstQueryParamValueAsArray("manifests");
         if (manifests != null)
         {
             assetFilter ??= new AssetFilter();

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -7,6 +7,7 @@ using DLCS.Model.Assets;
 using DLCS.Web.Requests;
 using Hydra;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 using AssetFamily = DLCS.HydraModel.AssetFamily;
 
 namespace API.Converters;
@@ -328,7 +329,8 @@ public static class AssetConverter
             Reference3 = imageQuery.String3,
             NumberReference1 = imageQuery.Number1,
             NumberReference2 = imageQuery.Number2,
-            NumberReference3 = imageQuery.Number3
+            NumberReference3 = imageQuery.Number3,
+            Manifests = imageQuery.Manifests
         };
     }
 
@@ -342,7 +344,8 @@ public static class AssetConverter
             String3 = assetFilter.Reference3,
             Number1 = assetFilter.NumberReference1,
             Number2 = assetFilter.NumberReference2,
-            Number3 = assetFilter.NumberReference3
+            Number3 = assetFilter.NumberReference3,
+            Manifests = assetFilter.Manifests
         };
     }
 
@@ -412,6 +415,12 @@ public static class AssetConverter
         {
             assetFilter ??= new AssetFilter();
             assetFilter.NumberReference3 = number3;
+        }
+        var manifests = request.GetFirstQueryParamValueAsList("manifests");
+        if (manifests != null)
+        {
+            assetFilter ??= new AssetFilter();
+            assetFilter.Manifests = manifests;
         }
 
         return assetFilter;

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -7,7 +7,6 @@ using DLCS.Model.Assets;
 using DLCS.Web.Requests;
 using Hydra;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 using AssetFamily = DLCS.HydraModel.AssetFamily;
 
 namespace API.Converters;

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -98,7 +98,7 @@ public class CustomerImagesController : HydraController
         return await HandlePagedFetch<Asset, GetQueriedAllImages, DLCS.HydraModel.Image>(
             getQueriedAllImages,
             image => image.ToHydra(GetUrlRoots()),
-            errorTitle: "Get Batch Assets failed",
+            errorTitle: "Get All Images failed",
             cancellationToken: cancellationToken
         );
     }

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -57,7 +57,7 @@ public class CustomerImagesController : HydraController
         [FromServices] ImageIdListValidator validator,
         CancellationToken cancellationToken = default)
     {
-        var validationResult = await validator.ValidateAsync(imageIdentifiers, cancellationToken);
+        var validationResult = await validator.ValidateAsync(imageIdentifiers.Members, cancellationToken);
         if (!validationResult.IsValid)
         {
             return this.ValidationFailed(validationResult);

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -5,6 +5,7 @@ using API.Features.Image.Validation;
 using API.Infrastructure;
 using API.Infrastructure.Requests;
 using API.Settings;
+using DLCS.Core.Strings;
 using DLCS.Model;
 using DLCS.Model.Assets;
 using DLCS.Web.Requests;
@@ -56,7 +57,7 @@ public class CustomerImagesController : HydraController
         [FromServices] ImageIdListValidator validator,
         CancellationToken cancellationToken = default)
     {
-        var validationResult = await validator.ValidateAsync(imageIdentifiers.Members, cancellationToken);
+        var validationResult = await validator.ValidateAsync(imageIdentifiers, cancellationToken);
         if (!validationResult.IsValid)
         {
             return this.ValidationFailed(validationResult);
@@ -69,6 +70,37 @@ public class CustomerImagesController : HydraController
             a => a.ToHydra(GetUrlRoots()),
             "Get customer images failed",
             cancellationToken: cancellationToken);
+    }
+    
+    /// <summary>
+    /// Accepts a list of image identifiers in a query string, will return a list of matching images.
+    ///
+    /// This endpoint supports paging 
+    /// </summary>
+    [HttpGet]
+    [Route("allImages")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(HydraCollection<DLCS.HydraModel.Image>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(Error))]
+    public async Task<IActionResult> GetAllImagesPaged(
+        [FromRoute] int customerId,
+        [FromQuery] string? q = null,
+        CancellationToken cancellationToken = default)
+    {
+        var assetFilter = Request.GetAssetFilterFromQParam(q);
+        assetFilter = Request.UpdateAssetFilterFromQueryStringParams(assetFilter);
+        if (q.HasText() && assetFilter == null)
+        {
+            return this.HydraProblem("Could not parse query", null, 400);
+        }
+
+        var getQueriedAllImages = new GetQueriedAllImages(customerId, assetFilter);
+
+        return await HandlePagedFetch<Asset, GetQueriedAllImages, DLCS.HydraModel.Image>(
+            getQueriedAllImages,
+            image => image.ToHydra(GetUrlRoots()),
+            errorTitle: "Get Batch Assets failed",
+            cancellationToken: cancellationToken
+        );
     }
     
     /// <summary>

--- a/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
@@ -8,18 +8,13 @@ using Microsoft.EntityFrameworkCore;
 
 namespace API.Features.Customer.Requests;
 
-public class GetQueriedAllImages : IRequest<FetchEntityResult<PageOf<Asset>>>, IPagedRequest, IOrderableRequest,
+public class GetQueriedAllImages(int customerId, AssetFilter? assetFilter) : IRequest<FetchEntityResult<PageOf<Asset>>>,
+    IPagedRequest, IOrderableRequest,
     IAssetFilterableRequest
 {
-    public GetQueriedAllImages(int customerId, AssetFilter? assetFilter)
-    {
-        CustomerId = customerId;
-        AssetFilter = assetFilter;
-    }
-    
-    public int CustomerId { get; }
+    public int CustomerId { get; } = customerId;
 
-    public AssetFilter? AssetFilter { get; }
+    public AssetFilter? AssetFilter { get; } = assetFilter;
 
     public int Page { get; set; }
 
@@ -39,7 +34,6 @@ public class GetQueriedAllImagesHandler(DlcsContext dlcsContext)
     {
         var result = await dlcsContext.Images
             .AsNoTracking()
-            .Include(a => a.Batch)
             .Include(a => a.ImageDeliveryChannels.OrderBy(idc => idc.Channel))
             .ThenInclude(dc => dc.DeliveryChannelPolicy)
             .Where(a => a.Customer == request.CustomerId).CreatePagedResult(

--- a/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
@@ -1,0 +1,58 @@
+﻿using API.Infrastructure.Requests;
+using DLCS.Model.Assets;
+using DLCS.Model.Page;
+using DLCS.Repository;
+using DLCS.Repository.Assets;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace API.Features.Customer.Requests;
+
+public class GetQueriedAllImages : IRequest<FetchEntityResult<PageOf<Asset>>>, IPagedRequest, IOrderableRequest,
+    IAssetFilterableRequest
+{
+    public GetQueriedAllImages(int customerId, AssetFilter? assetFilter)
+    {
+        CustomerId = customerId;
+        AssetFilter = assetFilter;
+    }
+    
+    public int CustomerId { get; }
+
+    public AssetFilter? AssetFilter { get; }
+
+    public int Page { get; set; }
+
+    public int PageSize { get; set; }
+
+    public string? Field { get; set; }
+
+    public bool Descending { get; set; }
+}
+
+public class GetQueriedAllImagesHandler(DlcsContext dlcsContext)
+    : IRequestHandler<GetQueriedAllImages, FetchEntityResult<PageOf<Asset>>>
+{
+    private DlcsContext dlcsContext { get; } = dlcsContext;
+
+    public async Task<FetchEntityResult<PageOf<Asset>>> Handle(GetQueriedAllImages request, CancellationToken cancellationToken = default)
+    {
+        var result = await dlcsContext.Images
+            .AsNoTracking()
+            .Include(a => a.Batch)
+            .Include(a => a.ImageDeliveryChannels.OrderBy(idc => idc.Channel))
+            .ThenInclude(dc => dc.DeliveryChannelPolicy)
+            .Where(a => a.Customer == request.CustomerId).CreatePagedResult(
+                request,
+                i => i
+                    .ApplyAssetFilter(request.AssetFilter)
+                    .AsSplitQuery(),
+                images => images.AsOrderedAssetQuery(request),
+                cancellationToken);
+
+        // Any empty result set could be the result of an applied asset filter
+        return result.Total == 0
+            ? FetchEntityResult<PageOf<Asset>>.NotFound()
+            : FetchEntityResult<PageOf<Asset>>.Success(result);
+    }
+}

--- a/src/protagonist/DLCS.HydraModel/ImageQuery.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageQuery.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -25,6 +27,8 @@ public class ImageQuery
     public int? Number1 { get; set; }
     public int? Number2 { get; set; }
     public int? Number3 { get; set; }
+    
+    public List<string>? Manifests { get; set; }
 
     public static ImageQuery? Parse(string s)
     {

--- a/src/protagonist/DLCS.HydraModel/ImageQuery.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageQuery.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/src/protagonist/DLCS.HydraModel/ImageQuery.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageQuery.cs
@@ -27,7 +27,7 @@ public class ImageQuery
     public int? Number2 { get; set; }
     public int? Number3 { get; set; }
     
-    public List<string>? Manifests { get; set; }
+    public string[]? Manifests { get; set; }
 
     public static ImageQuery? Parse(string s)
     {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
@@ -9,7 +9,7 @@ public class AssetFilterTests
     public void Obtain_AssetFilter_From_Q_Param_Directly()
     {
         // arrange
-        var q = @"{""string1"":""s1"",""string2"":""s2"",""number3"":3,""space"":99}";
+        var q = @"{""string1"":""s1"",""string2"":""s2"",""number3"":3,""space"":99,""manifests"":[""first""]}";
         var httpRequest = new DefaultHttpContext().Request;
         httpRequest.QueryString = new QueryString("?q=" + q);
         
@@ -24,7 +24,7 @@ public class AssetFilterTests
         filter.NumberReference1.Should().BeNull();
         filter.NumberReference3.Should().Be(3);
         filter.Space.Should().Be(99);
-
+        filter.Manifests.Should().BeEquivalentTo("first");
     }
     
     [Fact]
@@ -51,7 +51,7 @@ public class AssetFilterTests
     public void Construct_AssetFilter_From_Specific_Params()
     {
         var httpRequest = new DefaultHttpContext().Request;
-        httpRequest.QueryString = new QueryString("?string1=s1&string2=s2&string3=s3&number1=1&number2=2&number3=3");
+        httpRequest.QueryString = new QueryString("?string1=s1&string2=s2&string3=s3&number1=1&number2=2&number3=3&manifests=first,second");
         
         // act
         var filter = httpRequest.UpdateAssetFilterFromQueryStringParams(null);
@@ -64,6 +64,7 @@ public class AssetFilterTests
         filter.NumberReference1.Should().Be(1);
         filter.NumberReference2.Should().Be(2);
         filter.NumberReference3.Should().Be(3);
+        filter.Manifests.Should().BeEquivalentTo("first", "second");
         filter.Space.Should().BeNull();
     }
     

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetFilterTests.cs
@@ -72,9 +72,9 @@ public class AssetFilterTests
     [Fact]
     public void Update_AssetFilter_From_Specific_Params()
     {
-        var q = @"{""string3"":""s3"",""number1"":1}";
+        var q = @"{""string3"":""s3"",""number1"":1,""manifests"":[""first""]}";
         var httpRequest = new DefaultHttpContext().Request;
-        httpRequest.QueryString = new QueryString("?q=" + q + "&string1=s1&string3=s3updated&number3=3");
+        httpRequest.QueryString = new QueryString("?q=" + q + "&string1=s1&string3=s3updated&number3=3&manifests=second");
         
         // act
         var filter = httpRequest.GetAssetFilterFromQParam();
@@ -88,6 +88,7 @@ public class AssetFilterTests
         filter.NumberReference1.Should().Be(1);
         filter.NumberReference2.Should().BeNull();
         filter.NumberReference3.Should().Be(3);
+        filter.Manifests.Should().BeEquivalentTo("second");
         filter.Space.Should().BeNull();
     }
     

--- a/src/protagonist/DLCS.Model.Tests/Assets/ImageQueryTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/ImageQueryTests.cs
@@ -9,7 +9,7 @@ public class ImageQueryTests
     {
         // arrange
         var s =
-            @"{""string1"":""s1"",""string2"":""s2"",""string3"":""s3"",""number1"":1,""number2"":2,""number3"":3,""space"":99}";
+            @"{""string1"":""s1"",""string2"":""s2"",""string3"":""s3"",""number1"":1,""number2"":2,""number3"":3,""space"":99,""manifests"":[""first""]}";
         
         // act
         var iq = ImageQuery.Parse(s);
@@ -22,5 +22,6 @@ public class ImageQueryTests
         iq.Number1.Should().Be(1);
         iq.Number2.Should().Be(2);
         iq.Number3.Should().Be(3);
+        iq.Manifests.Should().BeEquivalentTo("first");
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace DLCS.Model.Assets;
 
 public class AssetFilter
@@ -9,5 +11,6 @@ public class AssetFilter
     public int? NumberReference1 { get; set; }
     public int? NumberReference2 { get; set; }
     public int? NumberReference3 { get; set; }
+    public List<string>? Manifests { get; set; }
     public string[]? Tags { get; set; }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetFilter.cs
@@ -11,6 +11,6 @@ public class AssetFilter
     public int? NumberReference1 { get; set; }
     public int? NumberReference2 { get; set; }
     public int? NumberReference3 { get; set; }
-    public List<string>? Manifests { get; set; }
+    public string[]? Manifests { get; set; }
     public string[]? Tags { get; set; }
 }

--- a/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
@@ -106,6 +106,11 @@ public static class AssetQueryX
         {
             filtered = filtered.Where(a => a.NumberReference3 == assetFilter.NumberReference3);
         }
+        if (assetFilter.Manifests != null)
+        {
+            filtered = filtered.Where(a =>
+                a.Manifests != null && a.Manifests.Any(manifest => assetFilter.Manifests.Contains(manifest)));
+        }
 
         if (filterOnSpace && assetFilter.Space is > 0)
         {

--- a/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetQueryX.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using DLCS.Core.Collections;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 using DLCS.Model.Page;
@@ -106,10 +107,10 @@ public static class AssetQueryX
         {
             filtered = filtered.Where(a => a.NumberReference3 == assetFilter.NumberReference3);
         }
-        if (assetFilter.Manifests != null)
+        if (!assetFilter.Manifests.IsNullOrEmpty())
         {
             filtered = filtered.Where(a =>
-                a.Manifests != null && a.Manifests.Any(manifest => assetFilter.Manifests.Contains(manifest)));
+                a.Manifests.Any(manifest => assetFilter.Manifests.Contains(manifest)));
         }
 
         if (filterOnSpace && assetFilter.Space is > 0)

--- a/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
+++ b/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
@@ -78,11 +78,11 @@ public static class HttpRequestX
         return null;
     }
     
-    public static List<string>? GetFirstQueryParamValueAsList(this HttpRequest request, string paramName)
+    public static string[]? GetFirstQueryParamValueAsArray(this HttpRequest request, string paramName)
     {
         if (request.Query.ContainsKey(paramName))
         {
-            return request.Query[paramName].ToString().Split(',').ToList();
+            return request.Query[paramName].ToString().Split(',').ToArray();
         }
 
         return null;

--- a/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
+++ b/src/protagonist/DLCS.Web/Requests/HttpRequestX.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using DLCS.Core.Collections;
 using Microsoft.AspNetCore.Http;
 
@@ -71,6 +73,16 @@ public static class HttpRequestX
         if (int.TryParse(value, out var num))
         {
             return num;
+        }
+
+        return null;
+    }
+    
+    public static List<string>? GetFirstQueryParamValueAsList(this HttpRequest request, string paramName)
+    {
+        if (request.Query.ContainsKey(paramName))
+        {
+            return request.Query[paramName].ToString().Split(',').ToList();
         }
 
         return null;


### PR DESCRIPTION
Resolves #954

This PR implements the `GET /customers/{c}/allImages` endpoint along with query string support

Additionally, `manifests` has been added as a query parameter, which supports the following formats:

| Query Param                                  | Resulting query |
| -------------------------------------------- | --------------- |
| `?manifests=x`                               | has x           |
| `?manifests=x,y`                             | has x or y      |
| `?q={"manifests": ["x", "y"]}`               | has x or y      |
| `?q={"manifests": ["a", "b"]}?manifests=x,y` | has x or y      |

Finally, `?page`, `?pageSize` and `?orderBy`/`?orderByDescending` have been implemented onto the endpoint