### PR TITLE
Validate bulk asset patch member property

### DIFF
--- a/src/protagonist/API.Tests/Features/Customer/Validation/BulkAssetPatchValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/BulkAssetPatchValidatorTests.cs
@@ -1,0 +1,47 @@
+﻿using API.Features.Image.Validation;
+using API.Infrastructure.Requests;
+using API.Settings;
+using DLCS.Model;
+using FluentValidation.TestHelper;
+using Microsoft.Extensions.Options;
+
+namespace API.Tests.Features.Customer.Validation;
+
+public class BulkAssetPatchValidatorTests
+{
+    private readonly BulkAssetPatchValidator sut;
+
+    public BulkAssetPatchValidatorTests()
+    {
+        var apiSettings = new ApiSettings { MaxImageListSize = 4 };
+        sut = new BulkAssetPatchValidator(Options.Create(apiSettings));
+    }
+    
+    [Fact]
+    public void Members_Null()
+    {
+        BulkPatch<IdentifierOnly> bulkPatch = new BulkPatch<IdentifierOnly>()
+        {
+            Field = "unsupported",
+            Value = [""],
+            Members = null
+        };;
+        var result = sut.TestValidate(bulkPatch);
+        result.ShouldHaveValidationErrorFor(r => r.Members)
+            .WithErrorMessage("Member cannot be null");;
+    }
+    
+    [Fact]
+    public void Field_Unsupported()
+    {
+        BulkPatch<IdentifierOnly> bulkPatch = new BulkPatch<IdentifierOnly>()
+        {
+            Field = "unsupported",
+            Value = [""],
+            Members = []
+        };
+        var result = sut.TestValidate(bulkPatch);
+        result.ShouldHaveValidationErrorFor(r => r.Field)
+            .WithErrorMessage("Unsupported field 'unsupported'");;
+    }
+}

--- a/src/protagonist/API.Tests/Features/Customer/Validation/ImageIdListValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Customer/Validation/ImageIdListValidatorTests.cs
@@ -26,6 +26,15 @@ public class ImageIdListValidatorTests
         result.ShouldHaveValidationErrorFor(r => r)
             .WithErrorMessage("Members cannot be empty");;
     }
+    
+    [Fact]
+    public void Members_Null()
+    {
+        IdentifierOnly[] members = null;
+        var result = sut.TestValidate(members);
+        result.ShouldHaveValidationErrorFor(r => r)
+            .WithErrorMessage("Members cannot be null");;
+    }
 
     [Fact]
     public void Members_GreaterThanMaxBatchSize()

--- a/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
@@ -2,6 +2,7 @@
 using DLCS.Core.Collections;
 using DLCS.Model;
 using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.Extensions.Options;
 
 namespace API.Features.Customer.Validation;
@@ -28,5 +29,13 @@ public class ImageIdListValidator : AbstractValidator<IdentifierOnly[]?>
         RuleFor(c => c)
             .Must(m => (m?.Length ?? 0) <= maxBatch)
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
+    }
+    
+    protected override bool PreValidate(ValidationContext<IdentifierOnly[]?> context, ValidationResult result) {
+        if (context.InstanceToValidate == null) {
+            result.Errors.Add(new ValidationFailure("", "Members cannot be null"));
+            return false;
+        }
+        return true;
     }
 }

--- a/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/ImageIdListValidator.cs
@@ -31,8 +31,10 @@ public class ImageIdListValidator : AbstractValidator<IdentifierOnly[]?>
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
     }
     
-    protected override bool PreValidate(ValidationContext<IdentifierOnly[]?> context, ValidationResult result) {
-        if (context.InstanceToValidate == null) {
+    protected override bool PreValidate(ValidationContext<IdentifierOnly[]?> context, ValidationResult result) 
+    {
+        if (context.InstanceToValidate == null) 
+        {
             result.Errors.Add(new ValidationFailure("", "Members cannot be null"));
             return false;
         }

--- a/src/protagonist/API/Features/Image/Validation/BulkAssetPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/BulkAssetPatchValidator.cs
@@ -23,8 +23,10 @@ public class BulkAssetPatchValidator : AbstractValidator<BulkPatch<IdentifierOnl
             .WithMessage(f => $"Unsupported field '{f.Field}'");
     }
     
-    protected override bool PreValidate(ValidationContext<BulkPatch<IdentifierOnly>> context, ValidationResult result) {
-        if (context.InstanceToValidate.Members == null) {
+    protected override bool PreValidate(ValidationContext<BulkPatch<IdentifierOnly>> context, ValidationResult result) 
+    {
+        if (context.InstanceToValidate.Members == null) 
+        {
             result.Errors.Add(new ValidationFailure("Members", "Member cannot be null"));
             return false;
         }

--- a/src/protagonist/API/Features/Image/Validation/BulkAssetPatchValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/BulkAssetPatchValidator.cs
@@ -1,10 +1,10 @@
 ﻿using API.Features.Customer;
-using API.Features.Customer.Requests;
 using API.Features.Customer.Validation;
 using API.Infrastructure.Requests;
 using API.Settings;
 using DLCS.Model;
 using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.Extensions.Options;
 
 namespace API.Features.Image.Validation;
@@ -21,5 +21,13 @@ public class BulkAssetPatchValidator : AbstractValidator<BulkPatch<IdentifierOnl
         RuleFor(bp => bp.Field)
             .Equal(BulkAssetPatcher.SupportedFields.ManifestField)
             .WithMessage(f => $"Unsupported field '{f.Field}'");
+    }
+    
+    protected override bool PreValidate(ValidationContext<BulkPatch<IdentifierOnly>> context, ValidationResult result) {
+        if (context.InstanceToValidate.Members == null) {
+            result.Errors.Add(new ValidationFailure("Members", "Member cannot be null"));
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Resolves #1002 

This PR fixes an issue where an obtuse error with a stack trace is returned to the user when the `member` property is `null` - this now correctly responds with an error response and a status code of `400`