### PR TITLE
Use .AsSingleQuery over .AsSplitQuery for assets

### DIFF
--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -42,7 +42,7 @@ public class GetMultipleImagesByIdHandler
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
             .IncludeDeliveryChannelsWithPolicy()
-            .AsSplitQuery()
+            .AsSingleQuery()
             .ToListAsync(cancellationToken);
 
         return FetchEntityResult<IReadOnlyCollection<Asset>>.Success(results);

--- a/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetQueriedAllImages.cs
@@ -43,7 +43,7 @@ public class GetQueriedAllImagesHandler(DlcsContext dlcsContext)
                 request,
                 i => i
                     .ApplyAssetFilter(request.AssetFilter)
-                    .AsSplitQuery(),
+                    .AsSingleQuery(),
                 images => images.AsOrderedAssetQuery(request),
                 cancellationToken);
         return  FetchEntityResult<PageOf<Asset>>.Success(result);

--- a/src/protagonist/API/Features/Queues/Requests/GetBatchAssetsBase.cs
+++ b/src/protagonist/API/Features/Queues/Requests/GetBatchAssetsBase.cs
@@ -27,7 +27,7 @@ public abstract class GetBatchAssetsBase<T> : IRequestHandler<T, FetchEntityResu
             request,
             i => i
                 .ApplyAssetFilter(request.AssetFilter, true)
-                .AsSplitQuery(),
+                .AsSingleQuery(),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);
 

--- a/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
+++ b/src/protagonist/API/Features/Space/Requests/GetSpaceImages.cs
@@ -64,7 +64,7 @@ public class GetSpaceImagesHandler : IRequestHandler<GetSpaceImages, FetchEntity
                 .Where(a => a.Customer == request.CustomerId && a.Space == request.SpaceId)
                 .ApplyAssetFilter(request.AssetFilter)
                 .IncludeDeliveryChannelsWithPolicy()
-                .AsSplitQuery(),
+                .AsSingleQuery(),
             images => images.AsOrderedAssetQuery(request),
             cancellationToken);
         


### PR DESCRIPTION
The latter was resulting in inconsistent return sets as the default ordering is Created, which is not unique

Fixes #1029