### PR TITLE
Bump to localstack:4.13

### DIFF
--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -30,6 +30,8 @@ jobs:
         run: dotnet restore $SOLUTION
       - id: build-dotnet
         run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
+      - id: pre-pull-localstack
+        run: docker pull localstack/localstack:4.13
       - id: test-dotnet
         run: dotnet test $SOLUTION --filter 'Category!=Manual' --configuration $BUILD_CONFIG --no-restore --no-build --verbosity normal
 

--- a/compose/localstack/Dockerfile
+++ b/compose/localstack/Dockerfile
@@ -1,2 +1,2 @@
-FROM localstack/localstack
+FROM localstack/localstack:4.13
 COPY seed-resources.sh /etc/localstack/init/ready.d/seed-resources.sh

--- a/src/protagonist/Test.Helpers/Integration/LocalStackFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/LocalStackFixture.cs
@@ -49,7 +49,7 @@ public class LocalStackFixture : IAsyncLifetime
     {
         // Configure container binding to host port 0, which will use a random free port
         var localStackBuilder = new ContainerBuilder()
-            .WithImage("localstack/localstack:4.3")
+            .WithImage("localstack/localstack:4.13")
             .WithCleanUp(true)
             .WithLabel("protagonist_test", "True")
             .WithEnvironment("DEFAULT_REGION", "eu-west-1")


### PR DESCRIPTION
Previous version was running into issues in github actions.

The additional step to pre-pull the image was due to seeing the following in logs

> [testcontainers.org 00:00:27.32] failed to extract layer (application/vnd.docker.image.rootfs.diff.tar.gzip sha256:6446ac79eaeb1a2fcaa14312f02aeeddb4dd334b89b6d8243ac781f2edf710af) to overlayfs as "extract-218140170-xN9k sha256:96d7572f352de699ca61f6bcab25459a65bda7880a0dcdb712ece6a2f0a803db": failed to Lchown "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/68/fs/usr/local/bin/node" for UID 0, GID 0: lchown /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/68/fs/usr/local/bin/node: no such file or directory

Attempted pre-pulling way to rule out this being due to concurrent operations running.