### PR TITLE
Fix bug where use-original image not saved to s3

### DIFF
--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/AppetiserImageProcessorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageServer/AppetiserImageProcessorTests.cs
@@ -255,10 +255,7 @@ public class AppetiserImageProcessorTests
 
         A.CallTo(() => appetiserClient.GenerateDerivatives(context, assetId, A<IReadOnlyList<SizeParameter>>._,
                 A<ImageProcessorOperations>._, A<CancellationToken>._))
-            .Returns(new AppetiserResponseModel
-            {
-                JP2 = locationOnDisk,
-            });
+            .Returns(new AppetiserResponseModel());
 
         // Act
         await sut.ProcessImage(context);

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/AppetiserImageProcessor.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/AppetiserImageProcessor.cs
@@ -169,6 +169,12 @@ public class AppetiserImageProcessor(
                 SetAssetLocation(targetStorageLocation);
                 return;
             }
+            
+            // origin is image-server ready so set imageServerFile location to image downloaded from origin
+            if (string.IsNullOrEmpty(imageServerFile))
+            {
+                imageServerFile = context.AssetFromOrigin?.Location;
+            }
         }
         else
         {


### PR DESCRIPTION
Fixes #1052 

Issue was missed as warning logged so no apparent failure. Test was incorrectly setting JP2 path on return object.