### PR TITLE
Allow http origins larger than 2GB

### DIFF
--- a/src/protagonist/DLCS.Repository/Strategy/DefaultOriginStrategy.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/DefaultOriginStrategy.cs
@@ -11,30 +11,20 @@ namespace DLCS.Repository.Strategy;
 /// <summary>
 /// OriginStrategy implementation for 'default' assets.
 /// </summary>
-public class DefaultOriginStrategy : IOriginStrategy
+public class DefaultOriginStrategy(IHttpClientFactory httpClientFactory, ILogger<DefaultOriginStrategy> logger)
+    : IOriginStrategy
 {
-    private readonly IHttpClientFactory httpClientFactory;
-    private readonly ILogger<DefaultOriginStrategy> logger;
-    
-    public DefaultOriginStrategy(IHttpClientFactory httpClientFactory, ILogger<DefaultOriginStrategy> logger)
-    {
-        this.httpClientFactory = httpClientFactory;
-        this.logger = logger;
-    }
-
     public async Task<OriginResponse> LoadAssetFromOrigin(AssetId assetId, string origin,
         CustomerOriginStrategy? customerOriginStrategy, CancellationToken cancellationToken = default)
     {
-        // NOTE(DG): This will follow up to 8 redirections, as per deliverator.
-        // However, https -> http will fail. 
-        // Need to test relative redirects too.
         logger.LogDebug("Fetching {Asset} from Origin: {Url}", assetId, origin);
 
         try
         {
             var httpClient = httpClientFactory.CreateClient(HttpClients.OriginStrategy);
-            var response = await httpClient.GetAsync(origin, cancellationToken);
-            var originResponse = await CreateOriginResponse(response);
+            var response =
+                await httpClient.GetAsync(origin, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            var originResponse = await response.CreateOriginResponse(cancellationToken);
             return originResponse;
         }
         catch (Exception ex)
@@ -42,19 +32,5 @@ public class DefaultOriginStrategy : IOriginStrategy
             logger.LogError(ex, "Error fetching {Asset} from Origin: {Url}", assetId, origin);
             return OriginResponse.Empty;
         }
-    }
-    
-    private static async Task<OriginResponse> CreateOriginResponse(HttpResponseMessage response)
-    {
-        response.EnsureSuccessStatusCode();
-        var content = response.Content;
-        if (content == null)
-        {
-            return OriginResponse.Empty;
-        }
-
-        return new OriginResponse(await content.ReadAsStreamAsync())
-            .WithContentLength(content.Headers.ContentLength)
-            .WithContentType(content.Headers?.ContentType?.MediaType);
     }
 }

--- a/src/protagonist/DLCS.Repository/Strategy/OriginResponseHelpers.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/OriginResponseHelpers.cs
@@ -1,0 +1,24 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DLCS.Repository.Strategy;
+
+/// <summary>
+/// Helper methods for constructing OriginResponse obejcts
+/// </summary>
+internal static class OriginResponseHelpers
+{
+    /// <summary>
+    /// Create <see cref="OriginResponse"/> from provided <see cref="HttpResponseMessage"/>
+    /// </summary>
+    public static async Task<OriginResponse> CreateOriginResponse(this HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        response.EnsureSuccessStatusCode();
+        var content = response.Content;
+        return new OriginResponse(await content.ReadAsStreamAsync(cancellationToken))
+            .WithContentLength(content.Headers.ContentLength)
+            .WithContentType(content.Headers.ContentType?.MediaType);
+    }
+}


### PR DESCRIPTION
Updated behaviour of BasicHttp + Default strategy to handle files larger than 2GB.

The main change is updating HTTP client requests in `BasicHttpAuthOriginStrategy` and `DefaultOriginStrategy` to use `HttpCompletionOption.ResponseHeadersRead`. This avoids the entire resource being buffered initially, which results in an exception as the buffer is larger than `int.MaxValue` bytes. See https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpcompletionoption?view=net-9.0. 

Other change was to introduce `OriginResponseHelpers` as both strategies shared code for creating `OriginResponse`. `if (content == null)` was removed as it's invalid according to type nullability. These stategies haven't been touched since 2021, so likely dotnet3.1