### PR TITLE
Allow migrations to be run in all envs

### DIFF
--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -134,10 +134,11 @@ public class Startup
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
     {
+        DlcsContextConfiguration.TryRunMigrations(configuration, logger);
+        
         app.UseForwardedHeaders();
         if (env.IsDevelopment())
         {
-            DlcsContextConfiguration.TryRunMigrations(configuration, logger);
             app.UseDeveloperExceptionPage();
         }
 

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -122,12 +122,13 @@ public class Startup
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILogger<Startup> logger)
     {
+        DlcsContextConfiguration.TryRunMigrations(configuration, logger);
+        
         var applicationOptions = configuration.Get<OrchestratorSettings>();
         var pathBase = applicationOptions.PathBase;
-
+        
         if (env.IsDevelopment())
         {
-            DlcsContextConfiguration.TryRunMigrations(configuration, logger);
             app.UseDeveloperExceptionPage();
         }
 

--- a/src/protagonist/Utils/Migrator/Program.cs
+++ b/src/protagonist/Utils/Migrator/Program.cs
@@ -34,17 +34,8 @@ finally
     Log.CloseAndFlush();
 }
 
-class Migrator
+class Migrator(ILogger<Migrator> logger, IConfiguration configuration)
 {
-    private readonly ILogger<Migrator> logger;
-    private readonly IConfiguration configuration;
-
-    public Migrator(ILogger<Migrator> logger, IConfiguration configuration)
-    {
-        this.logger = logger;
-        this.configuration = configuration;
-    }
-
     public void Execute()
     {
         var connStr = configuration.GetConnectionString("PostgreSQLConnection");


### PR DESCRIPTION
Removes requirement for host env to be "Development". This is slightly riskier but allows that risk to be taken and simplifies some deployment scenarios. We will likely want to use other means for applying migrations in some prod environments.

There'll be a few migrations added as part of the Adjuncts work - this will mean they can be applied to envs easier, without needing to update and run the separate migrator svc.

> [!NOTE]
> This still requirest that `RunMigrations` setting is set to `true` to work