### PR TITLE
Generated manifests respect PathTemplates

### DIFF
--- a/docs/path-templates.md
+++ b/docs/path-templates.md
@@ -2,30 +2,59 @@
 
 The default path template for requests is `/{prefix}/{version}/{customer}/{space}/{assetPath}`, where:
 
-* `prefix` is route path (e.g. `iiif-manifest`, `iiif-av`, `iiif-img`)
+* `prefix` is route path (e.g. `thumbs`, `iiif-av`, `iiif-img`, `file`)
 * `version` is the version slug (e.g. `v2` or `v3`)
 * `customer` and `space` are self explanatory
 * `assetPath` is the asset identifier plus any specific elements for the current request - e.g. for image requests it will contain the full IIIF image request.
 
-By default the above format is reflected on info.json (from Thumbs and Orchestrator).
+By default the above format is reflected on info.json (from Thumbs and Orchestrator) and generated manifests (single-item and named-query manifests, see [#983](https://github.com/dlcs/protagonist/issues/983)).
 
 To facilitate using proxy servers to receive alternative URLs that are then rewritten to standard DLCS URLs, overrides to the default rules can be specified. These are used when outputting any self-referencing URIs (e.g. info.json `id` element).
+
+## Prefixes
+
+The default prefixes, listed above, can be changed by using `"PrefixReplacements"` key. This is a key-value pair, where the key is the default prefix, and the value is the replacement.
+
+## Output
+
+In manifests, image and thumb paths can have `{version}` slug as a path replacement values. As the NQ serves as an _"output everything we have"_ skeleton manifest we will always output all supported ImageApi versions. The logic for handling image paths (which are versioned) will be:
+
+* NQ will continue to always output all ImageApi versions (current v2 + v3)
+* If we have a `{version}` slug in the config then rewrite both. For canonical the `{version}` is `""`, so it will remove that version.
+* If we don't have a `{version}` slug then we'll rewrite paths for canonical ImageApi version but use the standard `/iiif-img/` paths for non-canonical.
+
+## Configuration Examples
 
 > [!IMPORTANT]
 > For the below to work the expectation is that the `x-forwarded-host` header is set in the proxy.
 
-```
+```json
 "PathRules": {
   "Default": "/{prefix}/{version}/{customer}/{space}/{assetPath}",
   "Overrides": {
-    "exclude-space.com": "/{prefix}/{customer}/extra/{assetPath}/",
-    "customer-specific.io": "/{prefix}/{assetPath}"
+    "exclude-space.com": {
+      "Path": "/{prefix}/{version}/{customer}/{assetPath}",
+      "PrefixReplacements": {
+        "iiif-img": "images",
+        "file": "bin"
+      }
+    },
+    "customer-specific.io": "/{prefix}/{assetPath}",
     "i-have-ark.io": "/{prefix}/ark:{assetPath:US}"
   }
 }
 ```
 
-As an convenience you can specify `"PathRules:OverridesAsJson"` appSetting, for Orchestrator only, that includes a string-based config. This makes it easier to configure via environment variables etc
+Note that it's possible to specify a simple string, or a complex object with both `"Path"` and `"PrefixReplacements"` specified. The following are equivalent in terms of how they are strongly typed:
+
+```json
+{
+  "string.com": "/{prefix}/{version}/{customer}/{space}/{assetPath}",
+  "complex.net": {
+    "Path": "/{prefix}/{version}/{customer}/{space}/{assetPath}"
+  }
+}
+```
 
 ## Formatters
 
@@ -43,7 +72,7 @@ For auth the path replacements are simpler:
 * `customer` is the customer the auth service is for
 * `behaviour` is the name of the auth service.
 
-```
+```json
 "Auth": {
   "AuthPathRules": {
     "Default": "/auth/{customer}/{behaviour}",

--- a/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
+++ b/src/protagonist/DLCS.Core/DlcsPathHelpers.cs
@@ -30,10 +30,10 @@ public static class DlcsPathHelpers
         string? assetPath = null)
         => DoubleSlashRegex.Replace(
             template
-                .Replace("{prefix}", prefix ?? string.Empty)
-                .Replace("{version}", version ?? string.Empty)
-                .Replace("{customer}", customer ?? string.Empty)
-                .Replace("{space}", space ?? string.Empty)
+                .Replace(Replacements.Prefix, prefix ?? string.Empty)
+                .Replace(Replacements.Version, version ?? string.Empty)
+                .Replace(Replacements.Customer, customer ?? string.Empty)
+                .Replace(Replacements.Space, space ?? string.Empty)
                 .ReplaceAssetPath(assetPath ?? string.Empty), "/");
 
     /// <summary>
@@ -48,8 +48,8 @@ public static class DlcsPathHelpers
         string? customer = null, 
         string? behaviour = null) =>
         template
-            .Replace("{customer}", customer ?? string.Empty)
-            .Replace("{behaviour}", behaviour ?? string.Empty);
+            .Replace(Replacements.Customer, customer ?? string.Empty)
+            .Replace(Replacements.Behaviour, behaviour ?? string.Empty);
     
     /// <summary>
     /// Replace known slugs in DLCS auth 2 path template.
@@ -68,13 +68,28 @@ public static class DlcsPathHelpers
         if (assetId != null)
         {
             template = template
-                .Replace("{assetId}", assetId.ToString())
-                .Replace("{asset}", assetId.Asset)
-                .Replace("{space}", assetId.Space.ToString());
+                .Replace(Replacements.AssetId, assetId.ToString())
+                .Replace(Replacements.Asset, assetId.Asset)
+                .Replace(Replacements.Space, assetId.Space.ToString());
         }
         
         return template
-            .Replace("{customer}", customer ?? string.Empty)
-            .Replace("{accessService}", accessService ?? string.Empty);
+            .Replace(Replacements.Customer, customer ?? string.Empty)
+            .Replace(Replacements.AccessService, accessService ?? string.Empty);
+    }
+    
+    /// <summary>
+    /// Class containing path values that are replaceable
+    /// </summary>
+    public static class Replacements
+    {
+        public const string Prefix = "{prefix}";
+        public const string Version = "{version}";
+        public const string Customer = "{customer}";
+        public const string Space = "{space}";
+        public const string Behaviour = "{behaviour}";
+        public const string AssetId = "{assetId}";
+        public const string Asset = "{asset}";
+        public const string AccessService = "{accessService}";
     }
 }

--- a/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -153,9 +153,9 @@ public class ConfigDrivenAssetPathGeneratorTests
 
         var options = Options.Create(new PathTemplateOptions
         {
-            Overrides = new Dictionary<string, string>
+            Overrides = new Dictionary<string, PathTemplate>
             {
-                ["test.example.com"] = "/{prefix}/{assetPath}"
+                ["test.example.com"] = new() { Path = "/{prefix}/{assetPath}" }
             }
         });
 

--- a/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/ConfigDrivenAssetPathGeneratorTests.cs
@@ -297,6 +297,20 @@ public class ConfigDrivenAssetPathGeneratorTests
         actual.Should().Be(expected);
     }
 
+    [Fact]
+    public void PathHasVersion_True_ForFallbackPath() 
+        => GetSut("default.com").PathHasVersion().Should().BeTrue("Default native path contains {version}");
+
+    [Fact]
+    public void PathHasVersion_True_IfHostSpecificHasVersion()
+        => GetSut("versioned.example.com").PathHasVersion().Should().BeTrue("Host template contains {version}");
+    
+    [Theory]
+    [InlineData("test.example.com")]
+    [InlineData("other.example.com")]
+    public void PathHasVersion_False_IfHostSpecificHasNoVersion(string hostname) 
+        => GetSut(hostname).PathHasVersion().Should().BeFalse("Host template contains {version}");
+
     private static ConfigDrivenAssetPathGenerator GetSut(string host, Action<HttpRequest> requestModifier = null)
     {
         var context = new DefaultHttpContext();
@@ -318,7 +332,8 @@ public class ConfigDrivenAssetPathGeneratorTests
                     {
                         ["iiif-img"] = "img",
                     }
-                }
+                },
+                ["versioned.example.com"] = new() { Path = "/{prefix}/{version}_{assetPath}" },
             }
         });
 

--- a/src/protagonist/DLCS.Web.Tests/Response/PathTemplateConverterTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/PathTemplateConverterTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using DLCS.Web.Response;
+
+namespace DLCS.Web.Tests.Response;
+
+public class PathTemplateConverterTests
+{
+    private readonly TypeConverter pathTemplateConverter = TypeDescriptor.GetConverter(typeof(PathTemplate));
+
+    [Fact]
+    public void CanConvertFrom_True_ForString()
+        => pathTemplateConverter.CanConvertFrom(typeof(string)).Should().BeTrue("Conversion from string supported");
+
+    [Theory]
+    [InlineData(typeof(PathTemplate))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(Dictionary<string, string>))]
+    public void CanConvertFrom_False_ForNonString(Type type)
+        => pathTemplateConverter.CanConvertFrom(type).Should().BeFalse("Conversion from non-string not supported");
+
+    [Fact]
+    public void ConvertFrom_String_SetsPath()
+    {
+        const string path = "/path/{space}";
+        var result = pathTemplateConverter.ConvertFrom(path) as PathTemplate;
+        
+        result.Path.Should().Be(path, "Path value set to provided string");
+        result.PrefixReplacements.Should().BeEmpty("No prefix replacements set but defaulted to empty dict");
+    }
+    
+    [Fact]
+    public void ConvertTo_String_ReturnsPath()
+    {
+        const string path = "/path/{space}";
+        var pathTemplate = new PathTemplate
+        {
+            Path = path,
+            PrefixReplacements = new() { ["space"] = "s" },
+        };
+        
+        var result = pathTemplateConverter.ConvertTo(pathTemplate, typeof(string));
+        
+        result.ToString().Should().Be(path, "Path value returned");
+    }
+}

--- a/src/protagonist/DLCS.Web.Tests/Response/PathTemplateTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/PathTemplateTests.cs
@@ -1,0 +1,24 @@
+﻿using DLCS.Web.Response;
+
+namespace DLCS.Web.Tests.Response;
+
+public class PathTemplateTests
+{
+    [Fact]
+    public void GetPrefixForPath_ReturnsProvidedPrefix_IfNoReplacement()
+    {
+        const string prefix = "iiif-img";
+        var pathTemplate = new PathTemplate { Path = "/path" };
+        pathTemplate.GetPrefixForPath(prefix).Should().Be(prefix, "No replacement found");
+    }
+    
+    [Fact]
+    public void GetPrefixForPath_ReturnsReplacement_IfFound()
+    {
+        const string prefix = "iiif-img";
+        const string replacement = "foo";
+        var pathTemplate = new PathTemplate { Path = "/path" };
+        pathTemplate.PrefixReplacements.Add(prefix, "foo");
+        pathTemplate.GetPrefixForPath(prefix).Should().Be(replacement, "No replacement found");
+    }
+}

--- a/src/protagonist/DLCS.Web.Tests/Response/PathTemplateTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/Response/PathTemplateTests.cs
@@ -19,6 +19,6 @@ public class PathTemplateTests
         const string replacement = "foo";
         var pathTemplate = new PathTemplate { Path = "/path" };
         pathTemplate.PrefixReplacements.Add(prefix, "foo");
-        pathTemplate.GetPrefixForPath(prefix).Should().Be(replacement, "No replacement found");
+        pathTemplate.GetPrefixForPath(prefix).Should().Be(replacement, "Replacement found");
     }
 }

--- a/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
+++ b/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
@@ -89,7 +89,7 @@ public static class ApplicationBuilderX
                 var overridesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(opts.OverridesAsJson);
                 foreach (var (key, value) in overridesDict)
                 {
-                    opts.Overrides.Add(key, value);
+                    opts.Overrides.Add(key, new PathTemplate { Path = value });
                 }
             }
         });

--- a/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
+++ b/src/protagonist/DLCS.Web/Configuration/ApplicationBuilderX.cs
@@ -77,20 +77,4 @@ public static class ApplicationBuilderX
         services.AddSingleton<IHttpMessageHandlerBuilderFilter, HeaderPropagationMessageHandlerBuilderFilter>();
         return services;
     }
-    
-    /// <summary>
-    /// Parse OverridesAsJson appSetting to strongly typed dictionary
-    /// </summary>
-    public static IServiceCollection HandlePathTemplates(this IServiceCollection services)
-        => services.PostConfigure<PathTemplateOptions>(opts =>
-        {
-            if (!string.IsNullOrEmpty(opts.OverridesAsJson))
-            {
-                var overridesDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(opts.OverridesAsJson);
-                foreach (var (key, value) in overridesDict)
-                {
-                    opts.Overrides.Add(key, new PathTemplate { Path = value });
-                }
-            }
-        });
 }

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -14,19 +14,12 @@ namespace DLCS.Web.Response;
 /// this allows e.g. "id" values on manifests to use different URL structures than the default DLCS paths.
 /// e.g. /images/{assetPath}/ rather than default of /iiif-img/{cust}/{space}/{assetPath} 
 /// </remarks>
-public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
+public class ConfigDrivenAssetPathGenerator(
+    IOptions<PathTemplateOptions> pathTemplateOptions,
+    IHttpContextAccessor httpContextAccessor) : IAssetPathGenerator
 {
-    private readonly IHttpContextAccessor httpContextAccessor;
-    private readonly PathTemplateOptions pathTemplateOptions;
+    private readonly PathTemplateOptions pathTemplateOptions = pathTemplateOptions.Value;
 
-    public ConfigDrivenAssetPathGenerator(
-        IOptions<PathTemplateOptions> pathTemplateOptions,
-        IHttpContextAccessor httpContextAccessor)
-    {
-        this.httpContextAccessor = httpContextAccessor;
-        this.pathTemplateOptions = pathTemplateOptions.Value;
-    }
-    
     public string GetRelativePathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false)
         => GetForPath(assetRequest, false, useNativeFormat, false);
 
@@ -34,32 +27,33 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
         bool includeQueryParams = true)
         => GetForPath(assetRequest, true, useNativeFormat, includeQueryParams);
 
-    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat, bool includeQueryParams)
+    private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat,
+        bool includeQueryParams)
         => GetPathForRequestInternal(
-            assetRequest, 
-            (request, template) => GeneratePathFromTemplate(request, template),
+            assetRequest,
+            GeneratePathFromTemplate,
             fullRequest,
             useNativeFormat,
             includeQueryParams);
-    
+
     private string GetPathForRequestInternal(IBasicPathElements assetRequest, PathGenerator pathGenerator,
         bool fullRequest, bool useNativeFormat, bool includeQueryParams)
     {
-        var request = httpContextAccessor.HttpContext.Request;
-        var host = request.Host.Value ?? string.Empty;
+        var request = httpContextAccessor.SafeHttpContext().Request;
+        var host = request.Host.Value;
         var template = useNativeFormat
             ? PathTemplateOptions.DefaultPathTemplate
             : pathTemplateOptions.GetPathTemplateForHost(host);
 
-        var path = pathGenerator(assetRequest, template.Path);
+        var path = pathGenerator(assetRequest, template);
 
         return fullRequest ? request.GetDisplayUrl(path, includeQueryParams) : path;
     }
 
     // Default path replacements
-    private string GeneratePathFromTemplate(IBasicPathElements assetRequest, string template)
-        => DlcsPathHelpers.GeneratePathFromTemplate(template,
-            prefix: assetRequest.RoutePrefix,
+    private static string GeneratePathFromTemplate(IBasicPathElements assetRequest, PathTemplate template)
+        => DlcsPathHelpers.GeneratePathFromTemplate(template.Path,
+            prefix: template.GetPrefixForPath(assetRequest.RoutePrefix),
             customer: assetRequest.CustomerPathValue,
             version: assetRequest.VersionPathValue,
             space: assetRequest.Space.ToString(),

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -27,6 +27,13 @@ public class ConfigDrivenAssetPathGenerator(
         bool includeQueryParams = true)
         => GetForPath(assetRequest, true, useNativeFormat, includeQueryParams);
 
+    public bool PathHasVersion()
+    {
+        var request = httpContextAccessor.SafeHttpContext().Request;
+        var template = pathTemplateOptions.GetPathTemplateForHost(request.Host.Value);
+        return template.Path.Contains(DlcsPathHelpers.Replacements.Version);
+    }
+
     private string GetForPath(IBasicPathElements assetRequest, bool fullRequest, bool useNativeFormat,
         bool includeQueryParams)
         => GetPathForRequestInternal(
@@ -40,10 +47,9 @@ public class ConfigDrivenAssetPathGenerator(
         bool fullRequest, bool useNativeFormat, bool includeQueryParams)
     {
         var request = httpContextAccessor.SafeHttpContext().Request;
-        var host = request.Host.Value;
         var template = useNativeFormat
             ? PathTemplateOptions.DefaultPathTemplate
-            : pathTemplateOptions.GetPathTemplateForHost(host);
+            : pathTemplateOptions.GetPathTemplateForHost(request.Host.Value);
 
         var path = pathGenerator(assetRequest, template);
 

--- a/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/ConfigDrivenAssetPathGenerator.cs
@@ -48,10 +48,10 @@ public class ConfigDrivenAssetPathGenerator : IAssetPathGenerator
         var request = httpContextAccessor.HttpContext.Request;
         var host = request.Host.Value ?? string.Empty;
         var template = useNativeFormat
-            ? PathTemplateOptions.DefaultPathFormat
+            ? PathTemplateOptions.DefaultPathTemplate
             : pathTemplateOptions.GetPathTemplateForHost(host);
 
-        var path = pathGenerator(assetRequest, template);
+        var path = pathGenerator(assetRequest, template.Path);
 
         return fullRequest ? request.GetDisplayUrl(path, includeQueryParams) : path;
     }

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -5,7 +5,7 @@ namespace DLCS.Web.Response;
 /// <summary>
 /// Delegate that uses values in <see cref="IBasicPathElements"/> to make replacements in given template
 /// </summary>
-public delegate string PathGenerator(IBasicPathElements assetRequest, string template);
+public delegate string PathGenerator(IBasicPathElements assetRequest, PathTemplate template);
 
 /// <summary>
 /// Generate paths related to running Dlcs instance.

--- a/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
+++ b/src/protagonist/DLCS.Web/Response/IAssetPathGenerator.cs
@@ -32,4 +32,9 @@ public interface IAssetPathGenerator
     /// <param name="includeQueryParams">If true, query params are included in path. Else they are omitted</param>
     string GetFullPathForRequest(IBasicPathElements assetRequest, bool useNativeFormat = false,
         bool includeQueryParams = true);
+
+    /// <summary>
+    /// Check if the path template for current host contains {version} replacement slug
+    /// </summary>
+    bool PathHasVersion();
 }

--- a/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
 
 namespace DLCS.Web.Response;
 
@@ -13,26 +16,73 @@ public class PathTemplateOptions
     internal const string DefaultPathFormat = "/{prefix}/{version}/{customer}/{space}/{assetPath}";
 
     /// <summary>
-    /// Default path template if no overrides found.
+    /// The default <see cref="PathTemplate"/> for DLCS
     /// </summary>
-    public string Default { get; set; } = DefaultPathFormat;
+    internal static readonly PathTemplate DefaultPathTemplate = new() { Path = DefaultPathFormat };
+
+    /// <summary>
+    /// Default path template if no host-specific overrides found.
+    /// </summary>
+    public PathTemplate Default { get; init; } = DefaultPathTemplate;
 
     /// <summary>
     /// Collection of path template overrides, keyed by hostname.
     /// </summary>
-    public Dictionary<string, string> Overrides { get; set; } = new();
-    
-    /// <summary>
-    /// "Overrides" dictionary as JSON blob, will be use to populate Overrides
-    /// Added as convenience for setting per-env settings using string-based config settings like ParameterStore
-    /// </summary>
-    public string? OverridesAsJson { get; set; }
+    public Dictionary<string, PathTemplate> Overrides { get; init; } = new();
 
     /// <summary>
-    /// Get template path for host. 
+    /// "Overrides" dictionary as JSON blob, will be used to populate Overrides
+    /// Added as convenience for setting per-env settings using string-based config settings like ParameterStore
+    /// </summary>
+    public string? OverridesAsJson { get; init; }
+
+    /// <summary>
+    /// Get <see cref="PathTemplate"/> for host. 
     /// </summary>
     /// <param name="host">Host to get template path for.</param>
     /// <returns>Returns path for host, or default if override not found.</returns>
-    public string GetPathTemplateForHost(string host)
-        => Overrides.TryGetValue(host, out var template) ? template : Default;
+    public PathTemplate GetPathTemplateForHost(string host)
+        => Overrides.GetValueOrDefault(host, Default);
+}
+
+/// <summary>
+/// Construct that stores host-specific path template and optional prefixReplacements for generating rewritten paths 
+/// </summary>
+/// <remarks>
+/// TypeConverter allows simple string values from appSettings to be mapped to maintain backwards compat
+/// </remarks>
+[TypeConverter(typeof(PathTemplateConverter))]
+public class PathTemplate
+{
+    /// <summary>
+    /// Path containing replacement values
+    /// </summary>
+    public required string Path { get; init; }
+    
+    /// <summary>
+    /// Optional prefix replacements, e.g. "iiif-img" => "images", "iiif-av" => "av"
+    /// Used to generate value to use for "{prefix}" replacement
+    /// </summary>
+    public Dictionary<string, string> PrefixReplacements { get; set; } = new();
+}
+
+/// <summary>
+/// Allows mapping appSettings directly to strongly typed <see cref="PathTemplate"/>.
+/// This only supports mapping to/from string
+/// </summary>
+public class PathTemplateConverter : TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType) =>
+        sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+    public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value) =>
+        value is string stringVal
+            ? new PathTemplate { Path = stringVal }
+            : base.ConvertFrom(context, culture, value);
+
+    public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value,
+        Type destinationType) =>
+        destinationType == typeof(string) && value is PathTemplate hostTemplate
+            ? hostTemplate.Path
+            : base.ConvertTo(context, culture, value, destinationType);
 }

--- a/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
@@ -64,6 +64,13 @@ public class PathTemplate
     /// Used to generate value to use for "{prefix}" replacement
     /// </summary>
     public Dictionary<string, string> PrefixReplacements { get; set; } = new();
+
+    /// <summary>
+    /// Get prefix value to use for provided native-prefix. Return value from prefix-replacements, if found, else
+    /// returns native prefix 
+    /// </summary>
+    public string GetPrefixForPath(string nativePrefix)
+        => PrefixReplacements.GetValueOrDefault(nativePrefix, nativePrefix);
 }
 
 /// <summary>

--- a/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
@@ -31,12 +31,6 @@ public class PathTemplateOptions
     public Dictionary<string, PathTemplate> Overrides { get; init; } = new();
 
     /// <summary>
-    /// "Overrides" dictionary as JSON blob, will be used to populate Overrides
-    /// Added as convenience for setting per-env settings using string-based config settings like ParameterStore
-    /// </summary>
-    public string? OverridesAsJson { get; init; }
-
-    /// <summary>
     /// Get <see cref="PathTemplate"/> for host. 
     /// </summary>
     /// <param name="host">Host to get template path for.</param>

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
 using Orchestrator.Settings;
+using Test.Helpers.Data;
 
 namespace Orchestrator.Tests.Assets;
 
@@ -69,7 +70,7 @@ public class MemoryAssetTrackerTests
         AvailableDeliveryChannel channel)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, Origin = "test" });
@@ -92,7 +93,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAsset_Null_IfAssetFoundButNotForDelivery(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, NotForDelivery = true });
@@ -152,7 +153,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_ReturnsOrchestrationAsset_IfImage(string deliveryChannels, string expectedOrigin)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId))
             .Returns(new Asset
@@ -176,7 +177,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_ReturnsOrchestrationAsset(string deliveryChannels, string expectedOrigin)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId))
             .Returns(new Asset
@@ -199,7 +200,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_ReturnsOrchestrationImage(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
 
         var assetId = new AssetId(1, 1, "go!");
 
@@ -230,7 +231,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_SetsOpenThumbsToEmpty_IfNullReturned(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
@@ -252,7 +253,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_Reingest_True_IfCreatedBeforeCutOff(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
@@ -275,7 +276,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_Reingest_False_IfCreatedAfterCutOff(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
@@ -299,7 +300,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_Null_IfWrongTypeAskedFor(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, Origin = "test" });
@@ -321,7 +322,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAsset_SetsRequiresAuthCorrectly(string roles, int maxUnauth, bool requiresAuth)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels("iiif-img");
+        var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
@@ -342,7 +343,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_Throws_IfFileDeliveryChannel_AndNoOrigin(string deliveryChannels)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
 
         A.CallTo(() => assetRepository.GetAsset(assetId))
@@ -365,7 +366,7 @@ public class MemoryAssetTrackerTests
     public async Task GetOrchestrationAssetT_SetsOptimisedAndMediaType_IfFileDeliveryChannel(string deliveryChannels, bool optimised)
     {
         // Arrange
-        var imageDeliveryChannels = GenerateImageDeliveryChannels(deliveryChannels);
+        var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => customerOriginStrategyRepository.GetCustomerOriginStrategy(assetId, A<string>._))
             .Returns(Task.FromResult(new CustomerOriginStrategy
@@ -383,20 +384,5 @@ public class MemoryAssetTrackerTests
         // Assert
         result.OptimisedOrigin.Should().Be(optimised);
         result.MediaType.ToString().Should().Be("audio/mpeg");
-    }
-    
-    private static List<ImageDeliveryChannel> GenerateImageDeliveryChannels(string deliveryChannels)
-    {
-        var imageDeliveryChannels = new List<ImageDeliveryChannel>();
-
-        foreach (var deliveryChannel in deliveryChannels.Split(","))
-        {
-            imageDeliveryChannels.Add(new ImageDeliveryChannel()
-            {
-                Channel = deliveryChannel
-            });
-        }
-
-        return imageDeliveryChannels;
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Features/Auth/Paths/ConfigDrivenAuthPathGeneratorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Auth/Paths/ConfigDrivenAuthPathGeneratorTests.cs
@@ -84,10 +84,10 @@ public class ConfigDrivenAuthPathGeneratorTests
             {
                 AuthPathRules = new PathTemplateOptions
                 {
-                    Default = "/auth/{customer}/{behaviour}",
-                    Overrides = new Dictionary<string, string>
+                    Default = new PathTemplate { Path = "/auth/{customer}/{behaviour}" },
+                    Overrides = new Dictionary<string, PathTemplate>
                     {
-                        ["test.example.com"] = "/authentication_{customer}/{behaviour}"
+                        ["test.example.com"] = new() { Path = "/authentication_{customer}/{behaviour}" }
                     }
                 },
                 Auth2PathRules = new TypedPathTemplateOptions

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
-using Orchestrator.Settings;
 using Test.Helpers.Data;
 
 namespace Orchestrator.Tests.Infrastructure.IIIF.Manifests;
@@ -38,10 +37,7 @@ public class ManifestV3BuilderTests
                 new List<Size> { new(150, 100), new(300, 200) },
                 new(300, 200)));
 
-        var options = Options.Create(new OrchestratorSettings());
-
-        sut = new ManifestV3Builder(builderUtils, assetPathGenerator, authBuilder, options,
-            new NullLogger<ManifestV3Builder>());
+        sut = new ManifestV3Builder(builderUtils, assetPathGenerator, authBuilder, new NullLogger<ManifestV3Builder>());
     }
 
     [Fact]
@@ -74,7 +70,7 @@ public class ManifestV3BuilderTests
     [Fact]
     public async Task BuildManifest_ImageThumb()
     {
-        var asset = GetImageAsset("iiif-img", "thumbs");
+        var asset = GetImageAsset("iiif-img,thumbs");
         
         var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
@@ -104,7 +100,7 @@ public class ManifestV3BuilderTests
     [Fact]
     public async Task BuildManifest_ImageThumbFile()
     {
-        var asset = GetImageAsset("iiif-img", "thumbs", "file");
+        var asset = GetImageAsset("iiif-img,thumbs,file");
         
         var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
@@ -164,7 +160,7 @@ public class ManifestV3BuilderTests
     [Fact]
     public async Task BuildManifest_ThumbFile()
     {
-        var asset = GetImageAsset("thumbs", "file");
+        var asset = GetImageAsset("thumbs,file");
         
         var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, true))
@@ -199,10 +195,7 @@ public class ManifestV3BuilderTests
             Id = AssetIdGenerator.GetAssetId(),
             MediaType = "audio/wav",
             Duration = 15000,
-            ImageDeliveryChannels = new List<ImageDeliveryChannel>
-            {
-                new() { Channel = "iiif-av" }
-            }
+            ImageDeliveryChannels = "iiif-av".GenerateDeliveryChannels()
         }.WithTestTranscodeMetadata(new AVTranscode
         {
             Duration = 14666, MediaType = "audio/mp3",
@@ -233,10 +226,7 @@ public class ManifestV3BuilderTests
             Id = AssetIdGenerator.GetAssetId(),
             MediaType = "audio/wav",
             Duration = 15000,
-            ImageDeliveryChannels = new List<ImageDeliveryChannel>
-            {
-                new() { Channel = "iiif-av" }, new() { Channel = "file" }
-            }
+            ImageDeliveryChannels = "iiif-av,file".GenerateDeliveryChannels()
         }.WithTestTranscodeMetadata(new AVTranscode
         {
             Duration = 14666, MediaType = "audio/mp3",
@@ -272,10 +262,7 @@ public class ManifestV3BuilderTests
             Duration = 15000,
             Width = 800,
             Height = 800,
-            ImageDeliveryChannels = new List<ImageDeliveryChannel>
-            {
-                new() { Channel = "iiif-av" }
-            }
+            ImageDeliveryChannels = "iiif-av".GenerateDeliveryChannels()
         }.WithTestTranscodeMetadata(new List<AVTranscode>
         {
             new()
@@ -326,10 +313,7 @@ public class ManifestV3BuilderTests
             Duration = 15000,
             Width = 800,
             Height = 800,
-            ImageDeliveryChannels = new List<ImageDeliveryChannel>
-            {
-                new() { Channel = "iiif-av" }, new() { Channel = "file" }
-            }
+            ImageDeliveryChannels = "iiif-av,file".GenerateDeliveryChannels()
         }.WithTestTranscodeMetadata(new List<AVTranscode>
         {
             new()
@@ -385,10 +369,7 @@ public class ManifestV3BuilderTests
             Duration = 15000,
             Width = 800,
             Height = 800,
-            ImageDeliveryChannels = new List<ImageDeliveryChannel>
-            {
-                new() { Channel = "iiif-av" }
-            }
+            ImageDeliveryChannels = "iiif-av".GenerateDeliveryChannels()
         };
         
         var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
@@ -438,13 +419,13 @@ public class ManifestV3BuilderTests
         image.Service.Should().BeNull("No image service");
     }
     
-    private static Asset GetImageAsset(params string[] deliveryChannels) =>
+    private static Asset GetImageAsset(string deliveryChannels) =>
         new()
         {
             Id = AssetIdGenerator.GetAssetId(),
             MediaType = "image/tiff",
             Width = 1500,
             Height = 1000,
-            ImageDeliveryChannels = deliveryChannels.Select(dc => new ImageDeliveryChannel { Channel = dc }).ToList()
+            ImageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels()
         };
 }

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -49,7 +49,7 @@ public class ManifestV3BuilderTests
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
             .Returns("https://dlcs.test/image-url/");
         var imageServices = new List<IService> { new ImageService3 { Id = "test-service" } };
-        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, false, null))
+        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, null))
             .Returns(imageServices);
 
         var manifest = await sut.BuildManifest(manifestId, "testLabel", asset.AsList(), pathElement,
@@ -77,7 +77,7 @@ public class ManifestV3BuilderTests
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
             .Returns("https://dlcs.test/image-url/");
         var imageServices = new List<IService> { new ImageService3 { Id = "test-service" } };
-        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, false, null))
+        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, null))
             .Returns(imageServices);
         A.CallTo(() => builderUtils.ShouldAddThumbs(asset, A<ImageSizeDetails>._)).Returns(true);
 
@@ -107,7 +107,7 @@ public class ManifestV3BuilderTests
         A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
             .Returns("https://dlcs.test/image-url/");
         var imageServices = new List<IService> { new ImageService3 { Id = "test-service" } };
-        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, false, null))
+        A.CallTo(() => builderUtils.GetImageServices(asset, pathElement, null))
             .Returns(imageServices);
         A.CallTo(() => builderUtils.ShouldAddThumbs(asset, A<ImageSizeDetails>._)).Returns(true);
 

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -12,8 +12,10 @@ using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
+using Orchestrator.Settings;
 using Test.Helpers.Data;
 
 namespace Orchestrator.Tests.Infrastructure.IIIF.Manifests;
@@ -36,7 +38,10 @@ public class ManifestV3BuilderTests
                 new List<Size> { new(150, 100), new(300, 200) },
                 new(300, 200)));
 
-        sut = new ManifestV3Builder(builderUtils, assetPathGenerator, authBuilder, new NullLogger<ManifestV3Builder>());
+        var options = Options.Create(new OrchestratorSettings());
+
+        sut = new ManifestV3Builder(builderUtils, assetPathGenerator, authBuilder, options,
+            new NullLogger<ManifestV3Builder>());
     }
 
     [Fact]

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
+using Test.Helpers;
 using Test.Helpers.Data;
 
 namespace Orchestrator.Tests.Infrastructure.IIIF.Manifests;
@@ -60,7 +61,7 @@ public class ManifestV3BuilderTests
         canvas.Thumbnail.Should().BeNull("No thumbnail delivery channel");
         canvas.Rendering.Should().BeNull("No file delivery channel");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(300, "Width of largest derivative");
         image.Height.Should().Be(200, "Height of largest derivative");
         image.Id.Should().Be("https://dlcs.test/image-url/");
@@ -90,7 +91,7 @@ public class ManifestV3BuilderTests
         canvas.Thumbnail.Should().NotBeNull("Has thumbnail delivery channel");
         canvas.Rendering.Should().BeNull("No file delivery channel");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(300, "Width of largest derivative");
         image.Height.Should().Be(200, "Height of largest derivative");
         image.Id.Should().Be("https://dlcs.test/image-url/");
@@ -123,7 +124,7 @@ public class ManifestV3BuilderTests
         rendering.Width.Should().Be(1500, "Width of origin");
         rendering.Height.Should().Be(1000, "Height of origin");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(300, "Width of largest derivative");
         image.Height.Should().Be(200, "Height of largest derivative");
         image.Id.Should().Be("https://dlcs.test/image-url/");
@@ -150,7 +151,7 @@ public class ManifestV3BuilderTests
         canvas.Thumbnail.Should().NotBeNull("Has thumbnail delivery channel");
         canvas.Rendering.Should().BeNull("No file delivery channel");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(300, "Width of largest derivative");
         image.Height.Should().Be(200, "Height of largest derivative");
         image.Id.Should().Be("https://dlcs.test/thumbs-url/");
@@ -180,7 +181,7 @@ public class ManifestV3BuilderTests
         rendering.Width.Should().Be(1500, "Width of origin");
         rendering.Height.Should().Be(1000, "Height of origin");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(300, "Width of largest derivative");
         image.Height.Should().Be(200, "Height of largest derivative");
         image.Id.Should().Be("https://dlcs.test/thumbs-url/");
@@ -214,7 +215,7 @@ public class ManifestV3BuilderTests
         canvas.Thumbnail.Should().BeNull("No thumbnail delivery channel");
         canvas.Rendering.Should().BeNull("No file delivery channel");
         
-        var sound = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Sound;
+        var sound = canvas.GetCanvasPaintingBody<Sound>();
         sound.Duration.Should().Be(14666, "Duration of transcode");
     }
     
@@ -248,7 +249,7 @@ public class ManifestV3BuilderTests
         rendering.Duration.Should().Be(15000, "Duration of origin");
         rendering.Format.Should().Be("audio/wav", "Mediatype of origin");
         
-        var sound = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Sound;
+        var sound = canvas.GetCanvasPaintingBody<Sound>();
         sound.Duration.Should().Be(14666, "Duration of transcode");
     }
     
@@ -289,7 +290,7 @@ public class ManifestV3BuilderTests
         canvas.Thumbnail.Should().BeNull("No thumbnail delivery channel");
         canvas.Rendering.Should().BeNull("No file delivery channel");
         
-        var choice = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as PaintingChoice;
+        var choice = canvas.GetCanvasPaintingBody<PaintingChoice>();
         choice.Items.Should().HaveCount(2, "2 transcodes for video");
         var first = choice.Items[0].As<Video>();
         first.Duration.Should().Be(14666, "From first transcode");
@@ -345,7 +346,7 @@ public class ManifestV3BuilderTests
         rendering.Height.Should().Be(800, "Height of origin");
         rendering.Format.Should().Be("video/raw", "Mediatype of origin");
         
-        var choice = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as PaintingChoice;
+        var choice = canvas.GetCanvasPaintingBody<PaintingChoice>();
         choice.Items.Should().HaveCount(2, "2 transcodes for video");
         var first = choice.Items[0].As<Video>();
         first.Duration.Should().Be(14666, "From first transcode");
@@ -412,7 +413,7 @@ public class ManifestV3BuilderTests
         rendering.Height.Should().Be(1000, "Height of origin");
         rendering.Format.Should().Be("image/tiff", "Format of origin");
         
-        var image = canvas.Items.Single().Items.Single().As<PaintingAnnotation>().Body as Image;
+        var image = canvas.GetCanvasPaintingBody<Image>();
         image.Width.Should().Be(1000, "Width of static placeholder");
         image.Height.Should().Be(1000, "Height of static placeholder");
         image.Format.Should().Be("image/png", "Type of static placeholder");

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -46,20 +46,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     private readonly FakeImageOrchestrator orchestrator = new();
     private const string SizesJsonContent = "{\"o\":[[800,800],[400,400],[200,200]],\"a\":[]}";
 
-    private readonly List<ImageDeliveryChannel> deliveryChannelsForImage =
-    [
-        new ImageDeliveryChannel
-        {
-            Channel = AssetDeliveryChannels.Image,
-            DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ImageDefault
-        },
-
-        new ImageDeliveryChannel
-        {
-            Channel = AssetDeliveryChannels.Thumbnails,
-            DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ThumbsDefault
-        }
-    ];
+    private readonly List<ImageDeliveryChannel> deliveryChannelsForImage;
 
     public ImageHandlingTests(ProtagonistAppFactory<Startup> factory, StorageFixture storageFixture)
     {
@@ -80,6 +67,8 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
                     .AddSingleton<TestProxyHandler>();
             })
             .CreateClient(new WebApplicationFactoryClientOptions {AllowAutoRedirect = false});
+
+        deliveryChannelsForImage = dbFixture.DbContext.GetImageDeliveryChannels();
         
         dbFixture.CleanUp();
     }

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using DLCS.Model.Assets;
-using DLCS.Model.Policies;
 using IIIF.Auth.V2;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
@@ -165,7 +164,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -192,7 +191,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -219,7 +218,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -244,7 +243,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
             
         var path = $"iiif-manifest/v2/{id}";
@@ -267,7 +266,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels)
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels)
             .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
             
@@ -293,7 +292,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin")
+        await dbFixture.DbContext.Images.AddTestAsset(id)
             .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
             .WithTestThumbnailMetadata();
         await dbFixture.DbContext.SaveChangesAsync();
@@ -568,7 +567,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 400,
-            origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
 
         var path = $"iiif-manifest/v2/{id}";
@@ -598,7 +597,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/{id}";
             
@@ -625,7 +624,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/v2/{id}";
         const string iiif2 = "application/ld+json; profile=\"http://iiif.io/api/presentation/2/context.json\"";
@@ -653,7 +652,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/{id}";
             
@@ -680,7 +679,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/{id}";
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
@@ -704,7 +703,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/{id}";
         const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
@@ -727,7 +726,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"iiif-manifest/{id}";
             
@@ -755,7 +754,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 400,
-            origin: "testorigin", imageDeliveryChannels: imageDeliveryChannels);
+            imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
 
         var path = $"iiif-manifest/v3/{id}";

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestRewriteEnabledTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestRewriteEnabledTests.cs
@@ -1,0 +1,367 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+using DLCS.Model.Assets.Metadata;
+using IIIF.ImageApi.V2;
+using IIIF.ImageApi.V3;
+using IIIF.Presentation.V3.Content;
+using IIIF.Serialisation;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Orchestrator.Infrastructure.IIIF;
+using Orchestrator.Tests.Infrastructure.IIIF.Manifests;
+using Orchestrator.Tests.Integration.Infrastructure;
+using Test.Helpers;
+using Test.Helpers.Data;
+using Test.Helpers.Integration;
+using IIIF3 = IIIF.Presentation.V3;
+
+namespace Orchestrator.Tests.Integration;
+
+/// <summary>
+/// Test of iiif-manifest handling when rewriting is enabled. Only tests rewrite logic, see
+/// <see cref="ManifestHandlingTests"/> and <see cref="NamedQueryTests"/> for full tests
+/// </summary>
+/// <remarks>
+/// These tests verify single asset manifest only, using common DC configurations.
+/// <see cref="ManifestV3BuilderTests"/> for more indepth tests of all DC permutations.</remarks>
+[Trait("Category", "Integration")]
+[Collection(DatabaseCollection.CollectionName)]
+public class ManifestRewriteEnabledTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly DlcsDatabaseFixture dbFixture;
+    private readonly HttpClient httpClient;
+    private readonly List<ImageDeliveryChannel> imageDeliveryChannels;
+    
+    public ManifestRewriteEnabledTests(ProtagonistAppFactory<Startup> factory, DlcsDatabaseFixture databaseFixture)
+    {
+        dbFixture = databaseFixture;
+
+        httpClient = factory
+            .WithTestServices(services =>
+            {
+                services.AddSingleton<IIIIFAuthBuilder, FakeAuth2Client>();
+            })
+            .WithConnectionString(dbFixture.ConnectionString)
+            .WithConfigValue("RewriteAssetPathsOnManifests", true.ToString())
+            .CreateClient();
+        
+        imageDeliveryChannels = dbFixture.DbContext.GetImageDeliveryChannels();
+        
+        dbFixture.CleanUp();
+    }
+
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|", "/const_value/v2/99/|asset|")]
+    [InlineData("versioned.com", "2", "/th/_|asset|", "/th/v2_|asset|")]
+    [InlineData("non-versioned.com", "3", "/thumbs/99/|asset|", "/thumbs/99/|asset|")]
+    public async Task Get_V2ManifestForImage_ReturnsManifest_PathsRewritten_ForThumb(string hostname, string postfix,
+        string expectedThumb, string expectedService)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedThumb = $"http://{hostname}{expectedThumb.Replace("|asset|", id.Asset)}";
+        expectedService = $"http://{hostname}{expectedService.Replace("|asset|", id.Asset)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v2/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should()
+            .Be($"http://{hostname}/iiif-manifest/v2/{id}", "Manifest id never changed");
+        jsonResponse.SelectToken("sequences[0].canvases[0].@id").ToString().Should()
+            .Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+        
+        ValidateThumbnail(jsonResponse.SelectToken("sequences[0].canvases[0].thumbnail"), "Canvas thumbnail rewritten");
+        ValidateThumbnail(jsonResponse.SelectToken("thumbnail"), "Manifest thumbnail rewritten");
+
+        void ValidateThumbnail(JToken jToken, string because)
+        {
+            // thumbnail.@id will be path to a jpeg
+            jToken.SelectToken("@id").Value<string>().Should()
+                .Be($"{expectedThumb}/full/200,200/0/default.jpg", because);
+
+            // service.@id will be path to a image service
+            jToken.SelectToken("service.@id").Value<string>().Should().Be(expectedService, because);
+        }
+    }
+
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|", "/const_value/v2/99/|asset|")]
+    [InlineData("versioned.com", "2", "/image/_|asset|", "/image/v2_|asset|")]
+    [InlineData("non-versioned.com", "3", "/image/99/|asset|", "/image/99/|asset|")]
+    public async Task Get_V2ManifestForImage_ReturnsManifest_PathsRewritten_ForImage(string hostname, string postfix,
+        string expectedThumb, string expectedService)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedThumb = $"http://{hostname}{expectedThumb.Replace("|asset|", id.Asset)}";
+        expectedService = $"http://{hostname}{expectedService.Replace("|asset|", id.Asset)}";
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v2/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var jsonResponse = JObject.Parse(await response.Content.ReadAsStringAsync());
+        jsonResponse["@id"].ToString().Should()
+            .Be($"http://{hostname}/iiif-manifest/v2/{id}", "Manifest id never changed");
+        jsonResponse.SelectToken("sequences[0].canvases[0].@id").ToString().Should()
+            .Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+        
+        var imageResource = jsonResponse.SelectToken("sequences[0].canvases[0].images[0].resource");
+        imageResource.SelectToken("@id").Value<string>().Should()
+            .Be($"{expectedThumb}/full/1024,1024/0/default.jpg", "@id is jpeg");
+        imageResource.SelectToken("service.@id").Value<string>().Should()
+            .Be(expectedService, "service@id is image service");
+    }
+    
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|", "/const_value/v2/99/|asset|")]
+    [InlineData("versioned.com", "2", "/th/_|asset|", "/th/v2_|asset|")]
+    [InlineData("non-versioned.com", "3", "/thumbs/99/|asset|", "/thumbs/99/|asset|")]
+    public async Task Get_V3ManifestForImage_ReturnsManifest_PathsRewritten_ForThumb(string hostname, string postfix,
+        string expectedThumb, string expectedService)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedThumb = $"http://{hostname}{expectedThumb.Replace("|asset|", id.Asset)}";
+        var (expectedService2, expectedService3) = GetImageVersionSpecific(hostname, expectedService, id);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+
+        manifest.Id.Should().Be($"http://{hostname}/iiif-manifest/v3/{id}", "Manifest id never changed");
+        
+        var canvas = manifest.Items.Single();
+        canvas.Id.Should().Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+        ValidateThumbnail(canvas.Thumbnail, "Canvas thumbnail rewritten");
+        ValidateThumbnail(manifest.Thumbnail, "Manifest thumbnail rewritten");
+
+        void ValidateThumbnail(List<ExternalResource> thumbnails, string because)
+        {
+            var thumbnail = thumbnails.Single();
+            
+            // thumbnail.id will be path to a jpeg
+            thumbnail.Id.Should().Be($"{expectedThumb}/full/200,200/0/default.jpg", because);
+
+            // imageService2 id will be path to a image service. This is not canonical so contains version
+            var image2 = thumbnail.GetService<ImageService2>();
+            image2.Id.Should().Be(expectedService2, because);
+            
+            // imageService3 id will be path to a image service. This is canonical so doesn't contain version
+            var image3 = thumbnail.GetService<ImageService3>();
+            image3.Id.Should().Be(expectedService3, because);
+        }
+    }
+
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|", "/const_value/v2/99/|asset|")]
+    [InlineData("versioned.com", "2", "/image/_|asset|", "/image/v2_|asset|")]
+    [InlineData("non-versioned.com", "3", "/image/99/|asset|", "/image/99/|asset|")]
+    public async Task Get_V3ManifestForImage_ReturnsManifest_PathsRewritten_ForImage(string hostname, string postfix,
+        string expectedThumb, string expectedService)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedThumb = $"http://{hostname}{expectedThumb.Replace("|asset|", id.Asset)}";
+        var (expectedService2, expectedService3) = GetImageVersionSpecific(hostname, expectedService, id);
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        manifest.Id.Should().Be($"http://{hostname}/iiif-manifest/v3/{id}", "Manifest id never changed");
+        
+        var canvas = manifest.Items.Single();
+        canvas.Id.Should().Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+
+        var imageResource = canvas.GetCanvasPaintingBody<Image>();
+        imageResource.Id.Should().Be($"{expectedThumb}/full/1024,1024/0/default.jpg", "id is jpeg");
+        
+        var image2 = imageResource.GetService<ImageService2>();
+        image2.Id.Should().Be(expectedService2, "ImageService2 is image service with version");
+            
+        // imageService3 id will be path to a image service. This is canonical so doesn't contain version
+        var image3 = imageResource.GetService<ImageService3>();
+        image3.Id.Should().Be(expectedService3, "ImageService3 is image service with version");
+    }
+    
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|")]
+    [InlineData("versioned.com", "2", "/av/_|asset|")]
+    [InlineData("non-versioned.com", "3", "/iiif-av/99/|asset|")]
+    public async Task Get_V3ManifestForVideo_ReturnsManifest_PathsRewritten_ForTranscode(string hostname, string postfix,
+        string expectedRewrite)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedRewrite = $"http://{hostname}{expectedRewrite.Replace("|asset|", id.Asset)}";
+        var asset = await dbFixture.DbContext.Images
+            .AddTestAsset(id, mediaType: "video/whatever")
+            .WithTestDeliveryChannel("iiif-av");
+        asset.Entity.WithTestTranscodeMetadata([
+            new AVTranscode
+            {
+                Duration = 10, Width = 20, Height = 30, MediaType = "video/avi",
+                Location = new Uri($"s3://dlcs-storage/{id}/full/full/max/max/0/default.avi")
+            }
+        ]);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        manifest.Id.Should().Be($"http://{hostname}/iiif-manifest/v3/{id}", "Manifest id never changed");
+        
+        var canvas = manifest.Items.Single();
+        canvas.Id.Should().Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+
+        var videoResource = canvas.GetCanvasPaintingBody<Video>();
+        videoResource.Id.Should().Be($"{expectedRewrite}/full/full/max/max/0/default.avi", "id is transcode");
+    }
+    
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|")]
+    [InlineData("versioned.com", "2", "/av/_|asset|")]
+    [InlineData("non-versioned.com", "3", "/iiif-av/99/|asset|")]
+    public async Task Get_V3ManifestForSound_ReturnsManifest_PathsRewritten_ForTranscode(string hostname, string postfix,
+        string expectedRewrite)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedRewrite = $"http://{hostname}{expectedRewrite.Replace("|asset|", id.Asset)}";
+        var asset = await dbFixture.DbContext.Images
+            .AddTestAsset(id, mediaType: "audio/whatever")
+            .WithTestDeliveryChannel("iiif-av");
+        asset.Entity.WithTestTranscodeMetadata([
+            new AVTranscode
+            {
+                Duration = 10, Width = 20, Height = 30, MediaType = "audio/avi",
+                Location = new Uri($"s3://dlcs-storage/{id}/full/max/default.mp3")
+            }
+        ]);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        manifest.Id.Should().Be($"http://{hostname}/iiif-manifest/v3/{id}", "Manifest id never changed");
+        
+        var canvas = manifest.Items.Single();
+        canvas.Id.Should().Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+
+        var soundResource = canvas.GetCanvasPaintingBody<Sound>();
+        soundResource.Id.Should().Be($"{expectedRewrite}/full/max/default.mp3", "id is transcode");
+    }
+    
+    [Theory]
+    [InlineData("my-proxy.com", "1", "/const_value/99/|asset|")]
+    [InlineData("versioned.com", "2", "/binary/_|asset|")]
+    [InlineData("non-versioned.com", "3", "/file/99/|asset|")]
+    public async Task Get_V3ManifestForFile_ReturnsManifest_PathsRewritten_ForFile(string hostname, string postfix,
+        string expectedRewrite)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: postfix);
+        expectedRewrite = $"http://{hostname}{expectedRewrite.Replace("|asset|", id.Asset)}";
+        await dbFixture.DbContext.Images
+            .AddTestAsset(id, mediaType: "application/pdf")
+            .WithTestDeliveryChannel("file");
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Add("Host", hostname);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        manifest.Id.Should().Be($"http://{hostname}/iiif-manifest/v3/{id}", "Manifest id never changed");
+        
+        var canvas = manifest.Items.Single();
+        canvas.Id.Should().Be($"http://{hostname}/iiif-img/{id}/canvas/c/1", "Canvas id never changed");
+
+        var rendering = canvas.Rendering.Single();
+        rendering.Id.Should().Be(expectedRewrite, "rendering path rewritten");
+
+        var soundResource = canvas.GetCanvasPaintingBody<Image>();
+        soundResource.Id.Should().Be($"http://{hostname}/static/dataset/placeholder.png",
+            "id is placeholder, never changed");
+    }
+
+    /// <summary>
+    /// The value provided to tests contains the `v2` slug as that's not the canonical version. The ImageServices output
+    /// on the manifest will contain v2 for ImageService2 but won't output a version for ImageService3 as it's canonical.
+    /// This method is a helper to get the expected imageService 2+3 paths. 
+    /// </summary>
+    private static (string expectedService2, string expectedService3) GetImageVersionSpecific(string hostname,
+        string expectedVersioned, AssetId assetId)
+    {
+        var expectedService2 = $"http://{hostname}{expectedVersioned.Replace("|asset|", assetId.Asset)}";
+        var expectedService3 = $"http://{hostname}{expectedVersioned
+            .Replace("|asset|", assetId.Asset)
+            .Replace("v2", string.Empty)
+            .Replace("//", "/")}";
+        return (expectedService2, expectedService3);
+    }
+}

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -312,7 +312,7 @@ public class NamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Theory]
     [InlineData("iiif-resource/99/manifest-slash-test/with%2Fforward%2Fslashes/1")]
     [InlineData("iiif-resource/99/manifest-slash-test/with%2fforward%2fslashes/1")]
-    public async Task Get_ReturnsManifestWithSlashes(string path)
+    public async Task Get_ReturnsV3Manifest_ArgsWithSlashes(string path)
     {
         // Arrange
         dbFixture.DbContext.NamedQueries.Add(new NamedQuery

--- a/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
+++ b/src/protagonist/Orchestrator.Tests/appsettings.Testing.json
@@ -22,7 +22,22 @@
   "PathRules": {
     "Default": "/{prefix}/{version}/{customer}/{space}/{assetPath}",
     "Overrides": {
-      "my-proxy.com": "/const_value/{version}/{customer}/{assetPath}"
+      "my-proxy.com": "/const_value/{version}/{customer}/{assetPath}",
+      "versioned.com": {
+        "Path": "/{prefix}/{version}_{assetPath}",
+        "PrefixReplacements": {
+          "iiif-img": "image",
+          "iiif-av": "av",
+          "thumbs": "th",
+          "file": "binary"
+        }
+      },
+      "non-versioned.com": {
+        "Path": "/{prefix}/{customer}/{assetPath}",
+        "PrefixReplacements": {
+          "iiif-img": "image"
+        }
+      }
     }
   },
   "ImageServerPathConfig": {

--- a/src/protagonist/Orchestrator/Features/Auth/Paths/ConfigDrivenAuthPathGenerator.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/Paths/ConfigDrivenAuthPathGenerator.cs
@@ -27,7 +27,7 @@ public class ConfigDrivenAuthPathGenerator : IAuthPathGenerator
         var host = request.Host.Value;
         var template = orchestratorSettings.Auth.AuthPathRules.GetPathTemplateForHost(host);
 
-        var path = DlcsPathHelpers.GenerateAuthPathFromTemplate(template, customer, behaviour);
+        var path = DlcsPathHelpers.GenerateAuthPathFromTemplate(template.Path, customer, behaviour);
         return request.GetDisplayUrl(path, includeQueryParams: false);
     }
 

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/IBuildManifests.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/IBuildManifests.cs
@@ -10,7 +10,7 @@ namespace Orchestrator.Infrastructure.IIIF.Manifests;
 /// <summary>
 /// Interface for construction of a manifest
 /// </summary>
-/// <typeparam name="T">Type of manifest build</typeparam>
+/// <typeparam name="T">Type of manifest to build</typeparam>
 public interface IBuildManifests<T>
     where T : JsonLdBase
 {

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/IBuildManifests.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/IBuildManifests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using DLCS.Model.Assets;
 using DLCS.Model.PathElements;
 using IIIF;
+using PresentationApiVersion = IIIF.Presentation.Version;
 
 namespace Orchestrator.Infrastructure.IIIF.Manifests;
 
@@ -16,4 +17,26 @@ public interface IBuildManifests<T>
 {
     Task<T> BuildManifest(string manifestId, string label, List<Asset> assets, CustomerPathElement customerPathElement,
         ManifestType manifestType, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Base class for manifest building, ensures that <see cref="IManifestBuilderUtils"/> is configured with correct
+/// version 
+/// </summary>
+public abstract class ManifestBuilderBase<T>(IManifestBuilderUtils builderUtils) : IBuildManifests<T>
+    where T : JsonLdBase
+{
+    protected readonly IManifestBuilderUtils BuilderUtils = builderUtils;
+
+    public Task<T> BuildManifest(string manifestId, string label, List<Asset> assets, CustomerPathElement customerPathElement,
+        ManifestType manifestType, CancellationToken cancellationToken)
+    {
+        BuilderUtils.SetPresentationVersion(PresentationApiVersion);
+        return BuildManifestImpl(manifestId, label, assets, customerPathElement, manifestType, cancellationToken);
+    }
+
+    protected abstract PresentationApiVersion PresentationApiVersion { get; }
+
+    protected abstract Task<T> BuildManifestImpl(string manifestId, string label, List<Asset> assets,
+        CustomerPathElement customerPathElement, ManifestType manifestType, CancellationToken cancellationToken);
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
@@ -19,6 +19,9 @@ namespace Orchestrator.Infrastructure.IIIF.Manifests;
 
 public interface IManifestBuilderUtils
 {
+    /// <summary>
+    /// Feature flag can control whether to rewrite asset-paths, in accordance to pathTemplate, or use native paths
+    /// </summary>
     bool UseNativeFormatForAssets { get; }
     
     Task<ImageSizeDetails> RetrieveThumbnails(Asset asset, CancellationToken cancellationToken);

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -22,8 +22,6 @@ using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
 using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Orchestrator.Settings;
 using IIIFAuth2 = IIIF.Auth.V2;
 
 namespace Orchestrator.Infrastructure.IIIF.Manifests;

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -47,6 +47,13 @@ public class OrchestratorSettings
     /// If true, requests for info.json will cause image to be orchestrated.
     /// </summary>
     public bool OrchestrateOnInfoJson { get; set; } = true;
+
+    /// <summary>
+    /// If true, asset paths on single-item and NamedQuery manifests are rewritten in accordance with
+    /// <see cref="PathTemplateOptions"/>.
+    /// If false, native paths are always used.
+    /// </summary>
+    public bool RewriteAssetPathsOnManifests { get; set; }
     
     /// <summary>
     /// Optional date, any info.json files generated prior to this date will be considered stale and regenerated.
@@ -119,11 +126,6 @@ public class ProxySettings
     /// Get the root path that thumb handler is listening on
     /// </summary>
     public string ThumbResizePath { get; set; } = "thumbs";
-
-    /// <summary>
-    /// Get the root path for serving images
-    /// </summary>
-    public string ImagePath { get; set; } = "iiif-img";
 
     /// <summary>
     /// A collection of resize config for serving resized thumbs rather than handling requests via image-server

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -84,8 +84,7 @@ public class Startup
             .AddCorrelationIdHeaderPropagation()
             .AddInfoJsonClient()
             .AddIIIFBuilding()
-            .AddIIIFAuth(orchestratorSettings)
-            .HandlePathTemplates();
+            .AddIIIFAuth(orchestratorSettings);
         
         // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
         services.Configure<ForwardedHeadersOptions>(opts =>

--- a/src/protagonist/Test.Helpers/Data/DeliveryChannelData.cs
+++ b/src/protagonist/Test.Helpers/Data/DeliveryChannelData.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using DLCS.Model.Assets;
+using DLCS.Model.Policies;
+using DLCS.Repository;
+
+namespace Test.Helpers.Data;
+
+public static class DeliveryChannelData
+{
+    /// <summary>
+    /// Helper function to get default delivery channel and default thumbs policy for given customer
+    /// </summary>
+    public static List<ImageDeliveryChannel> GetImageDeliveryChannels(this DlcsContext dlcsContext, int customer = 99)
+    {
+        var thumbsPolicy = dlcsContext.DeliveryChannelPolicies
+            .Single(d => d.Channel == AssetDeliveryChannels.Thumbnails && d.Customer == customer);
+
+        return
+        [
+            new ImageDeliveryChannel
+            {
+                Channel = AssetDeliveryChannels.Image,
+                DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ImageDefault,
+            },
+
+            new ImageDeliveryChannel
+            {
+                Channel = AssetDeliveryChannels.Thumbnails,
+                DeliveryChannelPolicyId = thumbsPolicy.Id,
+            }
+        ];
+    }
+
+    /// <summary>
+    /// Return <see cref="ImageDeliveryChannel"/> without policyId from provided comma delimited list of channels
+    /// </summary>
+    public static List<ImageDeliveryChannel> GenerateDeliveryChannels(this string csvDeliveryChannels)
+        => csvDeliveryChannels
+            .Split(",")
+            .Select(deliveryChannel => new ImageDeliveryChannel { Channel = deliveryChannel })
+            .ToList();
+}

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -207,18 +207,6 @@ public static class DatabaseTestDataPopulation
             TotalSizeOfThumbnails = sizeOfThumbs
         });
 
-    public static ValueTask<EntityEntry<AssetApplicationMetadata>> AddTestAssetApplicationMetadata(
-        this DbSet<AssetApplicationMetadata> assetApplicationMetadata, AssetId assetId,
-        string metadataType, string metadataValue)
-        => assetApplicationMetadata.AddAsync(new AssetApplicationMetadata()
-        {
-            AssetId = assetId,
-            MetadataType = metadataType,
-            MetadataValue = metadataValue,
-            Created = DateTime.UtcNow,
-            Modified = DateTime.UtcNow
-        });
-
     public static ValueTask<EntityEntry<Asset>> WithTestThumbnailMetadata(
         this ValueTask<EntityEntry<Asset>> asset,
         string metadataValue = "{\"a\": [], \"o\": [[769,1024],[300,400],[150,200],[75,100]]}")
@@ -232,7 +220,7 @@ public static class DatabaseTestDataPopulation
         string deliveryChannel,
         int? policyId = null)
     {
-        asset.Result.Entity.ImageDeliveryChannels.Add(new ImageDeliveryChannel()
+        asset.Result.Entity.ImageDeliveryChannels.Add(new ImageDeliveryChannel
         {
             Channel = deliveryChannel,
             DeliveryChannelPolicyId = policyId ?? deliveryChannel switch

--- a/src/protagonist/Test.Helpers/ManifestHelpers.cs
+++ b/src/protagonist/Test.Helpers/ManifestHelpers.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using IIIF;
+using IIIF.Presentation.V3;
+using IIIF.Presentation.V3.Annotation;
+
+namespace Test.Helpers;
+
+public static class ManifestHelpers
+{
+    /// <summary>
+    /// Get canvas.items[0].items[0].body
+    /// </summary>
+    public static T GetCanvasPaintingBody<T>(this Canvas canvas)
+        where T : class, IPaintable 
+        => canvas.Items!.Single().Items!.OfType<PaintingAnnotation>().Single().Body as T;
+
+    /// <summary>
+    /// Get service[0] from resource
+    /// </summary>
+    public static T GetService<T>(this ResourceBase resourceBase)
+        where T : IService
+        => resourceBase.Service!.OfType<T>().Single();
+}

--- a/src/protagonist/Thumbs/Startup.cs
+++ b/src/protagonist/Thumbs/Startup.cs
@@ -59,7 +59,6 @@ public class Startup
             opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
         });
         services.AddHttpContextAccessor();
-        services.HandlePathTemplates();
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)

--- a/src/protagonist/Thumbs/ThumbsMiddleware.cs
+++ b/src/protagonist/Thumbs/ThumbsMiddleware.cs
@@ -44,8 +44,7 @@ public class ThumbsMiddleware
         defaultImageApiVersion = configuration.GetValue<Version>("DefaultIIIFImageVersion", Version.V3);
     }
 
-    public async Task Invoke(HttpContext context,
-        AssetDeliveryPathParser parser)
+    public async Task Invoke(HttpContext context, AssetDeliveryPathParser parser)
     {
         try
         {


### PR DESCRIPTION
## Main Changes

There are 2 main points in this PR:
* Single item and named query manifests now respect pathTemplate config for asset paths. This can be controlled by a feature flag, default is to have it disabled.
* Asset path `{prefix}` values can be transformed.

### Summary

Introduced `PathTemplate` class for strongly typed pathTemplates, contains `Path` and `PrefixReplacements`. To maintain backwards compatibility with existing configurations added a `[TypeConverter]` to convert from a string appSetting.

`PathTemplate` is passed to `IAssetPathGenerator`, conversion logic for prefix replacement happens in that class only. 

Some refactoring if manifest building classes
* `ManifestBuilderUtils` checks config flag for whether to rewrite values. This is now also aware of the manifest version that calls will result on as this can change how some versioned paths are handled.
  * Refactored some internal methods to avoid duplication of calling logic for determining paths to generate.
* Add base class inheriting from `IBuildManifests<T>`, this was simplest (not necessarily cleanest!) way to ensure Manifest presentation version is set in `ManifestBuilderUtils`.

## Additional

Added helpers for generating test data or accessing Manifest properties to avoid repetitive code.

Updated path-template docs.

Also removed `OverridesAsJson` helper property as it's only used by one customer and doesn't solve much.
Resolves #983