### PR TITLE
Fix bug in batch duplicate detection

### DIFF
--- a/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
@@ -46,11 +46,11 @@ public class QueuePostValidatorTests
         {
             Members = new[]
             {
-                new Image { ModelId = "1/2/f" },
-                new Image { ModelId = "1/2/fo" },
-                new Image { ModelId = "1/2/foo" },
-                new Image { ModelId = "1/2/bar" },
-                new Image { ModelId = "1/2/baz" },
+                new Image { ModelId = "f" },
+                new Image { ModelId = "fo" },
+                new Image { ModelId = "foo" },
+                new Image { ModelId = "bar" },
+                new Image { ModelId = "baz" },
             }
         };
         var result = sut.TestValidate(model);
@@ -66,10 +66,10 @@ public class QueuePostValidatorTests
         {
             Members = new[]
             {
-                new Image { ModelId = "1/2/fo" },
-                new Image { ModelId = "1/2/foo" },
-                new Image { ModelId = "1/2/bar" },
-                new Image { ModelId = "1/2/baz" },
+                new Image { ModelId = "fo" },
+                new Image { ModelId = "foo" },
+                new Image { ModelId = "bar" },
+                new Image { ModelId = "baz" },
             }
         };
         var result = sut.TestValidate(model);
@@ -84,15 +84,33 @@ public class QueuePostValidatorTests
         {
             Members = new[]
             {
-                new Image { ModelId = "1/2/foo" },
-                new Image { ModelId = "1/2/bar" },
-                new Image { ModelId = "1/2/foo" },
+                new Image { ModelId = "foo", Space = 2 },
+                new Image { ModelId = "bar", Space = 2 },
+                new Image { ModelId = "foo", Space = 2 },
+                new Image { ModelId = "foo", Space = 3 },
             }
         };
         var result = sut.TestValidate(model);
         result
             .ShouldHaveValidationErrorFor(r => r.Members)
-            .WithErrorMessage("Members contains 1 duplicate Id(s): 1/2/foo");
+            .WithErrorMessage("Members contains 1 duplicate Id(s): Id:foo,Space:2");
+    }
+    
+    [Fact]
+    public void Members_NoValidationError_IfContainsDuplicateIds_WithDifferentSpace()
+    {
+        var sut = GetSut();
+        var model = new HydraCollection<Image>
+        {
+            Members = new[]
+            {
+                new Image { ModelId = "foo", Space = 10, },
+                new Image { ModelId = "bar", Space = 10, },
+                new Image { ModelId = "foo", Space = 20, },
+            }
+        };
+        var result = sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(r => r.Members);
     }
 
     [Theory]

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -114,7 +114,7 @@ public class CustomerQueueController : HydraController
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST: /customers/99/queue/priority
+    ///     POST: /customers/99/queue/priority  
     ///     {
     ///         "@context": "http://www.w3.org/ns/hydra/context.jsonld",
     ///         "@type": "Collection",

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -16,12 +16,15 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
     {
         RuleFor(c => c.Members)
             .NotEmpty().WithMessage("Members cannot be empty");
-        
+
         RuleFor(c => c.Members)
-            .Must(m => m.IsNullOrEmpty() || m.Select(a => a.ModelId).Distinct().Count() == m.Length)
+            .Must(m => m.IsNullOrEmpty() || m.Select(a => $"{a.Space}/{a.ModelId}").Distinct().Count() == m.Length)
             .WithMessage((_, mem) =>
             {
-                var dupes = mem!.Select(a => a.ModelId).GetDuplicates().ToList();
+                var dupes = mem!.Select(a => new { a.Space, a.ModelId })
+                    .GetDuplicates()
+                    .Select(dup => $"Id:{dup.ModelId},Space:{dup.Space}")
+                    .ToList();
                 return $"Members contains {dupes.Count} duplicate Id(s): {string.Join(",", dupes)}";
             });
 
@@ -32,7 +35,7 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
 
         RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(),
             "default", "create");
-
+        
         // In addition to above validation, batched updates must have ModelId + Space as this can't be taken from
         // path
         RuleForEach(c => c.Members).ChildRules(members =>


### PR DESCRIPTION
Items with same 'id' but in diff space were detected as duplicate.

Previous tests were incorrect as assumed validator would receive the full Id (`cust/space/id`) but we only have the `id` part at this stage. Changed the returned error message to avoid needing to pass customerId around.

Fixes #1027