### PR TITLE
Improve ImageCacheTypeConverter, handle spaces and trim

### DIFF
--- a/src/protagonist/API.Tests/Converters/ImageCacheTypeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/ImageCacheTypeConverterTests.cs
@@ -5,20 +5,22 @@ namespace API.Tests.Converters;
 
 public class ImageCacheTypeConverterTests
 {
-    [Fact]
-    public void ImageCacheTypeConverter_ConvertsString_WithCdnAndInternalCache()
+    [Theory]
+    [InlineData("cdn,internalCache")]
+    [InlineData("internalCache,cdn")]
+    [InlineData("cdn,,internalCache")]
+    [InlineData("cdn, internalCache")]
+    [InlineData("cdn ,internalCache")]
+    public void ImageCacheTypeConverter_ConvertsString_WithCdnAndInternalCache(string imageCacheTypeString)
     {
-        // Arrange
-        var imageCacheTypeString = "cdn,internalCache";
-
         // Act
         var convertedImageCacheFlags = ImageCacheTypeConverter.ConvertToImageCacheType(imageCacheTypeString, ',');
         
         // Assert
-        convertedImageCacheFlags.HasFlag(ImageCacheType.Cdn).Should().BeTrue();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.InternalCache).Should().BeTrue();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.None).Should().BeFalse();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.Unknown).Should().BeFalse();
+        convertedImageCacheFlags.Should().HaveFlag(ImageCacheType.Cdn)
+            .And.HaveFlag(ImageCacheType.InternalCache)
+            .And.NotHaveFlag(ImageCacheType.None)
+            .And.NotHaveFlag(ImageCacheType.Unknown);
     }
     
     [Fact]
@@ -28,9 +30,9 @@ public class ImageCacheTypeConverterTests
         var convertedImageCacheFlags = ImageCacheTypeConverter.ConvertToImageCacheType(null, ',');
         
         // Assert
-        convertedImageCacheFlags.HasFlag(ImageCacheType.Cdn).Should().BeFalse();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.InternalCache).Should().BeFalse();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.None).Should().BeTrue();
-        convertedImageCacheFlags.HasFlag(ImageCacheType.Unknown).Should().BeFalse();
+        convertedImageCacheFlags.Should().NotHaveFlag(ImageCacheType.Cdn)
+            .And.NotHaveFlag(ImageCacheType.InternalCache)
+            .And.HaveFlag(ImageCacheType.None)
+            .And.NotHaveFlag(ImageCacheType.Unknown);
     }
 }

--- a/src/protagonist/API/Converters/ImageCacheTypeConverter.cs
+++ b/src/protagonist/API/Converters/ImageCacheTypeConverter.cs
@@ -6,6 +6,10 @@ namespace API.Converters;
 
 public static class ImageCacheTypeConverter
 {
+    /// <summary>
+    /// Convert comma-delimited list of values to <see cref="ImageCacheType"/> flags enum
+    /// e.g. "cdn", "internalCache" or "cdn,internalCache"
+    /// </summary>
     public static ImageCacheType ConvertToImageCacheType(string? imageCache, char separator)
     {
         if (imageCache.IsNullOrEmpty())
@@ -15,7 +19,8 @@ public static class ImageCacheTypeConverter
 
         ImageCacheType? imageCacheType = null;
 
-        foreach (var imageCacheValue in imageCache.Split(separator))
+        foreach (var imageCacheValue in imageCache.Split(separator,
+                     StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
             var convertedImageCacheType = imageCacheValue.GetEnumFromString<ImageCacheType>();
 


### PR DESCRIPTION
Noticed possible issues while reviewing usage while writing a cleanup script. The changes were to handle possibility of these payloads

```cs
[InlineData("cdn,,internalCache")]
[InlineData("cdn, internalCache")]
[InlineData("cdn ,internalCache")]
```