### PR TITLE
Output dimension on v3 manifest thumbnails

### DIFF
--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestBuilderUtils.cs
@@ -36,7 +36,7 @@ public interface IManifestBuilderUtils
     List<IService> GetImageServiceForThumbnail(Asset asset, CustomerPathElement customerPathElement,
         List<Size> thumbnailSizes);
 
-    string GetFullQualifiedThumbPath(Asset asset, CustomerPathElement customerPathElement,
+    ThumbnailPathAndSize GetFullQualifiedThumb(Asset asset, CustomerPathElement customerPathElement,
         List<Size> availableThumbs);
 
     string GetFullQualifiedImagePath(Asset asset, CustomerPathElement customerPathElement, Size size,
@@ -87,7 +87,7 @@ public class ManifestBuilderUtils(
             image2 => image2.Sizes = thumbnailSizes,
             image3 => image3.Sizes = thumbnailSizes);
 
-    public string GetFullQualifiedThumbPath(Asset asset, CustomerPathElement customerPathElement,
+    public ThumbnailPathAndSize GetFullQualifiedThumb(Asset asset, CustomerPathElement customerPathElement,
         List<Size> availableThumbs)
     {
         var targetThumb = orchestratorSettings.TargetThumbnailSize;
@@ -95,7 +95,8 @@ public class ManifestBuilderUtils(
         // Get the thumbnail size that is closest to the system-wide TargetThumbnailSize
         var closestSize = availableThumbs.SizeClosestTo(targetThumb);
 
-        return GetFullQualifiedImagePath(asset, customerPathElement, closestSize, true);
+        return new ThumbnailPathAndSize(GetFullQualifiedImagePath(asset, customerPathElement, closestSize, true),
+            closestSize);
     }
 
     public string GetFullQualifiedImagePath(Asset asset, CustomerPathElement customerPathElement, Size size,
@@ -267,3 +268,8 @@ public class ImageSizeDetails(List<Size> openThumbnails, Size maxDerivativeSize)
     /// </summary>
     public Size MaxDerivativeSize { get; } = maxDerivativeSize;
 }
+
+/// <summary>
+/// Path to a thumbnail and the size of that thumbnail
+/// </summary>
+public record ThumbnailPathAndSize(string Path, Size Size);

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV2Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV2Builder.cs
@@ -104,9 +104,11 @@ public class ManifestV2Builder : ManifestBuilderBase<Manifest>
 
             if (BuilderUtils.ShouldAddThumbs(asset, thumbnailSizes))
             {
+                var targetThumbnail =
+                    BuilderUtils.GetFullQualifiedThumb(asset, customerPathElement, thumbnailSizes.OpenThumbnails);
                 canvas.Thumbnail = new Thumbnail
                 {
-                    Id = BuilderUtils.GetFullQualifiedThumbPath(asset, customerPathElement, thumbnailSizes.OpenThumbnails),
+                    Id = targetThumbnail.Path,
                     Service = BuilderUtils.GetImageServiceForThumbnail(asset, customerPathElement,
                         thumbnailSizes.OpenThumbnails)
                 }.AsList();

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -250,11 +250,15 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
 
         if (!BuilderUtils.ShouldAddThumbs(asset, thumbnailSizes)) return (annotationPage, null);
 
+        var targetThumbnail = BuilderUtils.GetFullQualifiedThumb(asset, customerPathElement, thumbnailSizes.OpenThumbnails);
         var thumbnail = new Image
         {
-            Id = BuilderUtils.GetFullQualifiedThumbPath(asset, customerPathElement, thumbnailSizes.OpenThumbnails),
+            Id = targetThumbnail.Path,
+            Width = targetThumbnail.Size.Width,
+            Height = targetThumbnail.Size.Height,
             Format = "image/jpeg",
-            Service = BuilderUtils.GetImageServiceForThumbnail(asset, customerPathElement, thumbnailSizes.OpenThumbnails)
+            Service = BuilderUtils.GetImageServiceForThumbnail(asset, customerPathElement,
+                thumbnailSizes.OpenThumbnails)
         };
         return (annotationPage, thumbnail);
     }


### PR DESCRIPTION
Extend `ManifestBuilderUtils` function that returned path to return path and `Size` object. The latter can then be used to set the w + h.

Resolves #1070 