### PR TITLE
Match batch names in BatchCompletedNotification

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are a variety of technologies used across the projects, including:
 
 [Github actions](.github/workflows) are used to build and push new Docker images to github container registry.
 
-The main entry point is [`run_build.yml`](.github/workflows/run_build.yml). This runs `dotnet test` then uses the parameterised `build_docker.yml` files to handle Docker image creation.
+The main entry point is [`run_build.yml`](.github/workflows/run_build.yml). This runs `dotnet test` then uses the parameterised `docker-build-and-push` files to handle Docker image creation.
 
 PRs to `main`, `develop`, pushes to `main`, `develop` and `v*` tags will:
 * Build + test dotnet code

--- a/src/protagonist/DLCS.AWS/SNS/BatchCompletedNotification.cs
+++ b/src/protagonist/DLCS.AWS/SNS/BatchCompletedNotification.cs
@@ -2,33 +2,21 @@ using DLCS.Model.Assets;
 
 namespace DLCS.AWS.SNS;
 
-public class BatchCompletedNotification
+public class BatchCompletedNotification(Batch completedBatch)
 {
-    public int Id { get; private set; }
-    
-    public int CustomerId { get; private set; }
-    
-    public int Total { get; private set; }
-    
-    public int Success { get; private set; }
-    
-    public int Errors { get; private set; }
-    
-    public bool Superseded { get; private set; }
-    
-    public DateTime Started { get; private set; }
-    
-    public DateTime? Finished { get; private set; }
+    public int Id { get; private set; } = completedBatch.Id;
 
-    public BatchCompletedNotification(Batch completedBatch)
-    {
-        Id = completedBatch.Id;
-        CustomerId = completedBatch.Customer;
-        Total = completedBatch.Count;
-        Success = completedBatch.Completed;
-        Errors = completedBatch.Errors;
-        Superseded = completedBatch.Superseded;
-        Started = completedBatch.Submitted;
-        Finished = completedBatch.Finished;
-    }
+    public int Customer { get; private set; } = completedBatch.Customer;
+
+    public int Count { get; private set; } = completedBatch.Count;
+
+    public int Completed { get; private set; } = completedBatch.Completed;
+
+    public int Errors { get; private set; } = completedBatch.Errors;
+
+    public bool Superseded { get; private set; } = completedBatch.Superseded;
+
+    public DateTime Submitted { get; private set; } = completedBatch.Submitted;
+
+    public DateTime? Finished { get; private set; } = completedBatch.Finished;
 }

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -86,7 +86,7 @@ public class TopicPublisher : ITopicPublisher
             {
                 {"CustomerId", new MessageAttributeValue
                 {
-                    StringValue = message.CustomerId.ToString(),
+                    StringValue = message.Customer.ToString(),
                     DataType = "String"
                 }}
             } 


### PR DESCRIPTION
Resolves #1011 

This Pr modifies the names of some of the properties in `BatchCompletedNotification` so that they match the values found in `Batch`

> [!Note]
> This PR has the related fix https://github.com/dlcs/iiif-presentation/pull/385, which must be release first