### PR TITLE
Bump iiif-net package

### DIFF
--- a/src/protagonist/Directory.Packages.props
+++ b/src/protagonist/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FluentAssertions" Version="6.6.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageVersion Include="iiif-net" Version="0.3.4" />
+    <PackageVersion Include="iiif-net" Version="0.3.11" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="LazyCache" Version="2.4.0" />
     <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />


### PR DESCRIPTION
Version bump is to get changes from https://github.com/digirati-co-uk/iiif-net/pull/81

This resolves issue where serialised `Sound` and `Video` annotation bodies on manifests would have dimensions output before `id` and `type`. Not functionally broken but ensures a predictable pattern in serialised JSON.