### PR TITLE
Set Default PathTemplate to new object

### DIFF
--- a/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
+++ b/src/protagonist/DLCS.Web/Response/PathTemplateOptions.cs
@@ -23,7 +23,7 @@ public class PathTemplateOptions
     /// <summary>
     /// Default path template if no host-specific overrides found.
     /// </summary>
-    public PathTemplate Default { get; init; } = DefaultPathTemplate;
+    public PathTemplate Default { get; init; } = new() { Path = DefaultPathFormat };
 
     /// <summary>
     /// Collection of path template overrides, keyed by hostname.


### PR DESCRIPTION
Defaulting to existing object resulted in it being overwritten if the default templates were changed.

The result of this is the the `"Default"` (not the canonical / native) path was used in some instances where `useNativeFormat=true` was passed to path generator