### PR TITLE
Update ThumbCreator to use maxUnauth replacements

### DIFF
--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -7,13 +7,13 @@ namespace DLCS.Model.Tests.Assets;
 
 public class AssetXTests
 {
-    private readonly List<SizeParameter> sizeParameters = new()
-    {
+    private readonly List<SizeParameter> sizeParameters =
+    [
         SizeParameter.Parse("!800,800"),
         SizeParameter.Parse("!400,400"),
         SizeParameter.Parse("!200,200"),
         SizeParameter.Parse("!100,100"),
-    };
+    ];
     
     [Fact]
     public void GetAvailableThumbSizes_Correct_MaxUnauthorisedNoRoles()
@@ -174,5 +174,38 @@ public class AssetXTests
         // Assert
         asset.Ingesting.Should().BeFalse();
         asset.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(10));
+    }
+
+    [Theory]
+    [InlineData(null, 5000, 5000, "MaxWidth null (unset), fallback to system default")]
+    [InlineData(0, 5000, 5000, "MaxWidth 0 (unset), fallback to system default")]
+    [InlineData(512, 5000, 512, "MaxWidth as smaller than system default")]
+    [InlineData(8000, 5000, 5000, "System default as smaller than maxWidth")]
+    public void GetLargestOpenFullSize_ReturnsMaxWidth_IfNoRoles(int? maxWidth, int systemMaxWidth, int expected,
+        string because)
+    {
+        var asset = new Asset { MaxWidth = maxWidth };
+        asset.GetLargestOpenFullSize(systemMaxWidth).Should().Be(expected, because);
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void GetLargestOpenFullSize_Returns0_IfOpenFullMaxUnset_AndHasRoles(int? openFullMax)
+    {
+        var asset = new Asset { OpenFullMax = openFullMax, Roles = "https://test.role" };
+        asset.GetLargestOpenFullSize(1000).Should().Be(0);
+    }
+    
+    [Theory]
+    [InlineData(1000, null, 5000, 1000, "OpenFullMax as smallest (MaxWidth null = unset)")]
+    [InlineData(1000, 0, 5000, 1000, "OpenFullMax as smallest (MaxWidth 0 = unset)")]
+    [InlineData(1000, 512, 5000, 512, "MaxWidth as smallest")]
+    [InlineData(1000, 8000, 500, 500, "System default as smallest")]
+    public void GetLargestOpenFullSize_ReturnsSmallestOfAvailableValues_IfHasRoles(int? openFullMax, int? maxWidth, int systemMaxWidth, int expected,
+        string because)
+    {
+        var asset = new Asset { MaxWidth = maxWidth, OpenFullMax = openFullMax, Roles = "https://test.role" };
+        asset.GetLargestOpenFullSize(systemMaxWidth).Should().Be(expected, because);
     }
 }

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -113,6 +113,11 @@ public class Asset : ICloneable, IDeliverable
     /// OR MaxUnauthorised >= 0
     /// </summary>
     public bool RequiresAuth => !string.IsNullOrWhiteSpace(Roles) || MaxUnauthorised >= 0;
+    
+    /// <summary>
+    /// Indicates whether this asset has any roles assigned to it.
+    /// </summary>
+    public bool HasRoles => !string.IsNullOrWhiteSpace(Roles);
 
     /// <summary>
     /// A list of image delivery channels attached to this asset

--- a/src/protagonist/DLCS.Model/Assets/AssetX.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetX.cs
@@ -81,6 +81,32 @@ public static class AssetX
         asset.Ingesting = false;
         asset.Finished = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Calculates the longest edge value for an open /full/ region request, based on maxWidth, openFullMax and Roles.
+    /// </summary>
+    /// <param name="asset">The asset for which to determine the longest edge of the open full region.</param>
+    /// <param name="systemMaxWidth">The system default maxWidth.</param>
+    /// <returns>The longest edge value for the open full region, or 0 if no open thumbnails are available.</returns>
+    /// <remarks>
+    /// This is used to determine the largest size available for Orchestrator requests and thumb generation
+    /// </remarks>
+    public static int GetLargestOpenFullSize(this Asset asset, int systemMaxWidth)
+    {
+        // The effective MaxWidth value can be from the Asset or the system-wide default
+        var effectiveMaxWidth = (asset.MaxWidth ?? 0) == 0
+            ? systemMaxWidth
+            : Math.Min(asset.MaxWidth!.Value, systemMaxWidth);
+        
+        // If no role, the only restriction is maxWidth (openFullMax is ignored)
+        if (!asset.HasRoles) return effectiveMaxWidth;
+
+        // If OpenFullMax == 0 then there are no "open" full sizes, because we have role(s)
+        if ((asset.OpenFullMax ?? 0) == 0) return 0;
+
+        // We have an OpenFullMax value, if we also have MaxWidth return the smallest of that an OpenFullMax
+        return Math.Min(effectiveMaxWidth, asset.OpenFullMax!.Value);
+    }
     
     private static bool AssetIsUnavailableForSize(Asset asset, int boundingSize)
         => asset.RequiresAuth && boundingSize > asset.MaxUnauthorised;

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -4,8 +4,10 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Policies;
 using Engine.Ingest.Image;
+using Engine.Settings;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Test.Helpers.Storage;
 
 namespace Engine.Tests.Ingest.Image;
@@ -14,18 +16,23 @@ public class ThumbCreatorTests
 {
     private readonly TestBucketWriter bucketWriter;
     private readonly ThumbCreator sut;
-    private readonly List<ImageDeliveryChannel> thumbsDeliveryChannel = new()
-    {
-        new ImageDeliveryChannel
+    private readonly List<ImageDeliveryChannel> thumbsDeliveryChannel =
+    [
+        new()
         {
             DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ThumbsDefault,
             Channel = AssetDeliveryChannels.Thumbnails
         }
-    };
+    ];
     
     public ThumbCreatorTests()
     {
         bucketWriter = new TestBucketWriter();
+        sut = GetSut();
+    }
+
+    private ThumbCreator GetSut(int maxWidth = 5000)
+    {
         var storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
         
         A.CallTo(() => storageKeyGenerator.GetThumbsSizesJsonLocation(A<AssetId>._))
@@ -36,8 +43,8 @@ public class ThumbCreatorTests
                 var authSlug = open ? "o" : "a";
                 return new ObjectInBucket("thumbs-bucket", $"{assetId}/{authSlug}/{size}.jpg");
             });
-
-        sut = new ThumbCreator(bucketWriter, storageKeyGenerator, new NullLogger<ThumbCreator>());
+        var options = Options.Create(new EngineSettings { MaxWidth = maxWidth });
+        return new ThumbCreator(bucketWriter, storageKeyGenerator, options, new NullLogger<ThumbCreator>());
     }
 
     [Fact]
@@ -170,6 +177,49 @@ public class ThumbCreatorTests
         
         // Act
         var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(3);
+        
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/a/1000.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents(thumbSizes);
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+        asset.AssetApplicationMetadata.Should()
+            .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_Restriction_FromSystemMaxWidth()
+    {
+        // Effective MaxWidth is 700 but this is set at the system, not asset, level
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, ImageDeliveryChannels = thumbsDeliveryChannel
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[[606,1000]]}";
+        
+        // Act
+        var thumbsCreated = await GetSut(700).CreateNewThumbs(asset, imagesOnDisk);
         
         // Assert
         thumbsCreated.Should().Be(3);

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -53,14 +53,17 @@ public class ThumbCreatorTests
         thumbsCreated.Should().Be(0);
     }
     
-    [Fact]
-    public async Task CreateNewThumbs_UploadsExpected_AllOpen()
+    [Theory]
+    [InlineData(100)]
+    [InlineData(0)]
+    public async Task CreateNewThumbs_UploadsExpected_AllOpen(int openFullMax)
     {
-        // Arrange
+        // All cases have MaxWidth=0 and no roles
+        // OpenFullMax is ignored as no roles so doesn't matter if it has a value or not
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 3030, Height = 5000, MaxUnauthorised = -1,
+            Width = 3030, Height = 5000, MaxWidth = 0, OpenFullMax = openFullMax,
             ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
@@ -100,11 +103,11 @@ public class ThumbCreatorTests
     [Fact]
     public async Task CreateNewThumbs_UploadsExpected_LargestFirst()
     {
-        // Arrange
+        // Similar test to above but proves thumbs are ordered internally 
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 3030, Height = 5000, MaxUnauthorised = -1,
+            Width = 3030, Height = 5000,
             ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
@@ -141,14 +144,18 @@ public class ThumbCreatorTests
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
     
-    [Fact]
-    public async Task CreateNewThumbs_UploadsExpected_LargestAuth()
+    [Theory]
+    [InlineData(1000)]
+    [InlineData(500)]
+    [InlineData(0)]
+    public async Task CreateNewThumbs_UploadsExpected_LargestAuth_NoRoles(int openFullMax)
     {
-        // Arrange
+        // MaxWidth is 700 and there are no roles so we won't create 'open' thumbs larger than 700
+        // included OpenFullMax to show this has no effect as no roles 
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 3030, Height = 5000, MaxUnauthorised = 700,
+            Width = 3030, Height = 5000, MaxWidth = 700, OpenFullMax = openFullMax,
             ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
@@ -185,14 +192,65 @@ public class ThumbCreatorTests
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
     
-    [Fact]
-    public async Task CreateNewThumbs_UploadsExpected_AuthMatchesImageSize()
+    [Theory]
+    [InlineData(700, 0)] // ofm only
+    [InlineData(700, 700)] // both ofm and mw match
+    [InlineData(700, 1024)] // mw is greater than ofm
+    [InlineData(1024, 700)] // ofm is greater than mw
+    public async Task CreateNewThumbs_UploadsExpected_LargestAuth_Roles(int openFullMax, int maxWidth)
     {
-        // Arrange
+        // Asset has roles. In all cases the effective 'max' value is 700
+        // This will be OpenFullMax or MaxWidth if one provided.
+        // If both provided it is OpenFullMax unless that value is larger than MaxWidth 
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 3030, Height = 5000, MaxUnauthorised = 500,
+            Width = 3030, Height = 5000, MaxWidth = maxWidth, OpenFullMax = openFullMax,
+            ImageDeliveryChannels = thumbsDeliveryChannel, Roles = "https://test"
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[[606,1000]]}";
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(3);
+        
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/a/1000.jpg")
+            .WithFilePath("1000.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents(thumbSizes);
+        
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+        asset.AssetApplicationMetadata.Should()
+            .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_AuthMatchesImageSize_OpenFullMax()
+    {
+        // MaxWidth is 500 and there are roles so we won't create 'open' thumbs larger than 500
+        // 500 also matches a size, this test confirms we allow that size but no larger
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, OpenFullMax = 500, Roles = "https://test",
             ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
@@ -236,8 +294,7 @@ public class ThumbCreatorTests
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 266, Height = 440,
-            ImageDeliveryChannels = thumbsDeliveryChannel
+            Width = 266, Height = 440, ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
         // NOTE - this handles multiple IIIF Image size parameters resulting in same image width
@@ -278,8 +335,7 @@ public class ThumbCreatorTests
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 266, Height = 440,
-            ImageDeliveryChannels = thumbsDeliveryChannel
+            Width = 266, Height = 440, ImageDeliveryChannels = thumbsDeliveryChannel
         };
 
         // NOTE - this handles using upscaling thumbnail size
@@ -316,15 +372,18 @@ public class ThumbCreatorTests
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
     
-    [Fact]
-    public async Task CreateNewThumbs_UploadsAllAuth_MaxUnauthorisedIs0()
+    [Theory]
+    [InlineData(256)]
+    [InlineData(0)]
+    public async Task CreateNewThumbs_UploadsExpected_AllAuth(int maxWidth)
     {
-        // Arrange
+        // All cases have a role and no OpenFullMax (so none available as open)
+        // Value of MaxWidth doesn't matter as none are available anonymously
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
-            Width = 3030, Height = 5000, MaxUnauthorised = 0,
-            ImageDeliveryChannels = thumbsDeliveryChannel
+            Width = 3030, Height = 5000, OpenFullMax = 0, Roles = "https://test",
+            ImageDeliveryChannels = thumbsDeliveryChannel, MaxWidth = maxWidth
         };
 
         var imagesOnDisk = new List<ImageOnDisk>

--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -5,7 +5,9 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.Metadata;
 using Engine.Data;
+using Engine.Settings;
 using IIIF;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace Engine.Ingest.Image;
@@ -13,9 +15,11 @@ namespace Engine.Ingest.Image;
 public class ThumbCreator(
     IBucketWriter bucketWriter,
     IStorageKeyGenerator storageKeyGenerator,
+    IOptions<EngineSettings> engineOptions,
     ILogger<ThumbCreator> logger)
     : IThumbCreator
 {
+    private readonly EngineSettings engineSettings = engineOptions.Value;
     private readonly AsyncKeyedLock asyncLocker = new();
 
     public async Task<int> CreateNewThumbs(Asset asset, IReadOnlyList<ImageOnDisk> thumbsToProcess)
@@ -75,38 +79,16 @@ public class ThumbCreator(
     
     private Size GetMaxOpenThumbnailSize(Asset asset, IReadOnlyList<ImageOnDisk> orderedThumbsToProcess)
     {
-        // The effective max dimension for open thumbnails
-        var effectiveMax = GetEffectiveOpenMaxDimension(asset);
-        logger.LogTrace("Effective max open dimension for {AssetId} is {MaxDimension}", asset.Id, effectiveMax);
+        // The max dimension for open thumbnails
+        var largestOpenDimension = asset.GetLargestOpenFullSize(engineSettings.MaxWidth);
+        logger.LogTrace("Max open dimension for {AssetId} is {MaxDimension}", asset.Id, largestOpenDimension);
+        
+        if (largestOpenDimension == 0) return new Size(0, 0);
 
-        // 0 with roles means "no open", without roles means "all open"
-        if (effectiveMax == 0)
-        {
-            if (asset.HasRoles)
-            {
-                return new Size(0, 0);
-            }
-
-            var largestImageOnDisk = orderedThumbsToProcess[0];
-            return new Size(largestImageOnDisk.Width, largestImageOnDisk.Height);
-        }
-
-        var thumb = orderedThumbsToProcess.FirstOrDefault(thumb => effectiveMax >= Math.Max(thumb.Width, thumb.Height));
+        // Find the largest thumbnail that fits within the max open dimension
+        var thumb = orderedThumbsToProcess.FirstOrDefault(thumb =>
+            largestOpenDimension >= Math.Max(thumb.Width, thumb.Height));
         return thumb == null ? new Size(0, 0) : new Size(thumb.Width, thumb.Height);
-    }
-    
-    private static int GetEffectiveOpenMaxDimension(Asset asset)
-    {
-        // If no role, only maxWidth can restrict (openFullMax is ignored)
-        if (!asset.HasRoles) return asset.MaxWidth ?? 0;
-            
-        // If OpenFullMax == 0 then there are no "open" thumbs, return 0
-        if ((asset.OpenFullMax ?? 0) == 0) return 0;
-
-        // We have an OpenFullMax value, if we also have MaxWidth return the smallest of that an OpenFullMax
-        return asset.MaxWidth > 0
-            ? Math.Min(asset.MaxWidth.Value, asset.OpenFullMax!.Value)
-            : asset.OpenFullMax ?? 0;
     }
 
     private async Task UploadThumbs(AssetId assetId, ImageOnDisk thumbCandidate, Size thumb, bool isOpen)

--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -6,7 +6,6 @@ using DLCS.Model.Assets;
 using DLCS.Model.Assets.Metadata;
 using Engine.Data;
 using IIIF;
-using IIIF.ImageApi;
 using Newtonsoft.Json;
 
 namespace Engine.Ingest.Image;
@@ -35,6 +34,7 @@ public class ThumbCreator(
         var orderedThumbs = thumbsToProcess.OrderByDescending(i => Math.Max(i.Height, i.Width)).ToList();
 
         var maxAvailableThumb = GetMaxOpenThumbnailSize(asset, orderedThumbs);
+        logger.LogTrace("Max available thumbnail size for {AssetId} is {MaxAvailableThumb}", assetId, maxAvailableThumb);
         var thumbnailSizes = new ThumbnailSizes(thumbsToProcess.Count);
         var processedWidths = new List<int>(thumbsToProcess.Count);
         
@@ -73,14 +73,40 @@ public class ThumbCreator(
         return thumbnailSizes.Count;
     }
     
-    private static Size GetMaxOpenThumbnailSize(Asset asset, List<ImageOnDisk> orderedThumbsToProcess)
+    private Size GetMaxOpenThumbnailSize(Asset asset, IReadOnlyList<ImageOnDisk> orderedThumbsToProcess)
     {
-        if (asset.MaxUnauthorised == 0) return new Size(0, 0);
-        if ((asset.MaxUnauthorised ?? -1) == -1) return new Size(orderedThumbsToProcess[0].Width, orderedThumbsToProcess[0].Height);
+        // The effective max dimension for open thumbnails
+        var effectiveMax = GetEffectiveOpenMaxDimension(asset);
+        logger.LogTrace("Effective max open dimension for {AssetId} is {MaxDimension}", asset.Id, effectiveMax);
 
-        var thumb = orderedThumbsToProcess.FirstOrDefault(thumb =>
-            asset.MaxUnauthorised >= Math.Max(thumb.Width, thumb.Height));
+        // 0 with roles means "no open", without roles means "all open"
+        if (effectiveMax == 0)
+        {
+            if (asset.HasRoles)
+            {
+                return new Size(0, 0);
+            }
+
+            var largestImageOnDisk = orderedThumbsToProcess[0];
+            return new Size(largestImageOnDisk.Width, largestImageOnDisk.Height);
+        }
+
+        var thumb = orderedThumbsToProcess.FirstOrDefault(thumb => effectiveMax >= Math.Max(thumb.Width, thumb.Height));
         return thumb == null ? new Size(0, 0) : new Size(thumb.Width, thumb.Height);
+    }
+    
+    private static int GetEffectiveOpenMaxDimension(Asset asset)
+    {
+        // If no role, only maxWidth can restrict (openFullMax is ignored)
+        if (!asset.HasRoles) return asset.MaxWidth ?? 0;
+            
+        // If OpenFullMax == 0 then there are no "open" thumbs, return 0
+        if ((asset.OpenFullMax ?? 0) == 0) return 0;
+
+        // We have an OpenFullMax value, if we also have MaxWidth return the smallest of that an OpenFullMax
+        return asset.MaxWidth > 0
+            ? Math.Min(asset.MaxWidth.Value, asset.OpenFullMax!.Value)
+            : asset.OpenFullMax ?? 0;
     }
 
     private async Task UploadThumbs(AssetId assetId, ImageOnDisk thumbCandidate, Size thumb, bool isOpen)

--- a/src/protagonist/Engine/Settings/EngineSettings.cs
+++ b/src/protagonist/Engine/Settings/EngineSettings.cs
@@ -1,9 +1,16 @@
 ﻿
+using DLCS.Core.Settings;
+
 namespace Engine.Settings;
 
 public class EngineSettings
 {
     public ImageIngestSettings? ImageIngest { get; set; }
+    
+    /// <summary>
+    /// The system maximum width value. Thumbnails will not be generated that exceed this.
+    /// </summary>
+    public int MaxWidth { get; set; } = SystemDefaults.MaxWidth;
 
     /// <summary>
     /// A collection of customer-specific overrides, keyed by customerId.


### PR DESCRIPTION
Resolves #1094 

Added new logic to use `maxWidth` and/or `openFullMax` in place of `maxUnauthorised` as this is now deprecated.

Update engine to handle new props - this controls what thumbnails are generated. Logic conforms to table in ADR: https://github.com/dlcs/protagonist/blob/develop/docs/adr/0010-replace-maxunauthorised.md#engine-1