### PR TITLE
Set missing ingesting/error prop on adjunct hydra output model

### DIFF
--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -812,7 +812,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
         adjunct.Origin.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://dlcs.digirati.io/adjuncts/99/1/PostAdjunct_CreatesHostedAdjunct/someAdjunctId");
-        
+        adjunct.Ingesting.Should().Be(true, "the adjunct was sent to engine for ingestion");
+        adjunct.Error.Should().BeNullOrEmpty("no errors yet");
         response.Headers.Location.Should()
             .Be(
                 $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/someAdjunctId");

--- a/src/protagonist/API/Converters/AdjunctConverter.cs
+++ b/src/protagonist/API/Converters/AdjunctConverter.cs
@@ -84,5 +84,7 @@ public static class AdjunctConverter
             Created = adjunct.Created,
             Finished = adjunct.Finished,
             Size = adjunct.Size,
+            Error = adjunct.Error,
+            Ingesting = adjunct.Ingesting
         };
 }


### PR DESCRIPTION
Fixes #1106 

Set newly created `error` and `ingesting` properties when converting to a Hydra output model for Adjuncts.

Included the props in the test.

`finished` handling will be done in #1077 - for now it will remain `now()`