### PR TITLE
Output external adjunct on Manifests

### DIFF
--- a/src/protagonist/DLCS.Model/Assets/Adjunct.cs
+++ b/src/protagonist/DLCS.Model/Assets/Adjunct.cs
@@ -72,6 +72,9 @@ public class Adjunct
     public Asset Asset { get; set; } = null!;
 }
 
+/// <summary>
+/// The type of linking property to use for adjunct. Determines how this is output on Manifest.
+/// </summary>
 public enum IIIFLinkType
 {
     [Description("seeAlso")]

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/AssetQueryableXTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/AssetQueryableXTests.cs
@@ -24,27 +24,28 @@ public class AssetQueryableXTests
     }
     
     [Fact]
-    public async Task IncludeRelevantMetadata_HandlesNoRelatedData()
+    public async Task IncludeRelationsForProjections_HandlesNoRelatedData()
     {
         var assetId = AssetIdGenerator.GetAssetId();
         await dbContext.Images.AddTestAsset(assetId);
         await dbContext.SaveChangesAsync();
         
-        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelevantMetadata().SingleAsync();
+        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelationsForProjections().SingleAsync();
 
         asset.Should().NotBeNull("Asset returned despite having no related data");
         asset.AssetApplicationMetadata.Should().BeNullOrEmpty();
         asset.ImageDeliveryChannels.Should().BeNullOrEmpty();
+        asset.Adjuncts.Should().BeNullOrEmpty();
     }
     
     [Fact]
-    public async Task IncludeRelevantMetadata_ReturnsRelatedThumbs()
+    public async Task IncludeRelationsForProjections_ReturnsRelatedThumbs()
     {
         var assetId = AssetIdGenerator.GetAssetId();
         await dbContext.Images.AddTestAsset(assetId).WithTestThumbnailMetadata().WithTestDeliveryChannel("iiif-img");
         await dbContext.SaveChangesAsync();
         
-        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelevantMetadata().SingleAsync();
+        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelationsForProjections().SingleAsync();
 
         asset.Should().NotBeNull();
         asset.AssetApplicationMetadata.Should().HaveCount(1)
@@ -53,7 +54,7 @@ public class AssetQueryableXTests
     }
     
     [Fact]
-    public async Task IncludeRelevantMetadata_ReturnsRelatedTranscodes()
+    public async Task IncludeRelationsForProjections_ReturnsRelatedTranscodes()
     {
         var assetId = AssetIdGenerator.GetAssetId();
         var fakeTranscodes = new List<AVTranscode>
@@ -63,7 +64,7 @@ public class AssetQueryableXTests
         (await dbContext.Images.AddTestAsset(assetId)).Entity.WithTestTranscodeMetadata(fakeTranscodes);
         await dbContext.SaveChangesAsync();
         
-        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelevantMetadata().SingleAsync();
+        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelationsForProjections().SingleAsync();
 
         asset.Should().NotBeNull();
         asset.AssetApplicationMetadata.Should().HaveCount(1)
@@ -71,7 +72,7 @@ public class AssetQueryableXTests
     }
 
     [Fact]
-    public async Task IncludeRelevantMetadata_ReturnsThumbsAndTranscodes()
+    public async Task IncludeRelationsForProjections_ReturnsThumbsAndTranscodes()
     {
         var assetId = AssetIdGenerator.GetAssetId();
         var fakeTranscodes = new List<AVTranscode>
@@ -83,7 +84,7 @@ public class AssetQueryableXTests
         await dbContext.SaveChangesAsync();
         
         var asset = await dbContext.Images.Where(i => i.Id == assetId)
-            .IncludeRelevantMetadata()
+            .IncludeRelationsForProjections()
             .SingleAsync();
 
         asset.Should().NotBeNull();
@@ -91,6 +92,24 @@ public class AssetQueryableXTests
         asset.AssetApplicationMetadata.Should().ContainSingle(m => m.MetadataType == "ThumbSizes");
         asset.AssetApplicationMetadata.Should().ContainSingle(m => m.MetadataType == "AVTranscodes");
         asset.ImageDeliveryChannels.Should().HaveCount(1);
+    }
+    
+    [Fact]
+    public async Task IncludeRelationsForProjections_ReturnsAdjuncts()
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+        const string adjuntId = "ekki mukk";
+        await dbContext.Images
+            .AddTestAsset(assetId)
+            .WithTestThumbnailMetadata()
+            .WithTestDeliveryChannel("iiif-img")
+            .WithTestAdjunct(adjuntId);
+        await dbContext.SaveChangesAsync();
+        
+        var asset = await dbContext.Images.Where(i => i.Id == assetId).IncludeRelationsForProjections().SingleAsync();
+
+        asset.Should().NotBeNull();
+        asset.Adjuncts.Should().ContainSingle(a => a.Id == adjuntId);
     }
 }
 

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -9,6 +9,7 @@ using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
 using IIIF.Serialisation;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
@@ -793,5 +794,67 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
         paintable.Service.OfType<ImageService3>().Single().Service.Should()
             .ContainSingle(s => s is AuthProbeService2 && s.Id.Contains(id.ToString()));
         paintable.Service.OfType<AuthProbeService2>().Single().Id.Should().Contain(id.ToString());
+    }
+
+    [Fact]
+    public async Task Get_V3ManifestWithAdjuncts_OutputsAdjunctsInCorrectLocation()
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images
+            .AddTestAsset(id, imageDeliveryChannels: imageDeliveryChannels)
+            .WithTestAdjunct("seeAlso1", type: "Dataset", mediaType: "text/xml", iiifLinkType: IIIFLinkType.SeeAlso,
+                profile: "http://www.loc.gov/standards/alto/v3/alto.xsd", label: new LanguageMap("en", "METS-ALTO XML"),
+                externalId: "https://mets.example/1", language: ["en-GB"])
+            .WithTestAdjunct("anno1", type: "Ignored", mediaType: "text/ignored",
+                iiifLinkType: IIIFLinkType.Annotations, label: new LanguageMap("en", "Line-level annos"),
+                externalId: "https://mets.example/w3c", language: ["ignored"])
+            .WithTestAdjunct("rendering1", type: "Text", mediaType: "application/pdf", iiifLinkType: IIIFLinkType.Rendering,
+                label: new LanguageMap("none", "PDF of image"), externalId: "https://pdf.example/1", language: ["fr"])
+            .WithTestAdjunct("seeAlso2", type: "Text", mediaType: "text/xml", iiifLinkType: IIIFLinkType.SeeAlso,
+                externalId: "https://other.example/2");
+        
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        List<AnnotationPage> expectedAnnos =
+        [
+            new() { Id = "https://mets.example/w3c", Label = new LanguageMap("en", "Line-level annos") }
+        ];
+
+        List<ExternalResource> expectedSeeAlso =
+        [
+            new("Dataset")
+            {
+                Id = "https://mets.example/1", Label = new LanguageMap("en", "METS-ALTO XML"),
+                Profile = "http://www.loc.gov/standards/alto/v3/alto.xsd", Format = "text/xml",
+                Language = ["en-GB"]
+            },
+            new("Text")
+            {
+                Id = "https://other.example/2", Format = "text/xml"
+            },
+        ];
+
+        List<ExternalResource> expectedRendering =
+        [
+            new("Text")
+            {
+                Id = "https://pdf.example/1", Label = new LanguageMap("none", "PDF of image"),
+                Format = "application/pdf", Language = ["fr"]
+            },
+        ];
+
+        var path = $"iiif-manifest/v3/{id}";
+
+        // Act
+        var response = await httpClient.GetAsync(path);
+            
+        // Assert
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        var canvas = manifest.Items!.Single();
+        
+        canvas.SeeAlso.Should().BeEquivalentTo(expectedSeeAlso);
+        canvas.Rendering.Should().BeEquivalentTo(expectedRendering);
+        canvas.Annotations.Should().BeEquivalentTo(expectedAnnos);
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -57,7 +57,8 @@ public class NamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
             maxUnauthorised: 10, roles: "default")
             .WithTestThumbnailMetadata()
-            .WithTestDeliveryChannel(AssetDeliveryChannels.Image);
+            .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
+            .WithTestAdjunct("test-adjunct", externalId: "https://example.com/see-also-1");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 4, ref1: "my-ref",
             notForDelivery: true)
             .WithTestThumbnailMetadata()
@@ -371,6 +372,41 @@ public class NamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
         {
             token["id"].Value<string>().Should().Contain(expectedOrder[count++]);
         }
+    }
+    
+    [Fact]
+    public async Task Get_ReturnsV3ManifestWithCorrectAdjuncts()
+    {
+        // Arrange
+        const string path = "iiif-resource/v3/99/test-named-query/my-ref/1";
+        const string iiif3 = "application/ld+json; profile=\"http://iiif.io/api/presentation/3/context.json\"";
+        
+        // Act
+        var response = await httpClient.GetAsync(path);
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Headers.Vary.Should().Contain("Accept");
+        response.Content.Headers.ContentType.ToString().Should().Be(iiif3);
+        
+        var manifest = (await response.Content.ReadAsStreamAsync()).FromJsonStream<IIIF3.Manifest>();
+        manifest.Items.Should().HaveCount(3);
+
+        bool checkedSeeAlso = false;
+        foreach (var canvas in manifest.Items!)
+        {
+            if (canvas.Id.Contains("matching-nothumbs"))
+            {
+                checkedSeeAlso = true;
+                canvas.SeeAlso.Should().ContainSingle(sa => sa.Id == "https://example.com/see-also-1");
+            }
+            else
+            {
+                canvas.SeeAlso.Should().BeNull();
+            }
+        }
+
+        checkedSeeAlso.Should().BeTrue("No seeAlso checked in test, verify test data");
     }
     
     [Fact]

--- a/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
@@ -10,6 +10,7 @@ using DLCS.Web.Requests;
 using IIIF;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
@@ -21,15 +22,8 @@ namespace Orchestrator.Features.Manifests;
 /// <summary>
 /// Methods for generating IIIF results from NamedQueries
 /// </summary>
-public class IIIFNamedQueryProjector
+public class IIIFNamedQueryProjector(IIIFManifestBuilder manifestBuilder, ILogger<IIIFNamedQueryProjector> logger)
 {
-    private readonly IIIFManifestBuilder manifestBuilder;
-
-    public IIIFNamedQueryProjector(IIIFManifestBuilder manifestBuilder) 
-    {
-        this.manifestBuilder = manifestBuilder;
-    }
-
     /// <summary>
     /// Project NamedQueryResult to IIIF presentation object
     /// </summary>
@@ -43,7 +37,11 @@ public class IIIFNamedQueryProjector
             .IncludeRelationsForProjections()
             .AsSplitQuery()
             .ToListAsync(cancellationToken);
-        if (assets.Count == 0) return null;
+        if (assets.Count == 0)
+        {
+            logger.LogDebug("No assets found that match NQ parameters");
+            return null;
+        }
 
         var orderedImages = NamedQueryProjections.GetOrderedAssets(assets, parsedNamedQuery).ToList();
 

--- a/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/IIIFNamedQueryProjector.cs
@@ -40,7 +40,7 @@ public class IIIFNamedQueryProjector
         var parsedNamedQuery = namedQueryResult.ParsedQuery.ThrowIfNull(nameof(request.Query))!;
 
         var assets = await namedQueryResult.Results
-            .IncludeRelevantMetadata()
+            .IncludeRelationsForProjections()
             .AsSplitQuery()
             .ToListAsync(cancellationToken);
         if (assets.Count == 0) return null;

--- a/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
+++ b/src/protagonist/Orchestrator/Features/Manifests/Requests/GetManifestForAsset.cs
@@ -63,7 +63,7 @@ public class GetManifestForAssetHandler : IRequestHandler<GetManifestForAsset, D
         var assetId = request.AssetRequest.GetAssetId();
 
         var asset = await dlcsContext.Images
-            .IncludeRelevantMetadata()
+            .IncludeRelationsForProjections()
             .FirstOrDefaultAsync(a => a.Id == assetId, cancellationToken);
         
         if (asset == null || asset.NotForDelivery)

--- a/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
@@ -8,13 +8,20 @@ namespace Orchestrator.Infrastructure;
 public static class AssetQueryableX
 {
     /// <summary>
-    /// Includes data from <see cref="AssetApplicationMetadata"/> and related <see cref="ImageDeliveryChannel"/> that is
-    /// relevant to Orchestrator processing for manifests and named query projections
+    /// Includes data from <see cref="AssetApplicationMetadata"/> and related <see cref="ImageDeliveryChannel"/> and
+    /// <see cref="Adjunct"/> that are relevant to Orchestrator processing manifests and named query projections
     /// </summary>
-    public static IQueryable<Asset> IncludeRelevantMetadata(this IQueryable<Asset> assets) =>
+    /// <remarks>
+    /// This currently only returns adjuncts with an ExternalId, which is currently ALL adjuncts. Future changes will
+    /// make ExternalId nullable, so this clause will prevent those appearing in Manifests until we want them. It can
+    /// be removed when DLCS hosted assets are available. 
+    /// </remarks>
+    public static IQueryable<Asset> IncludeRelationsForProjections(this IQueryable<Asset> assets) =>
         assets.Include(a =>
                 a.AssetApplicationMetadata.Where(md =>
                     md.MetadataType == AssetApplicationMetadataTypes.ThumbSizes ||
                     md.MetadataType == AssetApplicationMetadataTypes.AVTranscodes))
-            .Include(a => a.ImageDeliveryChannels);
+            .Include(a => a.ImageDeliveryChannels)
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            .Include(a => a.Adjuncts!.Where(adj => adj.ExternalId != null));
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFManifestBuilder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFManifestBuilder.cs
@@ -12,18 +12,10 @@ namespace Orchestrator.Infrastructure.IIIF;
 /// <summary>
 /// Class for creating IIIF Manifests from provided assets 
 /// </summary>
-public class IIIFManifestBuilder
+public class IIIFManifestBuilder(
+    IBuildManifests<IIIF3.Manifest> manifestV3Builder,
+    IBuildManifests<IIIF2.Manifest> manifestV2Builder)
 {
-    private readonly IBuildManifests<IIIF3.Manifest> manifestV3Builder;
-    private readonly IBuildManifests<IIIF2.Manifest> manifestV2Builder;
-
-    public IIIFManifestBuilder(IBuildManifests<IIIF3.Manifest> manifestV3Builder, 
-        IBuildManifests<IIIF2.Manifest> manifestV2Builder)
-    {
-        this.manifestV3Builder = manifestV3Builder;
-        this.manifestV2Builder = manifestV2Builder;
-    }
-
     public Task<IIIF3.Manifest> GenerateV3Manifest(List<Asset> assets, CustomerPathElement customerPathElement,
         string manifestId, string label, ManifestType manifestType, CancellationToken cancellationToken)
         => manifestV3Builder.BuildManifest(manifestId, label, assets, customerPathElement, manifestType,

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -209,6 +209,8 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
         {
             canvas.Thumbnail = thumbnail.AsListOf<ExternalResource>();
         }
+
+        AddAdjunctsToCanvas(canvas, asset);
         
         return new AssetCanvas(canvas, additionalContexts);
     }
@@ -268,7 +270,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
     {
         logger.LogTrace("{CanvasId} is timebased, processing", canvas.Id);
         var canvasId = canvas.Id;
-        var transcodes = asset.AssetApplicationMetadata.GetTranscodeMetadata(false);
+        var transcodes = asset.AssetApplicationMetadata.GetTranscodeMetadata();
         
         if (transcodes.IsNullOrEmpty())
         {
@@ -480,5 +482,47 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             .Cast<IService>()
             .ToList();
         return accessServices;
+    }
+    
+    private void AddAdjunctsToCanvas(Canvas canvas, Asset asset)
+    {
+        var adjuncts = asset.Adjuncts ?? Enumerable.Empty<Adjunct>();
+        
+        foreach (var adjunct in adjuncts)
+        {
+            logger.LogTrace("Adding adjunct {AdjunctId} to {CanvasId}", adjunct.Id, canvas.Id);
+            switch (adjunct.IIIFLink)
+            {
+                case IIIFLinkType.SeeAlso:
+                    canvas.SeeAlso ??= [];
+                    canvas.SeeAlso.Add(CreateExternalResource(adjunct));
+                    break;
+                case IIIFLinkType.Annotations:
+                    canvas.Annotations ??= [];
+                    canvas.Annotations.Add(new AnnotationPage
+                    {
+                        Id = adjunct.ExternalId.ToString(),
+                        Label = adjunct.Label,
+                    });
+                    break;
+                case IIIFLinkType.Rendering:
+                    canvas.Rendering ??= [];
+                    canvas.Rendering.Add(CreateExternalResource(adjunct));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(adjunct.IIIFLink), adjunct.IIIFLink,
+                        "IIIFLink type not supported");
+            }
+        }
+
+        // "rendering" and "seeAlso" are ExternalResources
+        ExternalResource CreateExternalResource(Adjunct adjunct) => new(adjunct.Type)
+        {
+            Id = adjunct.ExternalId.ToString(),
+            Format = adjunct.MediaType,
+            Profile = adjunct.Profile,
+            Label = adjunct.Label,
+            Language = adjunct.Language?.ToList(),
+        };
     }
 }

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -52,7 +52,7 @@ public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
         
         if (thumbnailSizes != null)
         {
-            logger.LogDebug("ThumbSizes metadata found for {AssetId}", asset.Id);
+            logger.LogTrace("ThumbSizes metadata found for {AssetId}", asset.Id);
             return thumbnailSizes;
         }
 

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Persistence/StoredNamedQueryManager.cs
@@ -54,7 +54,7 @@ public class StoredNamedQueryManager(
 
         // If we hit here there is no projection - create one
         var imageResults = await namedQueryResult.Results
-            .IncludeRelevantMetadata()
+            .IncludeRelationsForProjections()
             .AsSplitQuery()
             .ToListAsync(cancellationToken);
         if (imageResults.Count == 0)

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -66,7 +66,7 @@ public static class DatabaseTestDataPopulation
     
     public static ValueTask<EntityEntry<Asset>> WithTestAdjunct(
         this ValueTask<EntityEntry<Asset>> asset,
-        string id, string type = "Image", string mediaType = "image/jpg",
+        string id, string type = "Image", string mediaType = "image/jpeg",
         IIIFLinkType iiifLinkType = IIIFLinkType.SeeAlso,
         string profile = null, LanguageMap label = null,
         string[] language = null, string externalId = "https://someHost.com/someUri", DateTime? created = null,


### PR DESCRIPTION
Resolves #1074

Externally hosted adjuncts are now output on single-item and NQ manifests in accordance with rules on #1074

Summary of changes:
* Renamed `IncludeRelevantMetadata()` to `IncludeRelationsForProjections()` and extended to include adjuncts. The latter name seems clearer as adjuncts aren't metadata.
* Extend `ManifestV3Builcer` to add adjuncts to relevant canvases.

> [!NOTE]
> As mentioned in ticket `IncludeRelationsForProjections()` uses `.Include(a => a.Adjuncts!.Where(adj => adj.ExternalId != null)`. This is non-functional now but means that when hosted adjuncts are introduced to API they don't prematurely appear in generated Manifest.

> [!NOTE]
> In the case of `iiifLink = "annotations"`, some of the provided Adjuncts values are ignored. I will open a further ticket for returning to this as it's low priority.