### PR TITLE
Adjunct bugfixes

### DIFF
--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -170,18 +170,18 @@ public class HydraAdjunctValidatorTests
     }
     
     [Fact]
-    public void Language_Error_WhenLongerThan3Chars()
+    public void Language_Error_TooLong()
     {
         var adjunct = new Adjunct
         {
             MediaType = "mediaType",
             IIIFLink = "seeAlso",
             Type = "AnnotationPage",
-            Language = ["en", "german"],
+            Language = ["en", "an overly long language string"],
             ExternalId = "https://localhost/customers/1/spaces/1/images/assetId"
         };
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.Language)
-            .WithErrorMessage("All 'language' values must be 3 characters or less");
+            .WithErrorMessage("All 'language' values must be 10 characters or less. e.g. ISO language codes, sub-codes or 'none'");
     }
 }

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -1,12 +1,18 @@
 ﻿using API.Features.Adjuncts.Validation;
+using API.Settings;
 using DLCS.HydraModel;
 using FluentValidation.TestHelper;
+using Microsoft.Extensions.Options;
 
 namespace API.Tests.Features.Adjuncts.Validation;
 
 public class HydraAdjunctValidatorTests
 {
-    private readonly HydraAdjunctValidator sut = new();
+    private readonly HydraAdjunctValidator sut = new(Options.Create(
+        new ApiSettings
+        {
+            RestrictedResourceIdCharacterString = "\\ /"
+        }));
     
     [Fact]
     public void Valid_WhenAllValidatorsUsed()
@@ -17,7 +23,6 @@ public class HydraAdjunctValidatorTests
             MediaType = "mediaType",
             IIIFLink = "seeAlso",
             Type = "Image",
-            Id = "https://localhost/customers/1/spaces/1/images/assetId/adjuncts/adjunctId",
             Language = ["fra", "en"]
         };
         var result = sut.TestValidate(adjunct);
@@ -100,7 +105,7 @@ public class HydraAdjunctValidatorTests
     }
     
     [Fact]
-    public void ModelId_Null_WhenCreate()
+    public void ModelId_Null()
     {
         var adjunct = new Adjunct
         {
@@ -112,6 +117,41 @@ public class HydraAdjunctValidatorTests
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.ModelId)
             .WithErrorMessage("Adjunct identifier could not be found");
+    }
+    
+    [Theory]
+    [InlineData(" space")]
+    [InlineData("slash\\")]
+    [InlineData("other/slash")]
+    public void ModelId_InvalidCharacters(string modelId)
+    {
+        var adjunct = new Adjunct
+        {
+            MediaType = "mediaType",
+            IIIFLink = "seeAlso",
+            Type = "Image",
+            ExternalId = "https://localhost/customers/1/spaces/1/images/assetId/valid",
+            ModelId = modelId
+        };
+        var result = sut.TestValidate(adjunct);
+        result.ShouldHaveValidationErrorFor(r => r.ModelId)
+            .WithErrorMessage("Adjunct id contains at least one of the following restricted characters. Invalid values are: \\ /");
+    }
+    
+    [Fact]
+    public void ModelId_TooLong()
+    {
+        var adjunct = new Adjunct
+        {
+            MediaType = "mediaType",
+            IIIFLink = "seeAlso",
+            Type = "Image",
+            ExternalId = "https://localhost/customers/1/spaces/1/images/assetId/valid",
+            ModelId = new string('a', 201),
+        };
+        var result = sut.TestValidate(adjunct);
+        result.ShouldHaveValidationErrorFor(r => r.ModelId)
+            .WithErrorMessage("Adjunct id must be 200 characters or less");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -18,6 +18,7 @@ public class HydraAdjunctValidatorTests
             IIIFLink = "seeAlso",
             Type = "Image",
             Id = "https://localhost/customers/1/spaces/1/images/assetId/adjuncts/adjunctId",
+            Language = ["fra", "en"]
         };
         var result = sut.TestValidate(adjunct);
         result.ShouldNotHaveAnyValidationErrors();
@@ -41,7 +42,7 @@ public class HydraAdjunctValidatorTests
     [Fact]
     public void ExternalId_Null()
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")
+        var adjunct = new Adjunct
         {
             ExternalId = null,
             MediaType = "mediaType",
@@ -58,7 +59,7 @@ public class HydraAdjunctValidatorTests
     [InlineData("Invalid")]
     public void IIIFLink_NotValid(string iiifLink)
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")
+        var adjunct = new Adjunct
         {
             MediaType = "mediaType",
             IIIFLink = iiifLink,
@@ -73,7 +74,7 @@ public class HydraAdjunctValidatorTests
     [Fact]
     public void IIIFLink_Null()
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")
+        var adjunct = new Adjunct
         {
             MediaType = "mediaType",
             Type = "Image",
@@ -87,7 +88,7 @@ public class HydraAdjunctValidatorTests
     [Fact]
     public void MediaType_Null()
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")
+        var adjunct = new Adjunct
         {
             IIIFLink = "seeAlso",
             Type = "Image",
@@ -101,7 +102,7 @@ public class HydraAdjunctValidatorTests
     [Fact]
     public void ModelId_Null_WhenCreate()
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", null)
+        var adjunct = new Adjunct
         {
             MediaType = "mediaType",
             IIIFLink = "seeAlso",
@@ -116,7 +117,7 @@ public class HydraAdjunctValidatorTests
     [Fact]
     public void Type_Error_WhenNotSet()
     {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", null)
+        var adjunct = new Adjunct
         {
             MediaType = "mediaType",
             IIIFLink = "seeAlso",
@@ -126,5 +127,21 @@ public class HydraAdjunctValidatorTests
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.Type)
             .WithErrorMessage("'@type' is required");
+    }
+    
+    [Fact]
+    public void Language_Error_WhenLongerThan3Chars()
+    {
+        var adjunct = new Adjunct
+        {
+            MediaType = "mediaType",
+            IIIFLink = "seeAlso",
+            Type = "AnnotationPage",
+            Language = ["en", "german"],
+            ExternalId = "https://localhost/customers/1/spaces/1/images/assetId"
+        };
+        var result = sut.TestValidate(adjunct);
+        result.ShouldHaveValidationErrorFor(r => r.Language)
+            .WithErrorMessage("All 'language' values must be 3 characters or less");
     }
 }

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -71,22 +71,6 @@ public class HydraAdjunctValidatorTests
     }
     
     [Fact]
-    public void Id_NotMatched()
-    {
-        var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")
-        {
-            MediaType = "mediaType",
-            IIIFLink = "seeAlso",
-            Type = "Image",
-            Id = "https://localhost/customers/1/spaces/1/images/assetId/adjuncts/different",
-            ExternalId = "https://localhost/customers/1/spaces/1/images/assetId/valid"
-        };
-        var result = sut.TestValidate(adjunct);
-        result.ShouldHaveValidationErrorFor(r => r)
-            .WithErrorMessage("'id' and '@id' must have a matching adjunct identifier");
-    }
-    
-    [Fact]
     public void IIIFLink_Null()
     {
         var adjunct = new Adjunct("https://localhost", 1, 1, "assetId", "adjunctId")

--- a/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/Assets/ApiAssetRepositoryTests.cs
@@ -304,7 +304,7 @@ public class ApiAssetRepositoryTests
     
         var result = AssetPreparer.PrepareAssetForUpsert(null, newAsset, false, false, new []{' '});
         result.Success.Should().BeFalse();
-        result.ErrorMessage.Should().Be("Asset id contains at least one of the following restricted characters. Valid values are:  ");
+        result.ErrorMessage.Should().Be("Asset id contains at least one of the following restricted characters. Invalid values are:  ");
     }
 
     [Fact]

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -8,22 +8,14 @@ namespace API.Tests.Features.Images.Validation;
 
 public class HydraImageValidatorTests
 {
-    public HydraImageValidator GetSut()
-    {
-        var apiSettings = new ApiSettings()
-        {
-            RestrictedAssetIdCharacterString = "\\ "
-        };
-        return new HydraImageValidator();
-    }
-    
+    private HydraImageValidator sut => new();
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
     public void MediaType_NullOrEmpty_OnCreate(string mediaType)
     {
-        var sut = GetSut();
         var model = new Image { MediaType = mediaType };
         var result = sut.TestValidate(model, options => options.IncludeRuleSets("default", "create"));
         result.ShouldHaveValidationErrorFor(a => a.MediaType);
@@ -32,7 +24,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Batch_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Batch = "10" };
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.Batch);
@@ -41,7 +32,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Width_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Width = 10 };
         var result = sut.TestValidate(model);
         result
@@ -52,7 +42,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Height_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Height = 10 };
         var result = sut.TestValidate(model);
         result
@@ -63,7 +52,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Duration_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Duration = 10 };
         var result = sut.TestValidate(model);
         result
@@ -74,7 +62,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Finished_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Finished = DateTime.Today };
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.Finished);
@@ -83,7 +70,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void Created_Provided()
     {
-        var sut = GetSut();
         var model = new Image { Created = DateTime.Today };
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.Created);
@@ -92,7 +78,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_DeliveryChannelMissingChannel()
     {
-        var sut = GetSut();
         var model = new Image { DeliveryChannels = new[]
         {
             new DeliveryChannel()
@@ -111,7 +96,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenNoneAndMoreDeliveryChannels()
     {
-        var sut = GetSut();
         var model = new Image { DeliveryChannels = new[]
         {
             new DeliveryChannel()
@@ -130,7 +114,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenDefaultAndMoreDeliveryChannels()
     {
-        var sut = GetSut();
         var model = new Image { DeliveryChannels = new[]
         {
             new DeliveryChannel()
@@ -149,7 +132,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsWithNoNone()
     {
-        var sut = GetSut();
         var model = new Image { DeliveryChannels = new[]
         {
             new DeliveryChannel()
@@ -168,7 +150,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenOnlyNone()
     {
-        var sut = GetSut();
         var model = new Image { DeliveryChannels = new[]
         {
             new DeliveryChannel()
@@ -195,7 +176,6 @@ public class HydraImageValidatorTests
     [InlineData("application/pdf", "none")]
     public void DeliveryChannel_NoValidationError_WhenChannelValidForMediaType(string mediaType, string channel)
     {
-        var sut = GetSut();
         var model = new Image { 
             MediaType = mediaType,
             DeliveryChannels = new[]
@@ -218,7 +198,6 @@ public class HydraImageValidatorTests
     [InlineData("application/pdf", "iiif-av")]
     public void DeliveryChannel_ValidationError_WhenWrongChannelForMediaType(string mediaType, string channel)
     {
-        var sut = GetSut();
         var model = new Image { 
             MediaType = mediaType,
             DeliveryChannels = new[]
@@ -235,7 +214,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenEmpty_OnPatch()
     {
-        var sut = GetSut();
         var model = new Image
         {
             DeliveryChannels = Array.Empty<DeliveryChannel>()
@@ -248,7 +226,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void ImageOptimisationPolicy_ValidationError()
     {
-        var sut = GetSut();
         var model = new Image
         {
             ImageOptimisationPolicy = "some-iop-policy"
@@ -260,7 +237,6 @@ public class HydraImageValidatorTests
     [Fact]
     public void ThumbnailPolicy_ValidationError()
     {
-        var sut = GetSut();
         var model = new Image
         {
             ThumbnailPolicy = "some-tp-policy"

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -170,12 +170,47 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
 
-        await dbContext.Images.AddTestAsset(assetId); 
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId");
+        await dbContext.SaveChangesAsync();
+        
+        const string newAdjunctJson = @"{
+          ""id"": ""someAdjunctId"",
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PostAsync(path, content);
+
+        // Assert
+        var x = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        
+        var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
+        error.Detail.Should().Be("Create failed. An adjunct with id 'someAdjunctId' already exists");
+    }
+    
+    [Fact]
+    public async Task PostAdjunct_Returns409_WhenIdAlreadyExists_DifferentCase()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        const string adjunctId = "someAdjunctId";
+
+        await dbContext.Images.AddTestAsset(assetId) 
+            .WithTestAdjunct(adjunctId.ToUpper());
         await dbContext.SaveChangesAsync();
         
         const string newAdjunctJson = $@"{{
-          ""id"": ""someAdjunctId"",
+          ""id"": ""{adjunctId}"",
           ""@type"": ""Image"",
           ""externalId"": ""https://some-location.com/an-adjunct"",
           ""iiifLink"": ""seeAlso"",
@@ -194,7 +229,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         
         var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
-        error.Detail.Should().Be("An adjunct with id 'someAdjunctId' already exists");
+        error.Detail.Should().Be("Create failed. An adjunct with id 'someAdjunctId' already exists");
     }
     
     [Fact]
@@ -203,8 +238,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
 
-        await dbContext.Images.AddTestAsset(assetId); 
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId");
         await dbContext.SaveChangesAsync();
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts/someAdjunctId";
@@ -241,6 +276,26 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task GetAdjunct_NotFound_WhenAdjunctDiffersByCase()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        const string adjunctId = "bonobo";
+
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct(adjunctId.ToUpper());
+        await dbContext.SaveChangesAsync();
+
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/{adjunctId}";
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).GetAsync(path);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
     public async Task GetAdjunct_NotFound_WhenNoAsset()
     {
         // Arrange
@@ -261,10 +316,10 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
 
-        await dbContext.Images.AddTestAsset(assetId); 
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId2", assetId);
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId);
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId3", assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId2")
+            .WithTestAdjunct("someAdjunctId")
+            .WithTestAdjunct("someAdjunctId3");
         await dbContext.SaveChangesAsync();
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts";
@@ -385,17 +440,50 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task PutAdjunct_Returns409_WhenIdAlreadyExists_DifferentCase()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        const string adjunctId = "someAdjunctId";
+
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct(adjunctId.ToUpper());
+        await dbContext.SaveChangesAsync();
+        
+        const string updateAdjunctJson = @"{
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/{adjunctId}";
+        var content = new StringContent(updateAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        
+        var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
+        error.Detail.Should().Be($"Create failed. An adjunct with id '{adjunctId}' already exists");
+    }
     
     [Fact]
     public async Task PutAdjunct_UpdatesAdjunct_WhenIdAlreadyExists()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId, created: DateTime.UtcNow.AddDays(-2));
-        await dbContext.Images.AddTestAsset(assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId", created: DateTime.UtcNow.AddDays(-2));
         await dbContext.SaveChangesAsync();
         
-        const string newAdjunctJson = @"{
+        const string updateAdjunctJson = @"{
           ""id"": ""someAdjunctId"",
           ""@type"": ""Image"",
           ""externalId"": ""https://some-location.com/an-adjunct"",
@@ -406,7 +494,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         }";
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts/someAdjunctId";
-        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+        var content = new StringContent(updateAdjunctJson, Encoding.UTF8, "application/json");
 
         // Act
         var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
@@ -583,8 +671,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
 
-        await dbContext.Images.AddTestAsset(assetId);
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId");
         await dbContext.SaveChangesAsync();
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts/someAdjunctId";

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -107,6 +107,37 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task PostAdjunct_FailsToCreateExternalAdjunct_IfIdMissing()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+
+        await dbContext.Images.AddTestAsset(assetId); 
+        await dbContext.SaveChangesAsync();
+        
+        const string newAdjunctJson = @"{
+          ""@type"": ""Image"",
+          ""externalId"": ""https://example.com/adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PostAsync(path, content);
+
+        // Assert
+        var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        error.Detail.Should().Be("Adjunct identifier could not be found");
+    }
+    
+    [Fact]
     public async Task PostAdjunct_FailsToCreateAdjunct_WhenIdAlreadyExists()
     {
         // Arrange
@@ -295,7 +326,9 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         
         var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
-        error.Detail.Should().Be("The adjunct id from the request URI does not match the 'id' from the request body");
+        error.Detail.Should()
+            .Be(
+                "The adjunct id from the request URI (differentId) does not match the 'id' from the request body (someAdjunctId)");
     }
     
     [Fact]
@@ -345,6 +378,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
+        const string adjunctId = "someAdjunctId";
 
         await dbContext.Images.AddTestAsset(assetId);
         await dbContext.SaveChangesAsync();
@@ -369,9 +403,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
 
-        adjunct.Id.Should()
-            .Be(
-                $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/someAdjunctId");
+        var expectedAdjunctId = $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}";
+        adjunct.Id.Should().Be(expectedAdjunctId);
         adjunct.IIIFLink.Should().Be("seeAlso");
         adjunct.Label.First().Key.Should().Be("label");
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
@@ -381,9 +414,98 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
         
-        response.Headers.Location.Should()
+        response.Headers.Location.Should().Be(expectedAdjunctId);
+        
+        dbContext.Adjuncts.Any(a => a.AssetId == assetId && a.Id == adjunctId).Should()
+            .BeTrue("Adjunct persisted to DB");
+    }
+    
+    [Fact]
+    public async Task PutAdjunct_CreatesAdjunct_UsingIdFromUri_IfBodyIdMissing()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        var adjunctId = assetId.Asset;
+
+        await dbContext.Images.AddTestAsset(assetId); 
+        await dbContext.SaveChangesAsync();
+        
+        const string newAdjunctJson = @"{
+          ""@type"": ""AnnotationPage"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""annotations"",
+          ""mediaType"": ""application/json"",
+          ""label"": {""none"": [""value""]}
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/{adjunctId}";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
+        
+        var expectedAdjunctId = $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}";
+        
+        adjunct.Id.Should().Be(expectedAdjunctId);
+        adjunct.IIIFLink.Should().Be("annotations");
+        adjunct.Label.First().Key.Should().Be("none");
+        adjunct.AssetId.Should().BeNull(); // TODO - can this go?
+        adjunct.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
+        adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
+        
+        response.Headers.Location.Should().Be(expectedAdjunctId);
+
+        dbContext.Adjuncts.Any(a => a.AssetId == assetId && a.Id == adjunctId).Should()
+            .BeTrue("Adjunct persisted to DB");
+    }
+    
+    [Fact]
+    public async Task PutAdjunct_CreatesAdjunct_UsingIdFromUri_IfBodyIdEmpty()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        var adjunctId = assetId.Asset;
+
+        await dbContext.Images.AddTestAsset(assetId); 
+        await dbContext.SaveChangesAsync();
+        
+        const string newAdjunctJson = @"{
+          ""id"": """",           
+          ""@type"": ""AnnotationPage"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""annotations"",
+          ""mediaType"": ""application/json"",
+          ""label"": {""none"": [""value""]}
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/{adjunctId}";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
+        
+        adjunct.Id.Should()
             .Be(
-                $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/someAdjunctId");
+                $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}");
+        adjunct.IIIFLink.Should().Be("annotations");
+        adjunct.Label.First().Key.Should().Be("none");
+        adjunct.AssetId.Should().BeNull(); // TODO - can this go?
+        adjunct.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
+        adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
+        
+        dbContext.Adjuncts.Any(a => a.AssetId == assetId && a.Id == adjunctId).Should().BeTrue("Adjunct persisted to DB");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -191,7 +191,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var response = await httpClient.AsCustomer(assetId.Customer).PostAsync(path, content);
 
         // Assert
-        var x = await response.Content.ReadAsStringAsync();
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         
         var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
@@ -230,6 +229,35 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         
         var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
         error.Detail.Should().Be("Create failed. An adjunct with id 'someAdjunctId' already exists");
+    }
+    
+    [Fact]
+    public async Task PostAdjunct_Returns404_WhenAssetDoesNotExist()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        
+        const string newAdjunctJson = @"{
+          ""id"": ""adj123"",
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PostAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        
+        var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
+        error.Detail.Should().Be($"Asset with id '{assetId}' not found");
     }
     
     [Fact]
@@ -377,6 +405,34 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+    
+    [Fact]
+    public async Task PutAdjunct_Returns404_WhenAssetDoesNotExist()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        
+        const string newAdjunctJson = @"{
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/foo";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        
+        var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
+        error.Detail.Should().Be($"Asset with id '{assetId}' not found");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -589,6 +589,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
           ""mediaType"": ""a-mediaType"",
           ""label"": {""label"": [""value""]},
           ""language"": [""en""],
+          ""size"": 1234,
         }";
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts/someAdjunctId";
@@ -610,6 +611,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
+        adjunct.Size.Should().Be(1234);
         
         response.Headers.Location.Should().Be(expectedAdjunctId);
         

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -74,7 +74,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task PostAdjunct_FailsToCreateExternalAdjunct_FailsValidation()
+    public async Task PostAdjunct_Returns400_FailsValidation()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
@@ -106,7 +106,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task PostAdjunct_FailsToCreateExternalAdjunct_IfIdMissing()
+    public async Task PostAdjunct_Returns400_IfIdMissing()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
@@ -137,7 +137,35 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task PostAdjunct_FailsToCreateAdjunct_WhenIdAlreadyExists()
+    public async Task PostAdjunct_Returns400_WhenIdInvalid()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+
+        await dbContext.Images.AddTestAsset(assetId); 
+        await dbContext.SaveChangesAsync();
+        
+        var newAdjunctJson = @"{
+          ""id"": ""model Id"",
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PostAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task PostAdjunct_Returns409_WhenIdAlreadyExists()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
@@ -297,7 +325,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task PutAdjunct_FailsToCreateAdjunct_WhenIdDiffersBetweenBodyAndUri()
+    public async Task PutAdjunct_Returns400_WhenIdDiffersBetweenBodyAndUri()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
@@ -328,6 +356,34 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         error.Detail.Should()
             .Be(
                 "The adjunct id from the request URI (differentId) does not match the 'id' from the request body (someAdjunctId)");
+    }
+
+    [Fact]
+    public async Task PutAdjunct_Returns400_WhenIdInvalid()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+
+        await dbContext.Images.AddTestAsset(assetId); 
+        await dbContext.SaveChangesAsync();
+        
+        var newAdjunctJson = @"{
+          ""id"": ""model Id"",
+          ""@type"": ""Image"",
+          ""externalId"": ""https://some-location.com/an-adjunct"",
+          ""iiifLink"": ""seeAlso"",
+          ""mediaType"": ""a-mediaType"",
+          ""label"": {""label"": [""value""]},
+          ""language"": [""en""],
+        }";
+        
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/differentId";
+        var content = new StringContent(newAdjunctJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -65,7 +65,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.IIIFLink.Should().Be("seeAlso");
         adjunct.Label.First().Key.Should().Be("label");
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
-        adjunct.AssetId.Should().BeNull();
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
         
@@ -366,7 +365,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.IIIFLink.Should().Be("seeAlso");
         adjunct.Label.First().Key.Should().Be("label");
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
-        adjunct.AssetId.Should().BeNull();
         adjunct.Created.Should().BeCloseTo(DateTime.UtcNow.AddDays(-2), TimeSpan.FromSeconds(5));
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
@@ -408,7 +406,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.IIIFLink.Should().Be("seeAlso");
         adjunct.Label.First().Key.Should().Be("label");
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
-        adjunct.AssetId.Should().BeNull();
         adjunct.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
@@ -453,7 +450,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.Id.Should().Be(expectedAdjunctId);
         adjunct.IIIFLink.Should().Be("annotations");
         adjunct.Label.First().Key.Should().Be("none");
-        adjunct.AssetId.Should().BeNull(); // TODO - can this go?
         adjunct.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
@@ -499,7 +495,6 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
                 $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}");
         adjunct.IIIFLink.Should().Be("annotations");
         adjunct.Label.First().Key.Should().Be("none");
-        adjunct.AssetId.Should().BeNull(); // TODO - can this go?
         adjunct.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -2616,10 +2616,10 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var assetId = new AssetId(99, 1, nameof(Delete_RemovesAssetAndAssociatedEntities_FromDb));
-        await dbContext.Images.AddTestAsset(assetId);
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("someAdjunctId");
         await dbContext.ImageLocations.AddTestImageLocation(assetId);
         await dbContext.ImageStorages.AddTestImageStorage(assetId, size: 400L, thumbSize: 100L);
-        await dbContext.Adjuncts.AddTestAdjunct("someAdjunctId", assetId);
         var customerSpaceStorage = await dbContext.CustomerStorages.AddTestCustomerStorage(space: 1, numberOfImages: 100,
             sizeOfStored: 1000L, sizeOfThumbs: 1000L);
         var customerStorage = await dbContext.CustomerStorages.AddTestCustomerStorage(space: 0, numberOfImages: 200,

--- a/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
+++ b/src/protagonist/API.Tests/Settings/ApiSettingsTests.cs
@@ -5,6 +5,11 @@ namespace API.Tests.Settings;
 
 public class ApiSettingsTests
 {
+    private static readonly ApiSettings InvalidCharacterSettings = new()
+    {
+        RestrictedResourceIdCharacterString = "\\  /"
+    };
+
     [Fact]
     public void ApiSettings_LegacySupportDisabledForAllCustomers_byDefault()
     {
@@ -40,10 +45,7 @@ public class ApiSettingsTests
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
             LegacySupport = true,
-            NovelSpaces = new List<string>()
-            {
-                "1"
-            }
+            NovelSpaces = ["1"]
         });
         
         // Assert
@@ -66,7 +68,7 @@ public class ApiSettingsTests
     public void LegacyModeEnabledForSpace_LegacySupportEnabledForAllCustomers_WhenDefaultLegacySupportEnabled()
     {
         // Arrange
-        var settings = new ApiSettings()
+        var settings = new ApiSettings
         {
             DefaultLegacySupport = true
         };
@@ -84,10 +86,7 @@ public class ApiSettingsTests
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
             LegacySupport = true,
-            NovelSpaces = new List<string>()
-            {
-                "1"
-            }
+            NovelSpaces = ["1"]
         });
         
         // Assert
@@ -100,7 +99,7 @@ public class ApiSettingsTests
     public void LegacyModeEnabledForSpace_LegacySupportDisabledForSpace_WhenDefaultLegacyEnabled()
     {
         // Arrange
-        var settings = new ApiSettings()
+        var settings = new ApiSettings
         {
             DefaultLegacySupport = true
         };
@@ -108,10 +107,7 @@ public class ApiSettingsTests
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
             LegacySupport = true,
-            NovelSpaces = new List<string>()
-            {
-                "1"
-            }
+            NovelSpaces = ["1"]
         });
         
         settings.CustomerOverrides.Add("3", new CustomerOverrideSettings()
@@ -129,7 +125,7 @@ public class ApiSettingsTests
     public void LegacyModeEnabledForSpace_LegacySupportDisabledForCustomer_WhenDefaultLegacyEnabled()
     {
         // Arrange
-        var settings = new ApiSettings()
+        var settings = new ApiSettings
         {
             DefaultLegacySupport = true
         };
@@ -158,7 +154,7 @@ public class ApiSettingsTests
     public void LegacyModeEnabledForCustomer_LegacySupportDisabledForAllCustomers_WhenDefaultLegacySupportDisabled()
     {
         // Arrange
-        var settings = new ApiSettings()
+        var settings = new ApiSettings
         {
             DefaultLegacySupport = true
         };
@@ -176,10 +172,7 @@ public class ApiSettingsTests
         settings.CustomerOverrides.Add("2", new CustomerOverrideSettings()
         {
             LegacySupport = true,
-            NovelSpaces = new List<string>()
-            {
-                "1"
-            }
+            NovelSpaces = ["1"]
         });
         
         // Assert
@@ -190,7 +183,7 @@ public class ApiSettingsTests
     public void LegacyModeEnabledForCustomer_LegacySupportDisabledForCustomer_WhenDefaultLegacySupportEnabled()
     {
         // Arrange
-        var settings = new ApiSettings()
+        var settings = new ApiSettings
         {
             DefaultLegacySupport = true
         };
@@ -207,4 +200,33 @@ public class ApiSettingsTests
         // Assert
         settings.LegacyModeEnabledForCustomer(2).Should().BeFalse();
     }
+
+    [Fact]
+    public void DoesResourceIdContainRestrictedCharacters_ReturnsFalse_SettingEmpty()
+    {
+        var settings = new ApiSettings
+        {
+            RestrictedResourceIdCharacterString = ""
+        };
+        
+        settings.DoesResourceIdContainRestrictedCharacters("sp ace").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void DoesResourceIdContainRestrictedCharacters_ReturnsFalse_WhenNullOrEmpty(string resourceId)
+        => InvalidCharacterSettings.DoesResourceIdContainRestrictedCharacters(resourceId).Should().BeFalse();
+    
+    [Fact]
+    public void DoesResourceIdContainRestrictedCharacters_ReturnsFalse_NoInvalidChars()
+        => InvalidCharacterSettings.DoesResourceIdContainRestrictedCharacters("resourceId").Should().BeFalse();
+    
+    [Theory]
+    [InlineData("sp ace")]
+    [InlineData("\\")]
+    [InlineData("/")]
+    [InlineData("foo/bar")]
+    public void DoesResourceIdContainRestrictedCharacters_ReturnsTrue_NoInvalidChars(string resourceId)
+        => InvalidCharacterSettings.DoesResourceIdContainRestrictedCharacters(resourceId).Should().BeTrue();
 }

--- a/src/protagonist/API.Tests/appsettings.Testing.json
+++ b/src/protagonist/API.Tests/appsettings.Testing.json
@@ -28,6 +28,5 @@
       "LegacySupport": true,
       "NovelSpaces": ["4"]
     }
-  },
-  "RestrictedAssetIdCharacterString": "\\ "
+  }
 }

--- a/src/protagonist/API/Converters/AdjunctConverter.cs
+++ b/src/protagonist/API/Converters/AdjunctConverter.cs
@@ -39,14 +39,14 @@ public static class AdjunctConverter
         return new Adjunct
         {
             Id = adjunctId,
-            Type = hydraAdjunct.Type,
+            Type = hydraAdjunct.Type!,
             MediaType = hydraAdjunct.MediaType!,
             IIIFLink = iiifLink,
             AssetId = new AssetId(customerId, spaceId, assetId),
             Profile = hydraAdjunct.Profile,
             Label =  hydraAdjunct.Label.ToLanguageMap(),
             Language = hydraAdjunct.Language,
-            ExternalId = new Uri(hydraAdjunct.ExternalId),
+            ExternalId = new Uri(hydraAdjunct.ExternalId!),
             Size = hydraAdjunct.Size,
         };
     }

--- a/src/protagonist/API/Converters/AdjunctConverter.cs
+++ b/src/protagonist/API/Converters/AdjunctConverter.cs
@@ -11,7 +11,7 @@ namespace API.Converters;
 public static class AdjunctConverter
 {
     /// <summary>
-    /// This will create a DLCS.Model.Adjunct from a DLCS.HydraModel.Adjunct
+    /// This will create a DLCS <see cref="DLCS.Model.Assets.Adjunct"/> from a hydra <see cref="DLCS.HydraModel.Adjunct"/>
     /// </summary>
     /// <param name="hydraAdjunct">The incoming request</param>
     /// <param name="customerId">Required: an assertion of who this Asset belongs to</param>
@@ -20,7 +20,7 @@ public static class AdjunctConverter
     /// <param name="adjunctId">
     /// Optional: The potential id of the adjunct.
     /// If not supplied, will be determined from Hydra object.</param>
-    /// <returns>A DLCS model representation of the adjunct</returns>
+    /// <returns>A <see cref="DLCS.Model.Assets.Adjunct"/> representation of the adjunct</returns>
     public static Adjunct ToDlcsModel(this DLCS.HydraModel.Adjunct hydraAdjunct, int customerId, int spaceId,
         string assetId, string? adjunctId = null)
     {
@@ -28,17 +28,13 @@ public static class AdjunctConverter
         {
             adjunctId = hydraAdjunct.ModelId;
         }
-        
-        var enumParsed = Enum.TryParse(hydraAdjunct.IIIFLink, true, out IIIFLinkType iiifLink);
 
-        if (!enumParsed)
+        if (!Enum.TryParse(hydraAdjunct.IIIFLink, true, out IIIFLinkType iiifLink))
         {
-            throw new APIException("Hydra adjunct does iiifLink could not be parsed");
+            throw new APIException("Hydra adjunct 'iiifLink' could not be parsed");
         }
-        
-        Debug.Assert(adjunctId != null, "adjunctId != null");
 
-        var label = hydraAdjunct.Label.ToLanguageMap();
+        Debug.Assert(adjunctId != null, "adjunctId != null");
 
         return new Adjunct
         {
@@ -48,21 +44,21 @@ public static class AdjunctConverter
             IIIFLink = iiifLink,
             AssetId = new AssetId(customerId, spaceId, assetId),
             Profile = hydraAdjunct.Profile,
-            Label = label,
+            Label =  hydraAdjunct.Label.ToLanguageMap(),
             Language = hydraAdjunct.Language,
-            ExternalId = new Uri(hydraAdjunct.ExternalId)
+            ExternalId = new Uri(hydraAdjunct.ExternalId),
+            Size = hydraAdjunct.Size,
         };
     }
     
     /// <summary>
-    /// This will create a DLCS.HydraModel.Adjunct from a DLCS.Model.Adjunct
+    /// This will create a hydra <see cref="DLCS.HydraModel.Adjunct"/> from a DLCS <see cref="DLCS.Model.Assets.Adjunct"/> 
     /// </summary>
     /// <param name="adjunct">The DLCS adjunct to convert</param>
     /// <param name="urlRoots">The base address used to create FQDN paths</param>
-    /// <returns>A hydra model representation of the adjunct</returns>
-    public static DLCS.HydraModel.Adjunct ToHydra(this Adjunct adjunct, UrlRoots urlRoots)
-    {
-        return new DLCS.HydraModel.Adjunct(urlRoots.BaseUrl, adjunct.AssetId.Customer, adjunct.AssetId.Space, adjunct.AssetId.Asset, adjunct.Id)
+    /// <returns>A hydra <see cref="DLCS.HydraModel.Adjunct"/> representation of the adjunct</returns>
+    public static DLCS.HydraModel.Adjunct ToHydra(this Adjunct adjunct, UrlRoots urlRoots) 
+        => new(urlRoots.BaseUrl, adjunct.AssetId.Customer, adjunct.AssetId.Space, adjunct.AssetId.Asset, adjunct.Id)
         {
             Type = adjunct.Type,
             MediaType = adjunct.MediaType,
@@ -73,7 +69,7 @@ public static class AdjunctConverter
             ExternalId = adjunct.ExternalId.ToString(),
             PublicId = adjunct.ExternalId.ToString(),
             Created = adjunct.Created,
-            Finished = adjunct.Finished
+            Finished = adjunct.Finished,
+            Size = adjunct.Size,
         };
-    }
 }

--- a/src/protagonist/API/Converters/AdjunctConverter.cs
+++ b/src/protagonist/API/Converters/AdjunctConverter.cs
@@ -67,7 +67,6 @@ public static class AdjunctConverter
             Type = adjunct.Type,
             MediaType = adjunct.MediaType,
             IIIFLink = adjunct.IIIFLink.GetDescription(),
-            AssetId = adjunct.AssetId.ToString(),
             Profile = adjunct.Profile,
             Label = adjunct.Label,
             Language = adjunct.Language,

--- a/src/protagonist/API/Features/Adjuncts/AdjunctsController.cs
+++ b/src/protagonist/API/Features/Adjuncts/AdjunctsController.cs
@@ -85,9 +85,9 @@ public class AdjunctsController(
     public async Task<IActionResult> PutAdjunct(int customerId, int spaceId, string imageId, string adjunctId, [FromBody] Adjunct hydraAdjunct, 
         [FromServices] HydraAdjunctValidator validator, CancellationToken cancellationToken = default)
     {
-        if (hydraAdjunct.ModelId != null && adjunctId != hydraAdjunct.ModelId)
+        if (!string.IsNullOrEmpty(hydraAdjunct.ModelId) && adjunctId != hydraAdjunct.ModelId)
         {
-            return this.HydraProblem($"The adjunct id from the request URI does not match the 'id' from the request body",
+            return this.HydraProblem($"The adjunct id from the request URI ({adjunctId}) does not match the 'id' from the request body ({hydraAdjunct.ModelId})",
                 null, 400);
         }
         

--- a/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
+++ b/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
@@ -48,17 +48,21 @@ public class CreateOrUpdateAdjunctHandler(DlcsContext dbContext)
         }
         else
         {
-            adjunct.Created = DateTime.UtcNow;
             adjunct.Finished = DateTime.UtcNow;
-            
             await dbContext.Adjuncts.AddAsync(adjunct, cancellationToken);
         }
-        
+
         try
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
         catch (DbUpdateException ex) when (ex.GetDatabaseError() is UniqueConstraintError)
+        {
+            return ModifyEntityResult<Adjunct>.Failure(
+                $"Create failed. An adjunct with id '{adjunct.Id}' already exists",
+                WriteResult.Conflict);
+        }
+        catch (DbUpdateException ex)
         {
             return ModifyEntityResult<Adjunct>.Failure(
                 $"An adjunct with id '{adjunct.Id}' already exists",

--- a/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
+++ b/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
@@ -48,7 +48,9 @@ public class CreateOrUpdateAdjunctHandler(DlcsContext dbContext)
         }
         else
         {
+            adjunct.Created = DateTime.UtcNow;
             adjunct.Finished = DateTime.UtcNow;
+            
             await dbContext.Adjuncts.AddAsync(adjunct, cancellationToken);
         }
 

--- a/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
+++ b/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
@@ -56,17 +56,17 @@ public class CreateOrUpdateAdjunctHandler(DlcsContext dbContext)
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException ex) when (ex.GetDatabaseError() is UniqueConstraintError)
-        {
-            return ModifyEntityResult<Adjunct>.Failure(
-                $"Create failed. An adjunct with id '{adjunct.Id}' already exists",
-                WriteResult.Conflict);
-        }
         catch (DbUpdateException ex)
         {
-            return ModifyEntityResult<Adjunct>.Failure(
-                $"An adjunct with id '{adjunct.Id}' already exists",
-                WriteResult.Conflict);
+            var databaseError = ex.GetDatabaseError();
+            return databaseError switch
+            {
+                UniqueConstraintError => ModifyEntityResult<Adjunct>.Failure(
+                    $"Create failed. An adjunct with id '{adjunct.Id}' already exists", WriteResult.Conflict),
+                DbForeignKeyConstraintError => ModifyEntityResult<Adjunct>.Failure($"Asset with id '{adjunct.AssetId}' not found",
+                    WriteResult.NotFound),
+                _ => ModifyEntityResult<Adjunct>.Failure($"Unknown database error saving adjunct '{adjunct.AssetId}'")
+            };
         }
 
         return ModifyEntityResult<Adjunct>.Success(dbAdjunct ?? adjunct,

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -40,10 +40,11 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.Type)
             .NotEmpty()
             .WithMessage("'@type' is required");
-        
+
+        const int maximumLength = 10;
         RuleForEach(a => a.Language)
-            .MaximumLength(3)
-            .WithMessage("All 'language' values must be 3 characters or less");
+            .MaximumLength(maximumLength)
+            .WithMessage($"All 'language' values must be {maximumLength} characters or less. e.g. ISO language codes, sub-codes or 'none'");
     }
 
     private readonly List<string> validIIIFLinkTypes =

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -30,6 +30,10 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.Type)
             .NotEmpty()
             .WithMessage("'@type' is required");
+        
+        RuleForEach(a => a.Language)
+            .MaximumLength(3)
+            .WithMessage("All 'language' values must be 3 characters or less");
     }
 
     private readonly List<string> validIIIFLinkTypes =

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -23,10 +23,6 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
             .Must(a => Uri.IsWellFormedUriString(a, UriKind.Absolute))
             .WithMessage("'externalId' is required and must be a well formed URI");
         
-        RuleFor(a => a).Must(a => a.Id!.Split('/').Last() == a.ModelId)
-            .When(a => a.Id != null && a.ModelId != null)
-            .WithMessage("'id' and '@id' must have a matching adjunct identifier");
-        
         RuleFor(a => a.ModelId)
             .NotEmpty()
             .WithMessage("Adjunct identifier could not be found");

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -1,13 +1,15 @@
 ﻿using System.Collections.Generic;
+using API.Settings;
 using DLCS.Core.Enum;
 using DLCS.Model.Assets;
 using FluentValidation;
+using Microsoft.Extensions.Options;
 
 namespace API.Features.Adjuncts.Validation;
 
 public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
 {
-    public HydraAdjunctValidator()
+    public HydraAdjunctValidator(IOptions<ApiSettings> apiSettings)
     {
         RuleFor(a => a.IIIFLink).NotEmpty()
             .WithMessage("'iiifLink' is required");
@@ -26,6 +28,14 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.ModelId)
             .NotEmpty()
             .WithMessage("Adjunct identifier could not be found");
+        
+        RuleFor(a => a.ModelId)
+            .MaximumLength(Adjunct.MaxIdLength)
+            .WithMessage($"Adjunct id must be {Adjunct.MaxIdLength} characters or less");
+        
+        RuleFor(a => a.ModelId)
+            .Must(a => !apiSettings.Value.DoesResourceIdContainRestrictedCharacters(a))
+            .WithMessage($"Adjunct id contains at least one of the following restricted characters. Invalid values are: {new string(apiSettings.Value.RestrictedResourceIdCharacters)}");
         
         RuleFor(a => a.Type)
             .NotEmpty()

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -21,7 +21,6 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
             .WithMessage("'mediaType' is required");
         
         RuleFor(a => a.ExternalId)
-            .NotEmpty()
             .Must(a => Uri.IsWellFormedUriString(a, UriKind.Absolute))
             .WithMessage("'externalId' is required and must be a well formed URI");
         

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -94,7 +94,7 @@ public class AssetProcessor
             var existingAsset = assetFromDatabase?.Clone();
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
-                    settings.RestrictedAssetIdCharacters);
+                    settings.RestrictedResourceIdCharacters);
 
             if (!assetPreparationResult.Success)
             {

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -6,8 +6,8 @@ namespace API.Settings;
 
 public class ApiSettings
 {
-    private char[] restrictedAssetIdCharacters = Array.Empty<char>();
-    private string restrictedAssetIdCharacterString = "";
+    private char[] restrictedResourceIdCharacters = [];
+    private string restrictedResourceIdCharacterString = string.Empty;
     
     /// <summary>
     /// The base URI of DLCS to hand-off requests to.
@@ -83,20 +83,26 @@ public class ApiSettings
             : DefaultLegacySupport;
     
     /// <summary>
-    /// Characters that are not allowed in an asset id
+    /// Characters that are not allowed in resource ids (e.g. Adjunct and Asset)
     /// </summary>
-    public char[] RestrictedAssetIdCharacters => restrictedAssetIdCharacters;
+    public char[] RestrictedResourceIdCharacters => restrictedResourceIdCharacters;
 
     /// <summary>
-    /// A string of characters not allowed in an asset id
+    /// A string of characters not allowed in resource identifiers (e.g. Adjunct and Asset)
     /// </summary>
-    public string RestrictedAssetIdCharacterString
+    public string RestrictedResourceIdCharacterString
     {
-        get => restrictedAssetIdCharacterString;
+        get => restrictedResourceIdCharacterString;
         set
         {
-            restrictedAssetIdCharacterString = value;
-            restrictedAssetIdCharacters = restrictedAssetIdCharacterString.ToCharArray();
+            restrictedResourceIdCharacterString = value;
+            restrictedResourceIdCharacters = restrictedResourceIdCharacterString.ToCharArray();
         }
     }
+
+    /// <summary>
+    /// Check if the provided resourceId contains invalid characters
+    /// </summary>
+    public bool DoesResourceIdContainRestrictedCharacters(string? resourceId)
+        => !string.IsNullOrEmpty(resourceId) && resourceId.IndexOfAny(RestrictedResourceIdCharacters) != -1;
 }

--- a/src/protagonist/API/appsettings.json
+++ b/src/protagonist/API/appsettings.json
@@ -23,6 +23,7 @@
       "ApplicationName": "API"
     }
   },
+  "RestrictedResourceIdCharacterString": "\\ /",
   "AllowedHosts": "*",
   "PathBase": "",
   "Caching": {

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -40,9 +40,6 @@ public class Adjunct : DlcsResource
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 12, PropertyName = "iiifLink")]
     public string? IIIFLink { get; set; }
-    
-    [JsonIgnore]
-    public string? AssetId { get; set; }
 
     [RdfProperty(Description = "A schema or named set of functionality available from the resource.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -24,7 +24,7 @@ public class Adjunct : DlcsResource
     }
     
     [JsonProperty(Order = 3, PropertyName = "@type")]
-    public override required string Type { get; set; }
+    public override string? Type { get; set; }
     
     [RdfProperty(Description = "The identifier for the adjunct",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
@@ -59,7 +59,7 @@ public class Adjunct : DlcsResource
     [RdfProperty(Description = "A fully-qualified URL external to the platform.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 17, PropertyName = "externalId")]
-    public required string ExternalId { get; set; }
+    public string? ExternalId { get; set; }
     
     [RdfProperty(Description = "Where this adjunct is hosted publicly.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
@@ -74,10 +74,10 @@ public class Adjunct : DlcsResource
     [RdfProperty(Description = "When this adjunct was created.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 20, PropertyName = "created")]
-    public DateTime Created { get; set; }
+    public DateTime? Created { get; set; }
     
     [RdfProperty(Description = "When this adjunct last finished processing.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 22, PropertyName = "finished")]
-    public DateTime Finished { get; set; }
+    public DateTime? Finished { get; set; }
 }

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -10,6 +10,13 @@ namespace DLCS.HydraModel;
     UriTemplate = "/customers/{0}/spaces/{1}/images/{2}/adjuncts/{3}")]
 public class Adjunct : DlcsResource
 {
+    /// <summary>
+    /// 0-param ctor used for deserialising
+    /// </summary>
+    public Adjunct()
+    {
+    }
+    
     public Adjunct(string baseUrl, int customerId, int space, string assetId, string modelId)
     {
         ModelId = modelId;

--- a/src/protagonist/DLCS.Model/Assets/Adjunct.cs
+++ b/src/protagonist/DLCS.Model/Assets/Adjunct.cs
@@ -7,6 +7,8 @@ namespace DLCS.Model.Assets;
 
 public class Adjunct
 {
+    public const int MaxIdLength = 200;
+    
     /// <summary>
     /// Model id of the adjunct
     /// </summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -170,7 +170,7 @@ public static class AssetPreparer
         {
             if (updateAsset.Id.Asset.IndexOfAny(disallowedCharacters) != -1)
             {
-                return AssetPreparationResult.Failure($"Asset id contains at least one of the following restricted characters. Valid values are: {new string(disallowedCharacters)}");
+                return AssetPreparationResult.Failure($"Asset id contains at least one of the following restricted characters. Invalid values are: {new string(disallowedCharacters)}");
             }
         }
         

--- a/src/protagonist/DLCS.Repository.Tests/Exceptions/DbUpdateExceptionXTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Exceptions/DbUpdateExceptionXTests.cs
@@ -1,0 +1,60 @@
+﻿using DLCS.Repository.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace DLCS.Repository.Tests.Exceptions;
+
+public class DbUpdateExceptionXTests
+{
+    [Fact]
+    public void GetDatabaseError_Null_IfNoInnerException() 
+        => new DbUpdateException("Sample").GetDatabaseError().Should().BeNull();
+
+    [Fact]
+    public void GetDatabaseError_UniqueViolation_ReturnsExpected()
+    {
+        const string constraintName = "IX_Images_Foo_Bar";
+        var pgEx = new PostgresException("", "", "", PostgresErrorCodes.UniqueViolation, tableName: "Images",
+            constraintName: constraintName);
+        var exception = new DbUpdateException("Sample", pgEx);
+
+        var actual = exception.GetDatabaseError();
+
+        actual.Should().BeOfType<UniqueConstraintError>();
+        var ixError = actual as UniqueConstraintError;
+        ixError!.ConstraintName.Should().Be(constraintName);
+        ixError.TableName.Should().Be("Images");
+        ixError.ColumnNames.Should().BeEquivalentTo("Foo", "Bar");
+        ixError.Exception.Should().Be(pgEx);
+    }
+    
+    [Fact]
+    public void GetDatabaseError_ForeignKeyViolation_ReturnsExpected()
+    {
+        const string constraintName = "FK_Images_OtherTable_Foo_Bar";
+        var pgEx = new PostgresException("", "", "", PostgresErrorCodes.ForeignKeyViolation, tableName: "Images",
+            constraintName: constraintName);
+        var exception = new DbUpdateException("Sample", pgEx);
+
+        var actual = exception.GetDatabaseError();
+
+        actual.Should().BeOfType<DbForeignKeyConstraintError>();
+        var fkError = actual as DbForeignKeyConstraintError;
+        fkError!.ConstraintName.Should().Be(constraintName);
+        fkError.TableName.Should().Be("Images");
+        fkError.SecondaryTableName.Should().Be("OtherTable");
+        fkError.Exception.Should().Be(pgEx);
+    }
+    
+    [Fact]
+    public void GetDatabaseError_ReturnsDbError_ForOtherErrorCodes()
+    {
+        var pgEx = new PostgresException("", "", "", PostgresErrorCodes.InsufficientPrivilege);
+        var exception = new DbUpdateException("Sample", pgEx);
+
+        var actual = exception.GetDatabaseError();
+        actual!.ConstraintName.Should().BeNull();
+        actual.TableName.Should().BeNull();
+        actual.Exception.Should().Be(pgEx);
+    }
+}

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -707,10 +707,15 @@ public partial class DlcsContext : DbContext
         
         modelBuilder.Entity<Adjunct>(entity =>
         {
+            // NOTE - to allow case-sensitive writes but case-insensitive reads, use a unique constraint on LOWER(id).
+            // Ideally model with something like the following but that is not supported in EF, so added via migration
+            // see https://github.com/npgsql/efcore.pg/issues/119
+            // entity.HasIndex(a => a.Id.ToLower()).IsUnique();
+            
             entity.HasKey(a => new { a.Id, a.AssetId });
             
             entity.Property(a => a.Id)
-                .HasMaxLength(500);
+                .HasMaxLength(Adjunct.MaxIdLength);
             
             entity.Property(a => a.Label).HasColumnType("jsonb");
             entity.Property(a => a.Language)
@@ -725,10 +730,8 @@ public partial class DlcsContext : DbContext
                 .HasConversion(
                     i => i.GetDescription(),
                     i => i.GetEnumFromString<IIIFLinkType>(true));
+            
+            entity.Property(p => p.Created).HasDefaultValueSql("now()");
         });
-
-        OnModelCreatingPartial(modelBuilder);
     }
-
-    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
 }

--- a/src/protagonist/DLCS.Repository/Exceptions/DbForeignKeyConstraintError.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbForeignKeyConstraintError.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace DLCS.Repository.Exceptions;
+
+/// <summary>
+/// Provides additional Postgres specific information about a  <see cref="DbUpdateException"/> thrown by EF Core.
+/// This describes the case where the exception is a foreign key constraint violation.
+/// </summary>
+/// <param name="TableName">The main table involved, if any.</param>
+/// <param name="SecondaryTableName">The secondary table involved, if any.</param>
+/// <param name="ConstraintName">The constraint involved, if any.</param>
+/// <param name="Exception">The unwrapped database provider specific exception.</param>
+/// <remarks>Parsing is done assuming naming convention "FK_{Table1}_{Table2}_{Column1}". Note that column parsing not
+/// done as longer column names are truncated with '~'. e.g.
+/// FK_DefaultDeliveryChannels_DeliveryChannelPolicies_DeliveryCha~
+/// FK_ImageDeliveryChannels_DeliveryChannelPolicies_DeliveryChann~
+/// </remarks>
+public record DbForeignKeyConstraintError(
+    string? TableName,
+    string? SecondaryTableName,
+    string? ConstraintName,
+    Exception Exception) : DbError(TableName, ConstraintName, Exception)
+{
+    /// <summary>
+    /// Creates a <see cref="DbForeignKeyConstraintError"/> from a <see cref="PostgresException"/>.
+    /// </summary>
+    /// <param name="postgresException">The <see cref="PostgresException"/>.</param>
+    /// <returns>A <see cref="DbForeignKeyConstraintError"/> with extra information about the foreign key violation.</returns>
+    public static DbForeignKeyConstraintError FromPostgresException(PostgresException postgresException)
+    {
+        var constraintName = postgresException.ConstraintName;
+        var tableName = postgresException.TableName;
+       
+        var constraintPrefix = tableName != null ? $"FK_{tableName}_" : null;
+
+        string? secondaryTableName = null;
+        
+        if (constraintPrefix != null
+            && constraintName != null
+            && constraintName.StartsWith(constraintPrefix, StringComparison.Ordinal))
+        {
+            secondaryTableName = constraintName[constraintPrefix.Length..].Split('_')[0];
+        }
+
+
+        return new DbForeignKeyConstraintError(postgresException.TableName, secondaryTableName, postgresException.ConstraintName,
+            postgresException);
+    }
+}

--- a/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
@@ -20,8 +20,8 @@ public record UniqueConstraintError(
     IReadOnlyList<string> ColumnNames,
     string? TableName,
     string? ConstraintName,
-    Exception Exception) : DbError(TableName, ConstraintName, Exception) {
-    
+    Exception Exception) : DbError(TableName, ConstraintName, Exception)
+{
     /// <summary>
     /// Creates a <see cref="UniqueConstraintError"/> from a <see cref="PostgresException"/>.
     /// </summary>
@@ -32,15 +32,15 @@ public record UniqueConstraintError(
         var constraintName = postgresException.ConstraintName;
         var tableName = postgresException.TableName;
        
-        var constrainPrefix = tableName != null ? $"IX_{tableName}_" : null;
+        var constraintPrefix = tableName != null ? $"IX_{tableName}_" : null;
 
         var columnNames = Array.Empty<string>();
         
-        if (constrainPrefix != null
+        if (constraintPrefix != null
             && constraintName != null
-            && constraintName.StartsWith(constrainPrefix, StringComparison.Ordinal))
+            && constraintName.StartsWith(constraintPrefix, StringComparison.Ordinal))
         {
-            columnNames = constraintName[constrainPrefix.Length..].Split('_');
+            columnNames = constraintName[constraintPrefix.Length..].Split('_');
         }
         
         return new UniqueConstraintError(columnNames, tableName, constraintName, postgresException);

--- a/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbUniqueConstraintError.cs
@@ -7,9 +7,8 @@ using Npgsql;
 namespace DLCS.Repository.Exceptions;
 
 /// <summary>
-/// Provides additional Postgres specific information about a 
-/// <see cref="DbUpdateException"/> thrown by EF Core.This describes 
-/// the case where the exception is a unique constraint violation.
+/// Provides additional Postgres specific information about a  <see cref="DbUpdateException"/> thrown by EF Core.
+/// This describes the case where the exception is a unique constraint violation.
 /// </summary>
 /// <param name="ColumnNames">The column names parsed from the constraint 
 /// name assuming the constraint follows the "IX_{Table}_{Column1}_..._{ColumnN}" naming convention.</param>
@@ -48,7 +47,7 @@ public record UniqueConstraintError(
     }
     
     /// <summary>
-    /// Check if error is for specified columnt
+    /// Check if error is for specified column
     /// </summary>
     public bool ForColumn(string columnName) => ColumnNames.Contains(columnName);
 }

--- a/src/protagonist/DLCS.Repository/Exceptions/DbUpdateExceptionX.cs
+++ b/src/protagonist/DLCS.Repository/Exceptions/DbUpdateExceptionX.cs
@@ -23,9 +23,8 @@ public static class DbUpdateExceptionX
         {
             return postgresException.SqlState switch
             {
-                PostgresErrorCodes.UniqueViolation => UniqueConstraintError
-                    .FromPostgresException(postgresException),
-                //... Other error codes mapped to other error types.
+                PostgresErrorCodes.UniqueViolation => UniqueConstraintError.FromPostgresException(postgresException),
+                PostgresErrorCodes.ForeignKeyViolation => DbForeignKeyConstraintError.FromPostgresException(postgresException),
                 _ => new DbError(
                     postgresException.TableName,
                     postgresException.ConstraintName,

--- a/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20260115094832_Adjunct defaults and constraints")]
+    partial class Adjunctdefaultsandconstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class Adjunctdefaultsandconstraints : Migration
+    {
+        private const string IndexName = "IX_Adjuncts_Id";
+        
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Adjuncts",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValueSql: "now()",
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "Adjuncts",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+            
+            // This can't be modelled by EFCore, so instead we create manually
+            // see https://github.com/npgsql/efcore.pg/issues/119
+            migrationBuilder.Sql($"CREATE UNIQUE INDEX \"{IndexName}\" ON \"Adjuncts\" (LOWER(\"Id\"))");
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "Created",
+                table: "Adjuncts",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldDefaultValueSql: "now()");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "Adjuncts",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+            
+            migrationBuilder.Sql($"DROP INDEX \"{IndexName}\"");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
@@ -34,7 +34,7 @@ namespace DLCS.Repository.Migrations
             
             // This can't be modelled by EFCore, so instead we create manually
             // see https://github.com/npgsql/efcore.pg/issues/119
-            migrationBuilder.Sql($"CREATE UNIQUE INDEX \"{IndexName}\" ON \"Adjuncts\" (LOWER(\"Id\"));");
+            migrationBuilder.Sql($"CREATE UNIQUE INDEX \"{IndexName}\" ON \"Adjuncts\" (LOWER(\"Id\"), \"AssetId\");");
         }
 
         /// <inheritdoc />

--- a/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260115094832_Adjunct defaults and constraints.cs
@@ -34,8 +34,7 @@ namespace DLCS.Repository.Migrations
             
             // This can't be modelled by EFCore, so instead we create manually
             // see https://github.com/npgsql/efcore.pg/issues/119
-            migrationBuilder.Sql($"CREATE UNIQUE INDEX \"{IndexName}\" ON \"Adjuncts\" (LOWER(\"Id\"))");
-
+            migrationBuilder.Sql($"CREATE UNIQUE INDEX \"{IndexName}\" ON \"Adjuncts\" (LOWER(\"Id\"));");
         }
 
         /// <inheritdoc />
@@ -60,7 +59,7 @@ namespace DLCS.Repository.Migrations
                 oldType: "character varying(200)",
                 oldMaxLength: 200);
             
-            migrationBuilder.Sql($"DROP INDEX \"{IndexName}\"");
+            migrationBuilder.Sql($"DROP INDEX \"{IndexName}\";");
         }
     }
 }

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -64,25 +64,32 @@ public static class DatabaseTestDataPopulation
         });
     }
     
-    public static ValueTask<EntityEntry<Adjunct>> AddTestAdjunct(this DbSet<Adjunct> adjuncts,
-        string id, AssetId assetId, string type = "Image", string mediaType = "image/jpg", IIIFLinkType iiifLinkType = IIIFLinkType.SeeAlso, 
+    public static ValueTask<EntityEntry<Asset>> WithTestAdjunct(
+        this ValueTask<EntityEntry<Asset>> asset,
+        string id, string type = "Image", string mediaType = "image/jpg",
+        IIIFLinkType iiifLinkType = IIIFLinkType.SeeAlso,
         string profile = null, LanguageMap label = null,
-        string[] language = null, string externalId = "https://someHost.com/someUri", DateTime? created = null, long? size = null)
-        => adjuncts.AddAsync(
-            new Adjunct
-            {
-                Id = id,
-                Type = type,
-                MediaType = mediaType,
-                IIIFLink = iiifLinkType,
-                AssetId = assetId,
-                Profile = profile,
-                Label = label,
-                Language = language,
-                ExternalId = new Uri(externalId),
-                Created = created ?? DateTime.UtcNow,
-                Size = size
-            });
+        string[] language = null, string externalId = "https://someHost.com/someUri", DateTime? created = null,
+        long? size = null)
+    {
+        asset.Result.Entity.Adjuncts ??= [];
+        asset.Result.Entity.Adjuncts.Add(new Adjunct
+        {
+            Id = id,
+            Type = type,
+            MediaType = mediaType,
+            IIIFLink = iiifLinkType,
+            AssetId = asset.Result.Entity.Id,
+            Profile = profile,
+            Label = label,
+            Language = language,
+            ExternalId = new Uri(externalId),
+            Created = created ?? DateTime.UtcNow,
+            Size = size
+        });
+
+        return asset;
+    }
 
     public static ValueTask<EntityEntry<AuthToken>> AddTestToken(this DbSet<AuthToken> authTokens,
         int customer = 99, int ttl = 100, DateTime? expires = null, string? sessionUserId = null,


### PR DESCRIPTION
Fixes #1084 and fixes #1085

There are a few fixes from the above 2 tickets:

## "id" is required when creating an adjunct via PUT

This was related to validation of `.ModelId` in `HydraAdjunctValidator` by comparing it to `.Id`. This was unnecessary as the validation is already happening in `AdjunctController.PutAdjunct()`. Also extended check in controller to ignore `""` as well as explicitly `null` `"id"` values in PUT body.

Also introduced a new default ctor for Adjunct hydra model, this will be used when deserialising. The other ctor will be used when constructing the full model with hypermedia links, this takes values like customer and space that aren't in the actual payload received so we'd never be able to fully use this one.

## Language codes contained within "language" can be any size

Added `HydraAdjunctValidator` rule that all items in `language` have max of 10 characters.

This is to handle ISO (`en`, `fra`) codes, sub-codes (`US-NY`, `GB-SCT`, `zh-Hans-CN`) and 'none' (thanks @stephenwf !)

## Adjunct "id" can contain whitespace characters

Added `HydraAdjunctValidator` rule to check that none of the provided characters are present in the exclusion list applied to assets, and verified length for does not exceed 200 chars.  

The exclusion list was added in #701, originally titled `RestrictedAssetIdCharacterString`, now renamed to `RestrictedResourceIdCharacterString`. I also added the default list to the basic `appsettings.json` - this avoids the need to configure the same `"RestrictedAssetIdCharacterString" = "\\ "` config for every deployment of Protagonist. 

> [!WARNING]
> This is a renamed property but all usages use the default character list so there'll be no practical change.
>
> The previous default was "\\ " but it's now "\\ /". The `/` character was caught for Assets when parsing but it's now explicitly included as an invalid character.

## Adjuncts can share a nearly identical "id" when cased differently

This was handled by adding a unique constraint to DB, `CREATE UNIQUE INDEX xx ON "Adjuncts" (LOWER("Id"), "AssetId");`. 

This means that `Id` value will fail if we try to write `Test` and `test` while still maintaining case-sensitive reads (ie GET `/Test` would work but GET `/test` wouldn't).

Left some comments in code but had to do this manually, via migration, rather than via EFCore as it's not supported.

## Incorrect status code creating asset for not found Asset

Extended `GetDatabaseError` to return new `DbForeignKeyConstraintError` type to allow identification of FK constraint errors.

## Adjunct "size" value is ignored

`size` mapping missing from mapping class

## Other changes

* Removed `AssetId` from Hydra model. This wasn't used anywhere and was ignored by serialiser so unnecessary.
* Changed `.AddTestAdjunct()` helper to be a fluent method off of an added `Asset` to make test setup simpler.
* Added default `now()` value to `Adjuncts.Created`. Still set manually, without it, for external adjuncts, the `Finished` date is earlier than `Created` which was odd but may be of use elsewhere.
* Set DB max length of `Adjunct` to match validated length.

> [!NOTE]
> Contains a migration