### PR TITLE
Allow knownNetworks to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In addition to the above there are a number of `*.Tests` classes for automated t
 * Orchestrator - reverse proxy that serves user requests.
 * Portal - administration UI for managing assets.
 * Thumbs - simplified handling of thumbnail requests.
-* DeleteHandler - monitors queue for notifications + deletes asset derivatives on receipt.
+* CleanupHandler - monitors queue for notifications + deletes asset derivatives on receipt.
 * Migrator - Applies any pending EF migrations.
 
 ## Technology :robot:
@@ -63,6 +63,16 @@ PRs to `main`, `develop`, pushes to `main`, `develop` and `v*` tags will:
   * This won't happen for draft PRs unless `build-image` label is added
 
 Pushes to `main`, `develop` and `v*` tags will also run sonar analysis.
+
+## Configuration
+
+Multiple services use `ForwardedHeadersMiddleware` to listen for `X-Forwarded-Host` and `X-Forwarded-Proto`.
+
+By default these only allow these headers to be set by requests from a `KnownNetwork` or `KnownHost` (see [`ForwardedHeaderMiddleware`](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-8.0#forwarded-headers-middleware-options) docs for more options).
+
+To add to the default values, set `"KnownNetwork"` config setting, this should be set to a comma-delimited list of CIDR values.
+
+Applicable for `API`, `Thumbs` and `Orchestrator` services.
 
 ## Getting Started
 

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -123,18 +123,13 @@ public class Startup
         services
             .AddHealthChecks()
             .AddDbContextCheck<DlcsContext>("DLCS-DB");
-        
-        services.Configure<KestrelServerOptions>(options =>
-        {
-            options.Limits.MaxRequestBodySize = 100_000_000; // if don't set default value is: 30 MB
-        });
-        
-        // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
-        services.Configure<ForwardedHeadersOptions>(opts =>
-        {
-            opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
-        });
-        
+
+        services
+            .Configure<KestrelServerOptions>(options =>
+            {
+                options.Limits.MaxRequestBodySize = 100_000_000; // if don't set default value is: 30 MB
+            })
+            .ConfigureForwardedHeaders(configuration);
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)

--- a/src/protagonist/DLCS.Web/Configuration/ServiceCollectionX.cs
+++ b/src/protagonist/DLCS.Web/Configuration/ServiceCollectionX.cs
@@ -1,0 +1,57 @@
+﻿using DLCS.Core.Strings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+
+namespace DLCS.Web.Configuration;
+
+/// <summary>
+/// Extension methods for <see cref="IServiceCollection"/>, related to web configuration
+/// </summary>
+public static class ServiceCollectionX
+{
+    /// <summary>
+    /// Configures host to use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme
+    /// respectively.
+    /// If "KnownNetworks" configuration key found, this will be used to set ForwardedHeadersOptions.KnownNetworks 
+    /// </summary>
+    /// <remarks>
+    /// If "KnownNetworks" key not found, all networks are allowed. This maintains the behaviour that was present in
+    /// dotnet until .NET 8.0.17 + .NET 9.0.6 release and so avoids breaking changes.
+    /// If "KnownNetworks" key is found then the default is maintained and any CIDR addresses are added
+    /// </remarks>
+    public static IServiceCollection ConfigureForwardedHeaders(this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        const string configurationKey = "KnownNetworks";
+        const string allNetworks = "AllNetworks";
+        var knownNetworks = configuration.GetValue(configurationKey, allNetworks)!;
+
+        var logger = new SerilogLoggerFactory(Log.Logger).CreateLogger("ServiceCollection");
+        
+        // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
+        return services.Configure<ForwardedHeadersOptions>(opts =>
+        {
+            opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
+
+            if (knownNetworks.Equals(allNetworks))
+            {
+                logger.LogWarning("Forwarded header values accepted from all networks and proxies");
+                opts.KnownNetworks.Clear();
+                opts.KnownProxies.Clear();
+            }
+            else
+            {
+                logger.LogInformation("Forwarded header values accepted from networks: {KnownNetworks}", knownNetworks);
+                foreach (var kn in knownNetworks.SplitSeparatedString(","))
+                {
+                    opts.KnownNetworks.Add(IPNetwork.Parse(kn));
+                }
+            }
+        });
+    }
+}

--- a/src/protagonist/DLCS.Web/DLCS.Web.csproj
+++ b/src/protagonist/DLCS.Web/DLCS.Web.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
         <PackageReference Include="Serilog"/>
+        <PackageReference Include="Serilog.Extensions.Logging" />
         <PackageReference Include="Swashbuckle.AspNetCore"/>
     </ItemGroup>
 

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -86,11 +86,8 @@ public class Startup
             .AddIIIFBuilding()
             .AddIIIFAuth(orchestratorSettings);
         
-        // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
-        services.Configure<ForwardedHeadersOptions>(opts =>
-        {
-            opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
-        });
+        
+        services.ConfigureForwardedHeaders(configuration);
 
         services
             .AddFeatureFolderViews()

--- a/src/protagonist/Thumbs/Startup.cs
+++ b/src/protagonist/Thumbs/Startup.cs
@@ -54,11 +54,9 @@ public class Startup
             .AddTransient<IAssetPathGenerator, ConfigDrivenAssetPathGenerator>();
 
         // Use x-forwarded-host and x-forwarded-proto to set httpContext.Request.Host and .Scheme respectively
-        services.Configure<ForwardedHeadersOptions>(opts =>
-        {
-            opts.ForwardedHeaders = ForwardedHeaders.XForwardedHost | ForwardedHeaders.XForwardedProto;
-        });
-        services.AddHttpContextAccessor();
+        services
+            .ConfigureForwardedHeaders(configuration)
+            .AddHttpContextAccessor();
     }
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)


### PR DESCRIPTION
Fixes #1016 

Allows `"KnownNetworks"` config value to be set for Api, Orchestrator and Thumbs. This should be set to a string containing a comma delimited list of CIDR values, e.g.

```
"KnownNetworks": "192.0.0.1/27,192.1.0.10/32",
```

If config value not set, clear the `.KnownNetworks` and `.KnownProxies` config settings to replicate previous behaviour - this isn't great but avoids breaking changes when deploying.

