### PR TITLE
Correctly set image service profiles on manifests

### DIFF
--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
@@ -186,7 +186,7 @@ public class ManifestBuilderUtils(
             {
                 Id = GetFullyQualifiedId(asset, customerPathElement, isThumb, UseNativeFormatForAssets,
                     ImageApiVersion.V2),
-                Profile = ImageService2.Level2Profile,
+                Profile = isThumb ? ImageService2.Level0Profile : ImageService2.Level2Profile,
                 Context = ImageService2.Image2Context,
             };
             customiseImage2(image2);
@@ -206,7 +206,7 @@ public class ManifestBuilderUtils(
             {
                 Id = GetFullyQualifiedId(asset, customerPathElement, isThumb, UseNativeFormatForAssets,
                     ImageApiVersion.V3),
-                Profile = ImageService3.Level2Profile,
+                Profile = isThumb ? ImageService3.Level0Profile : ImageService3.Level2Profile,
                 Context = ImageService3.Image3Context,
             };
             customiseImage3(image3);

--- a/src/protagonist/Test.Helpers/ManifestHelpers.cs
+++ b/src/protagonist/Test.Helpers/ManifestHelpers.cs
@@ -2,6 +2,7 @@
 using IIIF;
 using IIIF.Presentation.V3;
 using IIIF.Presentation.V3.Annotation;
+using IIIF.Presentation.V3.Content;
 
 namespace Test.Helpers;
 
@@ -20,4 +21,11 @@ public static class ManifestHelpers
     public static T GetService<T>(this ResourceBase resourceBase)
         where T : IService
         => resourceBase.Service!.OfType<T>().Single();
+
+    /// <summary>
+    /// Get thumbnail[0] from resource, ensuring only 1
+    /// </summary>
+    public static ExternalResource GetSingleThumbnail(this ResourceBase resourceBase)
+        => resourceBase.Thumbnail!.Single();
+
 }


### PR DESCRIPTION
thumbnails are level0, images level2

resolves issue introduced by refactoring `ManifestBuilderUtils` in #1004 