### PR TITLE
Replace `maxUnauthorised` in Orchestrator

### DIFF
--- a/compose/docker-compose.orchestrator.yml
+++ b/compose/docker-compose.orchestrator.yml
@@ -11,6 +11,7 @@ services:
       - PROCESSOR_SELECTION_STRATEGY=ManualSelectionStrategy
       - PROCESSOR_MANUALSELECTIONSTRATEGY_JP2=GrokProcessor
       - MAX_SCALE=0
+      - MAX_PIXELS=0
     volumes:
       - $HOME\Docker\scratch:/home/cantaloupe/images/
 
@@ -28,6 +29,7 @@ services:
       - AWS_ACCESS_KEY_ID=${SS_AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${SS_AWS_SECRET_ACCESS_KEY}
       - MAX_SCALE=0
+      - MAX_PIXELS=0
     env_file:
       - .env
 

--- a/docs/adr/0011-orchestrator-proxy.md
+++ b/docs/adr/0011-orchestrator-proxy.md
@@ -1,0 +1,89 @@
+# Orchestrator Proxy Rules
+
+* Status: decided
+* Deciders: Tom Crane, Donald Gray
+* Date: 2026-02-20
+
+## Context and Problem Statement
+
+With the implementation of ADR [0010-replace-maxunauthorised](0010-replace-maxunauthorised.md) all images have an effective `maxWidth` value - either explicitly set or falling back to system default. 
+
+This protects the overall service and allows us to reject incoming image requests at the Orchestrator level before proxying them to downstream image-service. 
+
+Until now we have relied on the downstream image-service to apply size restrictions via whatever means they support. IIP Image supports [`MAX_CVT`](https://iipimage.sourceforge.io/documentation/server#configuration), which is the equivalent of `maxWidth`. Cantaloupe has [`max_pixels`](https://cantaloupe-project.github.io/manual/5.0/deployment.html#limiting) which is the equivalent of `maxArea`. We now have a single `maxWidth` property which maps directly to IIIF `maxWidth` - how do we enforce this limit at Orchestrator level without slowing down requests or altering image-serving behaviour?
+
+## Decision Drivers
+
+* Performance - we cannot slow down Orchestrator image handling.
+* Predictable behaviour between image servers.
+
+## Decision Outcome
+
+### Summary 
+
+Orchestrator will always rewrite the IIIF size parameter when proxying `/full/` or `/max/` size requests to specify the exact size. This will ensure we can consistently apply `maxWidth` behaviour without worrying about downstream image-server configuration (with the caveat that the image-server must be able to handle the potential `maxWidth` values).
+
+Orchestrator already interrogates all incoming image requests. To date it has checked incoming `full` region requests to see if they exceed `maxUnauthorised`, and all requests to determine which service to proxy them to (thumbs, special-server or image-server). This check is straightforward as we only need to know the incoming IIIF size parameter and image dimensions to make these decisions. However, we now need to calculate the size of the IIIF region parameter and include these in decision making. 
+
+Protagonist supports ImageApi v2.1 and v3.0. Both of these have slightly different supported image request parameters. We will implement "strict" and "lax" handling if Image requests in Orchestrator. The former will be the default, with the latter allowing us to avoid breaking changes upon release.
+
+> [!WARNING]
+> We have noted that version of Cantaloupe being used doesn't strictly follow some IIIF Image parameters so we will start with "strict" mode but may need to enable "lax".
+
+The rules for strict and lax are as below:
+
+**Strict**
+
+| ImageApiVersion | RequestSize  | Region         | ProxySize or Result                                               |
+| --------------- | ------------ | -------------- | ----------------------------------------------------------------- |
+| 2.1             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
+| 2.1             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
+| 3.0             | `/full/`     | *              | 400 BadRequest - `/full/` not valid                               |
+| *               | `/^full/`    | *              | 400 BadRequest - `/^full/` never valid                            |
+| 2.1             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`   |
+| 2.1             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
+| 3.0             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
+| 3.0             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
+| 2.1             | `/^max/`     | *              | 400 BadRequest - `^` not valid                                    |
+| 3.0             | `/^max/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
+| 3.0             | `/^max/`     | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`  |
+| 2.0             | Any with `^` | *              | 400 BadRequest - `^` not valid                                    |
+| *               | _other_      | lte `maxWidth` | Pass size through                                                 |
+| *               | _other_      | gt `maxWidth`  | 400 BadRequest - `^` not valid                                    |
+
+**Lax**
+
+The lax rules are identical to above, with the exception that we support `/full/` use for v3.0. i.e. we will still reject `^` for 2.0 requests.
+
+| ImageApiVersion | RequestSize  | Region         | ProxySize or Result                                               | Change from Strict   |
+| --------------- | ------------ | -------------- | ----------------------------------------------------------------- | -------------------- |
+| 2.1             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
+| 2.1             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
+| 3.0             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           | Treated like `/max/` |
+| 3.0             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` | Treated like `/max/` |
+| *               | `/^full/`    | *              | 400 BadRequest - `/^full/` never valid                            |                      |
+| 2.1             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`   |                      |
+| 2.1             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
+| 3.0             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
+| 3.0             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
+| 3.0             | `/^max/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
+| 3.0             | `/^max/`     | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`  |                      |
+| 2.0             | Any with `^` | *              |                                                                   |                      |
+| *               | _other_      | lte `maxWidth` | Pass size through                                                 |                      |
+| *               | _other_      | gt `maxWidth`  | 400 BadRequest - `^` not valid                                    |                      |
+
+### Pros and Cons
+
+#### Positive Consequences
+
+* Gives more control to Orchestrator, meaning we will have more consistent behaviour. Will afford changing downstream image-server without worrying about any potential 'quirks' affecting public requests, or whether they apply `maxArea` or `maxWidth` etc.
+* Allow rejection of images at Orchestrator level, less overall work done.
+* Will hopefully save image-server from doing calculations for `/full/` and `/max/` if we work out intended sizes upfront (will need proven via tests).
+* Should make cropping/sizes more predictable as we'll be doing more size calculation in Orchestrator using `iiif-net` lib (but not for _all_ sizes).
+
+#### Negative Consequences
+
+* Introduces more IIIF ImageRequest parsing logic to Orchestrator.
+* Doing more work per image request. This should all be quick calculations but overall it is still more work.
+* Not necessarily a negative but with this change we're updating core path functionality of Orchestrator that has been stable for a long time. Will need thorough testing!
+* Downstream image-server configuration needs to be able to handle any `maxWidth` specified by Orchestrator.

--- a/docs/adr/0011-orchestrator-proxy.md
+++ b/docs/adr/0011-orchestrator-proxy.md
@@ -21,7 +21,7 @@ Until now we have relied on the downstream image-service to apply size restricti
 
 ### Summary 
 
-Orchestrator will always rewrite the IIIF size parameter when proxying `/full/` or `/max/` size requests to specify the exact size. This will ensure we can consistently apply `maxWidth` behaviour without worrying about downstream image-server configuration (with the caveat that the image-server must be able to handle the potential `maxWidth` values).
+Orchestrator will always rewrite the IIIF size parameter when proxying `/full/`, `/max/` or `/!w,h/` size requests to specify the exact size. This will ensure we can consistently apply `maxWidth` behaviour without worrying about downstream image-server configuration (with the caveat that the image-server must be able to handle the potential `maxWidth` values).
 
 Orchestrator already interrogates all incoming image requests. To date it has checked incoming `full` region requests to see if they exceed `maxUnauthorised`, and all requests to determine which service to proxy them to (thumbs, special-server or image-server). This check is straightforward as we only need to know the incoming IIIF size parameter and image dimensions to make these decisions. However, we now need to calculate the size of the IIIF region parameter and include these in decision making. 
 
@@ -34,43 +34,47 @@ The rules for strict and lax are as below:
 
 **Strict**
 
-| ImageApiVersion | RequestSize  | Region         | ProxySize or Result                                               |
-| --------------- | ------------ | -------------- | ----------------------------------------------------------------- |
-| 2.1             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
-| 2.1             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
-| 3.0             | `/full/`     | *              | 400 BadRequest - `/full/` not valid                               |
-| *               | `/^full/`    | *              | 400 BadRequest - `/^full/` never valid                            |
-| 2.1             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`   |
-| 2.1             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
-| 3.0             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
-| 3.0             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |
-| 2.1             | `/^max/`     | *              | 400 BadRequest - `^` not valid                                    |
-| 3.0             | `/^max/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |
-| 3.0             | `/^max/`     | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`  |
-| 2.0             | Any with `^` | *              | 400 BadRequest - `^` not valid                                    |
-| *               | _other_      | lte `maxWidth` | Pass size through                                                 |
-| *               | _other_      | gt `maxWidth`  | 400 BadRequest - `^` not valid                                    |
+| ImageApiVersion | RequestSize                            | Region         | ProxySize or Result                                                |
+| --------------- | -------------------------------------- | -------------- | ------------------------------------------------------------------ |
+| 2.1             | `/full/`                               | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |
+| 2.1             | `/full/`                               | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |
+| 3.0             | `/full/`                               | *              | 400 BadRequest - `/full/` not valid                                |
+| *               | `/^full/`                              | *              | 400 BadRequest - `/^full/` never valid                             |
+| 2.1             | `/max/`                                | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`    |
+| 2.1             | `/max/`                                | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |
+| 3.0             | `/max/`                                | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |
+| 3.0             | `/max/`                                | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |
+| 2.1             | `/^max/`                               | *              | 400 BadRequest - `^` not valid                                     |
+| 3.0             | `/^max/`                               | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |
+| 3.0             | `/^max/`                               | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`   |
+| 2.0             | Any with `^`                           | *              | 400 BadRequest - `^` not valid                                     |
+| *               | `/!w,h/` where max(w,h) lte `maxWidth` | *              | `/w,h/` where w + h is calculated exact size                       |
+| *               | `/!w,h/` where max(w,h) gt `maxWidth`  | *              | `/w,h/` where w + h is the largest possible size within `maxWidth` |
+| *               | _other_                                | lte `maxWidth` | Pass size through                                                  |
+| *               | _other_                                | gt `maxWidth`  | 400 BadRequest - `^` not valid                                     |
 
 **Lax**
 
 The lax rules are identical to above, with the exception that we support `/full/` use for v3.0. i.e. we will still reject `^` for 2.0 requests.
 
-| ImageApiVersion | RequestSize  | Region         | ProxySize or Result                                               | Change from Strict   |
-| --------------- | ------------ | -------------- | ----------------------------------------------------------------- | -------------------- |
-| 2.1             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
-| 2.1             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
-| 3.0             | `/full/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           | Treated like `/max/` |
-| 3.0             | `/full/`     | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` | Treated like `/max/` |
-| *               | `/^full/`    | *              | 400 BadRequest - `/^full/` never valid                            |                      |
-| 2.1             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`   |                      |
-| 2.1             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
-| 3.0             | `/max/`      | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
-| 3.0             | `/max/`      | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth` |                      |
-| 3.0             | `/^max/`     | lte `maxWidth` | `/w,h/` where w + h is extracted region                           |                      |
-| 3.0             | `/^max/`     | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`  |                      |
-| 2.0             | Any with `^` | *              |                                                                   |                      |
-| *               | _other_      | lte `maxWidth` | Pass size through                                                 |                      |
-| *               | _other_      | gt `maxWidth`  | 400 BadRequest - `^` not valid                                    |                      |
+| ImageApiVersion | RequestSize                            | Region         | ProxySize or Result                                                | Change from Strict   |
+| --------------- | -------------------------------------- | -------------- | ------------------------------------------------------------------ | -------------------- |
+| 2.1             | `/full/`                               | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |                      |
+| 2.1             | `/full/`                               | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |                      |
+| 3.0             | `/full/`                               | lte `maxWidth` | `/w,h/` where w + h is extracted region                            | Treated like `/max/` |
+| 3.0             | `/full/`                               | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  | Treated like `/max/` |
+| *               | `/^full/`                              | *              | 400 BadRequest - `/^full/` never valid                             |                      |
+| 2.1             | `/max/`                                | lte `maxWidth` | `/w,h/` where w + h is extracted region scaled up to `maxWidth`    |                      |
+| 2.1             | `/max/`                                | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |                      |
+| 3.0             | `/max/`                                | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |                      |
+| 3.0             | `/max/`                                | gt `maxWidth`  | `/w,h/` where w + h is extracted region scaled down to `maxWidth`  |                      |
+| 3.0             | `/^max/`                               | lte `maxWidth` | `/w,h/` where w + h is extracted region                            |                      |
+| 3.0             | `/^max/`                               | gt `maxWidth`  | `/^w,h/` where w + h is extracted region scaled up to `maxWidth`   |                      |
+| 2.0             | Any with `^`                           | *              |                                                                    |                      |
+| *               | `/!w,h/` where max(w,h) lte `maxWidth` | *              | `/w,h/` where w + h is calculated exact size                       |
+| *               | `/!w,h/` where max(w,h) gt `maxWidth`  | *              | `/w,h/` where w + h is the largest possible size within `maxWidth` |
+| *               | _other_                                | lte `maxWidth` | Pass size through                                                  |                      |
+| *               | _other_                                | gt `maxWidth`  | 400 BadRequest - `^` not valid                                     |                      |
 
 ### Pros and Cons
 

--- a/docs/adr/readme.md
+++ b/docs/adr/readme.md
@@ -11,3 +11,4 @@
 9. [ElasticTranscoder Replacement](0008-et-replacement.md)
 10. [Engine Use Appetiser for Thumbs](0009-engine-appetiser-thumbs.md)
 11. [Replace `maxUnauthorised`](0010-replace-maxunauthorised.md)
+12. [Orchestrator Proxy Rules](0011-orchestrator-proxy.md)

--- a/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
+++ b/src/protagonist/CleanupHandler/AssetUpdatedHandler.cs
@@ -101,9 +101,9 @@ public class AssetUpdatedHandler(
                 }
             }
 
-            if (!Equals(assetAfter.Roles ?? string.Empty, assetBefore.Roles ?? string.Empty))
+            if (ShouldRemoveInfoJson(assetAfter, assetBefore))
             {
-                CleanupRolesChanged(assetAfter, s3Objects.foldersToRemove);
+                RemoveInfoJson(assetAfter, s3Objects.foldersToRemove);
             }
 
             if (s3Objects.objectsToRemove.Count > 0)
@@ -118,6 +118,16 @@ public class AssetUpdatedHandler(
 
             return true;
         }
+    }
+
+    // If a value has changed that can affect info.json we need to replace it
+    private static bool ShouldRemoveInfoJson(Asset assetAfter, Asset assetBefore)
+    {
+        var rolesChanged = !string.Equals(assetAfter.Roles ?? string.Empty, assetBefore.Roles ?? string.Empty,
+            StringComparison.OrdinalIgnoreCase);
+
+        var maxWidthChanged = (assetAfter.MaxWidth ?? 0) != (assetBefore.MaxWidth ?? 0);
+        return rolesChanged || maxWidthChanged;
     }
 
     private AssetUpdatedNotificationRequest? TryParseMessage(QueueMessage message)
@@ -140,20 +150,18 @@ public class AssetUpdatedHandler(
         }
     }
 
-    private static bool AssetStillIngesting(Asset assetAfter, Asset assetBefore)
-    {
-        return assetAfter.Ingesting == true && assetBefore.Finished > assetAfter.Finished;
-    }
-    
+    private static bool AssetStillIngesting(Asset assetAfter, Asset assetBefore) =>
+        assetAfter.Ingesting == true && assetBefore.Finished > assetAfter.Finished;
+
     private static bool NoCleanupRequired(QueueMessage message, Asset assetAfter, Asset assetBefore)
     {
         return !message.MessageAttributes.ContainsKey("engineNotified") &&
             (assetBefore.Roles ?? string.Empty) == (assetAfter.Roles ?? string.Empty);
     }
 
-    private void CleanupRolesChanged(Asset assetAfter, HashSet<ObjectInBucket> foldersToRemove)
+    private void RemoveInfoJson(Asset assetAfter, HashSet<ObjectInBucket> foldersToRemove)
     {
-        logger.LogDebug("{AssetId} changed role", assetAfter.Id);
+        logger.LogDebug("Deleting info.json files for {AssetId}", assetAfter.Id);
         var infoJsonRoot = storageKeyGenerator.GetInfoJsonRoot(assetAfter.Id);
         foldersToRemove.Add(infoJsonRoot);
     }
@@ -339,7 +347,7 @@ public class AssetUpdatedHandler(
 
     private async Task<List<ObjectInBucket>> ThumbsToBeDeleted(Asset assetAfter)
     {
-        var thumbSizes = await thumbRepository.GetAllSizes(assetAfter.Id) ?? new List<int[]>();
+        var thumbSizes = await thumbRepository.GetAllSizes(assetAfter.Id) ?? [];
         var thumbsBucketKeys = await bucketReader.GetMatchingKeys(storageKeyGenerator.GetThumbnailsRoot(assetAfter.Id));
 
         var thumbsBucketSizes = GetThumbSizesFromKeys(thumbsBucketKeys);

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -161,8 +161,7 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesOriginal_WhenFileChannelRemoved()
     {
         // Arrange
-        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile],
-            []);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile], []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -209,9 +208,7 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesTimebasedAssets_WhenTimebasedChannelRemoved()
     {
         // Arrange
-        var requestDetails = CreateMinimalRequestDetails(
-            [imageDeliveryChannelTimebased], [],
-            "video/mp3");
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelTimebased], [], "video/mp3");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -248,8 +245,7 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesThumbnailAssets_WhenThumbnailChannelRemoved()
     {
         // Arrange
-        var requestDetails = CreateMinimalRequestDetails(
-            [imageDeliveryChannelThumbnail], []);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelThumbnail], []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -364,8 +360,7 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesValidPaths_WhenImageChannelRemoved()
     {
         // Arrange
-        var requestDetails = CreateMinimalRequestDetails(
-            [imageDeliveryChannelUseOriginalImage], []);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelUseOriginalImage], []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -395,7 +390,7 @@ public class AssetUpdatedHandlerTests
             imageDeliveryChannelUseOriginalImage,
             imageDeliveryChannelFile
         };
-        
+
         var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, [imageDeliveryChannelFile]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
@@ -438,8 +433,7 @@ public class AssetUpdatedHandlerTests
             DeliveryChannelPolicyId = 34534
         };
 
-        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile],
-            [fileDeliveryChannelAfter]);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile], [fileDeliveryChannelAfter]);
     
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -594,7 +588,7 @@ public class AssetUpdatedHandlerTests
     }
     
     [Fact]
-    public async Task Handle_DoesNothing_WhenTimebasedChannelModfiedWithInvalidPresetDetails()
+    public async Task Handle_DoesNothing_WhenTimebasedChannelModifiedWithInvalidPresetDetails()
     {
         // Arrange
         var imageDeliveryChannelAfter = new ImageDeliveryChannel
@@ -636,7 +630,7 @@ public class AssetUpdatedHandlerTests
     }
     
         [Fact]
-    public async Task Handle_DeletesSomeThumbnailAssets_WhenThumbnailChannelModifed()
+    public async Task Handle_DeletesSomeThumbnailAssets_WhenThumbnailChannelModified()
     {
         // Arrange
         var imageDeliveryChannelsAfter = new List<ImageDeliveryChannel>
@@ -926,8 +920,8 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
+            [imageDeliveryChannelTimebased],
+            [imageDeliveryChannelAfter],
             "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
@@ -954,7 +948,7 @@ public class AssetUpdatedHandlerTests
         // Arrange
         var imageDeliveryChannelsAfter = new List<ImageDeliveryChannel>
         {
-            new ()
+            new()
             {
                 Channel = AssetDeliveryChannels.Thumbnails,
                 Id = 356367,
@@ -969,8 +963,7 @@ public class AssetUpdatedHandlerTests
             }
         };
 
-        var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelThumbnail }, imageDeliveryChannelsAfter);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelThumbnail], imageDeliveryChannelsAfter);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -1049,7 +1042,7 @@ public class AssetUpdatedHandlerTests
     }
     
     [Fact]
-    public async Task Handle_DeletesValidPaths_WhenImageChannelHasUpdatedUseOrginalPolicy()
+    public async Task Handle_DeletesValidPaths_WhenImageChannelHasUpdatedUseOriginalPolicy()
     {
         // Arrange
         var imageDeliveryChannelUseOriginalUpdated = new ImageDeliveryChannel
@@ -1148,7 +1141,7 @@ public class AssetUpdatedHandlerTests
             .MustNotHaveHappened();
     }
     
-    // maxWidth - 0 means unst, so equivalent to null
+    // maxWidth - 0 means unset, so equivalent to null
     
     [Theory]
     [InlineData(null, 512)]

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -38,7 +38,7 @@ public class AssetUpdatedHandlerTests
     {
         Id = 567587,
         Channel = AssetDeliveryChannels.Image,
-        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        DeliveryChannelPolicy = new DeliveryChannelPolicy
         {
             Id = KnownDeliveryChannelPolicies.ImageUseOriginal,
             Channel = AssetDeliveryChannels.Image,
@@ -52,7 +52,7 @@ public class AssetUpdatedHandlerTests
     {
         Id = 58465678,
         Channel = AssetDeliveryChannels.Image,
-        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        DeliveryChannelPolicy = new DeliveryChannelPolicy
         {
             Id = KnownDeliveryChannelPolicies.ImageDefault,
             Channel = AssetDeliveryChannels.Image,
@@ -66,7 +66,7 @@ public class AssetUpdatedHandlerTests
     {
         Id = 56785678,
         Channel = AssetDeliveryChannels.File,
-        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        DeliveryChannelPolicy = new DeliveryChannelPolicy
         {
             Id = KnownDeliveryChannelPolicies.FileNone,
             Channel = AssetDeliveryChannels.File,
@@ -80,7 +80,7 @@ public class AssetUpdatedHandlerTests
     {
         Channel = AssetDeliveryChannels.Thumbnails,
         Id = 34256,
-        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        DeliveryChannelPolicy = new DeliveryChannelPolicy
         {
             Channel = AssetDeliveryChannels.Thumbnails,
             Id = KnownDeliveryChannelPolicies.ThumbsDefault,
@@ -94,7 +94,7 @@ public class AssetUpdatedHandlerTests
     {
         Channel = AssetDeliveryChannels.Timebased,
         Id = 356367,
-        DeliveryChannelPolicy = new DeliveryChannelPolicy()
+        DeliveryChannelPolicy = new DeliveryChannelPolicy
         {
             Channel = AssetDeliveryChannels.Timebased,
             Created = DateTime.MinValue,
@@ -117,10 +117,7 @@ public class AssetUpdatedHandlerTests
                 }
             },
             ImageFolderTemplate = "/nas/{customer}/{space}/{image-dir}/{image}.jp2",
-            AssetModifiedSettings = new AssetModifiedSettings()
-            {
-                DryRun = false
-            }
+            AssetModifiedSettings = new AssetModifiedSettings { DryRun = false }
         };
         storageKeyGenerator = new S3StorageKeyGenerator(Options.Create(handlerSettings.AWS));
         bucketWriter = A.Fake<IBucketWriter>();
@@ -129,26 +126,9 @@ public class AssetUpdatedHandlerTests
         assetMetadataRepository = A.Fake<IAssetApplicationMetadataRepository>();
         thumbRepository = A.Fake<IThumbRepository>();
         cleanupHandlerAssetRepository = A.Fake<ICleanupHandlerAssetRepository>();
-        
-        A.CallTo(() => thumbRepository.GetAllSizes(A<AssetId>._)).Returns(new List<int[]>()
-        {
-            new[]
-            {
-                50, 100
-            },
-            new[]
-            {
-                100, 200
-            },
-            new[]
-            {
-                200, 400
-            },
-            new[]
-            {
-                516, 1024
-            }
-        });
+
+        A.CallTo(() => thumbRepository.GetAllSizes(A<AssetId>._))
+            .Returns([[50, 100], [100, 200], [200, 400], [516, 1024]]);
     }
 
     private AssetUpdatedHandler GetSut()
@@ -181,9 +161,8 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesOriginal_WhenFileChannelRemoved()
     {
         // Arrange
-        var requestDetails = CreateMinimalRequestDetails(new List<ImageDeliveryChannel>() { imageDeliveryChannelFile },
-            new List<ImageDeliveryChannel>(),
-            string.Empty, string.Empty);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile],
+            []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -211,8 +190,7 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore,
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -232,14 +210,14 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased }, new List<ImageDeliveryChannel>(),
-            string.Empty, string.Empty, "video/mp3");
+            [imageDeliveryChannelTimebased], [],
+            "video/mp3");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
         
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new []{ "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key" });
+            .Returns(["1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key"]);
 
         // Act
         var sut = GetSut();
@@ -271,8 +249,7 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelThumbnail }, new List<ImageDeliveryChannel>(),
-            string.Empty, string.Empty);
+            [imageDeliveryChannelThumbnail], []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -281,10 +258,9 @@ public class AssetUpdatedHandlerTests
                     A<CancellationToken>._))
             .Returns(true);
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new[]
-            {
+            .Returns([
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg"
-            });
+            ]);
 
         // Act
         var sut = GetSut();
@@ -311,8 +287,7 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore,
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -321,11 +296,10 @@ public class AssetUpdatedHandlerTests
                     A<CancellationToken>._))
             .Returns(true);
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new[]
-            {
+            .Returns([
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
                 "1/99/foo/stuff/2048.jpg"
-            });
+            ]);
 
         // Act
         var sut = GetSut();
@@ -353,8 +327,7 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore,
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -363,33 +336,14 @@ public class AssetUpdatedHandlerTests
                     A<CancellationToken>._))
             .Returns(true);
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new[]
-            {
+            .Returns([
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
                 "1/99/foo/stuff/2048.jpg"
-            });
-        
-        A.CallTo(() => thumbRepository.GetAllSizes(A<AssetId>._)).Returns(new List<int[]>()
-        {
-            new[]
-            {
-                100, 50
+            ]);
 
-            },
-            new[]
-            {
-                200, 100
-
-            },
-            new[]
-            {
-                400, 200
-            },
-            new[]
-            {
-                1024, 516
-            }
-        });
+        A.CallTo(() => thumbRepository.GetAllSizes(A<AssetId>._)).Returns([
+            [100, 50], [200, 100], [400, 200], [1024, 516]
+        ]);
 
         // Act
         var sut = GetSut();
@@ -411,8 +365,7 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage }, new List<ImageDeliveryChannel>(),
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage], []);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -443,8 +396,7 @@ public class AssetUpdatedHandlerTests
             imageDeliveryChannelFile
         };
         
-        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, new List<ImageDeliveryChannel>() { imageDeliveryChannelFile },
-            string.Empty, string.Empty);
+        var requestDetails = CreateMinimalRequestDetails(imageDeliveryChannelsBefore, [imageDeliveryChannelFile]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -460,7 +412,7 @@ public class AssetUpdatedHandlerTests
             .MustHaveHappened();
         A.CallTo(() =>
                 bucketWriter.DeleteFromBucket(
-                    A<ObjectInBucket[]>.That.Matches(o => o.Any(o => o.Key == "1/99/foo/original"))))
+                    A<ObjectInBucket[]>.That.Matches(o => o.Any(b => b.Key == "1/99/foo/original"))))
             .MustNotHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
@@ -471,11 +423,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DoesNotRemoveAnything_WhenFileChannelModified()
     {
         // Arrange
-        var fileDeliveryChannelAfter = new ImageDeliveryChannel()
+        var fileDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Id = 34512245,
             Channel = AssetDeliveryChannels.File,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Id = 34534,
                 Channel = AssetDeliveryChannels.File,
@@ -486,9 +438,8 @@ public class AssetUpdatedHandlerTests
             DeliveryChannelPolicyId = 34534
         };
 
-        var requestDetails = CreateMinimalRequestDetails(new List<ImageDeliveryChannel> { imageDeliveryChannelFile },
-            new List<ImageDeliveryChannel>() { fileDeliveryChannelAfter },
-            string.Empty, string.Empty);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile],
+            [fileDeliveryChannelAfter]);
     
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -507,11 +458,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DeletesUnneededTimebasedAssets_WhenTimebasedChannelModified()
     {
         // Arrange
-        var imageDeliveryChannelAfter = new ImageDeliveryChannel()
+        var imageDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Channel = AssetDeliveryChannels.Timebased,
             Id = 152445,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Id = 8239,
                 Channel = AssetDeliveryChannels.Timebased,
@@ -522,10 +473,8 @@ public class AssetUpdatedHandlerTests
             DeliveryChannelPolicyId = 8239
         };
 
-        var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
-            string.Empty, string.Empty, "video/*");
+        var requestDetails =
+            CreateMinimalRequestDetails([imageDeliveryChannelTimebased], [imageDeliveryChannelAfter], "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -535,9 +484,11 @@ public class AssetUpdatedHandlerTests
             { "webm-policy", new ("", "some-webm-preset", "oga") },
             { "oga-policy", new ("", "some-oga-preset", "webm") }
         });
-        
-        A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new []{ "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key", "1/99/foo/full/full/max/max/0/default.webm", "1/99/foo/full/full/max/max/0/default.oga" });
+
+        A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._)).Returns([
+            "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key",
+            "1/99/foo/full/full/max/max/0/default.webm", "1/99/foo/full/full/max/max/0/default.oga"
+        ]);
 
         // Act
         var sut = GetSut();
@@ -567,11 +518,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DoesNothing_WhenTimebasedChannelUpdatedWithInvalidPreset()
     {
         // Arrange
-        var imageDeliveryChannelAfter = new ImageDeliveryChannel()
+        var imageDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Channel = AssetDeliveryChannels.Timebased,
             Id = 23456,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Id = 8239,
                 Channel = AssetDeliveryChannels.Timebased,
@@ -589,9 +540,8 @@ public class AssetUpdatedHandlerTests
         });
 
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
-            string.Empty, string.Empty, "video/*");
+            [imageDeliveryChannelTimebased],
+            [imageDeliveryChannelAfter], "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -610,11 +560,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_ReturnsFalse_WhenTimebasedChannelUpdatedWithNoAvPresets()
     {
         // Arrange
-        var imageDeliveryChannelAfter = new ImageDeliveryChannel()
+        var imageDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Channel = AssetDeliveryChannels.Timebased,
             Id = 23456,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Id = 8239,
                 Channel = AssetDeliveryChannels.Timebased,
@@ -626,9 +576,9 @@ public class AssetUpdatedHandlerTests
         };
         
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
-            string.Empty, string.Empty, "video/*");
+            [imageDeliveryChannelTimebased],
+            [imageDeliveryChannelAfter],
+            "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -647,11 +597,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DoesNothing_WhenTimebasedChannelModfiedWithInvalidPresetDetails()
     {
         // Arrange
-        var imageDeliveryChannelAfter = new ImageDeliveryChannel()
+        var imageDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Channel = AssetDeliveryChannels.Timebased,
             Id = 345634,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Channel = AssetDeliveryChannels.Timebased,
                 Id = 8239,
@@ -663,9 +613,9 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
-            string.Empty, string.Empty, "video/*");
+            [imageDeliveryChannelTimebased],
+            [imageDeliveryChannelAfter],
+            "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -691,11 +641,11 @@ public class AssetUpdatedHandlerTests
         // Arrange
         var imageDeliveryChannelsAfter = new List<ImageDeliveryChannel>
         {
-            new ()
+            new()
             {
                 Channel = AssetDeliveryChannels.Thumbnails,
                 Id = 42356,
-                DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                DeliveryChannelPolicy = new DeliveryChannelPolicy
                 {
                     Id = 35467,
                     Channel = AssetDeliveryChannels.Thumbnails,
@@ -707,8 +657,7 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelThumbnail }, imageDeliveryChannelsAfter,
-            string.Empty, string.Empty);
+            [imageDeliveryChannelThumbnail], imageDeliveryChannelsAfter);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -717,11 +666,10 @@ public class AssetUpdatedHandlerTests
                     A<CancellationToken>._))
             .Returns(true);
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new[]
-            {
+            .Returns([
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
                 "1/99/foo/stuff/2048.jpg" , "1/99/full/100,200/0/default.jpg"
-            });
+            ]);
 
         // Act
         var sut = GetSut();
@@ -753,8 +701,7 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelUseOriginalImage }, new List<ImageDeliveryChannel> { imageDeliveryChannelDefaultImage },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage], [imageDeliveryChannelDefaultImage]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -776,8 +723,7 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelDefaultImage }, new List<ImageDeliveryChannel> { imageDeliveryChannelUseOriginalImage },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelDefaultImage], [imageDeliveryChannelUseOriginalImage]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -799,9 +745,8 @@ public class AssetUpdatedHandlerTests
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelUseOriginalImage },
-            new List<ImageDeliveryChannel> { imageDeliveryChannelDefaultImage, imageDeliveryChannelFile },
-            string.Empty, string.Empty);
+            [imageDeliveryChannelUseOriginalImage],
+            [imageDeliveryChannelDefaultImage, imageDeliveryChannelFile]);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -823,11 +768,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DoesNotRemoveAnything_WhenFilePolicyUpdated()
     {
         // Arrange
-        var fileDeliveryChannelAfter = new ImageDeliveryChannel()
+        var fileDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Id = 56785678,
             Channel = AssetDeliveryChannels.File,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Id = KnownDeliveryChannelPolicies.FileNone,
                 Channel = AssetDeliveryChannels.File,
@@ -838,9 +783,8 @@ public class AssetUpdatedHandlerTests
             DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.FileNone
         };
 
-        var requestDetails = CreateMinimalRequestDetails(new List<ImageDeliveryChannel> { imageDeliveryChannelFile },
-            new List<ImageDeliveryChannel>() { fileDeliveryChannelAfter },
-            string.Empty, string.Empty);
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile],
+            [fileDeliveryChannelAfter]);
     
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -877,8 +821,7 @@ public class AssetUpdatedHandlerTests
         // Get request and simulate 'before' asset having been ingested prior to DCP updating
         var requestDetails = CreateMinimalRequestDetails(
             [imageDeliveryChannelTimebased],
-            [imageDeliveryChannelAfter],
-            string.Empty, string.Empty, "video/*",
+            [imageDeliveryChannelAfter], "video/*",
             before => before.Finished = DateTime.UtcNow);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
@@ -891,7 +834,10 @@ public class AssetUpdatedHandlerTests
         });
 
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new []{ "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key", "1/99/foo/full/full/max/max/0/default.webm", "1/99/foo/full/full/max/max/0/default.oga" });
+            .Returns([
+                "1/99/foo/full/full/max/max/0/default.mp4", "1/99/foo/some/other/key",
+                "1/99/foo/full/full/max/max/0/default.webm", "1/99/foo/full/full/max/max/0/default.oga"
+            ]);
 
         // Act
         var sut = GetSut();
@@ -940,7 +886,7 @@ public class AssetUpdatedHandlerTests
         var requestDetails = CreateMinimalRequestDetails(
             [imageDeliveryChannelTimebased],
             [imageDeliveryChannelAfter],
-            string.Empty, string.Empty, "video/*", before => before.Finished = DateTime.UtcNow);
+            "video/*", before => before.Finished = DateTime.UtcNow);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -964,11 +910,11 @@ public class AssetUpdatedHandlerTests
     public async Task Handle_DoesNothing_WhenTimebasedPolicyUpdatedWithInvalidPresetDetails()
     {
         // Arrange
-        var imageDeliveryChannelAfter = new ImageDeliveryChannel()
+        var imageDeliveryChannelAfter = new ImageDeliveryChannel
         {
             Channel = AssetDeliveryChannels.Timebased,
             Id = 356367,
-            DeliveryChannelPolicy = new DeliveryChannelPolicy()
+            DeliveryChannelPolicy = new DeliveryChannelPolicy
             {
                 Channel = AssetDeliveryChannels.Timebased,
                 Id = KnownDeliveryChannelPolicies.AvDefaultVideo,
@@ -982,7 +928,7 @@ public class AssetUpdatedHandlerTests
         var requestDetails = CreateMinimalRequestDetails(
             new List<ImageDeliveryChannel>() { imageDeliveryChannelTimebased },
             new List<ImageDeliveryChannel>() { imageDeliveryChannelAfter },
-            string.Empty, string.Empty, "video/*");
+            "video/*");
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -1024,8 +970,7 @@ public class AssetUpdatedHandlerTests
         };
 
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel> { imageDeliveryChannelThumbnail }, imageDeliveryChannelsAfter,
-            string.Empty, string.Empty);
+            new List<ImageDeliveryChannel> { imageDeliveryChannelThumbnail }, imageDeliveryChannelsAfter);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -1034,11 +979,10 @@ public class AssetUpdatedHandlerTests
                     A<CancellationToken>._))
             .Returns(true);
         A.CallTo(() => bucketReader.GetMatchingKeys(A<ObjectInBucket>._))
-            .Returns(new[]
-            {
+            .Returns([
                 "1/99/foo/stuff/100.jpg", "1/99/foo/stuff/200.jpg", "1/99/foo/stuff/400.jpg", "1/99/foo/stuff/1024.jpg",
                 "1/99/foo/stuff/2048.jpg", "1/99/full/100,200/0/default.jpg"
-            });
+            ]);
 
         // Act
         var sut = GetSut();
@@ -1087,7 +1031,6 @@ public class AssetUpdatedHandlerTests
         var requestDetails = CreateMinimalRequestDetails(
             [imageDeliveryChannelDefaultImage],
             [imageDeliveryChannelDefaultUpdated],
-            string.Empty, string.Empty,
             customiseAssetBefore: before => before.Finished = DateTime.UtcNow);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
@@ -1127,7 +1070,6 @@ public class AssetUpdatedHandlerTests
         var requestDetails = CreateMinimalRequestDetails(
             [imageDeliveryChannelUseOriginalImage], 
             [imageDeliveryChannelUseOriginalUpdated],
-            string.Empty, string.Empty,
             customiseAssetBefore: before => before.Finished = DateTime.UtcNow);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
@@ -1144,19 +1086,24 @@ public class AssetUpdatedHandlerTests
             .MustHaveHappened();
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
-    
+
+    #region InfoJson
+
     // roles
     
     [Theory]
     [InlineData("", "new role")]
     [InlineData(null, "new role")]
     [InlineData("old role", null)]
+    [InlineData("old role", "")]
+    [InlineData("old role", "new role")]
     public async Task Handle_DeletesInfoJson_WhenRolesChanged(string? rolesBefore, string? rolesAfter)
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage }, new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
-            string.Empty, "new role");
+            [imageDeliveryChannelUseOriginalImage], [imageDeliveryChannelUseOriginalImage],
+            customiseAssetBefore: asset => asset.Roles = rolesBefore,
+            customiseAssetAfter: asset => asset.Roles = rolesAfter);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -1167,21 +1114,24 @@ public class AssetUpdatedHandlerTests
         
         // Assert
         response.Should().BeTrue();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
         A.CallTo(() =>
-                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
-        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._)).MustHaveHappened();
+                bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._))
+            .MustHaveHappened();
     }
     
     [Theory]
     [InlineData("", null)]
     [InlineData(null, "")]
     [InlineData(null, null)]
-    public async Task Handle_DeletesInfoJson_WhenRolesChangedBothNullOrEmpty(string? rolesBefore, string? rolesAfter)
+    [InlineData("", "")]
+    public async Task Handle_DoesNotDeleteInfoJson_WhenRolesChangedBothNullOrEmpty(string? rolesBefore, string? rolesAfter)
     {
         // Arrange
         var requestDetails = CreateMinimalRequestDetails(
-            new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage }, new List<ImageDeliveryChannel>() { imageDeliveryChannelUseOriginalImage },
-            rolesBefore, rolesAfter);
+            [imageDeliveryChannelUseOriginalImage], [imageDeliveryChannelUseOriginalImage],
+            customiseAssetBefore: asset => asset.Roles = rolesBefore,
+            customiseAssetAfter: asset => asset.Roles = rolesAfter);
 
         A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
             .Returns(requestDetails.assetAfter);
@@ -1192,21 +1142,83 @@ public class AssetUpdatedHandlerTests
         
         // Assert
         response.Should().BeTrue();
-        A.CallTo(() =>
-            bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
-        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._)).MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() => 
+                bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._))
+            .MustNotHaveHappened();
     }
+    
+    // maxWidth - 0 means unst, so equivalent to null
+    
+    [Theory]
+    [InlineData(null, 512)]
+    [InlineData(0, 512)]
+    [InlineData(1024, 512)]
+    [InlineData(512, null)]
+    [InlineData(512, 0)]
+    public async Task Handle_DeletesInfoJson_WhenMaxWidthChanged(int? maxWidthBefore, int? maxWidthAfter)
+    {
+        // Arrange
+        var requestDetails = CreateMinimalRequestDetails(
+            [imageDeliveryChannelUseOriginalImage], [imageDeliveryChannelUseOriginalImage],
+            customiseAssetBefore: asset => asset.MaxWidth = maxWidthBefore,
+            customiseAssetAfter: asset => asset.MaxWidth = maxWidthAfter);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() =>
+                bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._))
+            .MustHaveHappened();
+    }
+    
+    [Theory]
+    [InlineData(0, null)]
+    [InlineData(0, 0)]
+    [InlineData(null, 0)]
+    [InlineData(512, 512)]
+    public async Task Handle_DoesNotDeleteInfoJson_WhenMaxWidthNotChanged(int? maxWidthBefore, int? maxWidthAfter)
+    {
+        // Arrange
+        var requestDetails = CreateMinimalRequestDetails(
+            [imageDeliveryChannelUseOriginalImage], [imageDeliveryChannelUseOriginalImage],
+            customiseAssetBefore: asset => asset.MaxWidth = maxWidthBefore,
+            customiseAssetAfter: asset => asset.MaxWidth = maxWidthAfter);
+
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns(requestDetails.assetAfter);
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+        A.CallTo(() => 
+                bucketWriter.DeleteFolder(A<ObjectInBucket>.That.Matches(o => o.Key == "1/99/foo/info/"), A<bool>._))
+            .MustNotHaveHappened();
+    }
+    
+    #endregion
 
     private (QueueMessage queueMessage, Asset assetAfter) CreateMinimalRequestDetails(
         List<ImageDeliveryChannel> imageDeliveryChannelsBefore,
-        List<ImageDeliveryChannel> imageDeliveryChannelsAfter, string? rolesBefore, string? rolesAfter,
-        string mediaType = "image/jpg", Action<Asset>? customiseAssetBefore = null)
+        List<ImageDeliveryChannel> imageDeliveryChannelsAfter,
+        string mediaType = "image/jpeg", Action<Asset>? customiseAssetBefore = null,
+        Action<Asset>? customiseAssetAfter = null)
     {
         var assetBefore = new Asset
         {
             Id = new AssetId(1, 99, "foo"),
             ImageDeliveryChannels = imageDeliveryChannelsBefore,
-            Roles = rolesBefore,
             MediaType = mediaType
         };
         customiseAssetBefore?.Invoke(assetBefore);
@@ -1215,9 +1227,9 @@ public class AssetUpdatedHandlerTests
         {
             Id = new AssetId(1, 99, "foo"),
             ImageDeliveryChannels = imageDeliveryChannelsAfter,
-            Roles = rolesAfter,
             MediaType = mediaType
         };
+        customiseAssetAfter?.Invoke(assetAfter);
 
         var cleanupRequest = new AssetUpdatedNotificationRequest
         {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetTests.cs
@@ -10,23 +10,18 @@ namespace DLCS.Model.Tests.Assets;
 public class AssetTests
 {
     [Theory]
-    [InlineData(null, 1)]
-    [InlineData("", 2)]
-    [InlineData(" ", 1)]
-    [InlineData("role", 0)]
-    [InlineData("role", 1)]
-    [InlineData("role", -1)]
-    [InlineData("more,roles", -5)]
-    public void RequiresAuth_True_IfHaveRolesOrMaxUnauthorised(string roles, int maxUnauthorised)
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    [InlineData("role", true)]
+    [InlineData("more,roles", true)]
+    public void HasRoles_True_IfHaveRoles(string roles, bool expected)
     {
         // Arrange
-        var asset = new Asset {Roles = roles, MaxUnauthorised = maxUnauthorised};
-        
-        // Act
-        var actual = asset.RequiresAuth;
+        var asset = new Asset { Roles = roles };
         
         // Assert
-        actual.Should().BeTrue();
+        asset.HasRoles.Should().Be(expected);
     }
 
     [Fact]
@@ -58,7 +53,7 @@ public class AssetTests
     [Fact]
     public void Roles_Convert_From_List()
     {
-        var asset = new Asset { RolesList = new[] { "a", "b", "c" } };
+        var asset = new Asset { RolesList = ["a", "b", "c"] };
         var expected = "a,b,c";
         asset.Roles.Should().Be(expected);
     }
@@ -74,7 +69,7 @@ public class AssetTests
     [Fact]
     public void Tags_Convert_From_List()
     {
-        var asset = new Asset { TagsList = new[] { "a", "b", "c" } };
+        var asset = new Asset { TagsList = ["a", "b", "c"] };
         var expected = "a,b,c";
         asset.Tags.Should().Be(expected);
     }
@@ -87,20 +82,20 @@ public class AssetTests
         {
             Reference1 = "someReference",
             Reference2 = "ref2",
-            ImageDeliveryChannels =new List<ImageDeliveryChannel>()
+            ImageDeliveryChannels =new List<ImageDeliveryChannel>
             {
                 new()
                 {
                     DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ImageDefault,
                     Channel = AssetDeliveryChannels.Image,
-                    DeliveryChannelPolicy = new DeliveryChannelPolicy()
+                    DeliveryChannelPolicy = new DeliveryChannelPolicy
                     {
                         Id = KnownDeliveryChannelPolicies.ImageDefault,
                         Channel = AssetDeliveryChannels.Image
                     }
                 }
             },
-            AssetApplicationMetadata = new List<AssetApplicationMetadata>()
+            AssetApplicationMetadata = new List<AssetApplicationMetadata>
             {
                 new()
                 {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -16,13 +16,13 @@ public class AssetXTests
     ];
     
     [Fact]
-    public void GetAvailableThumbSizes_Correct_MaxUnauthorisedNoRoles()
+    public void GetAvailableThumbSizes_Correct_MaxWidthNoRoles()
     {
-        // Arrange
-        var asset = new Asset { Width = 5000, Height = 2500, MaxUnauthorised = 500 };
+        // Thumbs of 500 or less are open
+        var asset = new Asset { Width = 5000, Height = 2500, MaxWidth = 500 };
 
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
         sizes.Open.Should().BeEquivalentTo(new List<int[]>
@@ -38,15 +38,15 @@ public class AssetXTests
     }
     
     [Theory]
-    [InlineData(-1)]
+    [InlineData(null)]
     [InlineData(0)]
-    public void GetAvailableThumbSizes_Correct_IfRolesNoMaxUnauthorised(int maxUnauthorised)
+    public void GetAvailableThumbSizes_Correct_IfRolesNoOpenFullMax(int? openFullMax)
     {
-        // Arrange
-        var asset = new Asset { Width = 5000, Height = 2500, Roles = "GoodGuys", MaxUnauthorised = maxUnauthorised };
+        // No thumb sizes are open
+        var asset = new Asset { Width = 5000, Height = 2500, Roles = "GoodGuys", OpenFullMax = openFullMax };
         
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
         sizes.Open.Should().BeEmpty();
@@ -60,13 +60,13 @@ public class AssetXTests
     }
     
     [Fact]
-    public void GetAvailableThumbSizes_Correct_IfRolesMaxUnauthorised()
+    public void GetAvailableThumbSizes_Correct_IfRolesOpenFullMax()
     {
-        // Arrange
-        var asset = new Asset { Width = 2500, Height = 5000, Roles = "GoodGuys", MaxUnauthorised = 399 };
+        // Only thumbs 399px and below are available
+        var asset = new Asset { Width = 2500, Height = 5000, Roles = "GoodGuys", OpenFullMax = 399 };
         
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
         sizes.Open.Should().BeEquivalentTo(new List<int[]>
@@ -88,7 +88,7 @@ public class AssetXTests
         var asset = new Asset { Width = 300, Height = 150 };
         
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParameters);
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
         sizes.Open.Should().BeEquivalentTo(new List<int[]>
@@ -104,7 +104,7 @@ public class AssetXTests
     public void GetAvailableThumbSizes_HandlesNonConfinedSizeParameters_ExcludingDuplicates()
     {
         // Arrange
-        var asset = new Asset { Width = 5000, Height = 2500, MaxUnauthorised = 500 };
+        var asset = new Asset { Width = 5000, Height = 2500, MaxWidth = 500 };
         var sizeParametersWithNotConfined = new List<SizeParameter>
         {
             SizeParameter.Parse("800,"), // == 800,400
@@ -114,12 +114,34 @@ public class AssetXTests
         };
 
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined);
+        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined, 5000);
         
         // Assert
         sizes.Open.Should().BeEquivalentTo(new List<int[]>
         {
             new[] { 400, 200 },
+        });
+        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 800, 400 },
+        });
+    }
+    
+    [Fact]
+    public void GetAvailableThumbSizes_ObeySystemMaxWidth()
+    {
+        // Thumbs of 500 or less are open as maxWidth is smaller than asset maxWidth
+        var asset = new Asset { Width = 5000, Height = 2500, MaxWidth = 5000 };
+
+        // Act
+        var sizes = asset.GetAvailableThumbSizes(sizeParameters, 500);
+        
+        // Assert
+        sizes.Open.Should().BeEquivalentTo(new List<int[]>
+        {
+            new[] { 400, 200 },
+            new[] { 200, 100 },
+            new[] { 100, 50 },
         });
         sizes.Auth.Should().BeEquivalentTo(new List<int[]>
         {
@@ -156,7 +178,7 @@ public class AssetXTests
         };
 
         // Act
-        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined);
+        var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined, 4000);
         
         // Assert
         sizes.IsEmpty().Should().Be(ignored, reason);

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -25,16 +25,8 @@ public class AssetXTests
         var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
-        sizes.Open.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 400, 200 },
-            new[] { 200, 100 },
-            new[] { 100, 50 },
-        });
-        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 800, 400 },
-        });
+        sizes.Open.Should().BeEquivalentTo((List<int[]>)[[400, 200], [200, 100], [100, 50]]);
+        sizes.Auth.Should().BeEquivalentTo((List<int[]>)[[800, 400]]);
     }
     
     [Theory]
@@ -50,13 +42,7 @@ public class AssetXTests
         
         // Assert
         sizes.Open.Should().BeEmpty();
-        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 800, 400 },
-            new[] { 400, 200 },
-            new[] { 200, 100 },
-            new[] { 100, 50 },
-        });
+        sizes.Auth.Should().BeEquivalentTo((List<int[]>)[[800, 400], [400, 200], [200, 100], [100, 50]]);
     }
     
     [Fact]
@@ -69,16 +55,8 @@ public class AssetXTests
         var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
-        sizes.Open.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 200, 100 },
-            new[] { 100, 50 },
-        });
-        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 800, 400 },
-            new[] { 400, 200 },
-        });
+        sizes.Open.Should().BeEquivalentTo((List<int[]>)[[200, 100], [100, 50]]);
+        sizes.Auth.Should().BeEquivalentTo((List<int[]>)[[800, 400], [400, 200]]);
     }
     
     [Fact]
@@ -91,12 +69,7 @@ public class AssetXTests
         var sizes = asset.GetAvailableThumbSizes(sizeParameters, 5000);
         
         // Assert
-        sizes.Open.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 300, 150 },
-            new[] { 200, 100 },
-            new[] { 100, 50 },
-        });
+        sizes.Open.Should().BeEquivalentTo((List<int[]>)[[300, 150], [200, 100], [100, 50]]);
         sizes.Auth.Should().BeEmpty();
     }
     
@@ -117,16 +90,10 @@ public class AssetXTests
         var sizes = asset.GetAvailableThumbSizes(sizeParametersWithNotConfined, 5000);
         
         // Assert
-        sizes.Open.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 400, 200 },
-        });
-        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 800, 400 },
-        });
+        sizes.Open.Should().BeEquivalentTo((List<int[]>)[[400, 200]]);
+        sizes.Auth.Should().BeEquivalentTo((List<int[]>)[[800, 400]]);
     }
-    
+
     [Fact]
     public void GetAvailableThumbSizes_ObeySystemMaxWidth()
     {
@@ -135,20 +102,12 @@ public class AssetXTests
 
         // Act
         var sizes = asset.GetAvailableThumbSizes(sizeParameters, 500);
-        
+
         // Assert
-        sizes.Open.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 400, 200 },
-            new[] { 200, 100 },
-            new[] { 100, 50 },
-        });
-        sizes.Auth.Should().BeEquivalentTo(new List<int[]>
-        {
-            new[] { 800, 400 },
-        });
+        sizes.Open.Should().BeEquivalentTo((List<int[]>)[[400, 200], [200, 100], [100, 50]]);
+        sizes.Auth.Should().BeEquivalentTo((List<int[]>)[[800, 400]]);
     }
-    
+
     [Theory]
     [InlineData(250, 500, "100,", true, "Ignore width for portrait")]
     [InlineData(500, 250, "100,", false, "Width okay for landscape")]

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetXTests.cs
@@ -230,4 +230,14 @@ public class AssetXTests
         var asset = new Asset { MaxWidth = maxWidth, OpenFullMax = openFullMax, Roles = "https://test.role" };
         asset.GetLargestOpenFullSize(systemMaxWidth).Should().Be(expected, because);
     }
+
+    [Theory]
+    [InlineData(0, 5000, 5000)]
+    [InlineData(5000, 5000, 5000)]
+    [InlineData(50000, 5000, 5000)]
+    public void GetEffectiveMaxWidth_Correct(int assetMaxWidth, int systemMaxWidth, int expected)
+    {
+        var asset = new Asset { MaxWidth = assetMaxWidth };
+        asset.GetEffectiveMaxWidth(systemMaxWidth).Should().Be(expected);
+    }
 }

--- a/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
@@ -154,14 +154,21 @@ public class IIIFXTests
     public void IsFullOrEquivalent_True_IfFull()
     {
         var region = new RegionParameter { Full = true };
-        region.IsFullOrEquivalent(1, 1).Should().BeTrue("Explicitly requesting full image");
+        region.IsFullOrEquivalent(new Size(1, 1)).Should().BeTrue("Explicitly requesting full image");
     }
 
     [Fact]
     public void IsFullOrEquivalent_True_IfSquareRegion_AndImageSquare()
     {
         var region = new RegionParameter { Square = true };
-        region.IsFullOrEquivalent(100, 100).Should().BeTrue("Requesting square region for square image");
+        region.IsFullOrEquivalent(new Size(100, 100)).Should().BeTrue("Requesting square region for square image");
+    }
+    
+    [Fact]
+    public void IsFullOrEquivalent_True_IfPercentFullRegion()
+    {
+        var region = new RegionParameter { X = 0, Y = 0, W = 100, H = 100, Percent = true };
+        region.IsFullOrEquivalent(new Size(700, 200)).Should().BeTrue("Region is for full image");
     }
     
     [Theory]
@@ -171,17 +178,26 @@ public class IIIFXTests
     public void IsFullOrEquivalent_True_IfRequesting0XY_AndWHMatchImage(int w, int h)
     {
         var region = new RegionParameter { X = 0, Y = 0, W = w, H = h };
-        region.IsFullOrEquivalent(w, h).Should().BeTrue("Region is for full image");
+        region.IsFullOrEquivalent(new Size(w, h)).Should().BeTrue("Region is for full image");
     }
     
     [Theory]
-    [InlineData(100, 100)]
     [InlineData(200, 100)]
     [InlineData(100, 200)]
     public void IsFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage_ButPercent(int w, int h)
     {
         var region = new RegionParameter { X = 0, Y = 0, W = w, H = h, Percent = true };
-        region.IsFullOrEquivalent(w, h).Should().BeFalse("Percent region");
+        region.IsFullOrEquivalent(new Size(w, h)).Should().BeFalse("Percent region");
+    }
+    
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(1, 1)]
+    public void IsFullOrEquivalent_False_IfPercentFullRegion_Not0XY(int x, int y)
+    {
+        var region = new RegionParameter { X = x, Y = y, W = 100, H = 100, Percent = true };
+        region.IsFullOrEquivalent(new Size(100, 100)).Should().BeFalse("Region is for full image");
     }
     
     [Theory]
@@ -194,7 +210,7 @@ public class IIIFXTests
     public void IsFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage(int x, int y, int w, int h)
     {
         var region = new RegionParameter { X = x, Y = y, W = w, H = h };
-        region.IsFullOrEquivalent(100, 100).Should().BeFalse();
+        region.IsFullOrEquivalent(new Size(100, 100)).Should().BeFalse();
     }
 
     [Theory]

--- a/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/IIIF/IIIFXTests.cs
@@ -151,14 +151,14 @@ public class IIIFXTests
     }
 
     [Fact]
-    public void IsRegionFullOrEquivalent_True_IfFull()
+    public void IsFullOrEquivalent_True_IfFull()
     {
         var region = new RegionParameter { Full = true };
         region.IsFullOrEquivalent(1, 1).Should().BeTrue("Explicitly requesting full image");
     }
 
     [Fact]
-    public void IsRegionFullOrEquivalent_True_IfSquareRegion_AndImageSquare()
+    public void IsFullOrEquivalent_True_IfSquareRegion_AndImageSquare()
     {
         var region = new RegionParameter { Square = true };
         region.IsFullOrEquivalent(100, 100).Should().BeTrue("Requesting square region for square image");
@@ -168,7 +168,7 @@ public class IIIFXTests
     [InlineData(100, 100)]
     [InlineData(200, 100)]
     [InlineData(100, 200)]
-    public void IsRegionFullOrEquivalent_True_IfRequesting0XY_AndWHMatchImage(int w, int h)
+    public void IsFullOrEquivalent_True_IfRequesting0XY_AndWHMatchImage(int w, int h)
     {
         var region = new RegionParameter { X = 0, Y = 0, W = w, H = h };
         region.IsFullOrEquivalent(w, h).Should().BeTrue("Region is for full image");
@@ -178,7 +178,7 @@ public class IIIFXTests
     [InlineData(100, 100)]
     [InlineData(200, 100)]
     [InlineData(100, 200)]
-    public void IsRegionFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage_ButPercent(int w, int h)
+    public void IsFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage_ButPercent(int w, int h)
     {
         var region = new RegionParameter { X = 0, Y = 0, W = w, H = h, Percent = true };
         region.IsFullOrEquivalent(w, h).Should().BeFalse("Percent region");
@@ -191,9 +191,41 @@ public class IIIFXTests
     [InlineData(0, 0, 101, 100)]
     [InlineData(0, 0, 100, 101)]
     [InlineData(0, 0, 101, 101)]
-    public void IsRegionFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage(int x, int y, int w, int h)
+    public void IsFullOrEquivalent_False_IfRequesting0XY_AndWHMatchImage(int x, int y, int w, int h)
     {
         var region = new RegionParameter { X = x, Y = y, W = w, H = h };
         region.IsFullOrEquivalent(100, 100).Should().BeFalse();
     }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("info.json")]
+    public void IsExplicitFullSize_False_IfBaseOrInfoJson(string imageRequest)
+        => ImageRequest.Parse($"asset/{imageRequest}", "").IsExplicitFullSize().Should().BeFalse();
+    
+    [Theory]
+    [InlineData("full/max/0/default.jpg")]
+    [InlineData("full/10,20/90/default.jpg")]
+    [InlineData("square/!200,200/180/bitonal.jpg")]
+    [InlineData("0,0,512,512/512,/90/default.jpg")]
+    [InlineData("full/pct:80/90/default.png")]
+    [InlineData("pct:41.6,7.5,40,70/max/90/default.png")]
+    public void IsExplicitFullSize_False_IfNotFull(string imageRequest)
+        => ImageRequest.Parse($"asset/{imageRequest}", "").IsExplicitFullSize().Should().BeFalse();
+    
+    [Theory]
+    [InlineData("full/full/0/default.jpg")]
+    [InlineData("square/full/180/bitonal.jpg")]
+    [InlineData("0,0,512,512/full/90/default.jpg")]
+    [InlineData("pct:41.6,7.5,40,70/full/90/default.png")]
+    public void IsExplicitFullSize_True_IfFull(string imageRequest)
+        => ImageRequest.Parse($"asset/{imageRequest}", "").IsExplicitFullSize().Should().BeTrue();
+    
+    [Theory]
+    [InlineData("full/^full/0/default.jpg")]
+    [InlineData("square/^full/180/bitonal.jpg")]
+    [InlineData("0,0,512,512/^full/90/default.jpg")]
+    [InlineData("pct:41.6,7.5,40,70/^full/90/default.png")]
+    public void IsExplicitFullSize_True_IfUpscaleFull(string imageRequest)
+        => ImageRequest.Parse($"asset/{imageRequest}", "").IsExplicitFullSize().Should().BeTrue();
 }

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -13,6 +13,10 @@ namespace DLCS.Model.Assets;
 /// </summary>
 public class Asset : ICloneable, IDeliverable
 {
+    /// <summary>
+    /// A 'special' role that cannot be obtained by any user. AccessServices for this will not be advertised and Assets
+    /// that only have this role will have auth logic shortcut to reject access. 
+    /// </summary>
     public const string UnobtainableRole = "https://dlcs.io/roles/unobtainable";
     
     public AssetId Id { get; set; }
@@ -109,9 +113,10 @@ public class Asset : ICloneable, IDeliverable
     }
     
     /// <summary>
-    /// Indicates whether this asset requires authentication to view. This is required if either Roles are assigned
+    /// Indicates whether this asset requires authentication to view . This is required if either Roles are assigned
     /// OR MaxUnauthorised >= 0
     /// </summary>
+    [Obsolete("Use HasRoles instead")]
     public bool RequiresAuth => !string.IsNullOrWhiteSpace(Roles) || MaxUnauthorised >= 0;
     
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/Asset.cs
+++ b/src/protagonist/DLCS.Model/Assets/Asset.cs
@@ -113,13 +113,6 @@ public class Asset : ICloneable, IDeliverable
     }
     
     /// <summary>
-    /// Indicates whether this asset requires authentication to view . This is required if either Roles are assigned
-    /// OR MaxUnauthorised >= 0
-    /// </summary>
-    [Obsolete("Use HasRoles instead")]
-    public bool RequiresAuth => !string.IsNullOrWhiteSpace(Roles) || MaxUnauthorised >= 0;
-    
-    /// <summary>
     /// Indicates whether this asset has any roles assigned to it.
     /// </summary>
     public bool HasRoles => !string.IsNullOrWhiteSpace(Roles);

--- a/src/protagonist/DLCS.Model/Assets/AssetX.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetX.cs
@@ -98,9 +98,7 @@ public static class AssetX
     public static int GetLargestOpenFullSize(this Asset asset, int systemMaxWidth)
     {
         // The effective MaxWidth value can be from the Asset or the system-wide default
-        var effectiveMaxWidth = (asset.MaxWidth ?? 0) == 0
-            ? systemMaxWidth
-            : Math.Min(asset.MaxWidth!.Value, systemMaxWidth);
+        var effectiveMaxWidth = asset.GetEffectiveMaxWidth(systemMaxWidth);
         
         // If no role, the only restriction is maxWidth (openFullMax is ignored)
         if (!asset.HasRoles) return effectiveMaxWidth;
@@ -111,4 +109,12 @@ public static class AssetX
         // We have an OpenFullMax value, if we also have MaxWidth return the smallest of that an OpenFullMax
         return Math.Min(effectiveMaxWidth, asset.OpenFullMax!.Value);
     }
+
+    /// <summary>
+    /// Get the effective maxWidth value for asset, taking into account the system default maxWidth
+    /// </summary>
+    public static int GetEffectiveMaxWidth(this Asset asset, int systemMaxWidth)
+        => (asset.MaxWidth ?? 0) == 0
+            ? systemMaxWidth
+            : Math.Min(asset.MaxWidth!.Value, systemMaxWidth);
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetX.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetX.cs
@@ -17,8 +17,10 @@ public static class AssetX
     /// </summary>
     /// <param name="asset">Asset to extract thumbnails sizes for.</param>
     /// <param name="sizeParameters">List of thumbnail policy sizes used to calculate thumb sizes.</param>
+    /// <param name="systemMaxWidth">The system default maxWidth.</param>
     /// <returns>List of available thumbnail <see cref="Size"/></returns>
-    public static ThumbnailSizes GetAvailableThumbSizes(this Asset asset, List<SizeParameter> sizeParameters)
+    public static ThumbnailSizes GetAvailableThumbSizes(this Asset asset, List<SizeParameter> sizeParameters, 
+        int systemMaxWidth)
     {
         asset.ThrowIfNull(nameof(asset));
         sizeParameters.ThrowIfNull(nameof(sizeParameters));
@@ -29,6 +31,9 @@ public static class AssetX
             asset.Height.ThrowIfNull(nameof(asset.Height)));
 
         var thumbnailSizes = new ThumbnailSizes(sizeParameters.Count);
+        
+        // Get the largest possible open size, this is the maximum thumbnail size
+        var largestThumbnailSize = asset.GetLargestOpenFullSize(systemMaxWidth);
 
         foreach (var sizeParameter in sizeParameters)
         {
@@ -42,8 +47,7 @@ public static class AssetX
             if (generatedMax.Contains(maxDimension)) continue;
             generatedMax.Add(maxDimension);
             
-            var assetIsUnavailableForSize = AssetIsUnavailableForSize(asset, maxDimension);
-            if (assetIsUnavailableForSize)
+            if (maxDimension > largestThumbnailSize)
             {
                 thumbnailSizes.AddAuth(resized);
             }
@@ -107,7 +111,4 @@ public static class AssetX
         // We have an OpenFullMax value, if we also have MaxWidth return the smallest of that an OpenFullMax
         return Math.Min(effectiveMaxWidth, asset.OpenFullMax!.Value);
     }
-    
-    private static bool AssetIsUnavailableForSize(Asset asset, int boundingSize)
-        => asset.RequiresAuth && boundingSize > asset.MaxUnauthorised;
 }

--- a/src/protagonist/DLCS.Model/Assets/SizeCandidate.cs
+++ b/src/protagonist/DLCS.Model/Assets/SizeCandidate.cs
@@ -1,4 +1,5 @@
-﻿using IIIF;
+﻿using System.Diagnostics.CodeAnalysis;
+using IIIF;
 
 namespace DLCS.Model.Assets;
 
@@ -9,6 +10,7 @@ public class SizeCandidate
 {
     public int? LongestEdge { get; }
     
+    [MemberNotNullWhen(true, nameof(LongestEdge))]
     public bool KnownSize { get; }
     
     public SizeCandidate(int? longestEdge)

--- a/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
+++ b/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
@@ -101,6 +101,27 @@ public static class IIIFX
         }
 
         return true;
+    }
 
+    private const string FullToken = "full";
+    private const string UpscaleFullToken = "^full";
+
+    /// <summary>
+    /// Check if the provided <see cref="ImageRequest"/> is for "full" size parameter. This returns true for full or
+    /// ^full, despite the latter being invalid.
+    /// </summary>
+    /// <remarks>
+    /// For backwards compatibility, <see cref="ImageRequest"/> parsing does not differentiate between "full" and "max"
+    /// size parameter - it marks both as "Max"=true.
+    /// </remarks>
+    public static bool IsExplicitFullSize(this ImageRequest imageRequest)
+    {
+        if (imageRequest.IsBase || imageRequest.IsInformationRequest) return false;
+        
+        var path = imageRequest.ImageRequestPath;
+        if (string.IsNullOrWhiteSpace(path)) return false;
+
+        var pathSegments = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return pathSegments is [.., FullToken or UpscaleFullToken, _, _];
     }
 }

--- a/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
+++ b/src/protagonist/DLCS.Model/IIIF/IIIFX.cs
@@ -85,22 +85,24 @@ public static class IIIFX
     
     /// <summary>
     /// Checks if region parameter is /full/ or represents the full region.
-    /// E.g. if image is 200w 300h then /0,0,200,300/ represents the full region.
+    ///  - if image is 200w 300h then /0,0,200,300/ represents the full region.
+    ///  - if the image is square then /square/ represents the full region.
+    ///  - regardless of size /pct:0,0,100,100/ represents the full region.
     /// </summary>
-    public static bool IsFullOrEquivalent(this RegionParameter requestedRegion, int width, int height)
+    public static bool IsFullOrEquivalent(this RegionParameter requestedRegion, Size size)
     {
         if (requestedRegion.Full) return true;
-        if (requestedRegion.Square && width == height) return true;
+        if (requestedRegion.Square && size.GetShape() == ImageShape.Square) return true;
 
-        if (requestedRegion.Percent ||
-            requestedRegion.X + requestedRegion.Y != 0 ||
-            width != (int)requestedRegion.W ||
-            height != (int)requestedRegion.H)
-        {
-            return false;
-        }
+        // If x,y is not top left, then it's not full region 
+        if (requestedRegion is not { X: 0, Y: 0 }) return false;
 
-        return true;
+        // If asking for 100% width and height of image then it's full equivalent
+        if (requestedRegion is { Percent: true, W: 100, H: 100 }) return true;
+
+        // Else it's full equivalent if it's NOT pct: but asking for full region
+        return !requestedRegion.Percent && size.Width == (int)requestedRegion.W &&
+               size.Height == (int)requestedRegion.H;
     }
 
     private const string FullToken = "full";

--- a/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
+++ b/src/protagonist/DLCS.Repository/Assets/ThumbnailCalculator.cs
@@ -10,18 +10,12 @@ namespace DLCS.Repository.Assets;
 public static class ThumbnailCalculator
 {
     /// <summary>
-    /// Get a list of all 
+    /// Get a <see cref="SizeCandidate"/> for the given image request, from the list of available sizes.
     /// </summary>
-    /// <param name="sizes"></param>
-    /// <param name="imageRequest"></param>
-    /// <param name="allowResize"></param>
-    /// <returns></returns>
-    public static SizeCandidate GetCandidate(List<Size> sizes, ImageRequest imageRequest, bool allowResize)
-    {
-        return allowResize
+    public static SizeCandidate GetCandidate(List<Size> sizes, ImageRequest imageRequest, bool allowResize) =>
+        allowResize
             ? GetLongestEdgeAndSize(sizes, imageRequest)
             : GetLongestEdge(sizes, imageRequest);
-    }
 
     private static SizeCandidate GetLongestEdge(List<Size> sizes, ImageRequest imageRequest)
     {

--- a/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
@@ -100,4 +100,33 @@ public class ImageRequestXTests
         canHandle.Should().BeFalse();
         message.Should().Be("Requested pct: size value not supported");
     }
+
+    [Fact]
+    public void GetImageRequestOnly_Incorrect_IfInfoJson()
+    {
+        // This is obviously not a great behaviour but documents the lack of support for info.json etc
+        var imageRequest = ImageRequest.Parse("image/info.json", "");
+        imageRequest.GetImageRequestOnly().Should().Be("///.", "There are no safety checks");
+    }
+    
+    [Fact]
+    public void GetImageRequestOnly_Correct_AfterParse()
+    {
+        var imageRequest = ImageRequest.Parse("iiif-img/27/1/my-asset/full/800,/0/default.jpg", "iiif-img/27/1/");
+        imageRequest.GetImageRequestOnly().Should().Be("full/800,/0/default.jpg");
+    }
+    
+    [Fact]
+    public void GetImageRequestOnly_Correct_AfterAlteringParsedObject()
+    {
+        var imageRequest = ImageRequest.Parse("iiif-img/27/1/my-asset/full/800,/0/default.jpg", "iiif-img/27/1/");
+        
+        imageRequest.Size = SizeParameter.Parse("pct:24");
+        imageRequest.Quality = "bitonal";
+        imageRequest.Format = "tif";
+        imageRequest.Rotation = new RotationParameter { Angle = 90, Mirror = true };
+        imageRequest.Region = new RegionParameter { Square = true };
+        imageRequest.GetImageRequestOnly().Should().Be("square/pct:24/!90/bitonal.tif",
+            "Value reflects current state of ImageRequest");
+    }
 }

--- a/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
@@ -175,7 +175,7 @@ public class ImageRequestXTests
         var imageRequest = new ImageRequest
             { Format = "jpg", Quality = "translucent", Size = new SizeParameter { Max = true } };
         imageRequest.IsCandidateForImageHandling(out var message).Should().BeFalse();
-        message.Should().Match("Requested format 'translucent' not supported, must be one of '*'");
+        message.Should().Match("Requested quality 'translucent' not supported, must be one of '*'");
     }
     
     [Theory]

--- a/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
+++ b/src/protagonist/DLCS.Web.Tests/IIIF/ImageRequestXTests.cs
@@ -42,7 +42,7 @@ public class ImageRequestXTests
         canHandle.Should().BeFalse();
         message.Should().Be($"Requested quality '{quality}' not supported, use 'default' or 'color'");
     }
-    
+
     [Theory]
     [InlineData("90")]
     [InlineData("120")]
@@ -82,7 +82,7 @@ public class ImageRequestXTests
         canHandle.Should().BeTrue();
         message.Should().BeNull();
     }
-    
+
     [Fact]
     public void IsCandidateForThumbHandling_False_IfPercentSize()
     {
@@ -108,19 +108,19 @@ public class ImageRequestXTests
         var imageRequest = ImageRequest.Parse("image/info.json", "");
         imageRequest.GetImageRequestOnly().Should().Be("///.", "There are no safety checks");
     }
-    
+
     [Fact]
     public void GetImageRequestOnly_Correct_AfterParse()
     {
         var imageRequest = ImageRequest.Parse("iiif-img/27/1/my-asset/full/800,/0/default.jpg", "iiif-img/27/1/");
         imageRequest.GetImageRequestOnly().Should().Be("full/800,/0/default.jpg");
     }
-    
+
     [Fact]
     public void GetImageRequestOnly_Correct_AfterAlteringParsedObject()
     {
         var imageRequest = ImageRequest.Parse("iiif-img/27/1/my-asset/full/800,/0/default.jpg", "iiif-img/27/1/");
-        
+
         imageRequest.Size = SizeParameter.Parse("pct:24");
         imageRequest.Quality = "bitonal";
         imageRequest.Format = "tif";
@@ -128,5 +128,85 @@ public class ImageRequestXTests
         imageRequest.Region = new RegionParameter { Square = true };
         imageRequest.GetImageRequestOnly().Should().Be("square/pct:24/!90/bitonal.tif",
             "Value reflects current state of ImageRequest");
+    }
+
+    [Theory]
+    [InlineData("jpg")]
+    [InlineData("tif")]
+    [InlineData("gif")]
+    [InlineData("png")]
+    public void IsCandidateForImageHandling_True_IfAcceptedFormat(string format)
+    {
+        var imageRequest = new ImageRequest
+            { Format = format, Quality = "default", Size = new SizeParameter { Max = true } };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeTrue($"{format} accepted");
+        message.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("webp")]
+    [InlineData("jp2")]
+    [InlineData("pdf")]
+    [InlineData("not-in-spec")]
+    public void IsCandidateForImageHandling_False_IfNotAcceptedFormat(string format)
+    {
+        var imageRequest = new ImageRequest
+            { Format = format, Quality = "default", Size = new SizeParameter { Max = true } };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeFalse($"{format} not accepted");
+        message.Should().Match($"Requested format '{format}' not supported, must be one of '*'");
+    }
+
+    [Theory]
+    [InlineData("default")]
+    [InlineData("gray")]
+    [InlineData("bitonal")]
+    [InlineData("color")]
+    public void IsCandidateForImageHandling_True_IfAcceptedQuality(string quality)
+    {
+        var imageRequest = new ImageRequest
+            { Format = "jpg", Quality = quality, Size = new SizeParameter { Max = true } };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeTrue($"{quality} accepted");
+        message.Should().BeNull();
+    }
+
+    [Fact]
+    public void IsCandidateForImageHandling_False_IfNotAcceptedQuality()
+    {
+        var imageRequest = new ImageRequest
+            { Format = "jpg", Quality = "translucent", Size = new SizeParameter { Max = true } };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeFalse();
+        message.Should().Match("Requested format 'translucent' not supported, must be one of '*'");
+    }
+    
+    [Theory]
+    [InlineData("max")]
+    [InlineData("^max")]
+    [InlineData("full")]
+    [InlineData("!10,10")]
+    [InlineData("^!10,10")]
+    [InlineData("10,10")]
+    [InlineData("^10,10")]
+    [InlineData("20,")]
+    [InlineData("^20,")]
+    [InlineData(",20")]
+    [InlineData("^,20")]
+    public void IsCandidateForImageHandling_True_IfSizeValid(string size)
+    {
+        var imageRequest = new ImageRequest { Format = "jpg", Quality = "default", Size = SizeParameter.Parse(size) };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeTrue();
+        message.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("0,")]
+    [InlineData(",0")]
+    [InlineData("!0,0")]
+    [InlineData("20,0")]
+    [InlineData("0,20")]
+    public void IsCandidateForImageHandling_False_IfZeroSize(string size)
+    {
+        var imageRequest = new ImageRequest { Format = "jpg", Quality = "default", Size = SizeParameter.Parse(size) };
+        imageRequest.IsCandidateForImageHandling(out var message).Should().BeFalse();
+        message.Should().Be("Requested size must be greater than 0");
     }
 }

--- a/src/protagonist/DLCS.Web/IIIF/ImageApiVersionHelpers.cs
+++ b/src/protagonist/DLCS.Web/IIIF/ImageApiVersionHelpers.cs
@@ -49,7 +49,7 @@ public static class ImageApiVersionHelpers
     {
         if (!version.IsNullOrEmpty())
         {
-            switch (version![1])
+            switch (version[1])
             {
                 case '2':
                     return Version.V2;

--- a/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
+++ b/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using IIIF.ImageApi;
 
@@ -45,7 +46,8 @@ public static class ImageRequestX
     /// <param name="invalidMessage">String detailing why object cannot be handled</param>
     /// <returns>True if object can be handled, else false</returns>
     /// <remarks>This is a quick check - request may fail later in processing chain</remarks>
-    public static bool IsCandidateForImageHandling(this ImageRequest request, out string? invalidMessage)
+    public static bool IsCandidateForImageHandling(this ImageRequest request,
+        [NotNullWhen(false)] out string? invalidMessage)
     {
         invalidMessage = null;
         if (!Formats.All.Contains(request.Format, StringComparer.OrdinalIgnoreCase))
@@ -53,13 +55,13 @@ public static class ImageRequestX
             invalidMessage = $"Requested format '{request.Format}' not supported, must be one of '{Formats.AllCsv}'";
             return false;
         }
-        
+
         if (!Qualities.All.Contains(request.Quality, StringComparer.OrdinalIgnoreCase))
         {
-            invalidMessage = $"Requested format '{request.Quality}' not supported, must be one of '{Formats.AllCsv}'";
+            invalidMessage = $"Requested quality '{request.Quality}' not supported, must be one of '{Qualities.AllCsv}'";
             return false;
         }
-        
+
         var size = request.Size;
         if (!((size.Width ?? 1) > 0 && (size.Height ?? 1) > 0))
         {
@@ -69,7 +71,7 @@ public static class ImageRequestX
 
         return true;
     }
-    
+
     /// <summary>
     /// Check if the IIIF ImageRequest has request parameter that are able to be handled by Thumbnail service.
     /// Note: This checks Format, Quality, Rotation etc - this check may pass but thumbs still cannot handle due to size

--- a/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
+++ b/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
@@ -1,14 +1,75 @@
 ﻿using System;
+using System.Linq;
 using IIIF.ImageApi;
 
 namespace DLCS.Web.IIIF;
 
 public static class ImageRequestX
 {
-    private const string DefaultQuality = "default";
-    private const string ColorQuality = "color";
-    private const string JpgFormat = "jpg";
+    /// <summary>
+    /// A list of accepted IIIF image qualities
+    /// </summary>
+    /// <remarks>https://iiif.io/api/image/3.0/#quality</remarks>
+    private static class Qualities
+    {
+        public const string Color = "color";
+        public const string Gray = "gray";
+        public const string Bitonal = "bitonal";
+        public const string Default = "default";
 
+        public static readonly string[] All = [Color, Gray, Bitonal, Default];
+        
+        public static readonly string AllCsv = string.Join(',', All);
+    }
+    
+    /// <summary>
+    /// A list of accepted IIIF image formats
+    /// </summary>
+    /// <remarks>https://iiif.io/api/image/3.0/#45-format</remarks>
+    private static class Formats
+    {
+        public const string Jpg = "jpg";
+        public const string Tif = "tif";
+        public const string Gif = "gif";
+        public const string Png = "png";
+
+        public static readonly string[] All = [Jpg, Tif, Gif, Png];
+
+        public static readonly string AllCsv = string.Join(',', All);
+    }
+
+    /// <summary>
+    /// Check if the IIIF ImageRequest is a supported format, quality and non-zero size.  
+    /// </summary>
+    /// <param name="request">Candidate <see cref="ImageRequest"/></param>
+    /// <param name="invalidMessage">String detailing why object cannot be handled</param>
+    /// <returns>True if object can be handled, else false</returns>
+    /// <remarks>This is a quick check - request may fail later in processing chain</remarks>
+    public static bool IsCandidateForImageHandling(this ImageRequest request, out string? invalidMessage)
+    {
+        invalidMessage = null;
+        if (!Formats.All.Contains(request.Format, StringComparer.OrdinalIgnoreCase))
+        {
+            invalidMessage = $"Requested format '{request.Format}' not supported, must be one of '{Formats.AllCsv}'";
+            return false;
+        }
+        
+        if (!Qualities.All.Contains(request.Quality, StringComparer.OrdinalIgnoreCase))
+        {
+            invalidMessage = $"Requested format '{request.Quality}' not supported, must be one of '{Formats.AllCsv}'";
+            return false;
+        }
+        
+        var size = request.Size;
+        if (!((size.Width ?? 1) > 0 && (size.Height ?? 1) > 0))
+        {
+            invalidMessage = "Requested size must be greater than 0";
+            return false;
+        }
+
+        return true;
+    }
+    
     /// <summary>
     /// Check if the IIIF ImageRequest has request parameter that are able to be handled by Thumbnail service.
     /// Note: This checks Format, Quality, Rotation etc - this check may pass but thumbs still cannot handle due to size
@@ -20,15 +81,16 @@ public static class ImageRequestX
     public static bool IsCandidateForThumbHandling(this ImageRequest request, out string? invalidMessage)
     {
         invalidMessage = null;
-        if (!request.Format.Equals(JpgFormat, StringComparison.OrdinalIgnoreCase))
+        if (!request.Format.Equals(Formats.Jpg, StringComparison.OrdinalIgnoreCase))
         {
-            invalidMessage = $"Requested format '{request.Format}' not supported, use 'jpg'";
+            invalidMessage = $"Requested format '{request.Format}' not supported, use '{Formats.Jpg}'";
             return false;
         }
         
-        if (request.Quality is not (DefaultQuality or ColorQuality))
+        if (request.Quality is not (Qualities.Default or Qualities.Color))
         {
-            invalidMessage = $"Requested quality '{request.Quality}' not supported, use 'default' or 'color'";
+            invalidMessage =
+                $"Requested quality '{request.Quality}' not supported, use '{Qualities.Default}' or '{Qualities.Color}'";
             return false;
         }
 

--- a/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
+++ b/src/protagonist/DLCS.Web/IIIF/ImageRequestX.cs
@@ -46,4 +46,14 @@ public static class ImageRequestX
 
         return true;
     }
+
+    /// <summary>
+    /// For the given <see cref="ImageRequest"/>, get the {region}/{size}/{rotation}/{quality}.{format} only (ie no
+    /// identifier or prefix etc).
+    /// </summary>
+    /// <remarks>
+    /// This doesn't make any checks on whether the request has all required properties, or is for info.json etc
+    /// </remarks>
+    public static string GetImageRequestOnly(this ImageRequest request)
+        => $"{request.Region}/{request.Size}/{request.Rotation}/{request.Quality}.{request.Format}";
 }

--- a/src/protagonist/Directory.Packages.props
+++ b/src/protagonist/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FluentAssertions" Version="6.6.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageVersion Include="iiif-net" Version="0.3.13-rc1" />
+    <PackageVersion Include="iiif-net" Version="0.3.13" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="LazyCache" Version="2.4.0" />
     <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />

--- a/src/protagonist/Directory.Packages.props
+++ b/src/protagonist/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="FakeItEasy" Version="8.3.0" />
     <PackageVersion Include="FluentAssertions" Version="6.6.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
-    <PackageVersion Include="iiif-net" Version="0.3.11" />
+    <PackageVersion Include="iiif-net" Version="0.3.13-rc1" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="LazyCache" Version="2.4.0" />
     <PackageVersion Include="LazyCache.AspNetCore" Version="2.4.0" />

--- a/src/protagonist/Engine.Tests/Ingest/Image/ImageOnDiskTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ImageOnDiskTests.cs
@@ -1,0 +1,13 @@
+﻿using Engine.Ingest.Image;
+
+namespace Engine.Tests.Ingest.Image;
+
+public class ImageOnDiskTests
+{
+    [Theory]
+    [InlineData(100, 200, 200)]
+    [InlineData(200, 200, 200)]
+    [InlineData(200, 100, 200)]
+    public void MaxDimension_ReturnsMaxDimension(int w, int h, int expected) =>
+        new ImageOnDisk { Width = w, Height = h }.MaxDimension.Should().Be(expected);
+}

--- a/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Image/ThumbCreatorTests.cs
@@ -101,8 +101,8 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -145,8 +145,8 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -155,7 +155,7 @@ public class ThumbCreatorTests
     [InlineData(1000)]
     [InlineData(500)]
     [InlineData(0)]
-    public async Task CreateNewThumbs_UploadsExpected_LargestAuth_NoRoles(int openFullMax)
+    public async Task CreateNewThumbs_UploadsExpected_LargestExcluded_NoRoles(int openFullMax)
     {
         // MaxWidth is 700 and there are no roles so we won't create 'open' thumbs larger than 700
         // included OpenFullMax to show this has no effect as no roles 
@@ -173,17 +173,14 @@ public class ThumbCreatorTests
             new() { Width = 60, Height = 100, Path = "100.jpg" }
         };
         
-        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[[606,1000]]}";
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[]}";
         
         // Act
         var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
         
         // Assert
-        thumbsCreated.Should().Be(3);
+        thumbsCreated.Should().Be(2);
         
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/a/1000.jpg")
-            .WithFilePath("1000.jpg");
         bucketWriter
             .ShouldHaveKey("10/20/foo/o/500.jpg")
             .WithFilePath("500.jpg");
@@ -193,8 +190,8 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -216,17 +213,14 @@ public class ThumbCreatorTests
             new() { Width = 60, Height = 100, Path = "100.jpg" }
         };
         
-        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[[606,1000]]}";
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[]}";
         
         // Act
         var thumbsCreated = await GetSut(700).CreateNewThumbs(asset, imagesOnDisk);
         
         // Assert
-        thumbsCreated.Should().Be(3);
+        thumbsCreated.Should().Be(2, "System maxWidth of 700 prevents largest thumb being saved");
         
-        bucketWriter
-            .ShouldHaveKey("10/20/foo/a/1000.jpg")
-            .WithFilePath("1000.jpg");
         bucketWriter
             .ShouldHaveKey("10/20/foo/o/500.jpg")
             .WithFilePath("500.jpg");
@@ -236,22 +230,18 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
     
     [Theory]
     [InlineData(700, 0)] // ofm only
-    [InlineData(700, 700)] // both ofm and mw match
     [InlineData(700, 1024)] // mw is greater than ofm
-    [InlineData(1024, 700)] // ofm is greater than mw
     public async Task CreateNewThumbs_UploadsExpected_LargestAuth_Roles(int openFullMax, int maxWidth)
     {
-        // Asset has roles. In all cases the effective 'max' value is 700
-        // This will be OpenFullMax or MaxWidth if one provided.
-        // If both provided it is OpenFullMax unless that value is larger than MaxWidth 
+        // Asset has roles. In all cases the effective 'max' value is 700 from OpenFullMax so we do store
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
@@ -286,8 +276,51 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
+        asset.AssetApplicationMetadata.Should()
+            .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
+    }
+    
+    [Theory]
+    [InlineData(700, 700)] // both ofm and mw match
+    [InlineData(1024, 700)] // ofm is greater than mw
+    public async Task CreateNewThumbs_UploadsExpected_LargestExcluded_Roles(int openFullMax, int maxWidth)
+    {
+        // Asset has roles and openFullMax. MaxWidth makes effective 'max' 700, regardless of OpenFullMax value
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, MaxWidth = maxWidth, OpenFullMax = openFullMax,
+            ImageDeliveryChannels = thumbsDeliveryChannel, Roles = "https://test"
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[]}";
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(2);
+        
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents(thumbSizes);
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -331,8 +364,8 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -372,8 +405,8 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
@@ -416,24 +449,22 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }
     
-    [Theory]
-    [InlineData(256)]
-    [InlineData(0)]
-    public async Task CreateNewThumbs_UploadsExpected_AllAuth(int maxWidth)
+    [Fact]
+    public async Task CreateNewThumbs_UploadsExpected_AllAuth()
     {
         // All cases have a role and no OpenFullMax (so none available as open)
-        // Value of MaxWidth doesn't matter as none are available anonymously
+        // Value of MaxWidth ignored as 0
         var assetId = new AssetId(10, 20, "foo");
         var asset = new Asset(assetId)
         {
             Width = 3030, Height = 5000, OpenFullMax = 0, Roles = "https://test",
-            ImageDeliveryChannels = thumbsDeliveryChannel, MaxWidth = maxWidth
+            ImageDeliveryChannels = thumbsDeliveryChannel, MaxWidth = 0
         };
 
         var imagesOnDisk = new List<ImageOnDisk>
@@ -462,8 +493,75 @@ public class ThumbCreatorTests
         bucketWriter
             .ShouldHaveKey("10/20/foo/s.json")
             .WithContents(thumbSizes);
-        
         bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
+        asset.AssetApplicationMetadata.Should()
+            .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_UploadsNone_IfMaxWidthSmallerThanSmallestThumb()
+    {
+        // MaxWidth is 1 so no thumbnails will be created as they all exceed this
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, OpenFullMax = 0, Roles = "https://test",
+            ImageDeliveryChannels = thumbsDeliveryChannel, MaxWidth = 90
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(0);
+        
+        bucketWriter.Operations.Should().BeEmpty();
+        asset.AssetApplicationMetadata.Should().BeNullOrEmpty();
+    }
+    
+    [Fact]
+    public async Task CreateNewThumbs_DoesNotSaveThumbs_IfLargerThanMaxWidth()
+    {
+        // MaxWidth of 800 controls the largest possible thumb size
+        var assetId = new AssetId(10, 20, "foo");
+        var asset = new Asset(assetId)
+        {
+            Width = 3030, Height = 5000, ImageDeliveryChannels = thumbsDeliveryChannel, MaxWidth = 800
+        };
+
+        var imagesOnDisk = new List<ImageOnDisk>
+        {
+            new() { Width = 606, Height = 1000, Path = "1000.jpg" },
+            new() { Width = 302, Height = 500, Path = "500.jpg" },
+            new() { Width = 60, Height = 100, Path = "100.jpg" }
+        };
+        const string thumbSizes = "{\"o\":[[302,500],[60,100]],\"a\":[]}";
+        
+        // Act
+        var thumbsCreated = await sut.CreateNewThumbs(asset, imagesOnDisk);
+        
+        // Assert
+        thumbsCreated.Should().Be(2, "Largest thumb exceeds MaxWidth so disregarded");
+        
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/500.jpg")
+            .WithFilePath("500.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/o/100.jpg")
+            .WithFilePath("100.jpg");
+        bucketWriter
+            .ShouldHaveKey("10/20/foo/s.json")
+            .WithContents(thumbSizes);
+        bucketWriter.ShouldHaveNoUnverifiedPaths();
+        
         asset.AssetApplicationMetadata.Should()
             .Contain(i => i.MetadataType == "ThumbSizes" && i.MetadataValue == thumbSizes);
     }

--- a/src/protagonist/Engine/Ingest/Image/ImageOnDisk.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageOnDisk.cs
@@ -1,8 +1,13 @@
 ﻿namespace Engine.Ingest.Image;
 
+/// <summary>
+/// Represents an image that has been saved to disk
+/// </summary>
 public class ImageOnDisk
 {
     public string Path { get; set; } = null!;
     public int Height { get; set; }
     public int Width { get; set; }
+
+    public int MaxDimension => Math.Max(Height, Width);
 }

--- a/src/protagonist/Engine/Ingest/Image/ImageServer/AppetiserImageProcessor.cs
+++ b/src/protagonist/Engine/Ingest/Image/ImageServer/AppetiserImageProcessor.cs
@@ -91,6 +91,8 @@ public class AppetiserImageProcessor(
     
     private List<SizeParameter> GetThumbSizes(IngestionContext context)
     {
+        // NOTE - we may end up throwing away some generated thumbnails because they exceed maxWidth, however we don't
+        // know the size of the origin image yet so we always generate all possible thumbs.
         var thumbPolicy = context.Asset.ImageDeliveryChannels
             .GetThumbsChannel()?.DeliveryChannelPolicy
             .PolicyDataAs<List<string>>();

--- a/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
+++ b/src/protagonist/Engine/Ingest/Image/ThumbCreator.cs
@@ -41,11 +41,21 @@ public class ThumbCreator(
         logger.LogTrace("Max available thumbnail size for {AssetId} is {MaxAvailableThumb}", assetId, maxAvailableThumb);
         var thumbnailSizes = new ThumbnailSizes(thumbsToProcess.Count);
         var processedWidths = new List<int>(thumbsToProcess.Count);
+        var effectiveMaxWidth = asset.GetEffectiveMaxWidth(engineSettings.MaxWidth);
         
         using var processLock = await asyncLocker.LockAsync($"create:{assetId}");
 
         foreach (var thumbCandidate in orderedThumbs)
         {
+            // If exceeds the effectiveMaxWidth for image, discard...
+            if (thumbCandidate.MaxDimension > effectiveMaxWidth)
+            {
+                logger.LogDebug(
+                    "Thumbnail {Width},{Height} exceeds effective maxWidth of {MaxWidth} for asset {AssetId}",
+                    thumbCandidate.Width, thumbCandidate.Height, effectiveMaxWidth, assetId);
+                continue;
+            }
+            
             // Safety check for duplicate
             if (processedWidths.Contains(thumbCandidate.Width))
             {
@@ -100,6 +110,8 @@ public class ThumbCreator(
     
     private async Task CreateSizesJson(Asset asset, ThumbnailSizes thumbnailSizes)
     {
+        if (thumbnailSizes.Count == 0) return;
+        
         // NOTE - this data is read via AssetApplicationMetadataX.GetThumbsMetadata
         var serializedThumbnailSizes = JsonConvert.SerializeObject(thumbnailSizes);
         var sizesDest = storageKeyGenerator.GetThumbsSizesJsonLocation(asset.Id);

--- a/src/protagonist/Engine/readme.md
+++ b/src/protagonist/Engine/readme.md
@@ -77,6 +77,7 @@ These are in strongly typed to `EngineSettings` object and are split by prefix b
 | Key                | Description                                                 | Default |
 | ------------------ | ----------------------------------------------------------- | ------- |
 | `DownloadTemplate` | Template for download location for temporary working assets |         |
+| `MaxWidth`         | System default `maxWidth` property                          | 5000    |
 
 ### `ImageIngest:`
 

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -218,8 +218,8 @@ public class MemoryAssetTrackerTests
         
         // Assert
         result!.AssetId.Should().Be(assetId);
-        result.Height.Should().Be(10);
-        result.Width.Should().Be(50);
+        result.Size.Height.Should().Be(10);
+        result.Size.Width.Should().Be(50);
         result.OpenThumbs.Should().BeEquivalentTo(sizes);
         result.Reingest.Should().BeFalse();
     }

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -31,10 +31,11 @@ public class MemoryAssetTrackerTests
         sut = GetSut();
     }
 
-    private MemoryAssetTracker GetSut(DateTime? emptyImageLocationCreatedDate = null)
+    private MemoryAssetTracker GetSut(DateTime? emptyImageLocationCreatedDate = null, int maxWidth = 5000)
     {
         var orchestratorSettings = new OrchestratorSettings
         {
+            MaxWidth = maxWidth,
             Caching = new CacheSettings(),
             ReingestOnOrchestration = new ReingestOnOrchestrationSettings
             {
@@ -79,7 +80,7 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset(assetId);
 
         // Assert
-        result.AssetId.Should().Be(assetId);
+        result!.AssetId.Should().Be(assetId);
         result.Channels.Should().Be(channel);
         result.Should().BeOfType(expectedType);
     }
@@ -165,7 +166,7 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset<OrchestrationAsset>(assetId);
         
         // Assert
-        result.AssetId.Should().Be(assetId);
+        result!.AssetId.Should().Be(assetId);
         result.Origin.Should().Be(expectedOrigin);
         A.CallTo(() => thumbRepository.GetOpenSizes(A<AssetId>._)).MustHaveHappened();
     }
@@ -189,7 +190,7 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset<OrchestrationAsset>(assetId);
         
         // Assert
-        result.AssetId.Should().Be(assetId);
+        result!.AssetId.Should().Be(assetId);
         result.Origin.Should().Be(expectedOrigin);
         A.CallTo(() => thumbRepository.GetOpenSizes(A<AssetId>._)).MustNotHaveHappened();
     }
@@ -208,8 +209,7 @@ public class MemoryAssetTrackerTests
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels,
-            Height = 10, Width = 50, MaxUnauthorised = -1,
-            Origin = "test"
+            Height = 10, Width = 50, Origin = "test"
         });
         A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns(sizes);
 
@@ -217,12 +217,56 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
         
         // Assert
-        result.AssetId.Should().Be(assetId);
+        result!.AssetId.Should().Be(assetId);
         result.Height.Should().Be(10);
         result.Width.Should().Be(50);
-        result.MaxUnauthorised.Should().Be(-1);
         result.OpenThumbs.Should().BeEquivalentTo(sizes);
         result.Reingest.Should().BeFalse();
+    }
+    
+    [Theory]
+    [InlineData("", 0, null)]
+    [InlineData("", 100, null)]
+    [InlineData("role", 0, 0)]
+    [InlineData("role", 100, 100)]
+    public async Task GetOrchestrationAsset_SetsOpenFullMax_IfHasRole(string roles, int openFullMax, int? expected)
+    {
+        // Arrange
+        var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
+        var assetId = new AssetId(1, 1, "go!");
+        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        {
+            ImageDeliveryChannels = imageDeliveryChannels, Roles = roles, OpenFullMax = openFullMax
+        });
+        
+        // Act
+        var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result!.OpenFullMax.Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData(250, 250, 250)]
+    [InlineData(0, 100, 100)]
+    [InlineData(5000, 250, 250)]
+    [InlineData(250, 5000, 250)]
+    public async Task GetOrchestrationAsset_SetsMaxWidth(int assetMaxWidth, int systemMaxWidth, int expected)
+    {
+        // Arrange
+        var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
+        var assetId = new AssetId(1, 1, "go!");
+        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        {
+            ImageDeliveryChannels = imageDeliveryChannels, MaxWidth = assetMaxWidth
+        });
+        
+        // Act
+        var localSut = GetSut(maxWidth: systemMaxWidth);
+        var result = await localSut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result!.MaxWidth.Should().Be(expected);
     }
     
     [Theory]
@@ -235,7 +279,7 @@ public class MemoryAssetTrackerTests
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
-            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50, MaxUnauthorised = -1,
+            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today
         });
         A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
@@ -244,7 +288,7 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
 
         // Assert
-        result.OpenThumbs.Should().BeEmpty();
+        result!.OpenThumbs.Should().BeEmpty();
     }
 
     [Theory]
@@ -257,7 +301,7 @@ public class MemoryAssetTrackerTests
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
-            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50, MaxUnauthorised = -1,
+            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today.AddDays(-1)
         });
         A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
@@ -267,7 +311,7 @@ public class MemoryAssetTrackerTests
         var result = await localSut.GetOrchestrationAsset<OrchestrationImage>(assetId);
         
         // Assert
-        result.Reingest.Should().BeTrue();
+        result!.Reingest.Should().BeTrue();
     }
     
     [Theory]
@@ -280,7 +324,7 @@ public class MemoryAssetTrackerTests
         var assetId = new AssetId(1, 1, "otis");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
-            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50, MaxUnauthorised = -1,
+            ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today.AddDays(1)
         });
         A.CallTo(() => thumbRepository.GetOpenSizes(assetId)).Returns<List<int[]>>(null);
@@ -290,7 +334,7 @@ public class MemoryAssetTrackerTests
         var result = await localSut.GetOrchestrationAsset<OrchestrationImage>(assetId);
         
         // Assert
-        result.Reingest.Should().BeFalse();
+        result!.Reingest.Should().BeFalse();
     }
     
     [Theory]
@@ -313,27 +357,23 @@ public class MemoryAssetTrackerTests
     }
 
     [Theory]
-    [InlineData("", -1, false)]
-    [InlineData("", 0, true)]
-    [InlineData("", 10, true)]
-    [InlineData("role", -1, true)]
-    [InlineData("role", 0, true)]
-    [InlineData("role", 10, true)]
-    public async Task GetOrchestrationAsset_SetsRequiresAuthCorrectly(string roles, int maxUnauth, bool requiresAuth)
+    [InlineData("", false)]
+    [InlineData("role", true)]
+    public async Task GetOrchestrationAsset_SetsRequiresAuth_BaseOnRoles(string roles, bool requiresAuth)
     {
         // Arrange
         var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
         A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
         {
-            ImageDeliveryChannels = imageDeliveryChannels, MaxUnauthorised = maxUnauth, Roles = roles
+            ImageDeliveryChannels = imageDeliveryChannels, Roles = roles
         });
         
         // Act
         var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
         
         // Assert
-        result.RequiresAuth.Should().Be(requiresAuth);
+        result!.RequiresAuth.Should().Be(requiresAuth);
     }
     
     [Theory]
@@ -382,7 +422,7 @@ public class MemoryAssetTrackerTests
         var result = await sut.GetOrchestrationAsset<OrchestrationAsset>(assetId);
         
         // Assert
-        result.OptimisedOrigin.Should().Be(optimised);
+        result!.OptimisedOrigin.Should().Be(optimised);
         result.MediaType.ToString().Should().Be("audio/mpeg");
     }
 }

--- a/src/protagonist/Orchestrator.Tests/Features/IIIF/IIIFAuth1BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/IIIF/IIIFAuth1BuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Auth;
 using DLCS.Model.Auth.Entities;
 using IIIF.Auth.V1;
@@ -50,6 +51,21 @@ public class IIIFAuth1BuilderTests
         result.Should().BeNull();
     }
     
+    [Fact]
+    public async Task GetAuthServicesForAsset_Null_IfUnobtainableRole_Only()
+    {
+        // Arrange
+        var asset = GetAsset();
+        asset.Roles = [Asset.UnobtainableRole];
+        var sut = GetSut();
+        
+        // Act 
+        var result = await sut.GetAuthServicesForAsset(asset.AssetId, asset.Roles);
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
     [Theory]
     [InlineData("http://iiif.io/api/auth/1/login/clickthrough")]
     [InlineData("http://iiif.io/api/auth/3/clickthrough")]
@@ -58,7 +74,7 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {
@@ -81,7 +97,7 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {
@@ -108,7 +124,40 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
+        A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
+            .Returns(new List<AuthService>
+            {
+                new() { Name = "The-Parent", Label = "Parent", Description = "Parent Description", Profile = profile }
+            });
+        var sut = GetSut();
+        
+        // Act 
+        var result = await sut.GetAuthServicesForAsset(asset.AssetId, asset.Roles);
+        
+        // Assert
+        result.Id.Should().Be("The-Parent");
+        var authCookieSvc = result as AuthCookieService;
+        authCookieSvc.Label.LanguageValues
+            .Should().HaveCount(1)
+            .And.Subject.Should().OnlyContain(v => v.Value == "Parent");
+        authCookieSvc.Description.LanguageValues
+            .Should().HaveCount(1)
+            .And.Subject.Should().OnlyContain(v => v.Value == "Parent Description");
+        authCookieSvc.Service.Should().BeNullOrEmpty();
+    }
+    
+    [Theory]
+    [InlineData("http://iiif.io/api/auth/1/login")]
+    [InlineData("http://iiif.io/api/auth/1/clickthrough")]
+    [InlineData("http://iiif.io/api/auth/1/kiosk")]
+    [InlineData("http://iiif.io/api/auth/1/external")]
+    public async Task GetAuthServicesForAsset_ReturnsCookieServiceWithNoChildren_IfNoChildServices_AuthCookie1_IfAccompaniedByUnobtainable(string profile)
+    {
+        // Arrange
+        var asset = GetAsset();
+        const string roleName = "secret";
+        asset.Roles = [roleName, Asset.UnobtainableRole];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {
@@ -142,7 +191,7 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {
@@ -172,7 +221,7 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {
@@ -228,7 +277,7 @@ public class IIIFAuth1BuilderTests
         // Arrange
         var asset = GetAsset();
         const string roleName = "secret";
-        asset.Roles = new List<string> { roleName };
+        asset.Roles = [roleName];
         A.CallTo(() => authServicesRepository.GetAuthServicesForRole(99, roleName))
             .Returns(new List<AuthService>
             {

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -31,6 +31,7 @@ public class ImageRequestHandlerTests
     private readonly IAssetAccessValidator accessValidator;
     private readonly IServiceScopeFactory scopeFactory;
     private readonly ICustomHeaderRepository customHeaderRepository;
+    private static readonly int[] Item = [256, 256];
 
     public ImageRequestHandlerTests()
     {
@@ -47,14 +48,13 @@ public class ImageRequestHandlerTests
         A.CallTo(() => scope.ServiceProvider.GetService(typeof(IAssetAccessValidator))).Returns(accessValidator);
     }
 
-    private static OrchestratorSettings CreateOrchestratorSettings()
-    {
-        return new OrchestratorSettings
+    private static OrchestratorSettings CreateOrchestratorSettings() =>
+        new()
         {
             Proxy = new(),
-            ImageServerPathConfig = new()
+            ImageServerPathConfig = new Dictionary<ImageServer, ImageServerConfig>
             {
-                [ImageServer.Cantaloupe] = new ImageServerConfig
+                [ImageServer.Cantaloupe] = new()
                 {
                     Separator = "%2F",
                     PathTemplate = "/path",
@@ -64,7 +64,7 @@ public class ImageRequestHandlerTests
                         [Version.V2] = "cantaloupe-2"
                     }
                 },
-                [ImageServer.IIPImage] = new ImageServerConfig
+                [ImageServer.IIPImage] = new()
                 {
                     Separator = "/",
                     PathTemplate = "/path",
@@ -75,7 +75,6 @@ public class ImageRequestHandlerTests
                 }
             }
         };
-    }
 
     [Fact]
     public async Task HandleRequest_Returns404_IfAssetPathParserThrowsHttpException_NotFound()
@@ -106,8 +105,32 @@ public class ImageRequestHandlerTests
         var result = await sut.HandleRequest(new DefaultHttpContext());
             
         // Assert
-        result.Should().BeOfType<StatusCodeResult>()
-            .Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Fact]
+    public async Task HandleRequest_Returns400_IfUnableToDetermineImageVersion()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = context.Request.Path = "/iiif-img/v4/2/2/test-image/full/full/0/default.jpg";
+
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image
+            });
+        
+        var sut = GetImageRequestHandlerWithMockPathParser();
+            
+        // Act
+        var result = await sut.HandleRequest(context);
+            
+        // Assert
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Theory]
@@ -131,8 +154,7 @@ public class ImageRequestHandlerTests
         var result = await sut.HandleRequest(context);
             
         // Assert
-        result.Should().BeOfType<StatusCodeResult>()
-            .Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Theory]
@@ -154,6 +176,35 @@ public class ImageRequestHandlerTests
         // Assert
         result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+    
+    [Theory]
+    [InlineData("full/501,")]
+    [InlineData("full/,501")]
+    [InlineData("full/!501,501")]
+    [InlineData("square/pct:51,")]
+    [InlineData("0,0,512,512/512,")]
+    [InlineData("pct:0,0,52,52/!501,501")]
+    public async Task HandleRequest_Returns403_IfRequestedExceedsMaxWidth(string sizeAndRegion)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = $"/iiif-img/2/2/test-image/{sizeAndRegion}/0/default.jpg";
+
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
+            .Returns(new OrchestrationImage
+            {
+                Width = 1000, Height = 1000, MaxWidth = 500, 
+                Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
+            });
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        // Act
+        var result = await sut.HandleRequest(context);
+            
+        // Assert
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
 
     [Fact]
     public async Task HandleRequest_Returns401_IfAssetRequiresAuth_AndUserCannotAccess()
@@ -167,7 +218,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
-                Roles = roles, RequiresAuth = true, Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
+                Width = 1000, Height = 1000, MaxWidth = 5000, Roles = roles, RequiresAuth = true, 
+                Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
             AuthMechanism.Cookie, CancellationToken.None)).Returns(AssetAccessResult.Unauthorized);
@@ -186,7 +238,7 @@ public class ImageRequestHandlerTests
     [InlineData(",900")]
     [InlineData("!900,900")]
     [InlineData("pct:50")]
-    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequestSmallerThanMaxUnauthorised(
+    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullRequest_SizeEqualToOpenFullMax(
         string sizeParameter)
     {
         // Arrange
@@ -199,17 +251,17 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
+                OpenFullMax = 900, Width = 1800, Height = 1800, RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
 
         // Assert
-        result.Target.Should().Be(ProxyDestination.SpecialServer);
+        result!.Target.Should().Be(ProxyDestination.SpecialServer);
         result.HasPath.Should().BeTrue();
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
             AuthMechanism.Cookie, CancellationToken.None)).MustNotHaveHappened();
@@ -225,7 +277,7 @@ public class ImageRequestHandlerTests
     [InlineData("/square/900,/")]
     [InlineData("/square/,900/")]
     [InlineData("/square/!900,900/")]
-    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullOrEquivalentRequestSmallerThanMaxUnauthorised(string iiifRequest)
+    public async Task HandleRequest_ProxiesToSpecialServer_IfAssetRequiresAuth_AndUserNotAuthorised_ButFullOrEquivalentRequest_SizeEqualToOpenFullMax(string iiifRequest)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -237,14 +289,14 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                MaxUnauthorised = 900, Width = 900, Height = 900, RequiresAuth = true,
+                AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
+                OpenFullMax = 900, Width = 900, Height = 900, RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
 
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
@@ -256,10 +308,10 @@ public class ImageRequestHandlerTests
     [Theory]
     [InlineData("/full/901,901/", "Size too large")]
     [InlineData("/full/max/", "Max size")]
-    [InlineData("/0,0,512,512/900,/", "Tiled region")]
+    [InlineData("/0,0,900,900/900,/", "Tiled region")]
     [InlineData("/pct:0,0,512,512/!10,10/", "Percent region")]
     [InlineData("/square/!901,901/", "Square region too large")]
-    public async Task HandleRequest_Returns401_IfAssetRequiresAuth_AndUserNotAuthorised_AndRequestNotForMaxUnauthorised(
+    public async Task HandleRequest_Returns401_IfAssetRequiresAuth_AndUserNotAuthorised_AndRequestNotForOpenFullMax(
         string iiifRequest, string reason)
     {
         // Arrange
@@ -271,8 +323,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
-                Roles = roles, MaxUnauthorised = 900, Width = 1800, Height = 1800, RequiresAuth = true,
-                S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
+                Roles = roles, OpenFullMax = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
             AuthMechanism.Cookie, CancellationToken.None)).Returns(AssetAccessResult.Unauthorized);
@@ -286,7 +338,7 @@ public class ImageRequestHandlerTests
     }
 
     [Fact]
-    public async Task HandleRequest_ProxiesToThumbs_IfRequiresAuth_AndFullRegionOfKnownSize_SmallerThanMaxUnauthorised()
+    public async Task HandleRequest_ProxiesToThumbs_IfRequiresAuth_AndFullRegionOfKnownSize_SmallerThanOpenFullMax()
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -297,14 +349,14 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } }, Height = 1000, Width = 1000,
-                RequiresAuth = true, Roles = new List<string> { "role" }, MaxUnauthorised = 200,
+                AssetId = assetId, OpenThumbs = [[150, 150]], Height = 1000, Width = 1000,
+                RequiresAuth = true, Roles = ["role"], OpenFullMax = 200, MaxWidth = 5000, 
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
@@ -323,13 +375,13 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
+                AssetId = assetId, OpenThumbs = [[150, 150]], Height = 1000, Width = 1000, MaxWidth = 5000,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
@@ -348,14 +400,14 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 256, 256 } },
+                AssetId = assetId, OpenThumbs = [Item], MaxWidth = 5000,
                 Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
                 Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
@@ -374,14 +426,14 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]> { new[] { 256, 256 } },
+                AssetId = assetId, OpenThumbs = [[256, 256]], MaxWidth = 5000,
                 Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
                 Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
@@ -404,8 +456,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                RequiresAuth = true, Height = 1000, Width = 1000, MaxUnauthorised = 300,
+                AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
+                RequiresAuth = true, Height = 1000, Width = 1000, OpenFullMax = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = true
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -413,7 +465,7 @@ public class ImageRequestHandlerTests
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
+        var result = (ProxyImageServerResult)await sut.HandleRequest(context);
 
         // Assert
         result.Target.Should().Be(ProxyDestination.ImageServer);
@@ -436,8 +488,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Roles = roles, OpenThumbs = new List<int[]> { new[] { 150, 150 } },
-                RequiresAuth = true, Height = 1000, Width = 1000, MaxUnauthorised = 300,
+                AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
+                RequiresAuth = true, Height = 1000, Width = 1000, OpenFullMax = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = false
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -445,24 +497,26 @@ public class ImageRequestHandlerTests
         var sut = GetImageRequestHandlerWithMockPathParser();
 
         // Act
-        var result = await sut.HandleRequest(context) as StatusCodeResult;
+        var result = (StatusCodeResult)await sut.HandleRequest(context);
 
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
     
     [Theory]
-    [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg")] // full/<size>
-    [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg")] // /full/full
-    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg")] // /full/max
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png")] // png
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif")] // tif
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg")] // rotation
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg")] // rotation / mirrored
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg")] // bitonal
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg")] // gray
-    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/default.jpg")] // square
-    public async Task HandleRequest_ProxiesToSpecialServer_ForAllFull(string path)
+    [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg", "full/90,/0/default.jpg", false)] // full/<size>
+    [InlineData("/iiif-img/v2/2/2/test-image/full/full/0/default.jpg", "full/1000,1000/0/default.jpg", true)] // /full/full - v2
+    [InlineData("/iiif-img/v2/2/2/test-image/full/max/0/default.jpg", "full/5000,5000/0/default.jpg", true)] // /full/max - v2
+    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", "full/1000,1000/0/default.jpg", false)] // /full/max - v3
+    [InlineData("/iiif-img/2/2/test-image/full/^max/0/default.jpg", "full/^5000,5000/0/default.jpg", false)] // /full/^max - v3
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png", "full/!100,150/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif", "full/!100,150/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg", "full/!100,150/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg", "full/!100,150/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", "full/!100,150/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", "full/!100,150/0/gray.jpg", false)] // gray
+    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/bitonal.tif", "square/!100,150/0/bitonal.tif", false)] // square
+    public async Task HandleRequest_ProxiesToSpecialServer_ForAllFull_RewritingIfRequired(string path, string expectedProxyPath, bool version2)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -473,19 +527,19 @@ public class ImageRequestHandlerTests
             
         var sut = GetImageRequestHandlerWithMockPathParser();
 
-        List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
-
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                AssetId = assetId, OpenThumbs = [[150, 150]], S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1000
             });
+        
+        var destination = version2 ? "cantaloupe-2" : "cantaloupe-3";
 
-        var expected = $"cantaloupe-3s3:%2F%2Fstorage%2F2%2F2%2Ftest-image/{string.Join("/", path.Split("/")[5..])}";
+        var expected = $"{destination}s3:%2F%2Fstorage%2F2%2F2%2Ftest-image/{expectedProxyPath}";
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
@@ -493,17 +547,19 @@ public class ImageRequestHandlerTests
     }
         
     [Theory]
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/90,/0/default.jpg", false)] // UV without ?t=
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/full/0/default.jpg", true)] // /full/full
-    [InlineData("/iiif-img/2/2/test-image/pct:0,0,512,512/full/0/default.jpg", true)] // pct:
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/max/0/default.jpg", true)] // /full/max
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.png", false)] // png
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.tif", false)] // tif
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/90/default.jpg", false)] // rotation
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/!0/default.jpg", false)] // rotation / mirrored
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/bitonal.jpg", false)] // bitonal
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/gray.jpg", false)] // gray
-    public async Task HandleRequest_ProxiesToImageServer_ForAllTileRequests(string path, bool knownThumb)
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/90,/0/default.jpg", false, "0,0,512,512/90,/0/default.jpg", false)] // UV without ?t=
+    [InlineData("/iiif-img/v2/2/2/test-image/0,0,512,512/full/0/default.jpg", true, "0,0,512,512/512,512/0/default.jpg", true)] // /full
+    [InlineData("/iiif-img/v2/2/2/test-image/0,0,512,512/max/0/default.jpg", true, "0,0,512,512/5000,5000/0/default.jpg", true)] // v2 /max
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/max/0/default.jpg", true, "0,0,512,512/512,512/0/default.jpg", false)] // v3 /max
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/^max/0/default.jpg", true, "0,0,512,512/^5000,5000/0/default.jpg", false)] // v3 /^max
+    [InlineData("/iiif-img/v2/2/2/test-image/pct:0,0,512,512/full/0/default.jpg", true, "pct:0,0,512,512/1000,1000/0/default.jpg", true)] // pct: full v2
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.png", false, "0,0,512,512/!100,150/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.tif", false, "0,0,512,512/!100,150/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/90/default.jpg", false, "0,0,512,512/!100,150/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/!0/default.jpg", false, "0,0,512,512/!100,150/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/bitonal.jpg", false, "0,0,512,512/!100,150/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/gray.jpg", false, "0,0,512,512/!100,150/0/gray.jpg", false)] // gray
+    public async Task HandleRequest_ProxiesToImageServer_ForAllTileRequests(string path, bool knownThumb, string expectedProxyPath, bool version2)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -514,21 +570,20 @@ public class ImageRequestHandlerTests
             
         var sut = GetImageRequestHandlerWithMockPathParser();
 
-        List<int[]> openSizes = knownThumb
-            ? new List<int[]> { new[] { 150, 150 } }
-            : new List<int[]>();
+        List<int[]> openSizes = knownThumb ? [[150, 150]] : [];
 
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1000
             });
         
-        var expected = $"cantaloupe-3/path/{string.Join("/", path.Split("/")[5..])}";
+        var destination = version2 ? "cantaloupe-2" : "cantaloupe-3";
+        var expected = $"{destination}/path/{expectedProxyPath}";
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyImageServerResult;
+        var result = (ProxyImageServerResult)await sut.HandleRequest(context);
             
         // Assert
         result.Target.Should().Be(ProxyDestination.ImageServer);
@@ -540,7 +595,7 @@ public class ImageRequestHandlerTests
     [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-3", ProxyDestination.SpecialServer)]
     [InlineData(ImageServer.IIPImage, "/iiif-img/v2/2/2/test-image/full/90,/0/default.jpg", "cantaloupe-2", ProxyDestination.SpecialServer)]
     [InlineData(ImageServer.Cantaloupe, "/iiif-img/v2/2/2/test-image/5,5,5,5/90,/0/default.jpg", "cantaloupe-2", ProxyDestination.ImageServer)]
-    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/5,5,5,5/90,/0/default.jpg", "cantaloupe-3", ProxyDestination.ImageServer)]
+    [InlineData(ImageServer.Cantaloupe, "/iiif-img/v3/2/2/test-image/5,5,5,5/^90,/0/default.jpg", "cantaloupe-3", ProxyDestination.ImageServer)]
     [InlineData(ImageServer.IIPImage, "/iiif-img/v2/2/2/test-image/5,5,5,5/90,/0/default.jpg", "iip", ProxyDestination.ImageServer)]
     public async Task HandleRequest_ProxiesToCorrectImageServerEndpoint_ForVersionedRequests(ImageServer imageServer,
         string path, string startsWith, ProxyDestination proxyDestination)
@@ -558,12 +613,12 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
             });
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
 
         // Assert
         result.Target.Should().Be(proxyDestination);
@@ -589,12 +644,12 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
             });
 
         // Act
-        var result = await sut.HandleRequest(context) as StatusCodeResult;
+        var result = (StatusCodeResult)await sut.HandleRequest(context);
             
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -615,12 +670,12 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = new List<int[]>(), S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
             });
 
         // Act
-        var result = await sut.HandleRequest(context) as StatusCodeResult;
+        var result = (StatusCodeResult)await sut.HandleRequest(context);
             
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
@@ -628,7 +683,7 @@ public class ImageRequestHandlerTests
 
     [Theory]
     [InlineData("/iiif-img/2/2/test-image/full/!150,150/0/default.jpg", ProxyDestination.Thumbs)]
-    [InlineData("/iiif-img/2/2/test-image/5,5,5,5/90,/0/default.jpg", ProxyDestination.ImageServer)]
+    [InlineData("/iiif-img/2/2/test-image/5,5,90,90/90,/0/default.jpg", ProxyDestination.ImageServer)]
     [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", ProxyDestination.SpecialServer)] 
     public async Task HandleRequest_ProxiesAll_WithCustomHeaders(string path, ProxyDestination destination)
     {
@@ -647,17 +702,17 @@ public class ImageRequestHandlerTests
             
         var sut = GetImageRequestHandlerWithMockPathParser();
 
-        List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
+        List<int[]> openSizes = [[150, 150]];
 
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
             });
 
         // Act
-        var result = await sut.HandleRequest(context) as ProxyActionResult;
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
             
         // Assert
         result.Headers.Should().ContainKeys("x-test-header", "x-test-header-2");
@@ -679,17 +734,15 @@ public class ImageRequestHandlerTests
             
         var sut = GetImageRequestHandlerWithMockPathParser();
 
-        List<int[]> openSizes = new List<int[]> { new[] { 150, 150 } };
-
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = openSizes, S3Location = "",
-                Channels = AvailableDeliveryChannel.Image, Reingest = false
+                AssetId = assetId, OpenThumbs = [[150, 150]], S3Location = "", MaxWidth = 5000,
+                Channels = AvailableDeliveryChannel.Image, Reingest = false, Height = 1000, Width = 1512
             });
 
         // Act
-        var result = await sut.HandleRequest(context) as StatusCodeResult;
+        var result = (StatusCodeResult)await sut.HandleRequest(context);
             
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.NotFound);

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -7,6 +7,7 @@ using DLCS.Core.Types;
 using DLCS.Model.Assets.CustomHeaders;
 using DLCS.Model.PathElements;
 using DLCS.Web.Requests.AssetDelivery;
+using IIIF;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -194,7 +195,7 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
-                Width = 1000, Height = 1000, MaxWidth = 500, 
+                Size = new Size(1000, 1000), MaxWidth = 500, 
                 Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -218,7 +219,7 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
-                Width = 1000, Height = 1000, MaxWidth = 5000, Roles = roles, RequiresAuth = true, 
+                Size = new Size(1000, 1000), MaxWidth = 5000, Roles = roles, RequiresAuth = true, 
                 Channels = AvailableDeliveryChannel.Image, S3Location = "s3://"
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -252,7 +253,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
-                OpenFullMax = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                OpenFullMax = 900, Size = new Size(1800, 1800), RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -290,7 +291,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
-                OpenFullMax = 900, Width = 900, Height = 900, RequiresAuth = true,
+                OpenFullMax = 900, Size = new Size(900, 900), RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -323,7 +324,7 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(new AssetId(2, 2, "test-image")))
             .Returns(new OrchestrationImage
             {
-                Roles = roles, OpenFullMax = 900, Width = 1800, Height = 1800, RequiresAuth = true,
+                Roles = roles, OpenFullMax = 900, Size = new Size(1800, 1800), RequiresAuth = true,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -349,7 +350,7 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = [[150, 150]], Height = 1000, Width = 1000,
+                AssetId = assetId, OpenThumbs = [[150, 150]], Size = new Size(1000, 1000),
                 RequiresAuth = true, Roles = ["role"], OpenFullMax = 200, MaxWidth = 5000, 
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
@@ -375,7 +376,7 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, OpenThumbs = [[150, 150]], Height = 1000, Width = 1000, MaxWidth = 5000,
+                AssetId = assetId, OpenThumbs = [[150, 150]], Size = new Size(1000, 1000), MaxWidth = 5000,
                 S3Location = "s3://storage/2/2/test-image", Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -401,7 +402,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [Item], MaxWidth = 5000,
-                Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
+                Size = new Size(512, 512), S3Location = "s3://storage/2/2/test-image", 
                 Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -427,7 +428,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [[256, 256]], MaxWidth = 5000,
-                Height = 512, Width = 512, S3Location = "s3://storage/2/2/test-image", 
+                Size = new Size(512, 512), S3Location = "s3://storage/2/2/test-image", 
                 Channels = AvailableDeliveryChannel.Image
             });
         var sut = GetImageRequestHandlerWithMockPathParser();
@@ -457,7 +458,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
-                RequiresAuth = true, Height = 1000, Width = 1000, OpenFullMax = 300,
+                RequiresAuth = true, Size = new Size(1000, 1000), OpenFullMax = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = true
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -489,7 +490,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, Roles = roles, OpenThumbs = [[150, 150]], MaxWidth = 5000,
-                RequiresAuth = true, Height = 1000, Width = 1000, OpenFullMax = 300,
+                RequiresAuth = true, Size = new Size(1000, 1000), OpenFullMax = 300,
                 Channels = AvailableDeliveryChannel.Image, Reingest = false
             });
         A.CallTo(() => accessValidator.TryValidate(A<AssetId>.That.Matches(a => a.Customer == 2), roles,
@@ -531,7 +532,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [[150, 150]], S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1000
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1000),
             });
         
         var destination = version2 ? "cantaloupe-2" : "cantaloupe-3";
@@ -576,7 +577,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1000
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1000),
             });
         
         var destination = version2 ? "cantaloupe-2" : "cantaloupe-3";
@@ -614,7 +615,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1000),
             });
 
         // Act
@@ -645,7 +646,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1512),
             });
 
         // Act
@@ -671,7 +672,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [], S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1512),
             });
 
         // Act
@@ -708,7 +709,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = openSizes, S3Location = "s3://storage/2/2/test-image",
-                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000, Width = 1512
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Size = new Size(1000, 1512),
             });
 
         // Act
@@ -738,7 +739,7 @@ public class ImageRequestHandlerTests
             .Returns(new OrchestrationImage
             {
                 AssetId = assetId, OpenThumbs = [[150, 150]], S3Location = "", MaxWidth = 5000,
-                Channels = AvailableDeliveryChannel.Image, Reingest = false, Height = 1000, Width = 1512
+                Channels = AvailableDeliveryChannel.Image, Reingest = false, Size = new Size(1512, 1000)
             });
 
         // Act
@@ -768,8 +769,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000,
-                Width = 1000, S3Location = "s3://storage/2/2/test-image",
+                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000,
+                Size = new Size(1000, 1000), S3Location = "s3://storage/2/2/test-image",
             });
         
         // Act
@@ -800,8 +801,8 @@ public class ImageRequestHandlerTests
         A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
             .Returns(new OrchestrationImage
             {
-                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000,
-                Width = 1000, S3Location = "s3://storage/2/2/test-image",
+                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, 
+                Size = new Size(1000, 1000), S3Location = "s3://storage/2/2/test-image",
             });
         
         // Act

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -517,7 +517,7 @@ public class ImageRequestHandlerTests
     [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", "full/!100,150/0/bitonal.jpg", false)] // bitonal
     [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", "full/!100,150/0/gray.jpg", false)] // gray
     [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/bitonal.tif", "square/!100,150/0/bitonal.tif", false)] // square
-    public async Task HandleRequest_ProxiesToSpecialServer_ForAllFull_RewritingIfRequired(string path, string expectedProxyPath, bool version2)
+    public async Task HandleRequest_ProxiesToSpecialServer_ForAllLargeFull_RewritingIfRequired(string path, string expectedProxyPath, bool version2)
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -544,6 +544,44 @@ public class ImageRequestHandlerTests
             
         // Assert
         result.Target.Should().Be(ProxyDestination.SpecialServer);
+        result.Path.Should().Be(expected);
+    }
+    
+    [Theory]
+    [InlineData("/iiif-img/2/2/test-image/full/90,/0/default.jpg", "/2/2/test-image/full/90,/0/default.jpg", ProxyDestination.ResizeThumbs)] // full/<size>
+    [InlineData("/iiif-img/v2/2/2/test-image/full/full/0/default.jpg", "/v2/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/full - v2
+    [InlineData("/iiif-img/v2/2/2/test-image/full/max/0/default.jpg", "/v2/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/max - v2
+    [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", "/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/max - v3
+    [InlineData("/iiif-img/2/2/test-image/full/^max/0/default.jpg", "/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/^max - v3
+    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/default.jpg", "/2/2/test-image/square/!100,150/0/default.jpg", ProxyDestination.ResizeThumbs)] // square
+    public async Task HandleRequest_ProxiesToThumbs_ForFullThatAreSmallEnough_RewritingIfRequired(string path, string expectedProxyPath, ProxyDestination destination)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+
+        var settings = CreateOrchestratorSettings();
+        settings.Proxy.CanResizeThumbs = true;
+        var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
+
+        // Image is 2000x2000 but only 400 maxWidth
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, OpenThumbs = [[400, 400], [150, 150]], S3Location = "s3://storage/2/2/test-image",
+                Channels = AvailableDeliveryChannel.Image, MaxWidth = 400, Size = Size.Square(2000),
+            });
+        
+        var expected = $"thumbs{expectedProxyPath}";
+
+        // Act
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
+            
+        // Assert
+        result.Target.Should().Be(destination);
         result.Path.Should().Be(expected);
     }
     

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -135,19 +135,21 @@ public class ImageRequestHandlerTests
     }
     
     [Theory]
-    [InlineData("0,")]
-    [InlineData(",0")]
-    [InlineData("!0,0")]
-    [InlineData("20,0")]
-    [InlineData("0,20")]
-    public async Task HandleRequest_Returns400_IfInvalidSize(string size)
+    [InlineData("full/0,/0/default.jpg")] // size
+    [InlineData("0,0,512,512/,0/0/default.jpg")] // size
+    [InlineData("square/!0,0/0/default.jpg")] // size
+    [InlineData("full/20,0/0/default.jpg")] // size
+    [InlineData("full/0,20/0/default.jpg")] // size
+    [InlineData("full/max/0/vibrant.jpg")] // quality
+    [InlineData("full/max/0/default.pdf")] // format
+    public async Task HandleRequest_Returns400_IfInvalidRequest(string imageRequest)
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
 
         // Act
         var context = new DefaultHttpContext();
-        context.Request.Path = $"/iiif-img/{id}/full/{size}/0/default.jpg";
+        context.Request.Path = $"/iiif-img/{id}/{imageRequest}";
 
         var sut = GetImageRequestHandlerWithMockPathParser();
             

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -545,7 +545,7 @@ public class ImageRequestHandlerTests
         result.Target.Should().Be(ProxyDestination.SpecialServer);
         result.Path.Should().Be(expected);
     }
-        
+    
     [Theory]
     [InlineData("/iiif-img/2/2/test-image/0,0,512,512/90,/0/default.jpg", false, "0,0,512,512/90,/0/default.jpg", false)] // UV without ?t=
     [InlineData("/iiif-img/v2/2/2/test-image/0,0,512,512/full/0/default.jpg", true, "0,0,512,512/512,512/0/default.jpg", true)] // /full
@@ -747,6 +747,70 @@ public class ImageRequestHandlerTests
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+    
+    # region Strict/Lax mode handling
+    [Theory]
+    [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/full/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/square/full/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/pct:0,0,50,50/full/0/default.jpg")]
+    public async Task HandleRequest_StrictMode_RejectsV3FullSize(string path)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+            
+        var sut = GetImageRequestHandlerWithMockPathParser();
+
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000,
+                Width = 1000, S3Location = "s3://storage/2/2/test-image",
+            });
+        
+        // Act
+        var result = (StatusCodeResult)await sut.HandleRequest(context);
+            
+        // Assert
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Theory]
+    [InlineData("/iiif-img/2/2/test-image/full/full/0/default.jpg", "full/1000,1000/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/full/0/default.jpg", "0,0,512,512/512,512/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/square/full/0/default.jpg", "square/1000,1000/0/default.jpg")]
+    [InlineData("/iiif-img/2/2/test-image/pct:0,0,50,50/full/0/default.jpg", "pct:0,0,50,50/500,500/0/default.jpg")]
+    public async Task HandleRequest_LaxMode_TreatsV3FullSizeAsMax(string path, string expectedProxyPath)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        A.CallTo(() => customerRepository.GetCustomerPathElement("2")).Returns(new CustomerPathElement(2, "Test-Cust"));
+        var assetId = new AssetId(2, 2, "test-image");
+            
+        var settings = CreateOrchestratorSettings();
+        settings.StrictImageRequestParsing = false;
+        var sut = GetImageRequestHandlerWithMockPathParser(orchestratorSettings: settings);
+
+        A.CallTo(() => assetTracker.GetOrchestrationAsset<OrchestrationImage>(assetId))
+            .Returns(new OrchestrationImage
+            {
+                AssetId = assetId, Channels = AvailableDeliveryChannel.Image, MaxWidth = 5000, Height = 1000,
+                Width = 1000, S3Location = "s3://storage/2/2/test-image",
+            });
+        
+        // Act
+        var result = (ProxyActionResult)await sut.HandleRequest(context);
+            
+        // Assert
+        result.Path.Should().Contain(expectedProxyPath);
+    }
+    # endregion
 
     private ImageRequestHandler GetImageRequestHandlerWithMockPathParser(bool mockPathParser = false,
         OrchestratorSettings orchestratorSettings = null)

--- a/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/ImageRequestHandlerTests.cs
@@ -181,10 +181,8 @@ public class ImageRequestHandlerTests
     [Theory]
     [InlineData("full/501,")]
     [InlineData("full/,501")]
-    [InlineData("full/!501,501")]
     [InlineData("square/pct:51,")]
     [InlineData("0,0,512,512/512,")]
-    [InlineData("pct:0,0,52,52/!501,501")]
     public async Task HandleRequest_Returns403_IfRequestedExceedsMaxWidth(string sizeAndRegion)
     {
         // Arrange
@@ -361,7 +359,7 @@ public class ImageRequestHandlerTests
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!150,150/0/default.jpg");
+        result.Path.Should().Be("thumbs/2/2/test-image/full/150,150/0/default.jpg");
     }
 
     [Fact]
@@ -386,7 +384,7 @@ public class ImageRequestHandlerTests
             
         // Assert
         result.Target.Should().Be(ProxyDestination.Thumbs);
-        result.Path.Should().Be("thumbs/2/2/test-image/full/!150,150/0/default.jpg");
+        result.Path.Should().Be("thumbs/2/2/test-image/full/150,150/0/default.jpg");
     }
     
     [Fact]
@@ -510,13 +508,16 @@ public class ImageRequestHandlerTests
     [InlineData("/iiif-img/v2/2/2/test-image/full/max/0/default.jpg", "full/5000,5000/0/default.jpg", true)] // /full/max - v2
     [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", "full/1000,1000/0/default.jpg", false)] // /full/max - v3
     [InlineData("/iiif-img/2/2/test-image/full/^max/0/default.jpg", "full/^5000,5000/0/default.jpg", false)] // /full/^max - v3
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png", "full/!100,150/0/default.png", false)] // png
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif", "full/!100,150/0/default.tif", false)] // tif
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg", "full/!100,150/90/default.jpg", false)] // rotation
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg", "full/!100,150/!0/default.jpg", false)] // rotation / mirrored
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", "full/!100,150/0/bitonal.jpg", false)] // bitonal
-    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", "full/!100,150/0/gray.jpg", false)] // gray
-    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/bitonal.tif", "square/!100,150/0/bitonal.tif", false)] // square
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.png", "full/100,100/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/default.tif", "full/100,100/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/90/default.jpg", "full/100,100/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/!0/default.jpg", "full/100,100/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/bitonal.jpg", "full/100,100/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/full/!100,150/0/gray.jpg", "full/100,100/0/gray.jpg", false)] // gray
+    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/bitonal.tif", "square/100,100/0/bitonal.tif", false)] // square
+    [InlineData("/iiif-img/2/2/test-image/square/!5000,5000/0/bitonal.tif", "square/1000,1000/0/bitonal.tif", false)] // confined larger than maxWidth
+    [InlineData("/iiif-img/v2/2/2/test-image/square/!5000,5000/0/bitonal.tif", "square/5000,5000/0/bitonal.tif", true)] // confined larger than maxWidth v2
+    [InlineData("/iiif-img/2/2/test-image/square/^!6000,6000/0/bitonal.tif", "square/^5000,5000/0/bitonal.tif", false)] // confined larger than maxWidth v2
     public async Task HandleRequest_ProxiesToSpecialServer_ForAllLargeFull_RewritingIfRequired(string path, string expectedProxyPath, bool version2)
     {
         // Arrange
@@ -553,7 +554,7 @@ public class ImageRequestHandlerTests
     [InlineData("/iiif-img/v2/2/2/test-image/full/max/0/default.jpg", "/v2/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/max - v2
     [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", "/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/max - v3
     [InlineData("/iiif-img/2/2/test-image/full/^max/0/default.jpg", "/2/2/test-image/full/400,400/0/default.jpg", ProxyDestination.Thumbs)] // /full/^max - v3
-    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/default.jpg", "/2/2/test-image/square/!100,150/0/default.jpg", ProxyDestination.ResizeThumbs)] // square
+    [InlineData("/iiif-img/2/2/test-image/square/!100,150/0/default.jpg", "/2/2/test-image/square/100,100/0/default.jpg", ProxyDestination.ResizeThumbs)] // square
     public async Task HandleRequest_ProxiesToThumbs_ForFullThatAreSmallEnough_RewritingIfRequired(string path, string expectedProxyPath, ProxyDestination destination)
     {
         // Arrange
@@ -592,12 +593,14 @@ public class ImageRequestHandlerTests
     [InlineData("/iiif-img/2/2/test-image/0,0,512,512/max/0/default.jpg", true, "0,0,512,512/512,512/0/default.jpg", false)] // v3 /max
     [InlineData("/iiif-img/2/2/test-image/0,0,512,512/^max/0/default.jpg", true, "0,0,512,512/^5000,5000/0/default.jpg", false)] // v3 /^max
     [InlineData("/iiif-img/v2/2/2/test-image/pct:0,0,512,512/full/0/default.jpg", true, "pct:0,0,512,512/1000,1000/0/default.jpg", true)] // pct: full v2
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.png", false, "0,0,512,512/!100,150/0/default.png", false)] // png
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.tif", false, "0,0,512,512/!100,150/0/default.tif", false)] // tif
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/90/default.jpg", false, "0,0,512,512/!100,150/90/default.jpg", false)] // rotation
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/!0/default.jpg", false, "0,0,512,512/!100,150/!0/default.jpg", false)] // rotation / mirrored
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/bitonal.jpg", false, "0,0,512,512/!100,150/0/bitonal.jpg", false)] // bitonal
-    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/gray.jpg", false, "0,0,512,512/!100,150/0/gray.jpg", false)] // gray
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.png", false, "0,0,512,512/100,100/0/default.png", false)] // png
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/default.tif", false, "0,0,512,512/100,100/0/default.tif", false)] // tif
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/90/default.jpg", false, "0,0,512,512/100,100/90/default.jpg", false)] // rotation
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/!0/default.jpg", false, "0,0,512,512/100,100/!0/default.jpg", false)] // rotation / mirrored
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/bitonal.jpg", false, "0,0,512,512/100,100/0/bitonal.jpg", false)] // bitonal
+    [InlineData("/iiif-img/2/2/test-image/0,0,512,512/!100,150/0/gray.jpg", false, "0,0,512,512/100,100/0/gray.jpg", false)] // gray
+    [InlineData("/iiif-img/2/2/test-image/0,0,100,100/!512,512/0/gray.png", false, "0,0,100,100/100,100/0/gray.png", false)] // largest possible under maxWidth
+    [InlineData("/iiif-img/2/2/test-image/0,0,100,100/^!5120,5120/0/gray.png", false, "0,0,100,100/^5000,5000/0/gray.png", false)] // largest possible under maxWidth
     public async Task HandleRequest_ProxiesToImageServer_ForAllTileRequests(string path, bool knownThumb, string expectedProxyPath, bool version2)
     {
         // Arrange
@@ -721,7 +724,7 @@ public class ImageRequestHandlerTests
     }
 
     [Theory]
-    [InlineData("/iiif-img/2/2/test-image/full/!150,150/0/default.jpg", ProxyDestination.Thumbs)]
+    [InlineData("/iiif-img/2/2/test-image/full/150,150/0/default.jpg", ProxyDestination.Thumbs)]
     [InlineData("/iiif-img/2/2/test-image/5,5,90,90/90,/0/default.jpg", ProxyDestination.ImageServer)]
     [InlineData("/iiif-img/2/2/test-image/full/max/0/default.jpg", ProxyDestination.SpecialServer)] 
     public async Task HandleRequest_ProxiesAll_WithCustomHeaders(string path, ProxyDestination destination)

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/Auth/V2/IIIFAuth2ClientTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/Auth/V2/IIIFAuth2ClientTests.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using IIIF;
 using IIIF.Auth.V2;
 using IIIF.Serialisation;
@@ -19,7 +19,6 @@ namespace Orchestrator.Tests.Infrastructure.Auth.V2;
 public class IIIFAuth2ClientTests
 {
     private readonly ControllableHttpMessageHandler httpHandler;
-    private static readonly JsonSerializerOptions Settings = new(JsonSerializerDefaults.Web);
     private readonly IIIFAuth2Client sut;
 
     public IIIFAuth2ClientTests()
@@ -32,12 +31,29 @@ public class IIIFAuth2ClientTests
     }
 
     [Fact]
+    public async Task GetAuthServicesForAsset_NoOp_IfUnobtainableRoleOnly()
+    {
+        var orchestrationImage = new OrchestrationImage
+        {
+            AssetId = AssetId.FromString("99/100/foo"), Roles = [Asset.UnobtainableRole]
+        };
+        
+        // Act
+        var result = await sut.GetAuthServicesForAsset(orchestrationImage.AssetId, orchestrationImage.Roles,
+            CancellationToken.None);
+        
+        // Assert
+        httpHandler.CallsMade.Should().HaveCount(0);
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetAuthServicesForAsset_CallsCorrectPath_SingleRole()
     {
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1"]
         };
         
         // Act
@@ -46,14 +62,30 @@ public class IIIFAuth2ClientTests
         // Assert
         httpHandler.CallsMade.Should().ContainSingle(s => s == "http://auth-2/services/99/100/foo?roles=role1");
     }
-    
+
+    [Fact]
+    public async Task GetAuthServicesForAsset_CallsCorrectPath_IgnoringUnobtainableRole()
+    {
+        // Arrange
+        var orchestrationImage = new OrchestrationImage
+        {
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", Asset.UnobtainableRole]
+        };
+
+        // Act
+        await sut.GetAuthServicesForAsset(orchestrationImage.AssetId, orchestrationImage.Roles, CancellationToken.None);
+
+        // Assert
+        httpHandler.CallsMade.Should().ContainSingle(s => s == "http://auth-2/services/99/100/foo?roles=role1");
+    }
+
     [Fact]
     public async Task GetAuthServicesForAsset_CallsCorrectPath_MultipleRoles()
     {
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
         
         // Act
@@ -72,7 +104,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         httpHandler.SetResponse(new HttpResponseMessage(status));
@@ -91,7 +123,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
@@ -112,7 +144,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         var probeService = new AuthProbeService2
@@ -138,7 +170,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1"]
         };
         
         // Act
@@ -155,7 +187,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
         
         // Act
@@ -173,7 +205,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.InternalServerError));
@@ -192,7 +224,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         var probeServiceResult = new AuthProbeResult2 { Status = 200 };
@@ -214,7 +246,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1"]
         };
         
         // Act
@@ -230,7 +262,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
         
         // Act
@@ -251,7 +283,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         httpHandler.SetResponse(new HttpResponseMessage(statusCode));
@@ -270,7 +302,7 @@ public class IIIFAuth2ClientTests
         // Arrange
         var orchestrationImage = new OrchestrationImage
         {
-            AssetId = AssetId.FromString("99/100/foo"), Roles = new List<string> { "role1", "role2", "role3" }
+            AssetId = AssetId.FromString("99/100/foo"), Roles = ["role1", "role2", "role3"]
         };
 
         httpHandler.SetResponse(new HttpResponseMessage(HttpStatusCode.OK));

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/MetadataWithFallbackThumbSizeProviderTests.cs
@@ -21,7 +21,7 @@ public class MetadataWithFallbackThumbSizeProviderTests
         policyRepository = A.Fake<IPolicyRepository>();
 
         var settings = new OrchestratorSettings();
-        settings.ImageIngest.DefaultThumbs = new List<string> { "!400,400" };
+        settings.ImageIngest.DefaultThumbs = ["!400,400"];
         var orchestratorSettings = Options.Create(settings);
         sut = new MetadataWithFallbackThumbSizeProvider(policyRepository, orchestratorSettings,
             new NullLogger<MetadataWithFallbackThumbSizeProvider>());
@@ -33,8 +33,8 @@ public class MetadataWithFallbackThumbSizeProviderTests
         // Arrange
         const string thumbsMetadata = "{\"a\": [[769, 1024],[300,400]], \"o\": [[150, 200],[75, 100]]}";
         var expected = new ThumbnailSizes(
-            new List<int[]> { new[] { 150, 200 }, new[] { 75, 100 }, },
-            new List<int[]> { new[] { 769, 1024 }, new[] { 300, 400 }, });
+            [[150, 200], [75, 100]],
+            [[769, 1024], [300, 400]]);
         
         var assetId = AssetIdGenerator.GetAssetId();
         var asset = new Asset(assetId).WithTestThumbnailMetadata(thumbsMetadata);
@@ -79,8 +79,8 @@ public class MetadataWithFallbackThumbSizeProviderTests
     {
         // Arrange
         var expected = new ThumbnailSizes(
-            new List<int[]> { new[] { 100, 200 }, new[] { 75, 150 }, },
-            new List<int[]> { new[] { 500, 1000 }, new[] { 200, 400 }, });
+            [[100, 200], [75, 150]],
+            [[500, 1000], [200, 400]]);
         
         var assetId = AssetIdGenerator.GetAssetId();
         var asset = GetAssetWithThumbsChannel(assetId, 1000, 2000, 250);
@@ -102,13 +102,14 @@ public class MetadataWithFallbackThumbSizeProviderTests
         actual.Should().BeEquivalentTo(expected);
     }
 
-    private Asset GetAssetWithThumbsChannel(AssetId assetId, int w, int h, int maxUnauth)
+    private static Asset GetAssetWithThumbsChannel(AssetId assetId, int w, int h, int openFullMax)
     {
         var asset = new Asset(assetId)
         {
             Width = w,
             Height = h,
-            MaxUnauthorised = maxUnauth,
+            OpenFullMax = openFullMax,
+            Roles = "https://role.example",
             ImageDeliveryChannels = new List<ImageDeliveryChannel>
             {
                 new()

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/NamedQueries/PDF/FireballPdfCreatorTests.cs
@@ -29,6 +29,7 @@ public class FireballPdfCreatorTests
     private readonly FireballPdfCreator sut;
     private const int Customer = 99;
     private readonly IBucketWriter bucketWriter;
+    private static readonly int[] item = new[] { 500, 500 };
 
     public FireballPdfCreatorTests()
     {
@@ -200,36 +201,36 @@ public class FireballPdfCreatorTests
             {
                 Roles = "whitelist",
                 Id = AssetId.FromString("/99/1/image1.jpg"),
-                MaxUnauthorised = 0
+                OpenFullMax = 0
             },
             new()
             {
                 Roles = "whitelist,notwhitelist",
                 Id = AssetId.FromString("/99/1/image1.jpg"),
-                MaxUnauthorised = 0
+                OpenFullMax = 0
             },
             new()
             {
                 Roles = "notwhitelist",
                 Id = AssetId.FromString("/99/1/image1.jpg"),
-                MaxUnauthorised = 0
+                OpenFullMax = 0
             },
             new()
             {
                 Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
-                MaxUnauthorised = -1
+                OpenFullMax = 0
             },
             new()
             {
                 Roles = string.Empty,
                 Id = AssetId.FromString("/99/1/image1.jpg"),
-                MaxUnauthorised = -1
+                OpenFullMax = 0
             }
         };
 
         A.CallTo(() => thumbSizeProvider.GetThumbSizesForImage(A<Asset>._, CancellationToken.None))
-            .Returns(new ThumbnailSizes(new List<int[]>{ new[] { 500, 500 } }, new List<int[]>()));
+            .Returns(new ThumbnailSizes([item], []));
 
         var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
         responseMessage.Content =

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using DLCS.Model.IIIF;
 using IIIF;
 using IIIF.ImageApi;
 using Orchestrator.Infrastructure.ReverseProxy;
@@ -7,216 +8,505 @@ namespace Orchestrator.Tests.Infrastructure.ReverseProxy;
 
 public class ImageProxyPathHandlerTests
 {
-    [Theory]
-    [InlineData("full/^full")]
-    [InlineData("square/^full")]
-    [InlineData("0,0,512,512/^full")]
-    [InlineData("pct:41.6,7.5,40,70/^full")]
-    public void GetProxyImageRequest_Invalid_UpscaleFull(string imageRequest)
-    {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
-        result.IsValid.Should().BeFalse();
-        result.ErrorMessage.Should().Be("'^full' size is invalid. Use 'full' or '^max' instead.");
-        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-    
-    [Theory]
-    [InlineData("full/101,")]
-    [InlineData("square/,101")]
-    [InlineData("0,0,512,512/101,101")]
-    [InlineData("pct:41.6,7.5,40,70/!101,101")]
-    public void GetProxyImageRequest_Invalid_WouldRequireUpscale(string imageRequest)
-    {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
-        result.IsValid.Should().BeFalse();
-        result.ErrorMessage.Should().MatchEquivalentOf("SizeParameter * cannot upscale image size '*'");
-        result.ErrorStatusCode.Should().Be(HttpStatusCode.NotImplemented);
-    }
-    
-    [Theory]
-    [InlineData("101,0,10,10/full")]
-    [InlineData("101,101,10,10/256,")]
-    [InlineData("10,101,10,10/10,10")]
-    [InlineData("pct:101,0,10,10/full")]
-    [InlineData("pct:101,101,10,10/!10,10")]
-    [InlineData("pct:10,101,10,10/full")]
-    public void GetProxyImageRequest_Invalid_RegionOutOfBounds(string imageRequest)
-    {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
-        result.IsValid.Should().BeFalse();
-        result.ErrorMessage.Should().Be("Region is outside image bounds");
-        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-    
-    [Theory]
-    [InlineData("0,0,512,512/11,", 100, 100, 10)]
-    [InlineData("0,0,512,512/11,11", 100, 100, 10)]
-    [InlineData("0,0,512,512/,11", 100, 100, 10)]
-    [InlineData("full/11,", 100, 100, 10)]
-    [InlineData("full/11,11", 100, 100, 10)]
-    [InlineData("full/,11", 100, 100, 10)]
-    [InlineData("full/pct:15", 100, 100, 10)]
-    public void GetProxyImageRequest_Invalid_TooLarge(string imageRequest, int w, int h, int maxWidth)
-    {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProxyImageRequest(new Size(w, h), maxWidth);
-        result.IsValid.Should().BeFalse();
-        result.ErrorMessage.Should().MatchEquivalentOf("Requested size '*' exceeds maxWidth of *");
-        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
-    }
+    // Some of the test payload/expectations are duplicated between V2 + V3 tests but I've kept separate for ease
+    #region Image V2
 
     [Theory]
-    [MemberData(nameof(ValidSizeData.Portrait), MemberType = typeof(ValidSizeData))]
-    public void GetProxyImageRequest_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    [InlineData("full/^full")]
+    [InlineData("square/^!101,101")]
+    [InlineData("full/^max")]
+    [InlineData("0,0,512,512/^,123")]
+    [InlineData("pct:41.6,7.5,40,70/^pct:10")]
+    public void GetProxyImageRequest_V2_Invalid(string imageRequest)
     {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProxyImageRequest(imageSize, 5000);
-        result.IsValid.Should().BeTrue(imageRequest);
-        result.ErrorMessage.Should().BeNull(imageRequest);
-        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, new Size(100, 100), 500, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Be("Invalid size. '^' invalid for IIIF ImageApi 2.1");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
     }
     
     [Theory]
-    [MemberData(nameof(ValidSizeData.PortraitRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
-    public void GetProxyImageRequest_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+    [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_WouldRequireUpscale(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
-        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProxyImageRequest(imageSize, 500);
-        result.IsValid.Should().BeTrue(imageRequest);
-        result.ErrorMessage.Should().BeNull(imageRequest);
-        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        // Asserts we pass V2 parameters unchanged, even though dimension is larger than required 
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, false);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
     }
     
     [Theory]
-    [MemberData(nameof(ValidSizeData.Landscape), MemberType = typeof(ValidSizeData))]
-    public void GetProxyImageRequest_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+    [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Invalid_RegionOutOfBounds(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 500, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Be("Region is outside image bounds");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Invalid_ExceedMaxWidth(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 10, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
-        var result = parsed.GetProxyImageRequest(imageSize, 5000);
-        result.IsValid.Should().BeTrue(imageRequest);
-        result.ErrorMessage.Should().BeNull(imageRequest);
-        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
     }
     
     [Theory]
-    [MemberData(nameof(ValidSizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
-    public void GetProxyImageRequest_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProxyImageRequest(imageSize, 500);
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+
+    #endregion
+    
+    #region Image V3
+    [Theory]
+    [InlineData("full/^full")]
+    [InlineData("pct:0,0,10,50/^full")]
+    public void GetProxyImageRequest_V3_InvalidUpscaleFull(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, new Size(100, 100), 500, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Be("Invalid size. 'full' invalid for IIIF ImageApi 3.0");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+    }
+
+    [Theory]
+    [InlineData("square/full")]
+    [InlineData("512,512,1024,1024/full")]
+    public void GetProxyImageRequest_V3_InvalidFull_IfStrictMode(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, new Size(100, 100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Invalid size. 'full' invalid for IIIF ImageApi 3.0");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeV2), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_TreatsFullAsMax_IfLaxMode(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        
+        // Slightly hacky but we have examples of /full/ in v2 payloads so use those for testing
+        if (!parsed.IsExplicitFullSize()) return;
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, false);
         result.IsValid.Should().BeTrue(imageRequest);
-        result.ErrorMessage.Should().BeNull(imageRequest);
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
         result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
+
+    [Theory]
+    [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_WouldRequireUpscale_NoCaret(string imageRequest, Size imageSize, Size _,
+        string __)
+    {
+        // Asserts we pass V3 parameters unchanged, even though dimension is larger than required 
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
+            result.IsValid.Should().BeFalse(imageRequest);
+            result.ErrorMessage.Should().Match("SizeParameter /*/ cannot upscale image size '*'", imageRequest);
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+    }
     
-    /// <summary>
-    /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
-    /// </summary>
-    private class ValidSizeData
+    [Theory]
+    [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_RegionOutOfBounds(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 500, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Be("Region is outside image bounds");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_ExceedMaxWidth(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 10, strictMode);
+            result.IsValid.Should().BeFalse();
+            result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+            result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        foreach (var strictMode in new[] { true, false })
+        {
+            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
+            result.IsValid.Should().BeTrue(imageRequest);
+            result.ErrorMessage.Should().BeNull(imageRequest);
+            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+        }
+    }
+    #endregion
+    
+    private class SizeData
     {
         private static readonly Size PortraitSize = new(1000, 2000);
         private static readonly Size LandscapeSize = new(2000, 1000);
 
         /// <summary>
-        /// A series of valid image requests and expected sizes for Portrait images. maxWidth is 5000.
+        /// A series of valid image requests where region is out of bounds for 100,100 image
         /// </summary>
-        public static TheoryData<string, Size, Size, string> Portrait =>
+        public static TheoryData<string> RegionOutOfBounds =>
+        [
+            "101,0,10,10/max",
+            "101,101,10,10/256,",
+            "10,101,10,10/10,10",
+            "pct:101,0,10,10/max",
+            "pct:101,101,10,10/!10,10",
+            "pct:10,101,10,10/max"
+        ];
+        
+        /// <summary>
+        /// A series of valid image requests where size exceeds maxWidth of 10 for 100,100 image
+        /// </summary>
+        public static TheoryData<string> ExceedMaxWidth =>
+        [
+            "0,0,512,512/11,",
+            "0,0,512,512/11,11",
+            "0,0,512,512/,11",
+            "full/11,",
+            "full/11,11",
+            "full/,11",
+            "full/pct:15",
+            "square/11,",
+            "square/11,11",
+            "square/,11",
+        ];
+
+        /// <summary>
+        /// A series of valid image requests that would result in an upscaled image, without ^
+        ///
+        /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
+        /// </summary>
+        /// <remarks>These contain expected size etc but may result in an error, depending on version</remarks>
+        public static TheoryData<string, Size, Size, string> RequireUpscale =>
+            new()
+            {
+                { "full/101,", Size.Square(100), Size.Square(101), "101," },
+                { "square/,101,", Size.Square(100), Size.Square(101), ",101" },
+                { "0,0,512,512/101,101", Size.Square(100), Size.Square(101), "101,101" },
+                { "pct:41.6,7.5,40,70/!101,101", Size.Square(100), new Size(58, 101), "!101,101" },
+            };
+        
+        /// <summary>
+        /// A series of valid image requests and expected sizes for Portrait images. maxWidth is 5000
+        ///
+        /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> PortraitShared =>
             new()
             {
                 { "100,100,512,512/512,", PortraitSize, Size.Square(512), "512," },
                 { "0,0,512,512/,256", PortraitSize, Size.Square(256), ",256" },
                 { "0,0,128,512/64,256", PortraitSize, new Size(64, 256), "64,256" },
                 { "0,0,512,256/!256,256", PortraitSize, new Size(256, 128), "!256,256" },
-                { "0,0,512,256/max", PortraitSize, new Size(512, 256), "512,256" },
-                { "0,0,512,256/full", PortraitSize, new Size(512, 256), "512,256" },
-                { "0,0,512,256/^max", PortraitSize, new Size(5000, 2500), "^5000,2500" },
                 { "pct:10,10,25,50/,256", PortraitSize, new Size(64, 256), ",256" },
-                { "pct:10,10,25,50/^max", PortraitSize, new Size(1250, 5000), "^1250,5000" },
                 { "square/512,256", PortraitSize, new Size(512, 256), "512,256" },
                 { "square/!256,512", PortraitSize, Size.Square(256), "!256,512" },
-                { "square/full", PortraitSize, Size.Square(1000), "1000,1000" },
                 { "square/pct:50", PortraitSize, Size.Square(500), "pct:50" },
+                { "full/512,256", PortraitSize, new Size(512, 256), "512,256" },
+            };
+        
+        /// <summary>
+        /// V2 specific requests for portrait images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> PortraitV2 =>
+            new()
+            {
+                { "0,0,512,256/max", PortraitSize, new Size(5000, 2500), "5000,2500" },
+                { "pct:10,10,25,50/max", PortraitSize, new Size(1250, 5000), "1250,5000" },
+                { "0,0,512,256/full", PortraitSize, new Size(512, 256), "512,256" },
+                { "square/pct:250", PortraitSize, Size.Square(2500), "pct:250" },
+                { "square/max", PortraitSize, Size.Square(5000), "5000,5000" },
+                { "square/full", PortraitSize, Size.Square(1000), "1000,1000" },
+                { "full/full", PortraitSize, new Size(1000, 2000), "1000,2000" },
+                { "full/max", PortraitSize, new Size(2500, 5000), "2500,5000" },
+            };
+        
+        /// <summary>
+        /// V3 specific requests for portrait images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> PortraitV3 =>
+            new()
+            {
+                { "0,0,512,256/max", PortraitSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/^max", PortraitSize, new Size(5000, 2500), "^5000,2500" },
+                { "pct:10,10,25,50/^max", PortraitSize, new Size(1250, 5000), "^1250,5000" },
                 { "square/^pct:250", PortraitSize, Size.Square(2500), "^pct:250" },
                 { "square/max", PortraitSize, Size.Square(1000), "1000,1000" },
                 { "square/^max", PortraitSize, Size.Square(5000), "^5000,5000" },
-                { "full/512,256", PortraitSize, new Size(512, 256), "512,256" },
-                { "full/full", PortraitSize, new Size(1000, 2000), "1000,2000" },
                 { "full/max", PortraitSize, new Size(1000, 2000), "1000,2000" },
                 { "full/^max", PortraitSize, new Size(2500, 5000), "^2500,5000" },
             };
         
         /// <summary>
-        /// A series of valid image requests and expected sizes for Landscape images. maxWidth is 5000.
+        /// A series of valid image requests and expected sizes for landscape images. maxWidth is 5000.
+        ///
+        /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
         /// </summary>
-        public static TheoryData<string, Size, Size, string> Landscape =>
+        public static TheoryData<string, Size, Size, string> LandscapeShared =>
             new()
             {
                 { "100,100,512,512/512,", LandscapeSize, Size.Square(512), "512," },
                 { "0,0,512,512/,256", LandscapeSize, Size.Square(256), ",256" },
                 { "0,0,128,512/64,256", LandscapeSize, new Size(64, 256), "64,256" },
                 { "0,0,512,256/!256,256", LandscapeSize, new Size(256, 128), "!256,256" },
-                { "0,0,512,256/max", LandscapeSize, new Size(512, 256), "512,256" },
-                { "0,0,512,256/full", LandscapeSize, new Size(512, 256), "512,256" },
-                { "0,0,512,256/^max", LandscapeSize, new Size(5000, 2500), "^5000,2500" },
                 { "pct:10,10,25,50/,256", LandscapeSize, new Size(256, 256), ",256" },
-                { "pct:10,10,25,50/^max", LandscapeSize, new Size(5000, 5000), "^5000,5000" },
                 { "square/512,256", LandscapeSize, new Size(512, 256), "512,256" },
                 { "square/!256,512", LandscapeSize, Size.Square(256), "!256,512" },
-                { "square/full", LandscapeSize, Size.Square(1000), "1000,1000" },
                 { "square/pct:50", LandscapeSize, Size.Square(500), "pct:50" },
+                { "full/512,256", LandscapeSize, new Size(512, 256), "512,256" },
+            };
+        
+        /// <summary>
+        /// V2 specific requests for landscape images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> LandscapeV2 =>
+            new()
+            {
+                { "0,0,512,256/full", LandscapeSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/max", LandscapeSize, new Size(5000,2500), "5000,2500" },
+                { "square/full", LandscapeSize, Size.Square(1000), "1000,1000" },
+                { "square/max", LandscapeSize, Size.Square(5000), "5000,5000" },
+                { "full/full", LandscapeSize, new Size(2000, 1000), "2000,1000" },
+                { "full/max", LandscapeSize, new Size(5000,2500), "5000,2500" },
+            };
+        
+        /// <summary>
+        /// V3 specific requests for landscape images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> LandscapeV3 =>
+            new()
+            {
+                { "0,0,512,256/max", LandscapeSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/^max", LandscapeSize, new Size(5000, 2500), "^5000,2500" },
+                { "pct:10,10,25,50/^max", LandscapeSize, new Size(5000, 5000), "^5000,5000" },
                 { "square/^pct:250", LandscapeSize, Size.Square(2500), "^pct:250" },
                 { "square/max", LandscapeSize, Size.Square(1000), "1000,1000" },
                 { "square/^max", LandscapeSize, Size.Square(5000), "^5000,5000" },
-                { "full/512,256", LandscapeSize, new Size(512, 256), "512,256" },
-                { "full/full", LandscapeSize, new Size(2000, 1000), "2000,1000" },
                 { "full/max", LandscapeSize, new Size(2000, 1000), "2000,1000" },
                 { "full/^max", LandscapeSize, new Size(5000, 2500), "^5000,2500" },
             };
         
         /// <summary>
         /// A series of valid image requests and expected sizes for Portrait images. maxWidth is 500.
+        ///
+        /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
         /// </summary>
         public static TheoryData<string, Size, Size, string> PortraitRestrictedMaxWidth =>
             new()
         {
             { "0,0,512,256/max", PortraitSize, new Size(500, 250), "500,250" },
-            { "0,0,512,256/full", PortraitSize, new Size(500, 250), "500,250" },
-            { "0,0,512,256/^max", PortraitSize, new Size(500, 250), "500,250" },
-            { "pct:10,10,25,50/^max", PortraitSize, new Size(125, 500), "125,500" },
-            { "square/full", PortraitSize, Size.Square(500), "500,500" },
             { "square/max", PortraitSize, Size.Square(500), "500,500" },
-            { "square/^max", PortraitSize, Size.Square(500), "500,500" },
-            { "full/full", PortraitSize, new Size(250, 500), "250,500" },
             { "full/max", PortraitSize, new Size(250, 500), "250,500" },
-            { "full/^max", PortraitSize, new Size(250, 500), "250,500" },
         };
+        
+        public static TheoryData<string, Size, Size, string> PortraitRestrictedMaxWidthV2 =>
+            new()
+            {
+                { "0,0,512,256/full", PortraitSize, new Size(500, 250), "500,250" },
+                { "square/full", PortraitSize, Size.Square(500), "500,500" },
+                { "full/full", PortraitSize, new Size(250, 500), "250,500" },
+            };
+        
+        public static TheoryData<string, Size, Size, string> PortraitRestrictedMaxWidthV3 =>
+            new()
+            {
+                { "0,0,512,256/^max", PortraitSize, new Size(500, 250), "500,250" },
+                { "pct:10,10,25,50/^max", PortraitSize, new Size(125, 500), "125,500" },
+                { "square/^max", PortraitSize, Size.Square(500), "500,500" },
+                { "full/^max", PortraitSize, new Size(250, 500), "250,500" },
+            };
         
         /// <summary>
         /// A series of valid image requests and expected sizes for Landscape images. maxWidth is 500.
+        ///
+        /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
         /// </summary>
         public static TheoryData<string, Size, Size, string> LandscapeRestrictedMaxWidth =>
             new()
             {
                 { "0,0,512,256/max", LandscapeSize, new Size(500, 250), "500,250" },
+                { "square/max", LandscapeSize, Size.Square(500), "500,500" },
+                { "full/max", LandscapeSize, new Size(500, 250), "500,250" },
+            };
+        
+        public static TheoryData<string, Size, Size, string> LandscapeRestrictedMaxWidthV2 =>
+            new()
+            {
                 { "0,0,512,256/full", LandscapeSize, new Size(500, 250), "500,250" },
+                { "square/full", LandscapeSize, Size.Square(500), "500,500" },
+                { "full/full", LandscapeSize, new Size(500, 250), "500,250" },
+            };
+        
+        public static TheoryData<string, Size, Size, string> LandscapeRestrictedMaxWidthV3 =>
+            new()
+            {
                 { "0,0,512,256/^max", LandscapeSize, new Size(500, 250), "500,250" },
                 { "pct:10,10,25,50/^max", LandscapeSize, new Size(500, 500), "500,500" },
-                { "square/full", LandscapeSize, Size.Square(500), "500,500" },
-                { "square/max", LandscapeSize, Size.Square(500), "500,500" },
                 { "square/^max", LandscapeSize, Size.Square(500), "500,500" },
-                { "full/full", LandscapeSize, new Size(500, 250), "500,250" },
-                { "full/max", LandscapeSize, new Size(500, 250), "500,250" },
                 { "full/^max", LandscapeSize, new Size(500, 250), "500,250" },
             };
     }

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -212,6 +212,22 @@ public class ImageProxyPathHandlerTests
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
         result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
+    
+    [Theory]
+    [InlineData("0,0,200,200", false)]
+    [InlineData("pct:0,0,100,100", false)]
+    [InlineData("full", false)]
+    [InlineData("square", false)]
+    [InlineData("0,0,200,200", true)]
+    [InlineData("pct:0,0,100,100", true)]
+    [InlineData("full", true)]
+    [InlineData("square", true)]
+    public void GetProxyImageRequest_V2_RepresentsFullRegion(string region, bool strict)
+    {
+        var parsed = ImageRequest.Parse($"asset/{region}/!10,10/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(200), 500, strict);
+        result.RepresentsFullRegion.Should().BeTrue();
+    }
 
     #endregion
     
@@ -440,6 +456,22 @@ public class ImageProxyPathHandlerTests
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
         result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
+    
+    [Theory]
+    [InlineData("0,0,200,200", false)]
+    [InlineData("pct:0,0,100,100", false)]
+    [InlineData("full", false)]
+    [InlineData("square", false)]
+    [InlineData("0,0,200,200", true)]
+    [InlineData("pct:0,0,100,100", true)]
+    [InlineData("full", true)]
+    [InlineData("square", true)]
+    public void GetProxyImageRequest_V3_RepresentsFullRegion(string region, bool strict)
+    {
+        var parsed = ImageRequest.Parse($"asset/{region}/!10,10/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(200), 500, strict);
+        result.RepresentsFullRegion.Should().BeTrue();
+    }
 
     #endregion
     
@@ -477,7 +509,7 @@ public class ImageProxyPathHandlerTests
             "square/11,11",
             "square/,11",
         ];
-
+        
         /// <summary>
         /// A series of valid image requests that would result in an upscaled image, without ^
         ///

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -1,0 +1,205 @@
+﻿using IIIF;
+using IIIF.ImageApi;
+using Orchestrator.Infrastructure.ReverseProxy;
+
+namespace Orchestrator.Tests.Infrastructure.ReverseProxy;
+
+public class ImageProxyPathHandlerTests
+{
+    [Theory]
+    [InlineData("full/^full")]
+    [InlineData("square/^full")]
+    [InlineData("0,0,512,512/^full")]
+    [InlineData("pct:41.6,7.5,40,70/^full")]
+    public void GetProposedFinalSize_Invalid_UpscaleFull(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        var result = parsed.GetProposedFinalSize(new Size(100, 100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("'^full' size is invalid. Use 'full' or '^max' instead.");
+    }
+    
+    [Theory]
+    [InlineData("101,0,10,10/full")]
+    [InlineData("101,101,10,10/256,")]
+    [InlineData("10,101,10,10/10,10")]
+    [InlineData("pct:101,0,10,10/full")]
+    [InlineData("pct:101,101,10,10/!10,10")]
+    [InlineData("pct:10,101,10,10/full")]
+    public void GetProposedFinalSize_Invalid_RegionOutOfBounds(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProposedFinalSize(new Size(100, 100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Region is outside image bounds");
+    }
+    
+    [Theory]
+    [InlineData("0,0,512,512/11,", 100, 100, 10)]
+    [InlineData("0,0,512,512/11,11", 100, 100, 10)]
+    [InlineData("0,0,512,512/,11", 100, 100, 10)]
+    [InlineData("full/11,", 100, 100, 10)]
+    [InlineData("full/11,11", 100, 100, 10)]
+    [InlineData("full/,11", 100, 100, 10)]
+    [InlineData("full/pct:15", 100, 100, 10)]
+    public void GetProposedFinalSize_Invalid_TooLarge(string imageRequest, int w, int h, int maxWidth)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProposedFinalSize(new Size(w, h), maxWidth);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().MatchEquivalentOf("Requested size '*' exceeds maxWidth of *");
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidSizeData.Portrait), MemberType = typeof(ValidSizeData))]
+    public void GetProposedFinalSize_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProposedFinalSize(imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(ValidSizeData.PortraitRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
+    public void GetProposedFinalSize_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProposedFinalSize(imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(ValidSizeData.Landscape), MemberType = typeof(ValidSizeData))]
+    public void GetProposedFinalSize_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
+        var result = parsed.GetProposedFinalSize(imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(ValidSizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
+    public void GetProposedFinalSize_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProposedFinalSize(imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+    
+    /// <summary>
+    /// Values are: imageRequest, imageSize, expectedSize, expectedProxySize
+    /// </summary>
+    private class ValidSizeData
+    {
+        private static readonly Size PortraitSize = new(1000, 2000);
+        private static readonly Size LandscapeSize = new(2000, 1000);
+
+        /// <summary>
+        /// A series of valid image requests and expected sizes for Portrait images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> Portrait =>
+            new()
+            {
+                { "100,100,512,512/512,", PortraitSize, Size.Square(512), "512," },
+                { "0,0,512,512/,256", PortraitSize, Size.Square(256), ",256" },
+                { "0,0,128,512/64,256", PortraitSize, new Size(64, 256), "64,256" },
+                { "0,0,512,256/!256,256", PortraitSize, new Size(256, 128), "!256,256" },
+                { "0,0,512,256/max", PortraitSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/full", PortraitSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/^max", PortraitSize, new Size(5000, 2500), "^5000,2500" },
+                { "pct:10,10,25,50/,256", PortraitSize, new Size(64, 256), ",256" },
+                { "pct:10,10,25,50/^max", PortraitSize, new Size(1250, 5000), "^1250,5000" },
+                { "square/512,256", PortraitSize, new Size(512, 256), "512,256" },
+                { "square/!256,512", PortraitSize, Size.Square(256), "!256,512" },
+                { "square/full", PortraitSize, Size.Square(1000), "1000,1000" },
+                { "square/pct:50", PortraitSize, Size.Square(500), "pct:50" },
+                { "square/^pct:250", PortraitSize, Size.Square(2500), "^pct:250" },
+                { "square/max", PortraitSize, Size.Square(1000), "1000,1000" },
+                { "square/^max", PortraitSize, Size.Square(5000), "^5000,5000" },
+                { "full/512,256", PortraitSize, new Size(512, 256), "512,256" },
+                { "full/full", PortraitSize, new Size(1000, 2000), "1000,2000" },
+                { "full/max", PortraitSize, new Size(1000, 2000), "1000,2000" },
+                { "full/^max", PortraitSize, new Size(2500, 5000), "^2500,5000" },
+            };
+        
+        /// <summary>
+        /// A series of valid image requests and expected sizes for Landscape images. maxWidth is 5000.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> Landscape =>
+            new()
+            {
+                { "100,100,512,512/512,", LandscapeSize, Size.Square(512), "512," },
+                { "0,0,512,512/,256", LandscapeSize, Size.Square(256), ",256" },
+                { "0,0,128,512/64,256", LandscapeSize, new Size(64, 256), "64,256" },
+                { "0,0,512,256/!256,256", LandscapeSize, new Size(256, 128), "!256,256" },
+                { "0,0,512,256/max", LandscapeSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/full", LandscapeSize, new Size(512, 256), "512,256" },
+                { "0,0,512,256/^max", LandscapeSize, new Size(5000, 2500), "^5000,2500" },
+                { "pct:10,10,25,50/,256", LandscapeSize, new Size(256, 256), ",256" },
+                { "pct:10,10,25,50/^max", LandscapeSize, new Size(5000, 5000), "^5000,5000" },
+                { "square/512,256", LandscapeSize, new Size(512, 256), "512,256" },
+                { "square/!256,512", LandscapeSize, Size.Square(256), "!256,512" },
+                { "square/full", LandscapeSize, Size.Square(1000), "1000,1000" },
+                { "square/pct:50", LandscapeSize, Size.Square(500), "pct:50" },
+                { "square/^pct:250", LandscapeSize, Size.Square(2500), "^pct:250" },
+                { "square/max", LandscapeSize, Size.Square(1000), "1000,1000" },
+                { "square/^max", LandscapeSize, Size.Square(5000), "^5000,5000" },
+                { "full/512,256", LandscapeSize, new Size(512, 256), "512,256" },
+                { "full/full", LandscapeSize, new Size(2000, 1000), "2000,1000" },
+                { "full/max", LandscapeSize, new Size(2000, 1000), "2000,1000" },
+                { "full/^max", LandscapeSize, new Size(5000, 2500), "^5000,2500" },
+            };
+        
+        /// <summary>
+        /// A series of valid image requests and expected sizes for Portrait images. maxWidth is 500.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> PortraitRestrictedMaxWidth =>
+            new()
+        {
+            { "0,0,512,256/max", PortraitSize, new Size(500, 250), "500,250" },
+            { "0,0,512,256/full", PortraitSize, new Size(500, 250), "500,250" },
+            { "0,0,512,256/^max", PortraitSize, new Size(500, 250), "500,250" },
+            { "pct:10,10,25,50/^max", PortraitSize, new Size(125, 500), "125,500" },
+            { "square/full", PortraitSize, Size.Square(500), "500,500" },
+            { "square/max", PortraitSize, Size.Square(500), "500,500" },
+            { "square/^max", PortraitSize, Size.Square(500), "500,500" },
+            { "full/full", PortraitSize, new Size(250, 500), "250,500" },
+            { "full/max", PortraitSize, new Size(250, 500), "250,500" },
+            { "full/^max", PortraitSize, new Size(250, 500), "250,500" },
+        };
+        
+        /// <summary>
+        /// A series of valid image requests and expected sizes for Landscape images. maxWidth is 500.
+        /// </summary>
+        public static TheoryData<string, Size, Size, string> LandscapeRestrictedMaxWidth =>
+            new()
+            {
+                { "0,0,512,256/max", LandscapeSize, new Size(500, 250), "500,250" },
+                { "0,0,512,256/full", LandscapeSize, new Size(500, 250), "500,250" },
+                { "0,0,512,256/^max", LandscapeSize, new Size(500, 250), "500,250" },
+                { "pct:10,10,25,50/^max", LandscapeSize, new Size(500, 500), "500,500" },
+                { "square/full", LandscapeSize, Size.Square(500), "500,500" },
+                { "square/max", LandscapeSize, Size.Square(500), "500,500" },
+                { "square/^max", LandscapeSize, Size.Square(500), "500,500" },
+                { "full/full", LandscapeSize, new Size(500, 250), "500,250" },
+                { "full/max", LandscapeSize, new Size(500, 250), "500,250" },
+                { "full/^max", LandscapeSize, new Size(500, 250), "500,250" },
+            };
+    }
+}

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -12,151 +12,223 @@ public class ImageProxyPathHandlerTests
     #region Image V2
 
     [Theory]
-    [InlineData("full/^full")]
-    [InlineData("square/^!101,101")]
-    [InlineData("full/^max")]
-    [InlineData("0,0,512,512/^,123")]
-    [InlineData("pct:41.6,7.5,40,70/^pct:10")]
-    public void GetProxyImageRequest_V2_Invalid(string imageRequest)
+    [InlineData("full/^full", true)]
+    [InlineData("full/^full", false)]
+    [InlineData("square/^!101,101", true)]
+    [InlineData("square/^!101,101", false)]
+    [InlineData("full/^max", true)]
+    [InlineData("full/^max", false)]
+    [InlineData("0,0,512,512/^,123", true)]
+    [InlineData("0,0,512,512/^,123", false)]
+    [InlineData("pct:41.6,7.5,40,70/^pct:10", true)]
+    [InlineData("pct:41.6,7.5,40,70/^pct:10", false)]
+    public void GetProxyImageRequest_V2_Invalid(string imageRequest, bool strictMode)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, new Size(100, 100), 500, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Be("Invalid size. '^' invalid for IIIF ImageApi 2.1");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, new Size(100, 100), 500, strictMode);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Invalid size. '^' invalid for IIIF ImageApi 2.1");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_WouldRequireUpscale_IfStrictMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
+    {
+        // Asserts we pass V2 parameters unchanged, even though dimension is larger than required 
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Valid_WouldRequireUpscale(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    public void GetProxyImageRequest_V2_Valid_WouldRequireUpscale_IfLaxMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
     {
         // Asserts we pass V2 parameters unchanged, even though dimension is larger than required 
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, false);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Invalid_RegionOutOfBounds_IfStrictMode(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Region is outside image bounds");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Invalid_RegionOutOfBounds(string imageRequest)
+    public void GetProxyImageRequest_V2_Invalid_RegionOutOfBounds_IfLaxMode(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 500, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Be("Region is outside image bounds");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 500, false);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Region is outside image bounds");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Invalid_ExceedMaxWidth_IfStrictMode(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 10);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Invalid_ExceedMaxWidth(string imageRequest)
+    public void GetProxyImageRequest_V2_Invalid_ExceedMaxWidth_IfLaxMode(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 10, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(100), 10, false);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Portrait_IfStrictMode(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.PortraitV2), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_V2_Valid_Portrait_IfLaxMode(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Portrait_Restricted_IfStrictMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    public void GetProxyImageRequest_V2_Valid_Portrait_Restricted_IfLaxMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.LandscapeV2), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_V2_Valid_Landscape_IfStrictMode(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Landscape_IfLaxMode(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 5000, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V2_Valid_Landscape_Restricted_IfStrictMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV2), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V2_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    public void GetProxyImageRequest_V2_Valid_Landscape_Restricted_IfLaxMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V2, imageSize, 500, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
 
     #endregion
     
     #region Image V3
+
     [Theory]
-    [InlineData("full/^full")]
-    [InlineData("pct:0,0,10,50/^full")]
-    public void GetProxyImageRequest_V3_InvalidUpscaleFull(string imageRequest)
+    [InlineData("full/^full", true)]
+    [InlineData("full/^full", false)]
+    [InlineData("pct:0,0,10,50/^full", true)]
+    [InlineData("pct:0,0,10,50/^full", false)]
+    public void GetProxyImageRequest_V3_InvalidUpscaleFull(string imageRequest, bool strictMode)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, new Size(100, 100), 500, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Be("Invalid size. 'full' invalid for IIIF ImageApi 3.0");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, new Size(100, 100), 500, strictMode);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Invalid size. 'full' invalid for IIIF ImageApi 3.0");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
     [Theory]
@@ -189,115 +261,186 @@ public class ImageProxyPathHandlerTests
 
     [Theory]
     [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Invalid_WouldRequireUpscale_NoCaret(string imageRequest, Size imageSize, Size _,
+    public void GetProxyImageRequest_V3_Invalid_WouldRequireUpscale_NoCaret_IfStrictMode(string imageRequest, Size imageSize, Size _,
         string __)
     {
         // Asserts we pass V3 parameters unchanged, even though dimension is larger than required 
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
-            result.IsValid.Should().BeFalse(imageRequest);
-            result.ErrorMessage.Should().Match("SizeParameter /*/ cannot upscale image size '*'", imageRequest);
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500);
+        result.IsValid.Should().BeFalse(imageRequest);
+        result.ErrorMessage.Should().Match("SizeParameter /*/ cannot upscale image size '*'", imageRequest);
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Theory]
+    [MemberData(nameof(SizeData.RequireUpscale), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_WouldRequireUpscale_NoCaret_IfLaxMode(string imageRequest, Size imageSize, Size _,
+        string __)
+    {
+        // Asserts we pass V3 parameters unchanged, even though dimension is larger than required 
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, false);
+        result.IsValid.Should().BeFalse(imageRequest);
+        result.ErrorMessage.Should().Match("SizeParameter /*/ cannot upscale image size '*'", imageRequest);
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_RegionOutOfBounds_IfStrictMode(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Region is outside image bounds");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.RegionOutOfBounds), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Invalid_RegionOutOfBounds(string imageRequest)
+    public void GetProxyImageRequest_V3_Invalid_RegionOutOfBounds_IfLaxMode(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 500, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Be("Region is outside image bounds");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 500, false);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Region is outside image bounds");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Invalid_ExceedMaxWidth_IfStrictMode(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 10);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.ExceedMaxWidth), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Invalid_ExceedMaxWidth(string imageRequest)
+    public void GetProxyImageRequest_V3_Invalid_ExceedMaxWidth_IfLaxMode(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 10, strictMode);
-            result.IsValid.Should().BeFalse();
-            result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
-            result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, Size.Square(100), 10, false);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().Match("Requested size '*' exceeds maxWidth of *");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Portrait_IfStrictMode(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.PortraitShared), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.PortraitV3), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_V3_Valid_Portrait_IfLaxMode(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Portrait_Restricted_IfStrictMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.PortraitRestrictedMaxWidth), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.PortraitRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    public void GetProxyImageRequest_V3_Valid_Portrait_Restricted_IfLaxMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Landscape_IfStrictMode(string imageRequest, Size imageSize, Size expectedSize,
+        string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.LandscapeShared), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.LandscapeV3), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_V3_Valid_Landscape_IfLaxMode(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 5000, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
+    [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
+    public void GetProxyImageRequest_V3_Valid_Landscape_Restricted_IfStrictMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
     
     [Theory]
     [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(SizeData))]
     [MemberData(nameof(SizeData.LandscapeRestrictedMaxWidthV3), MemberType = typeof(SizeData))]
-    public void GetProxyImageRequest_V3_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
-        string sizeParameter)
+    public void GetProxyImageRequest_V3_Valid_Landscape_Restricted_IfLaxMode(string imageRequest, Size imageSize,
+        Size expectedSize, string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        foreach (var strictMode in new[] { true, false })
-        {
-            var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, strictMode);
-            result.IsValid.Should().BeTrue(imageRequest);
-            result.ErrorMessage.Should().BeNull(imageRequest);
-            result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
-            result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
-        }
+        var result = parsed.GetProxyImageRequest(Version.V3, imageSize, 500, false);
+        result.IsValid.Should().BeTrue(imageRequest);
+        result.ErrorMessage.Should().BeNull(imageRequest);
+        result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter, imageRequest);
     }
+
     #endregion
     
     private class SizeData

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -228,6 +228,46 @@ public class ImageProxyPathHandlerTests
         var result = parsed.GetProxyImageRequest(Version.V2, Size.Square(200), 500, strict);
         result.RepresentsFullRegion.Should().BeTrue();
     }
+    
+    [Theory]
+    [InlineData(5000, 1000, 1000, "1000,1000", 1000, 1000)]
+    [InlineData(500, 1000, 1000,"500,500", 500, 500)]
+    [InlineData(5000, 1000, 500, "1000,500",1000, 500)]
+    [InlineData(500, 1000, 500, "500,250",500, 250)]
+    [InlineData(5000, 500, 1000, "500,1000",500, 1000)]
+    [InlineData(500,  500, 1000, "250,500",250, 500)]
+    [InlineData(5000, 600, 600, "1000,1000", 1000, 1000)]
+    [InlineData(500, 600, 600,"500,500", 500, 500)]
+    public void GetProxyImageRequest_V2_Confined_ReturnsLargestPossible_IfStrictMode(int maxWidth, int w, int h, string sizeParameter, int expectedW, int expectedH)
+    {
+        // These all use /full/!1000,1000/ but leaving as this for simplicity
+        var parsed = ImageRequest.Parse("asset/full/!1000,1000/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, new Size(w, h), maxWidth);
+        result.IsValid.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+        result.RequestedSize.Should().BeEquivalentTo(new Size(expectedW, expectedH));
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter);
+    }
+    
+    [Theory]
+    [InlineData(5000, 1000, 1000, "1000,1000", 1000, 1000)]
+    [InlineData(500, 1000, 1000,"500,500", 500, 500)]
+    [InlineData(5000, 1000, 500, "1000,500",1000, 500)]
+    [InlineData(500, 1000, 500, "500,250",500, 250)]
+    [InlineData(5000, 500, 1000, "500,1000",500, 1000)]
+    [InlineData(500,  500, 1000, "250,500",250, 500)]
+    [InlineData(5000, 600, 600, "1000,1000", 1000, 1000)]
+    [InlineData(500, 600, 600,"500,500", 500, 500)]
+    public void GetProxyImageRequest_V2_Confined_ReturnsLargestPossible_IfLaxMode(int maxWidth, int w, int h, string sizeParameter, int expectedW, int expectedH)
+    {
+        // These all use /full/!1000,1000/ but leaving as this for simplicity
+        var parsed = ImageRequest.Parse("asset/full/!1000,1000/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V2, new Size(w, h), maxWidth, false);
+        result.IsValid.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+        result.RequestedSize.Should().BeEquivalentTo(new Size(expectedW, expectedH));
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter);
+    }
 
     #endregion
     
@@ -473,6 +513,45 @@ public class ImageProxyPathHandlerTests
         result.RepresentsFullRegion.Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("full/!1000,1000/", 5000, 1000, 1000, "1000,1000", 1000, 1000)]
+    [InlineData("full/!1000,1000/", 500, 1000, 1000,"500,500", 500, 500)]
+    [InlineData("full/!1000,1000/", 5000, 1000, 500, "1000,500",1000, 500)]
+    [InlineData("full/!1000,1000/", 500, 1000, 500, "500,250",500, 250)]
+    [InlineData("full/!1000,1000/", 5000, 500, 1000, "500,1000",500, 1000)]
+    [InlineData("full/!1000,1000/", 500,  500, 1000, "250,500",250, 500)]
+    [InlineData("full/^!1000,1000/", 5000, 600, 600, "^1000,1000", 1000, 1000)]
+    [InlineData("full/^!1000,1000/", 500, 600, 600,"^500,500", 500, 500)]
+    public void GetProxyImageRequest_V3_Confined_ReturnsLargestPossible_IfStrictMode(string request, int maxWidth, int w, int h, string sizeParameter, int expectedW, int expectedH)
+    {
+        // These all use /full/!1000,1000/ but leaving as this for simplicity
+        var parsed = ImageRequest.Parse($"asset/{request}0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, new Size(w, h), maxWidth);
+        result.IsValid.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+        result.RequestedSize.Should().BeEquivalentTo(new Size(expectedW, expectedH));
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter);
+    }
+    
+    [Theory]
+    [InlineData("full/!1000,1000/", 5000, 1000, 1000, "1000,1000", 1000, 1000)]
+    [InlineData("full/!1000,1000/", 500, 1000, 1000,"500,500", 500, 500)]
+    [InlineData("full/!1000,1000/", 5000, 1000, 500, "1000,500",1000, 500)]
+    [InlineData("full/!1000,1000/", 500, 1000, 500, "500,250",500, 250)]
+    [InlineData("full/!1000,1000/", 5000, 500, 1000, "500,1000",500, 1000)]
+    [InlineData("full/!1000,1000/", 500,  500, 1000, "250,500",250, 500)]
+    [InlineData("full/^!1000,1000/", 5000, 600, 600, "^1000,1000", 1000, 1000)]
+    [InlineData("full/^!1000,1000/", 500, 600, 600,"^500,500", 500, 500)]
+    public void GetProxyImageRequest_V3_Confined_ReturnsLargestPossible_IfLaxMode(string request, int maxWidth, int w, int h, string sizeParameter, int expectedW, int expectedH)
+    {
+        // These all use /full/!1000,1000/ but leaving as this for simplicity
+        var parsed = ImageRequest.Parse($"asset/{request}0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(Version.V3, new Size(w, h), maxWidth, false);
+        result.IsValid.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+        result.RequestedSize.Should().BeEquivalentTo(new Size(expectedW, expectedH));
+        result.ProxySizeParameter!.ToString().Should().Be(sizeParameter);
+    }
     #endregion
     
     private class SizeData
@@ -522,7 +601,6 @@ public class ImageProxyPathHandlerTests
                 { "full/101,", Size.Square(100), Size.Square(101), "101," },
                 { "square/,101,", Size.Square(100), Size.Square(101), ",101" },
                 { "0,0,512,512/101,101", Size.Square(100), Size.Square(101), "101,101" },
-                { "pct:41.6,7.5,40,70/!101,101", Size.Square(100), new Size(58, 101), "!101,101" },
             };
         
         /// <summary>
@@ -536,10 +614,10 @@ public class ImageProxyPathHandlerTests
                 { "100,100,512,512/512,", PortraitSize, Size.Square(512), "512," },
                 { "0,0,512,512/,256", PortraitSize, Size.Square(256), ",256" },
                 { "0,0,128,512/64,256", PortraitSize, new Size(64, 256), "64,256" },
-                { "0,0,512,256/!256,256", PortraitSize, new Size(256, 128), "!256,256" },
+                { "0,0,512,256/!256,256", PortraitSize, new Size(256, 128), "256,128" },
                 { "pct:10,10,25,50/,256", PortraitSize, new Size(64, 256), ",256" },
                 { "square/512,256", PortraitSize, new Size(512, 256), "512,256" },
-                { "square/!256,512", PortraitSize, Size.Square(256), "!256,512" },
+                { "square/!256,512", PortraitSize, Size.Square(256), "256,256" },
                 { "square/pct:50", PortraitSize, Size.Square(500), "pct:50" },
                 { "full/512,256", PortraitSize, new Size(512, 256), "512,256" },
             };
@@ -587,10 +665,10 @@ public class ImageProxyPathHandlerTests
                 { "100,100,512,512/512,", LandscapeSize, Size.Square(512), "512," },
                 { "0,0,512,512/,256", LandscapeSize, Size.Square(256), ",256" },
                 { "0,0,128,512/64,256", LandscapeSize, new Size(64, 256), "64,256" },
-                { "0,0,512,256/!256,256", LandscapeSize, new Size(256, 128), "!256,256" },
+                { "0,0,512,256/!256,256", LandscapeSize, new Size(256, 128), "256,128" },
                 { "pct:10,10,25,50/,256", LandscapeSize, new Size(256, 256), ",256" },
                 { "square/512,256", LandscapeSize, new Size(512, 256), "512,256" },
-                { "square/!256,512", LandscapeSize, Size.Square(256), "!256,512" },
+                { "square/!256,512", LandscapeSize, Size.Square(256), "256,256" },
                 { "square/pct:50", LandscapeSize, Size.Square(500), "pct:50" },
                 { "full/512,256", LandscapeSize, new Size(512, 256), "512,256" },
             };

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/ReverseProxy/ImageProxyPathHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using IIIF;
+﻿using System.Net;
+using IIIF;
 using IIIF.ImageApi;
 using Orchestrator.Infrastructure.ReverseProxy;
 
@@ -11,12 +12,27 @@ public class ImageProxyPathHandlerTests
     [InlineData("square/^full")]
     [InlineData("0,0,512,512/^full")]
     [InlineData("pct:41.6,7.5,40,70/^full")]
-    public void GetProposedFinalSize_Invalid_UpscaleFull(string imageRequest)
+    public void GetProxyImageRequest_Invalid_UpscaleFull(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
-        var result = parsed.GetProposedFinalSize(new Size(100, 100), 500);
+        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
         result.IsValid.Should().BeFalse();
         result.ErrorMessage.Should().Be("'^full' size is invalid. Use 'full' or '^max' instead.");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+    
+    [Theory]
+    [InlineData("full/101,")]
+    [InlineData("square/,101")]
+    [InlineData("0,0,512,512/101,101")]
+    [InlineData("pct:41.6,7.5,40,70/!101,101")]
+    public void GetProxyImageRequest_Invalid_WouldRequireUpscale(string imageRequest)
+    {
+        var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.jpg", "");
+        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
+        result.IsValid.Should().BeFalse();
+        result.ErrorMessage.Should().MatchEquivalentOf("SizeParameter * cannot upscale image size '*'");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.NotImplemented);
     }
     
     [Theory]
@@ -26,12 +42,13 @@ public class ImageProxyPathHandlerTests
     [InlineData("pct:101,0,10,10/full")]
     [InlineData("pct:101,101,10,10/!10,10")]
     [InlineData("pct:10,101,10,10/full")]
-    public void GetProposedFinalSize_Invalid_RegionOutOfBounds(string imageRequest)
+    public void GetProxyImageRequest_Invalid_RegionOutOfBounds(string imageRequest)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProposedFinalSize(new Size(100, 100), 500);
+        var result = parsed.GetProxyImageRequest(new Size(100, 100), 500);
         result.IsValid.Should().BeFalse();
         result.ErrorMessage.Should().Be("Region is outside image bounds");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
     [Theory]
@@ -42,21 +59,22 @@ public class ImageProxyPathHandlerTests
     [InlineData("full/11,11", 100, 100, 10)]
     [InlineData("full/,11", 100, 100, 10)]
     [InlineData("full/pct:15", 100, 100, 10)]
-    public void GetProposedFinalSize_Invalid_TooLarge(string imageRequest, int w, int h, int maxWidth)
+    public void GetProxyImageRequest_Invalid_TooLarge(string imageRequest, int w, int h, int maxWidth)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProposedFinalSize(new Size(w, h), maxWidth);
+        var result = parsed.GetProxyImageRequest(new Size(w, h), maxWidth);
         result.IsValid.Should().BeFalse();
         result.ErrorMessage.Should().MatchEquivalentOf("Requested size '*' exceeds maxWidth of *");
+        result.ErrorStatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
     [Theory]
     [MemberData(nameof(ValidSizeData.Portrait), MemberType = typeof(ValidSizeData))]
-    public void GetProposedFinalSize_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_Valid_Portrait(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProposedFinalSize(imageSize, 5000);
+        var result = parsed.GetProxyImageRequest(imageSize, 5000);
         result.IsValid.Should().BeTrue(imageRequest);
         result.ErrorMessage.Should().BeNull(imageRequest);
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
@@ -65,11 +83,11 @@ public class ImageProxyPathHandlerTests
     
     [Theory]
     [MemberData(nameof(ValidSizeData.PortraitRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
-    public void GetProposedFinalSize_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_Valid_Portrait_Restricted(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProposedFinalSize(imageSize, 500);
+        var result = parsed.GetProxyImageRequest(imageSize, 500);
         result.IsValid.Should().BeTrue(imageRequest);
         result.ErrorMessage.Should().BeNull(imageRequest);
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
@@ -78,11 +96,11 @@ public class ImageProxyPathHandlerTests
     
     [Theory]
     [MemberData(nameof(ValidSizeData.Landscape), MemberType = typeof(ValidSizeData))]
-    public void GetProposedFinalSize_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_Valid_Landscape(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/180/bitonal.jpg", "");
-        var result = parsed.GetProposedFinalSize(imageSize, 5000);
+        var result = parsed.GetProxyImageRequest(imageSize, 5000);
         result.IsValid.Should().BeTrue(imageRequest);
         result.ErrorMessage.Should().BeNull(imageRequest);
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);
@@ -91,11 +109,11 @@ public class ImageProxyPathHandlerTests
     
     [Theory]
     [MemberData(nameof(ValidSizeData.LandscapeRestrictedMaxWidth), MemberType = typeof(ValidSizeData))]
-    public void GetProposedFinalSize_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
+    public void GetProxyImageRequest_Valid_Landscape_Restricted(string imageRequest, Size imageSize, Size expectedSize,
         string sizeParameter)
     {
         var parsed = ImageRequest.Parse($"asset/{imageRequest}/0/default.tif", "");
-        var result = parsed.GetProposedFinalSize(imageSize, 500);
+        var result = parsed.GetProxyImageRequest(imageSize, 500);
         result.IsValid.Should().BeTrue(imageRequest);
         result.ErrorMessage.Should().BeNull(imageRequest);
         result.RequestedSize.Should().BeEquivalentTo(expectedSize, imageRequest);

--- a/src/protagonist/Orchestrator.Tests/Integration/AuthHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/AuthHandlingTests.cs
@@ -7,12 +7,14 @@ using System.Text.RegularExpressions;
 using AngleSharp.Html.Dom;
 using AngleSharp.Html.Parser;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using IIIF.Auth.V2;
 using IIIF.Serialisation;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Orchestrator.Tests.Integration.Infrastructure;
 using Stubbery;
+using Test.Helpers.Data;
 using Test.Helpers.Integration;
 
 namespace Orchestrator.Tests.Integration;
@@ -115,8 +117,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["error"].Value<string>().Should().Be("missingCredentials");
-        responseBody["description"].Value<string>().Should().Be("Required cookie missing");
+        responseBody["error"]!.Value<string>().Should().Be("missingCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Required cookie missing");
     }
     
     [Fact]
@@ -135,8 +137,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Id not found in cookie");
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Id not found in cookie");
     }
     
     [Fact]
@@ -155,8 +157,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
     }
     
     [Fact]
@@ -177,8 +179,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
     }
     
     [Fact]
@@ -199,8 +201,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
     }
     
     [Fact]
@@ -220,8 +222,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var responseBody = JObject.Parse(await response.Content.ReadAsStringAsync());
-        responseBody["accessToken"].Value<string>().Should().Be(token.Entity.BearerToken);
-        responseBody["expiresIn"].Value<int>().Should().Be(token.Entity.Ttl);
+        responseBody["accessToken"]!.Value<string>().Should().Be(token.Entity.BearerToken);
+        responseBody["expiresIn"]!.Value<int>().Should().Be(token.Entity.Ttl);
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     #endregion
@@ -239,9 +241,9 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["error"].Value<string>().Should().Be("missingCredentials");
-        responseBody["description"].Value<string>().Should().Be("Required cookie missing");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["error"]!.Value<string>().Should().Be("missingCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Required cookie missing");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
 
@@ -259,9 +261,9 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Id not found in cookie");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Id not found in cookie");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     
@@ -279,9 +281,9 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     
@@ -301,9 +303,9 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     
@@ -323,9 +325,9 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["error"].Value<string>().Should().Be("invalidCredentials");
-        responseBody["description"].Value<string>().Should().Be("Credentials provided unknown or expired");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["error"]!.Value<string>().Should().Be("invalidCredentials");
+        responseBody["description"]!.Value<string>().Should().Be("Credentials provided unknown or expired");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     
@@ -345,10 +347,10 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var responseBody = await ParseHtmlTokenReponse(response);
-        responseBody["accessToken"].Value<string>().Should().Be(token.Entity.BearerToken);
-        responseBody["expiresIn"].Value<int>().Should().Be(token.Entity.Ttl);
-        responseBody["messageId"].Value<string>().Should().Be("123");
+        var responseBody = await ParseHtmlTokenResponse(response);
+        responseBody["accessToken"]!.Value<string>().Should().Be(token.Entity.BearerToken);
+        responseBody["expiresIn"]!.Value<int>().Should().Be(token.Entity.Ttl);
+        responseBody["messageId"]!.Value<string>().Should().Be("123");
         response.Headers.CacheControl!.NoStore.Should().BeTrue();
     }
     #endregion
@@ -364,7 +366,7 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        result.Headers.CacheControl.Private.Should().BeTrue();
+        result.Headers.CacheControl!.Private.Should().BeTrue();
 
         var probeResult2 = (await result.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
         probeResult2.Status.Should().Be(401);
@@ -383,8 +385,8 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.NotFound);
-        result.Headers.CacheControl.Should().BeNull();
-        result.Content.Headers.ContentType.MediaType
+        result.Headers.CacheControl!.Should().BeNull();
+        result.Content.Headers.ContentType!.MediaType
             .Should().Be("application/problem+json", "this isn't an AuthProbeResult2");
     }
 
@@ -392,7 +394,7 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
     public async Task ProbeService_ReturnsProbeResultWith200Status_IfOpen()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(ProbeService_ReturnsProbeResultWith200Status_IfOpen)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"auth/v2/probe/{id}";
@@ -404,18 +406,18 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        result.Headers.CacheControl.Private.Should().BeTrue("asset is open but all auth responses should be private");
+        result.Headers.CacheControl!.Private.Should().BeTrue("asset is open but all auth responses should be private");
 
         var probeResult2 = (await result.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
         probeResult2.Status.Should().Be(200);
     }
     
     [Fact]
-    public async Task ProbeService_ReturnsProbeResultWith200Status_IfHasMaxUnauth_WithoutRoles()
+    public async Task ProbeService_ReturnsProbeResultWith401Status_IfHasUnobtainableRoleOnly()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(ProbeService_ReturnsProbeResultWith200Status_IfHasMaxUnauth_WithoutRoles)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 100);
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: Asset.UnobtainableRole);
         await dbFixture.DbContext.SaveChangesAsync();
         var path = $"auth/v2/probe/{id}";
         
@@ -426,7 +428,29 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        result.Headers.CacheControl.Private.Should().BeTrue();
+        result.Headers.CacheControl!.Private.Should().BeTrue("asset is open but all auth responses should be private");
+
+        var probeResult2 = (await result.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
+        probeResult2.Status.Should().Be(401);
+    }
+    
+    [Fact]
+    public async Task ProbeService_ReturnsProbeResultWith200Status_IfHasOpenFullMax_WithoutRoles()
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 100);
+        await dbFixture.DbContext.SaveChangesAsync();
+        var path = $"auth/v2/probe/{id}";
+        
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("bearer", "12345");
+        var result = await httpClient.SendAsync(request);
+        
+        // Assert
+        result.StatusCode.Should().Be(HttpStatusCode.OK);
+        result.Headers.CacheControl!.Private.Should().BeTrue();
 
         var probeResult2 = (await result.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
         probeResult2.Status.Should().Be(200);
@@ -436,7 +460,7 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
     public async Task ProbeService_ReturnsProbeResult_FromDownstreamAuthService()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(ProbeService_ReturnsProbeResult_FromDownstreamAuthService)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(
             id, 
             maxUnauthorised: 100, 
@@ -457,13 +481,13 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         
         // Assert
         result.StatusCode.Should().Be(HttpStatusCode.OK);
-        result.Headers.CacheControl.Private.Should().BeTrue();
+        result.Headers.CacheControl!.Private.Should().BeTrue();
 
         var probeResult2 = (await result.Content.ReadAsStreamAsync()).FromJsonStream<AuthProbeResult2>();
         probeResult2.Should().BeEquivalentTo(downstreamProbeResult);
     }
     
-    private async Task<JObject> ParseHtmlTokenReponse(HttpResponseMessage response)
+    private static async Task<JObject> ParseHtmlTokenResponse(HttpResponseMessage response)
     {
         var htmlParser = new HtmlParser();
         var regex = new Regex("window.parent.postMessage\\(({.*}),.*");
@@ -471,7 +495,7 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         var document = htmlParser.ParseDocument(await response.Content.ReadAsStreamAsync());
         var scriptElement = document.QuerySelector("script") as IHtmlScriptElement;
         
-        var text = scriptElement.Text
+        var text = scriptElement!.Text
             .Replace("\n", string.Empty)
             .Replace("\r", string.Empty)
             .Replace("\t", string.Empty);

--- a/src/protagonist/Orchestrator.Tests/Integration/AuthHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/AuthHandlingTests.cs
@@ -463,7 +463,7 @@ public class AuthHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>, 
         var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(
             id, 
-            maxUnauthorised: 100, 
+            openFullMax: 100, 
             roles: "test-role");
         await dbFixture.DbContext.SaveChangesAsync();
 

--- a/src/protagonist/Orchestrator.Tests/Integration/FakeAuth2Client.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/FakeAuth2Client.cs
@@ -9,13 +9,13 @@ namespace Orchestrator.Tests.Integration;
 
 public class FakeAuth2Client : IIIIFAuthBuilder
 {
-    public Task<IService> GetAuthServicesForAsset(AssetId assetId, List<string> roles, CancellationToken cancellationToken = default)
+    public Task<IService> GetAuthServicesForAsset(AssetId assetId, IReadOnlyList<string> roles, CancellationToken cancellationToken = default)
     {
         var probeService = new AuthProbeService2
         {
             Id = $"http://localhost/auth/v2/probe/{assetId}",
-            Service = new List<IService>
-            {
+            Service =
+            [
                 new AuthAccessService2
                 {
                     Id = $"http://localhost/auth/v2/access/{assetId.Customer}/clickthrough",
@@ -32,7 +32,7 @@ public class FakeAuth2Client : IIIIFAuthBuilder
                         }
                     }
                 }
-            }
+            ]
         };
 
         return Task.FromResult((IService)probeService);

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1237,6 +1237,28 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
     
+    [Fact]
+    public async Task Get_UnsupportedFormat_Returns400()
+    {
+        // Act
+        var response = await httpClient.GetAsync("iiif-img/99/1/my-image/full/full/0/default.pdf");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("Requested format 'pdf' not supported, must be one of 'jpg,tif,gif,png'");
+    }
+    
+    [Fact]
+    public async Task Get_UnsupportedQuality_Returns400()
+    {
+        // Act
+        var response = await httpClient.GetAsync("iiif-img/99/1/my-image/full/full/0/transparent.jpg");
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("Requested quality 'transparent' not supported, must be one of 'color,gray,bitonal,default'");
+    }
+    
     [Theory]
     [InlineData("iiif-img/99/1/test-auth-nocookid/full/!200,200/0/default.jpg", "id")]
     [InlineData("iiif-img/test/1/test-auth-nocookdisplay/full/!200,200/0/default.jpg", "display")]

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -13,7 +13,6 @@ using DLCS.Model.Assets;
 using DLCS.Model.Auth.Entities;
 using DLCS.Model.Policies;
 using IIIF;
-using IIIF.ImageApi;
 using IIIF.ImageApi.V2;
 using IIIF.ImageApi.V3;
 using IIIF.Serialisation;
@@ -30,6 +29,7 @@ using Test.Helpers.Data;
 using Test.Helpers.Integration;
 using Yarp.ReverseProxy.Forwarder;
 using Version = IIIF.ImageApi.Version;
+// ReSharper disable PossibleNullReferenceException
 
 namespace Orchestrator.Tests.Integration;
 
@@ -303,11 +303,128 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task GetInfoJsonV2_RestrictedImage_NoRole_HasMaxWidthSet()
+    public async Task GetInfoJsonV2_SystemLevelMaxWidth_IfNotSetForAsset()
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 500,
+            imageDeliveryChannels: deliveryChannelsForImage);
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": [[400,400],[200,200]]}"
+        });
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/v2/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService2>();
+
+        infoJson.ProfileDescription.MaxArea.Should().BeNull();
+        infoJson.ProfileDescription.MaxHeight.Should().BeNull();
+        infoJson.ProfileDescription.MaxWidth.Should().Be(5000, "Fallback to system-default");
+    }
+    
+    [Fact]
+    public async Task GetInfoJson_SystemLevelMaxWidth_IfNotSetForAsset()
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 500,
+            imageDeliveryChannels: deliveryChannelsForImage);
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": [[400,400],[200,200]]}"
+        });
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService3>();
+
+        infoJson.MaxArea.Should().BeNull();
+        infoJson.MaxHeight.Should().BeNull();
+        infoJson.MaxWidth.Should().Be(5000, "Fallback to system-default");
+    }
+    
+    [Theory]
+    [InlineData(500, 256)]
+    [InlineData(512, 512)]
+    [InlineData(1024, 512)]
+    public async Task GetInfoJsonV2_AssetLevelLevelMaxWidth_IfSetForAsset(int maxWidth, int tileSize)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: maxWidth.ToString());
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 400, maxWidth: maxWidth,
+            imageDeliveryChannels: deliveryChannelsForImage);
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": [[400,400],[200,200]]}"
+        });
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/v2/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService2>();
+
+        infoJson.ProfileDescription.MaxArea.Should().BeNull();
+        infoJson.ProfileDescription.MaxHeight.Should().BeNull();
+        infoJson.ProfileDescription.MaxWidth.Should().Be(maxWidth, "Fallback to system-default");
+        infoJson.Tiles[0].Width.Should().Be(tileSize, "Tiles rewritten if default larger than maxWidth");
+    }
+    
+    [Theory]
+    [InlineData(500, 256)]
+    [InlineData(512, 512)]
+    [InlineData(1024, 512)]
+    public async Task GetInfoJson_AssetLevelLevelMaxWidth_IfSetForAsset(int maxWidth, int tileSize)
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId(assetPostfix: maxWidth.ToString());
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 400, maxWidth: maxWidth,
+            imageDeliveryChannels: deliveryChannelsForImage);
+
+        await amazonS3.PutObjectAsync(new PutObjectRequest
+        {
+            Key = $"{id}/s.json",
+            BucketName = LocalStackFixture.ThumbsBucketName,
+            ContentBody = "{\"o\": [[400,400],[200,200]]}"
+        });
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService3>();
+
+        infoJson.MaxArea.Should().BeNull();
+        infoJson.MaxHeight.Should().BeNull();
+        infoJson.MaxWidth.Should().Be(maxWidth, "Fallback to system-default");
+        infoJson.Tiles[0].Width.Should().Be(tileSize, "Tiles rewritten if default larger than maxWidth");
+    }
+    
+    [Fact]
+    public async Task GetInfoJsonV2_RestrictedImage_UnobtainableRole_HasMaxWidthSet()
+    {
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 500, roles: Asset.UnobtainableRole,
+            imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -324,19 +441,16 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService2>();
 
         infoJson.Id.Should().Be($"http://localhost/iiif-img/v2/{id}");
-        infoJson.Service.Should().BeNull();
-        infoJson.ProfileDescription.MaxArea.Should().BeNull();
-        infoJson.ProfileDescription.MaxHeight.Should().BeNull();
-        infoJson.ProfileDescription.MaxWidth.Should().Be(500);
-        infoJson.Tiles[0].Width.Should().Be(256);
+        infoJson.Service.Should().BeNull("We don't advertise unobtainable role");
     }
     
     [Fact]
-    public async Task GetInfoJson_RestrictedImage_NoRole_HasMaxWidthSet()
+    public async Task GetInfoJson_RestrictedImage_UnobtainableRole_NoServicesAdvertised()
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 500, roles: Asset.UnobtainableRole,
+            imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -354,11 +468,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var infoJson = responseStream.FromJsonStream<ImageService3>();
 
         infoJson.Id.Should().Be($"http://localhost/iiif-img/{id}");
-        infoJson.Service.Should().BeNull();
-        infoJson.MaxArea.Should().BeNull();
-        infoJson.MaxHeight.Should().BeNull();
-        infoJson.MaxWidth.Should().Be(500);
-        infoJson.Tiles[0].Width.Should().Be(256);
+        infoJson.Service.Should().BeNull("We don't advertise unobtainable role");
     }
 
     [Fact]
@@ -784,7 +894,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const string roleName = "my-test-role";
         const string authServiceName = "my-auth-service";
         const string logoutServiceName = "my-logout-service";
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
@@ -834,7 +944,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const string authServiceName = "my-auth-service";
         const string logoutServiceName = "my-logout-service";
 
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: roleName, openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.Roles.AddAsync(new Role
         {
@@ -880,11 +990,12 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task GetInfoJson_RestrictedImage_NoRole_HasNoService()
+    public async Task GetInfoJson_RestrictedImage_UnobtainableRole_HasNoService()
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, maxUnauthorised: 500, imageDeliveryChannels: deliveryChannelsForImage);
+        await dbFixture.DbContext.Images.AddTestAsset(id, openFullMax: 500, roles: Asset.UnobtainableRole,
+            imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
         {
@@ -901,7 +1012,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var responseStream = await response.Content.ReadAsStreamAsync();
         var infoJson = responseStream.FromJsonStream<ImageService3>();
 
-        infoJson.Id.Should().Be("http://localhost/iiif-img/99/1/GetInfoJson_RestrictedImage_NoRole_HasNoService");
+        infoJson.Id.Should().Be($"http://localhost/iiif-img/{id}");
         infoJson.Service.Should().BeNull();
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
@@ -915,7 +1026,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "unknown-role", maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "unknown-role", openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
 
         await amazonS3.PutObjectAsync(new PutObjectRequest
@@ -945,7 +1056,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -973,7 +1084,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.SaveChangesAsync();
         
@@ -1003,7 +1114,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -1038,7 +1149,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 500,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 500,
             imageDeliveryChannels: deliveryChannelsForImage);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -1133,7 +1244,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId(asset: "test-auth-nocook", assetPostfix: type);
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", openFullMax: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1153,7 +1264,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId(asset: "test-auth-invalidcook", assetPostfix: type);
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", maxUnauthorised: 100,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "basic", openFullMax: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
@@ -1175,7 +1286,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId(asset: "test-auth-expcook", assetPostfix: type);
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
@@ -1202,7 +1313,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId(asset: "test-auth-cook-tile", assetPostfix: type);
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
@@ -1240,7 +1351,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId(asset: "test-auth-cook", assetPostfix: type);
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 100,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 100,
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         var userSession =
@@ -1568,7 +1679,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,100,100/200,200/0/default.jpg");
+        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,400,400/200,200/0/default.jpg");
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
@@ -1597,7 +1708,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,100,100/200,200/0/default.jpg");
+        var response = await httpClient.GetAsync($"iiif-img/{id}/0,0,100,100/^200,200/0/default.jpg");
         
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -1397,7 +1397,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
-        var expectedPath = new Uri("http://thumbs/thumbs/99/1/known-thumb/full/!200,200/0/default.jpg");
+        var expectedPath = new Uri("http://thumbs/thumbs/99/1/known-thumb/full/200,200/0/default.jpg");
         
         // Act
         var response = await httpClient.GetAsync("iiif-img/99/1/known-thumb/full/!200,200/0/default.jpg");
@@ -1424,7 +1424,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
-        var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!123,123/0/default.jpg");
+        var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/123,123/0/default.jpg");
         
         // Act
         var response = await httpClient.GetAsync($"iiif-img/{id}/full/!123,123/0/default.jpg");
@@ -1533,7 +1533,7 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
             imageDeliveryChannels: deliveryChannelsForImage);
         await dbFixture.DbContext.ImageLocations.AddTestImageLocation(id);
         await dbFixture.DbContext.SaveChangesAsync();
-        var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/!600,600/0/default.jpg");
+        var expectedPath = new Uri($"http://thumbresize/thumbs/{id}/full/600,600/0/default.jpg");
         
         // Act
         var response = await httpClient.GetAsync($"iiif-img/{id}/full/!600,600/0/default.jpg");

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -580,7 +580,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 400,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 400,
             imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
 

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -767,7 +767,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
     {
         // Arrange
         var id = AssetIdGenerator.GetAssetId();
-        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", maxUnauthorised: 400,
+        await dbFixture.DbContext.Images.AddTestAsset(id, roles: "clickthrough", openFullMax: 400,
             imageDeliveryChannels: imageDeliveryChannels);
         await dbFixture.DbContext.SaveChangesAsync();
 

--- a/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/NamedQueryTests.cs
@@ -55,7 +55,7 @@ public class NamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
             .WithTestThumbnailMetadata()
             .WithTestDeliveryChannel(AssetDeliveryChannels.Image);
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "default")
+            openFullMax: 10, roles: "default")
             .WithTestThumbnailMetadata()
             .WithTestDeliveryChannel(AssetDeliveryChannels.Image)
             .WithTestAdjunct("test-adjunct", externalId: "https://example.com/see-also-1");

--- a/src/protagonist/Orchestrator.Tests/Integration/PdfTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/PdfTests.cs
@@ -55,12 +55,12 @@ public class PdfTests : IClassFixture<ProtagonistAppFactory<Startup>>
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-1"), num1: 2, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-2"), num1: 1, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-3-auth"), num1: 3, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "default");
+            openFullMax: 10, roles: "default");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-4"), num1: 4, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-5"), num1: 5, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-6"), num1: 6, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-pdf-6-auth"), num1: 6, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "clickthrough");
+            openFullMax: 10, roles: "clickthrough");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 6, ref1: "my-ref",
             notForDelivery: true);
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/limited-projection"), num1: 2,

--- a/src/protagonist/Orchestrator.Tests/Integration/RawNamedQueryTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/RawNamedQueryTests.cs
@@ -42,7 +42,7 @@ public class RawNamedQueryTests : IClassFixture<ProtagonistAppFactory<Startup>>
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-1"), num1: 2, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-2"), num1: 1, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-nothumbs"), num1: 3, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "default");
+            openFullMax: 10, roles: "default");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 4, ref1: "my-ref",
             notForDelivery: true);
         

--- a/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/TimebasedHandlingTests.cs
@@ -10,6 +10,7 @@ using DLCS.Model.Policies;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Orchestrator.Tests.Integration.Infrastructure;
+using Test.Helpers.Data;
 using Test.Helpers.Integration;
 using Yarp.ReverseProxy.Forwarder;
 
@@ -112,7 +113,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_Returns404_IfNotForDelivery()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNotForDelivery)}");
+        var id = AssetIdGenerator.GetAssetId();
         await dbFixture.DbContext.Images.AddTestAsset(id, notForDelivery: true, imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
@@ -127,15 +128,15 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_Returns404_IfNoTimebasedChannel()
     {
         // Arrange
-        var id = AssetId.FromString($"99/1/{nameof(Get_Returns404_IfNoTimebasedChannel)}");
-        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels: new List<ImageDeliveryChannel>
-        {
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, imageDeliveryChannels:
+        [
             new()
             {
                 Channel = AssetDeliveryChannels.File,
                 DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.FileNone
             }
-        });
+        ]);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
@@ -149,16 +150,16 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetDoesNotRequireAuth_ProxiesToS3Location()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/test-noauth");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: -1,
-            origin: "/test/space", imageDeliveryChannels: deliveryChannelsForTimebased);
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", origin: "/test/space",
+            imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
         var expectedPath =
             new Uri(
-                "https://protagonist-storage.s3.eu-west-1.amazonaws.com/99/1/test-noauth/full/full/max/max/0/default.mp4");
+                $"https://protagonist-storage.s3.eu-west-1.amazonaws.com/{id}/full/full/max/max/0/default.mp4");
         
         // Act
-        var response = await httpClient.GetAsync("/iiif-av/99/1/test-noauth/full/full/max/max/0/default.mp4");
+        var response = await httpClient.GetAsync($"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
 
         // Assert
@@ -171,13 +172,13 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetRequiresAuth_Returns401_IfNoAuthProvided()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/test-auth");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg",
             origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var response = await httpClient.GetAsync("/iiif-av/99/1/test-auth/full/full/max/max/0/default.mp4");
+        var response = await httpClient.GetAsync($"/iiif-av/{id}/full/full/max/max/0/default.mp4");
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -188,15 +189,14 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetRequiresAuth_Returns401_IfBearerTokenProvided_ButInvalid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/bearer-fail");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg",
             origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
         const string bearerToken = "ababababab";
 
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            "/iiif-av/99/1/bearer-fail/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Authorization", $"bearer {bearerToken}");
         var response = await httpClient.SendAsync(request);
 
@@ -209,8 +209,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetRequiresAuth_Returns401_IfBearerTokenValid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/bearer-pass");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg",
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -220,8 +220,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         await dbFixture.DbContext.SaveChangesAsync();
         
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            "/iiif-av/99/1/bearer-pass/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Authorization", $"bearer {authToken.Entity.BearerToken}");
         var response = await httpClient.SendAsync(request);
 
@@ -234,8 +233,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Head_AssetRequiresAuth_Returns200_IfBearerTokenValid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/bearer-head");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -245,8 +244,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Head,
-            "/iiif-av/99/1/bearer-head/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Head, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Authorization", $"bearer {authToken.Entity.BearerToken}");
         var response = await httpClient.SendAsync(request);
 
@@ -259,8 +257,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Head_AssetRequiresAuth_Returns401_IfBearerTokenProvided_ButInvalid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/bearer-head-invalid");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -283,14 +281,13 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetRequiresAuth_Returns401_IfCookieProvided_ButInvalid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/cookie-fail");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "basic", imageDeliveryChannels: deliveryChannelsForTimebased);
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            "/iiif-av/99/1/cookie-fail/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Cookie", "dlcs-token-99=blabla;");
         var response = await httpClient.SendAsync(request);
 
@@ -303,8 +300,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Get_AssetRequiresAuth_ProxiesToS3_IfCookieTokenValid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/cookie-pass");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -315,11 +312,10 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         
         var expectedPath =
             new Uri(
-                "https://protagonist-storage.s3.eu-west-1.amazonaws.com/99/1/cookie-pass/full/full/max/max/0/default.mp4");
+                $"https://protagonist-storage.s3.eu-west-1.amazonaws.com/{id}/full/full/max/max/0/default.mp4");
 
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Get,
-            "/iiif-av/99/1/cookie-pass/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Cookie", $"dlcs-token-99=id={authToken.Entity.CookieId};");
         var response = await httpClient.SendAsync(request);
         var proxyResponse = await response.Content.ReadFromJsonAsync<ProxyResponse>();
@@ -333,8 +329,8 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     public async Task Head_AssetRequiresAuth_Returns200_IfCookieValid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/cookie-head");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(
@@ -344,8 +340,7 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
         await dbFixture.DbContext.SaveChangesAsync();
 
         // Act
-        var request = new HttpRequestMessage(HttpMethod.Head,
-            "/iiif-av/99/1/cookie-head/full/full/max/max/0/default.mp4");
+        var request = new HttpRequestMessage(HttpMethod.Head, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
         request.Headers.Add("Cookie", $"dlcs-token-99=id={authToken.Entity.CookieId};");
         var response = await httpClient.SendAsync(request);
 
@@ -355,11 +350,36 @@ public class TimebasedHandlingTests : IClassFixture<ProtagonistAppFactory<Startu
     }
     
     [Fact]
+    public async Task Head_AssetRequiresAuth_Returns401_IfCookieValid_ButUnobtainableRole()
+    {
+        // This is not a realistic test but confirms we will shortcut auth requests if 'unobtainable' role
+        // Arrange
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
+            origin: "/test/space", roles: Asset.UnobtainableRole, imageDeliveryChannels: deliveryChannelsForTimebased);
+        var userSession =
+            await dbFixture.DbContext.SessionUsers.AddTestSession(
+                DlcsDatabaseFixture.ClickThroughAuthService.AsList());
+        var authToken = await dbFixture.DbContext.AuthTokens.AddTestToken(expires: DateTime.UtcNow.AddMinutes(15),
+            sessionUserId: userSession.Entity.Id);
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var request = new HttpRequestMessage(HttpMethod.Head, $"/iiif-av/{id}/full/full/max/max/0/default.mp4");
+        request.Headers.Add("Cookie", $"dlcs-token-99=id={authToken.Entity.CookieId};");
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.Should().ContainKey("x-asset-id").WhoseValue.Should().ContainSingle(id.ToString());
+    }
+    
+    [Fact]
     public async Task Head_AssetRequiresAuth_Returns401_IfCookieProvided_ButInvalid()
     {
         // Arrange
-        var id = AssetId.FromString("99/1/cookie-head-invalid");
-        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", maxUnauthorised: 100,
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, mediaType: "video/mpeg", 
             origin: "/test/space", roles: "clickthrough", imageDeliveryChannels: deliveryChannelsForTimebased);
         var userSession =
             await dbFixture.DbContext.SessionUsers.AddTestSession(

--- a/src/protagonist/Orchestrator.Tests/Integration/ZipTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ZipTests.cs
@@ -52,7 +52,7 @@ public class ZipTests : IClassFixture<ProtagonistAppFactory<Startup>>
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-zip-1"), num1: 2, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-zip-2"), num1: 1, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-zip-3-auth"), num1: 3, ref1: "my-ref",
-            maxUnauthorised: 10, roles: "default");
+            roles: "default");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-zip-4"), num1: 4, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/matching-zip-5"), num1: 5, ref1: "my-ref");
         dbFixture.DbContext.Images.AddTestAsset(AssetId.FromString("99/1/not-for-delivery"), num1: 6, ref1: "my-ref",

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Caching;

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -18,36 +18,22 @@ namespace Orchestrator.Assets;
 /// <summary>
 /// <see cref="IAssetTracker"/> implementation using in-memory tracking
 /// </summary>
-public class MemoryAssetTracker : IAssetTracker
+public class MemoryAssetTracker(
+    IAssetRepository assetRepository,
+    IAppCache appCache,
+    IThumbRepository thumbRepository,
+    ICustomerOriginStrategyRepository customerOriginStrategyRepository,
+    IOptions<OrchestratorSettings> orchestratorOptions,
+    ILogger<MemoryAssetTracker> logger)
+    : IAssetTracker
 {
-    private readonly IAssetRepository assetRepository;
-    private readonly IAppCache appCache;
-    private readonly CacheSettings cacheSettings;
-    private readonly IThumbRepository thumbRepository;
-    private readonly ICustomerOriginStrategyRepository customerOriginStrategyRepository;
-    private readonly ILogger<MemoryAssetTracker> logger;
-    private readonly ReingestOnOrchestrationSettings reingestSettings;
+    private readonly CacheSettings cacheSettings = orchestratorOptions.Value.Caching;
+    private readonly ReingestOnOrchestrationSettings reingestSettings = orchestratorOptions.Value.ReingestOnOrchestration;
+    private readonly int systemMaxWidth = orchestratorOptions.Value.MaxWidth;
 
     // Null object to store in cache for short duration
     private static readonly OrchestrationAsset NullOrchestrationAsset =
         new() { AssetId = new AssetId(-1, -1, "__notfound__") };
-    
-    public MemoryAssetTracker(
-        IAssetRepository assetRepository,
-        IAppCache appCache,
-        IThumbRepository thumbRepository,
-        ICustomerOriginStrategyRepository customerOriginStrategyRepository,
-        IOptions<OrchestratorSettings> orchestratorOptions,
-        ILogger<MemoryAssetTracker> logger)
-    {
-        this.assetRepository = assetRepository;
-        this.appCache = appCache;
-        this.thumbRepository = thumbRepository;
-        this.customerOriginStrategyRepository = customerOriginStrategyRepository;
-        this.logger = logger;
-        cacheSettings = orchestratorOptions.Value.Caching;
-        reingestSettings = orchestratorOptions.Value.ReingestOnOrchestration;
-    }
 
     public async Task<OrchestrationAsset?> GetOrchestrationAsset(AssetId assetId)
     {
@@ -113,27 +99,11 @@ public class MemoryAssetTracker : IAssetTracker
 
     private static string GetCacheKey(AssetId assetId) => $"Track:{assetId}";
 
-    private bool IsNullAsset(OrchestrationAsset orchestrationAsset)
+    private static bool IsNullAsset(OrchestrationAsset orchestrationAsset)
         => orchestrationAsset.AssetId == NullOrchestrationAsset.AssetId;
 
     private async Task<OrchestrationAsset> ConvertAssetToTrackedAsset(AssetId assetId, Asset asset)
     {
-        T SetDefaults<T>(T orchestrationAsset)
-            where T : OrchestrationAsset
-        {
-            if (asset.HasDeliveryChannel(AssetDeliveryChannels.File))
-                orchestrationAsset.Channels |= AvailableDeliveryChannel.File;
-            if (asset.HasDeliveryChannel(AssetDeliveryChannels.Image))
-                orchestrationAsset.Channels |= AvailableDeliveryChannel.Image;
-            if (asset.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
-                orchestrationAsset.Channels |= AvailableDeliveryChannel.Timebased;
-            
-            orchestrationAsset.AssetId = assetId;
-            orchestrationAsset.Roles = asset.RolesList.ToList();
-            orchestrationAsset.RequiresAuth = asset.RequiresAuth;
-            return orchestrationAsset;
-        }
-
         OrchestrationAsset orchestrationAsset;
         
         if (asset.HasDeliveryChannel(AssetDeliveryChannels.Image))
@@ -150,8 +120,10 @@ public class MemoryAssetTracker : IAssetTracker
                 S3Location = imageLocation?.S3,
                 Width = asset.Width ?? 0,
                 Height = asset.Height ?? 0,
+                MaxWidth = asset.GetEffectiveMaxWidth(systemMaxWidth),
+                OpenFullMax = asset.HasRoles ? asset.OpenFullMax : null,
                 MaxUnauthorised = asset.MaxUnauthorised ?? 0,
-                OpenThumbs = getOpenThumbs.Result ?? new List<int[]>(),
+                OpenThumbs = getOpenThumbs.Result ?? [],
                 Reingest = GetReingestFlag(asset, imageLocation),
             };
         }
@@ -169,7 +141,22 @@ public class MemoryAssetTracker : IAssetTracker
             orchestrationAsset.MediaType = new StringValues(asset.MediaType ?? "application/octet-stream");
         }
         
-        return SetDefaults(orchestrationAsset);
+        return SetDefaults();
+
+        OrchestrationAsset SetDefaults()
+        {
+            if (asset.HasDeliveryChannel(AssetDeliveryChannels.File))
+                orchestrationAsset.Channels |= AvailableDeliveryChannel.File;
+            if (asset.HasDeliveryChannel(AssetDeliveryChannels.Image))
+                orchestrationAsset.Channels |= AvailableDeliveryChannel.Image;
+            if (asset.HasDeliveryChannel(AssetDeliveryChannels.Timebased))
+                orchestrationAsset.Channels |= AvailableDeliveryChannel.Timebased;
+            
+            orchestrationAsset.AssetId = assetId;
+            orchestrationAsset.Roles = asset.RolesList.ToList();
+            orchestrationAsset.RequiresAuth = asset.HasRoles;
+            return orchestrationAsset;
+        }
     }
     
     private bool GetReingestFlag(Asset asset, ImageLocation? imageLocation)

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -6,6 +6,7 @@ using DLCS.Core.Guard;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
+using IIIF;
 using LazyCache;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -117,8 +118,7 @@ public class MemoryAssetTracker(
             orchestrationAsset = new OrchestrationImage
             {
                 S3Location = imageLocation?.S3,
-                Width = asset.Width ?? 0,
-                Height = asset.Height ?? 0,
+                Size = new Size(asset.Width ?? 0, asset.Height ?? 0),
                 MaxWidth = asset.GetEffectiveMaxWidth(systemMaxWidth),
                 OpenFullMax = asset.HasRoles ? asset.OpenFullMax : null,
                 OpenThumbs = getOpenThumbs.Result ?? [],

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -122,7 +122,6 @@ public class MemoryAssetTracker(
                 Height = asset.Height ?? 0,
                 MaxWidth = asset.GetEffectiveMaxWidth(systemMaxWidth),
                 OpenFullMax = asset.HasRoles ? asset.OpenFullMax : null,
-                MaxUnauthorised = asset.MaxUnauthorised ?? 0,
                 OpenThumbs = getOpenThumbs.Result ?? [],
                 Reingest = GetReingestFlag(asset, imageLocation),
             };

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using DLCS.Core.Types;
+using IIIF;
 using Microsoft.Extensions.Primitives;
 
 namespace Orchestrator.Assets;
@@ -51,14 +52,9 @@ public class OrchestrationAsset
 public class OrchestrationImage : OrchestrationAsset
 {
     /// <summary>
-    /// Get or set asset Width
+    /// Get or set the image dimensions
     /// </summary>
-    public int Width { get; set; }
-    
-    /// <summary>
-    /// Get or set asset Height
-    /// </summary>
-    public int Height { get; set; }
+    public Size Size { get; set; } = null!;
     
     /// <summary>
     /// The maximum size available for any user. This will be asset MaxWidth, falling back to system default 

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -13,10 +13,10 @@ public class OrchestrationAsset
     /// <summary>
     /// Get or set the AssetId for tracked Asset
     /// </summary>
-    public AssetId AssetId { get; set; }
+    public AssetId AssetId { get; set; } = null!;
 
     /// <summary>
-    /// Get boolean indicating whether asset is restricted or not.
+    /// Get boolean indicating whether asset is restricted or not. 
     /// </summary>
     public bool RequiresAuth { get; set; }
 
@@ -63,12 +63,23 @@ public class OrchestrationImage : OrchestrationAsset
     /// <summary>
     /// Get maximum dimension available for unauthorised user
     /// </summary>
+    [Obsolete("Use MaxWidth and OpenFullMax instead")]
     public int MaxUnauthorised { get; set; }
+    
+    /// <summary>
+    /// The maximum size available for any user. This will be asset MaxWidth, falling back to system-default 
+    /// </summary>
+    public int MaxWidth { get; set; }
+    
+    /// <summary>
+    /// The maximum dimension available for /full/ requests for an unauthorised user
+    /// </summary>
+    public int? OpenFullMax { get; set; }
 
     /// <summary>
     /// Gets or sets list of thumbnail sizes
     /// </summary>
-    public List<int[]> OpenThumbs { get; set; } = new();
+    public List<int[]> OpenThumbs { get; set; } = [];
     
     /// <summary>
     /// Get or set location in S3 where image-server source is located 

--- a/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
+++ b/src/protagonist/Orchestrator/Assets/OrchestrationAsset.cs
@@ -61,13 +61,7 @@ public class OrchestrationImage : OrchestrationAsset
     public int Height { get; set; }
     
     /// <summary>
-    /// Get maximum dimension available for unauthorised user
-    /// </summary>
-    [Obsolete("Use MaxWidth and OpenFullMax instead")]
-    public int MaxUnauthorised { get; set; }
-    
-    /// <summary>
-    /// The maximum size available for any user. This will be asset MaxWidth, falling back to system-default 
+    /// The maximum size available for any user. This will be asset MaxWidth, falling back to system default 
     /// </summary>
     public int MaxWidth { get; set; }
     

--- a/src/protagonist/Orchestrator/Features/Auth/Requests/ProbeService.cs
+++ b/src/protagonist/Orchestrator/Features/Auth/Requests/ProbeService.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Web;
 using DLCS.Web.Auth;
 using MediatR;
@@ -16,35 +17,22 @@ namespace Orchestrator.Features.Auth.Requests;
 /// <summary>
 /// Handles IIIF Authorization Flow 2.0 ProbeService request
 /// </summary>
-public class ProbeService : IRequest<DescriptionResourceResponse>
+/// <remarks>
+/// Probe service will always return a 200 status code, the response will contain the status code the user will receive
+/// if they make a request for the associated asset.
+/// </remarks>
+public class ProbeService(int customer, int space, string asset) : IRequest<DescriptionResourceResponse>
 {
-    public AssetId AssetId { get; }
-
-    public ProbeService(int customer, int space, string asset)
-    {
-        AssetId = new AssetId(customer, space, asset);
-    }
+    public AssetId AssetId { get; } = new(customer, space, asset);
 }
 
-public class ProbeServiceHandler : IRequestHandler<ProbeService, DescriptionResourceResponse>
+public class ProbeServiceHandler(
+    IIIFAuth2Client iiifAuth2Client,
+    IAssetTracker assetTracker,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<ProbeServiceHandler> logger)
+    : IRequestHandler<ProbeService, DescriptionResourceResponse>
 {
-    private readonly IIIFAuth2Client iiifAuth2Client;
-    private readonly IAssetTracker assetTracker;
-    private readonly IHttpContextAccessor httpContextAccessor;
-    private readonly ILogger<ProbeServiceHandler> logger;
-
-    public ProbeServiceHandler(
-        IIIFAuth2Client iiifAuth2Client,
-        IAssetTracker assetTracker,
-        IHttpContextAccessor httpContextAccessor,
-        ILogger<ProbeServiceHandler> logger)
-    {
-        this.iiifAuth2Client = iiifAuth2Client;
-        this.assetTracker = assetTracker;
-        this.httpContextAccessor = httpContextAccessor;
-        this.logger = logger;
-    }
-    
     public async Task<DescriptionResourceResponse> Handle(ProbeService request, CancellationToken cancellationToken)
     {
         var assetId = request.AssetId;
@@ -73,6 +61,12 @@ public class ProbeServiceHandler : IRequestHandler<ProbeService, DescriptionReso
         {
             logger.LogInformation("ProbeService request for auth asset {AssetId} with no roles", assetId);
             return DescriptionResourceResponse.Restricted(AuthProbeResult2Builder.Okay);
+        }
+
+        if (asset.Roles.ContainsOnly(Asset.UnobtainableRole))
+        {
+            logger.LogInformation("ProbeService request for auth asset {AssetId} with unobtainable role", assetId);
+            return DescriptionResourceResponse.Restricted(AuthProbeResult2Builder.UnobtainableRole);
         }
 
         var authProbeResult =

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -38,6 +38,7 @@ public class ImageRequestHandler
     private readonly IOptions<OrchestratorSettings> orchestratorSettings;
     private readonly Dictionary<string, CompiledRegexThumbUpscaleConfig> upscaleConfig;
     private readonly bool haveUpscaleRules;
+    private readonly bool strictImageRequests;
 
     public ImageRequestHandler(
         ILogger<ImageRequestHandler> logger,
@@ -57,6 +58,7 @@ public class ImageRequestHandler
                             .ToDictionary(kvp => kvp.Key, kvp => new CompiledRegexThumbUpscaleConfig(kvp.Value)) ??
                         new Dictionary<string, CompiledRegexThumbUpscaleConfig>();
         haveUpscaleRules = upscaleConfig.Count > 0;
+        strictImageRequests = orchestratorSettings.Value.StrictImageRequestParsing;
     }
 
     /// <summary>
@@ -131,8 +133,8 @@ public class ImageRequestHandler
         
         // Get the proposed image size - this is required to determine if we will exceed this
         var incomingImageRequest = assetRequest.IIIFImageRequest;
-        var proxyRequest =
-            incomingImageRequest.GetProxyImageRequest(imageApiVersion.Value, imageSize, orchestrationImage.MaxWidth);
+        var proxyRequest = incomingImageRequest.GetProxyImageRequest(imageApiVersion.Value, imageSize,
+            orchestrationImage.MaxWidth, strictImageRequests);
         if (!proxyRequest.IsValid)
         {
             return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value);

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -7,7 +7,6 @@ using DLCS.Core.Collections;
 using DLCS.Core.Strings;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.CustomHeaders;
-using DLCS.Model.IIIF;
 using DLCS.Repository.Assets;
 using DLCS.Web.IIIF;
 using DLCS.Web.Requests.AssetDelivery;
@@ -128,8 +127,8 @@ public class ImageRequestHandler
                 assetRequest.NormalisedFullPath);
             return new StatusCodeResult(HttpStatusCode.BadRequest);
         }
-        
-        var imageSize = new Size(orchestrationImage.Width, orchestrationImage.Height);
+
+        var imageSize = orchestrationImage.Size;
         
         // Parse the incoming request to get proxy result, based in image + requested size only
         var incomingImageRequest = assetRequest.IIIFImageRequest;
@@ -140,20 +139,16 @@ public class ImageRequestHandler
             return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value);
         }
         
-        var requestedFullRegion =
-            incomingImageRequest.Region.IsFullOrEquivalent(orchestrationImage.Width,
-                orchestrationImage.Height);
-        
         // If there are roles, we may have restricted access..
         if (orchestrationImage.RequiresAuth)
         {
-            if (await IsRequestUnauthorised(assetRequest, orchestrationImage, requestedFullRegion, proxyRequest))
+            if (await IsRequestUnauthorised(assetRequest, orchestrationImage, proxyRequest))
             {
                 return new StatusCodeResult(HttpStatusCode.Unauthorized);
             }
         }
         
-        if (requestedFullRegion)
+        if (proxyRequest.RepresentsFullRegion)
         {
             // /full/ or equiv region but not /max/ size - can it be handled by thumbnail service?
             if (!incomingImageRequest.Size.Max)
@@ -198,11 +193,11 @@ public class ImageRequestHandler
     }
 
     private async Task<bool> IsRequestUnauthorised(ImageAssetDeliveryRequest assetRequest,
-        OrchestrationImage orchestrationImage, bool requestedFullRegion, ProxyImageRequest proxyRequest)
+        OrchestrationImage orchestrationImage, ProxyImageRequest proxyRequest)
     {
         // If the image has an openFullMax, and the region is /full/ then user may be able to see requested
         // size without doing auth check
-        if (requestedFullRegion && orchestrationImage.OpenFullMax > 0)
+        if (proxyRequest.RepresentsFullRegion && orchestrationImage.OpenFullMax > 0)
         {
             // If requested maxDimension < openFullMax then anyone can view as this is a /full/ region
             if (proxyRequest.RequestedSize!.MaxDimension <= orchestrationImage.OpenFullMax)

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -77,7 +77,7 @@ public class ImageRequestHandler
         if (!assetRequest.IIIFImageRequest.IsCandidateForImageHandling(out var message))
         {
             logger.LogDebug("Request for {Path}: invalid {Message}", httpContext.Request.Path, message);
-            return new StatusCodeResult(HttpStatusCode.BadRequest);
+            return new StatusCodeResult(HttpStatusCode.BadRequest, message);
         }
         
         var orchestrationImage = await assetRequestProcessor.GetAsset<OrchestrationImage>(httpContext, assetRequest);
@@ -137,7 +137,7 @@ public class ImageRequestHandler
             logger.LogDebug(
                 "Unable to fulfil image request: {Path}. ProxyRequest invalid: {ErrorStatus} - {ErrorMessage}",
                 assetRequest.NormalisedFullPath, proxyRequest.ErrorStatusCode, proxyRequest.ErrorMessage);
-            return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value);
+            return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value, proxyRequest.ErrorMessage);
         }
         
         // If there are roles, we may have restricted access..

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -73,10 +73,10 @@ public class ImageRequestHandler
         {
             return new StatusCodeResult(statusCode ?? HttpStatusCode.InternalServerError);
         }
-
-        if (!IsSizeValid(assetRequest.IIIFImageRequest.Size))
+        
+        if (!assetRequest.IIIFImageRequest.IsCandidateForImageHandling(out var message))
         {
-            logger.LogDebug("Request for {Path}: invalid size", httpContext.Request.Path);
+            logger.LogDebug("Request for {Path}: invalid {Message}", httpContext.Request.Path, message);
             return new StatusCodeResult(HttpStatusCode.BadRequest);
         }
         
@@ -113,8 +113,6 @@ public class ImageRequestHandler
         await SetCustomHeaders(orchestrationImage, result);
         return proxyActionResult;
     }
-
-    private static bool IsSizeValid(SizeParameter size) => (size.Width ?? 1) > 0 && (size.Height ?? 1) > 0;
 
     private async Task<IProxyActionResult> HandleRequestInternal(HttpContext httpContext,
         OrchestrationImage orchestrationImage, ImageAssetDeliveryRequest assetRequest)

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -136,6 +136,9 @@ public class ImageRequestHandler
             orchestrationImage.MaxWidth, strictImageRequests);
         if (!proxyRequest.IsValid)
         {
+            logger.LogDebug(
+                "Unable to fulfil image request: {Path}. ProxyRequest invalid: {ErrorStatus} - {ErrorMessage}",
+                assetRequest.NormalisedFullPath, proxyRequest.ErrorStatusCode, proxyRequest.ErrorMessage);
             return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value);
         }
         
@@ -148,29 +151,30 @@ public class ImageRequestHandler
             }
         }
         
+        // Update the SizeParameter as it may have altered during parsing
+        assetRequest.IIIFImageRequest.Size = proxyRequest.ProxySizeParameter;
+        
         if (proxyRequest.RepresentsFullRegion)
         {
-            // /full/ or equiv region but not /max/ size - can it be handled by thumbnail service?
-            if (!incomingImageRequest.Size.Max)
+            // /full/ or equiv region - can it be handled by thumbnail service?
+            var canHandleByThumbResponse = CanRequestBeHandledByThumb(assetRequest, orchestrationImage);
+            if (canHandleByThumbResponse.CanHandle)
             {
-                var canHandleByThumbResponse = CanRequestBeHandledByThumb(assetRequest, orchestrationImage);
-                if (canHandleByThumbResponse.CanHandle)
-                {
-                    logger.LogDebug("'{Path}' can be handled by thumb, proxying to thumbs. IsResize: {IsResize}",
-                        httpContext.Request.Path, canHandleByThumbResponse.IsResize);
+                logger.LogDebug("'{Path}' can be handled by thumb, proxying to thumbs. IsResize: {IsResize}",
+                    httpContext.Request.Path, canHandleByThumbResponse.IsResize);
 
-                    var pathReplacement = canHandleByThumbResponse.IsResize
-                        ? orchestratorSettings.Value.Proxy.ThumbResizePath
-                        : orchestratorSettings.Value.Proxy.ThumbsPath;
-                    var proxyDestination = canHandleByThumbResponse.IsResize
-                        ? ProxyDestination.ResizeThumbs
-                        : ProxyDestination.Thumbs;
-                    var proxyResult = new ProxyActionResult(proxyDestination,
-                        orchestrationImage.RequiresAuth,
-                        httpContext.Request.Path.ToString().Replace("iiif-img", pathReplacement));
-                    return proxyResult;
-                } 
+                var pathReplacement = canHandleByThumbResponse.IsResize
+                    ? orchestratorSettings.Value.Proxy.ThumbResizePath
+                    : orchestratorSettings.Value.Proxy.ThumbsPath;
+                var proxyDestination = canHandleByThumbResponse.IsResize
+                    ? ProxyDestination.ResizeThumbs
+                    : ProxyDestination.Thumbs;
+                var proxyResult = new ProxyActionResult(proxyDestination,
+                    orchestrationImage.RequiresAuth,
+                    assetRequest.IIIFImageRequest.ToString().Replace("iiif-img", pathReplacement));
+                return proxyResult;
             }
+
             // /full/ that cannot be handled by thumbs (e.g. format, size, rotation, quality), handle with special-server
             if (orchestrationImage.S3Location.IsNullOrEmpty())
             {
@@ -188,7 +192,7 @@ public class ImageRequestHandler
         return GetImageServerProxyResult(false);
 
         IProxyActionResult GetImageServerProxyResult(bool specialServer) =>
-            GenerateImageServerProxyResult(orchestrationImage, assetRequest, proxyRequest, imageApiVersion.Value,
+            GenerateImageServerProxyResult(orchestrationImage, assetRequest, imageApiVersion.Value,
                 specialServer);
     }
 
@@ -225,7 +229,7 @@ public class ImageRequestHandler
         // Contains Image Request Parameters that thumbs can't handle, abort
         if (!imageRequest.IsCandidateForThumbHandling(out _)) return (false, false);
 
-        var openSizes = orchestrationImage.OpenThumbs.Select(wh => Size.FromArray(wh)).ToList();
+        var openSizes = orchestrationImage.OpenThumbs.Select(Size.FromArray).ToList();
 
         // No open thumbs so cannot handle by thumb, abort
         if (openSizes.IsNullOrEmpty()) return (false, false);
@@ -265,8 +269,7 @@ public class ImageRequestHandler
     }
 
     private IProxyActionResult GenerateImageServerProxyResult(OrchestrationImage orchestrationImage,
-        ImageAssetDeliveryRequest requestModel, ProxyImageRequest proxyRequest, Version imageApiVersion, 
-        bool specialServer)
+        ImageAssetDeliveryRequest requestModel, Version imageApiVersion, bool specialServer)
     {
         // get the redirect path - S3:// path for special-server or /path/on/disk for image-server
         var settings = orchestratorSettings.Value;
@@ -280,9 +283,7 @@ public class ImageRequestHandler
                 requestModel.NormalisedFullPath);
             return new StatusCodeResult(HttpStatusCode.BadRequest);
         }
-
-        // Update the SizeParameter as it may have altered during parsing
-        requestModel.IIIFImageRequest.Size = proxyRequest.ProxySizeParameter!;
+        
         var imageServerPath = downstreamPath.ToConcatenated('/', requestModel.IIIFImageRequest.GetImageRequestOnly());
         IProxyActionResult proxyActionResult = specialServer
             ? new ProxyActionResult(ProxyDestination.SpecialServer, orchestrationImage.RequiresAuth, imageServerPath)

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -22,6 +22,7 @@ using Orchestrator.Infrastructure;
 using Orchestrator.Infrastructure.Auth;
 using Orchestrator.Infrastructure.ReverseProxy;
 using Orchestrator.Settings;
+using Version = IIIF.ImageApi.Version;
 
 namespace Orchestrator.Features.Images;
 
@@ -112,17 +113,39 @@ public class ImageRequestHandler
         return proxyActionResult;
     }
 
-    private bool IsSizeValid(SizeParameter size) => (size.Width ?? 1) > 0 && (size.Height ?? 1) > 0;
+    private static bool IsSizeValid(SizeParameter size) => (size.Width ?? 1) > 0 && (size.Height ?? 1) > 0;
 
     private async Task<IProxyActionResult> HandleRequestInternal(HttpContext httpContext,
         OrchestrationImage orchestrationImage, ImageAssetDeliveryRequest assetRequest)
     {
+        // Get the requested version
+        var imageApiVersion = GetImageApiVersion(assetRequest);
+        if (imageApiVersion == null)
+        {
+            logger.LogDebug("Unable to fulfil image request: {Path}. Could not parse ImageVersion",
+                assetRequest.NormalisedFullPath);
+            return new StatusCodeResult(HttpStatusCode.BadRequest);
+        }
+        
+        var imageSize = new Size(orchestrationImage.Width, orchestrationImage.Height);
+        
+        // Get the proposed image size - this is required to determine if we will exceed this
+        var incomingImageRequest = assetRequest.IIIFImageRequest;
+        var proxyRequest =
+            incomingImageRequest.GetProxyImageRequest(imageApiVersion.Value, imageSize, orchestrationImage.MaxWidth);
+        if (!proxyRequest.IsValid)
+        {
+            return new StatusCodeResult(proxyRequest.ErrorStatusCode.Value);
+        }
+        
         var requestedFullRegion =
-            assetRequest.IIIFImageRequest.Region.IsFullOrEquivalent(orchestrationImage.Width,
+            incomingImageRequest.Region.IsFullOrEquivalent(orchestrationImage.Width,
                 orchestrationImage.Height);
+        
+        // If there are roles, we may have restricted access..
         if (orchestrationImage.RequiresAuth)
         {
-            if (await IsRequestUnauthorised(assetRequest, orchestrationImage, requestedFullRegion))
+            if (await IsRequestUnauthorised(assetRequest, orchestrationImage, requestedFullRegion, proxyRequest))
             {
                 return new StatusCodeResult(HttpStatusCode.Unauthorized);
             }
@@ -131,7 +154,7 @@ public class ImageRequestHandler
         if (requestedFullRegion)
         {
             // /full/ or equiv region but not /max/ size - can it be handled by thumbnail service?
-            if (!assetRequest.IIIFImageRequest.Size.Max)
+            if (!incomingImageRequest.Size.Max)
             {
                 var canHandleByThumbResponse = CanRequestBeHandledByThumb(assetRequest, orchestrationImage);
                 if (canHandleByThumbResponse.CanHandle)
@@ -160,36 +183,36 @@ public class ImageRequestHandler
             }
             else
             {
-                return GenerateImageServerProxyResult(orchestrationImage, assetRequest, specialServer: true);
+                return GetImageServerProxyResult(true);
             }
         }
         
         // Fallback to image-server, with orchestration if required
-        return GenerateImageServerProxyResult(orchestrationImage, assetRequest, specialServer: false);
+        return GetImageServerProxyResult(false);
+
+        IProxyActionResult GetImageServerProxyResult(bool specialServer) =>
+            GenerateImageServerProxyResult(orchestrationImage, assetRequest, proxyRequest, imageApiVersion.Value,
+                specialServer);
     }
-    
+
     private async Task<bool> IsRequestUnauthorised(ImageAssetDeliveryRequest assetRequest,
-        OrchestrationImage orchestrationImage, bool requestedFullRegion)
+        OrchestrationImage orchestrationImage, bool requestedFullRegion, ProxyImageRequest proxyRequest)
     {
-        // If the image has a maxUnauthorised, and the region is /full/ then user may be able to see requested
+        // If the image has an openFullMax, and the region is /full/ then user may be able to see requested
         // size without doing auth check
-        var imageRequest = assetRequest.IIIFImageRequest;
-        if (requestedFullRegion && orchestrationImage.MaxUnauthorised > 0)
+        if (requestedFullRegion && orchestrationImage.OpenFullMax > 0)
         {
-            var imageSize = new Size(orchestrationImage.Width, orchestrationImage.Height);
-            var proposedSize = imageRequest.Size.GetResultingSize(imageSize);
-            
-            // If resulting maxDimension < maxUnauthorised then anyone can view
-            if (proposedSize.MaxDimension <= orchestrationImage.MaxUnauthorised)
+            // If requested maxDimension < openFullMax then anyone can view as this is a /full/ region
+            if (proxyRequest.RequestedSize!.MaxDimension <= orchestrationImage.OpenFullMax)
             {
                 logger.LogDebug(
-                    "Request for {ImageRequest} requires auth but viewable due to maxUnauthorised size of {MaxUnauth}",
-                    imageRequest.OriginalPath, orchestrationImage.MaxUnauthorised);
+                    "Request for {ImageRequest} requires auth but viewable due to openFullMax size of {OpenFullMax}",
+                    assetRequest.IIIFImageRequest.OriginalPath, orchestrationImage.OpenFullMax);
                 return false;
             }
         }
-
-        // IAssetAccessValidator is in container with a Lifetime.Scope
+        
+        // IAssetAccessValidator is in container with ServiceLifetime.Scoped
         using var scope = scopeFactory.CreateScope();
         var assetAccessValidator = scope.ServiceProvider.GetRequiredService<IAssetAccessValidator>();
         var authResult = await assetAccessValidator.TryValidate(assetRequest.GetAssetId(), orchestrationImage.Roles,
@@ -198,7 +221,6 @@ public class ImageRequestHandler
         return authResult == AssetAccessResult.Unauthorized;
     }
 
-    // TODO handle known thumb size that doesn't exist yet - call image-server and save to s3 on way back
     private (bool CanHandle, bool IsResize) CanRequestBeHandledByThumb(ImageAssetDeliveryRequest requestModel,
         OrchestrationImage orchestrationImage)
     {
@@ -246,21 +268,14 @@ public class ImageRequestHandler
     }
 
     private IProxyActionResult GenerateImageServerProxyResult(OrchestrationImage orchestrationImage,
-        ImageAssetDeliveryRequest requestModel, bool specialServer)
+        ImageAssetDeliveryRequest requestModel, ProxyImageRequest proxyRequest, Version imageApiVersion, 
+        bool specialServer)
     {
-        var imageApiVersion = GetImageApiVersion(requestModel);
-        if (imageApiVersion == null)
-        {
-            logger.LogDebug("Unable to fulfil image request: {Path}. Could not parse ImageVersion",
-                requestModel.NormalisedFullPath);
-            return new StatusCodeResult(HttpStatusCode.BadRequest);
-        }
-        
         // get the redirect path - S3:// path for special-server or /path/on/disk for image-server
         var settings = orchestratorSettings.Value;
         var downstreamPath = specialServer
-            ? settings.GetSpecialServerPath(orchestrationImage.S3Location, imageApiVersion.Value)
-            : settings.GetImageServerPath(orchestrationImage.AssetId, imageApiVersion.Value);
+            ? settings.GetSpecialServerPath(orchestrationImage.S3Location ?? string.Empty, imageApiVersion)
+            : settings.GetImageServerPath(orchestrationImage.AssetId, imageApiVersion);
 
         if (string.IsNullOrEmpty(downstreamPath))
         {
@@ -268,8 +283,10 @@ public class ImageRequestHandler
                 requestModel.NormalisedFullPath);
             return new StatusCodeResult(HttpStatusCode.BadRequest);
         }
-        
-        var imageServerPath = $"{downstreamPath}{requestModel.IIIFImageRequest.ImageRequestPath}";
+
+        // Update the SizeParameter as it may have altered during parsing
+        requestModel.IIIFImageRequest.Size = proxyRequest.ProxySizeParameter!;
+        var imageServerPath = downstreamPath.ToConcatenated('/', requestModel.IIIFImageRequest.GetImageRequestOnly());
         IProxyActionResult proxyActionResult = specialServer
             ? new ProxyActionResult(ProxyDestination.SpecialServer, orchestrationImage.RequiresAuth, imageServerPath)
             : new ProxyImageServerResult(orchestrationImage, orchestrationImage.RequiresAuth, imageServerPath);
@@ -282,7 +299,7 @@ public class ImageRequestHandler
     /// - Null if a specific version requested in path but it cannot be handled
     /// - Default version from appconfig
     /// </summary>
-    private IIIF.ImageApi.Version? GetImageApiVersion(ImageAssetDeliveryRequest requestModel) 
+    private Version? GetImageApiVersion(ImageAssetDeliveryRequest requestModel) 
         => requestModel.VersionPathValue.HasText()
             ? requestModel.VersionPathValue.ParseToIIIFImageApiVersion()
             : orchestratorSettings.Value.DefaultIIIFImageVersion;

--- a/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRequestHandler.cs
@@ -131,7 +131,7 @@ public class ImageRequestHandler
         
         var imageSize = new Size(orchestrationImage.Width, orchestrationImage.Height);
         
-        // Get the proposed image size - this is required to determine if we will exceed this
+        // Parse the incoming request to get proxy result, based in image + requested size only
         var incomingImageRequest = assetRequest.IIIFImageRequest;
         var proxyRequest = incomingImageRequest.GetProxyImageRequest(imageApiVersion.Value, imageSize,
             orchestrationImage.MaxWidth, strictImageRequests);

--- a/src/protagonist/Orchestrator/Features/Images/ImageRouteHandlers.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageRouteHandlers.cs
@@ -57,7 +57,7 @@ public static class ImageRouteHandlers
             logger.LogDebug("Handling request '{Path}'", httpContext.Request.Path);
             if (RequestIIIFIdentifier(httpContext))
             {
-                HandleStatusCodeResult(httpContext, StatusCodeResult.NotFound);
+                await HandleStatusCodeResult(httpContext, StatusCodeResult.NotFound);
                 return;
             }
 
@@ -72,7 +72,7 @@ public static class ImageRouteHandlers
     {
         if (proxyActionResult is StatusCodeResult statusCodeResult)
         {
-            HandleStatusCodeResult(httpContext, statusCodeResult);
+            await HandleStatusCodeResult(httpContext, statusCodeResult);
             return;
         }
 
@@ -84,12 +84,12 @@ public static class ImageRouteHandlers
             
             if (orchestrationResult == OrchestrationResult.NotFound)
             {
-                HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.NotFound));
+                await HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.NotFound));
                 return;
             }
             if (orchestrationResult == OrchestrationResult.Error)
             {
-                HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.InternalServerError));
+                await HandleStatusCodeResult(httpContext, new StatusCodeResult(HttpStatusCode.InternalServerError));
                 return;
             }
         }
@@ -98,12 +98,18 @@ public static class ImageRouteHandlers
         await ProxyRequest(logger, httpContext, forwarder, destinationSelector, proxyAction);
     }
     
-    private static void HandleStatusCodeResult(HttpContext httpContext, StatusCodeResult statusCodeResult)
+    private static async Task HandleStatusCodeResult(HttpContext httpContext, StatusCodeResult statusCodeResult)
     {
         httpContext.Response.StatusCode = (int)statusCodeResult.StatusCode;
         foreach (var header in statusCodeResult.Headers)
         {
             httpContext.Response.Headers.Add(header);
+        }
+
+        if (!string.IsNullOrEmpty(statusCodeResult.Message) && !httpContext.Response.HasStarted)
+        {
+            httpContext.Response.ContentType = "text/plain; charset=utf-8";
+            await httpContext.Response.WriteAsync(statusCodeResult.Message);
         }
     }
 

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
@@ -14,8 +14,8 @@ namespace Orchestrator.Features.Images.ImageServer;
 /// <summary>
 /// Implementation of <see cref="InfoJsonConstructorTemplate{T}"/> responsible for building IIIF ImageService2
 /// info.json. Assets requiring auth will have the following updates:
-///  If Roles are present, Auth v0/1 (dependant on DB profiles) and Auth v2 services are added. Only auth2 context added
-///  If no Roles (ie MaxUnauthorised only) the profile.maxWidth property is set  
+/// If Roles are present, Auth v0/1 (dependant on DB profiles) and Auth v2 services are added. Only auth2 context added
+/// The maxWidth property is set in all instances  
 /// </summary>
 public class InfoJson2Constructor(
     IIIIFAuthBuilder iiifAuthBuilder,

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using IIIF;
 using IIIF.ImageApi.V2;
@@ -19,20 +17,15 @@ namespace Orchestrator.Features.Images.ImageServer;
 ///  If Roles are present, Auth v0/1 (dependant on DB profiles) and Auth v2 services are added. Only auth2 context added
 ///  If no Roles (ie MaxUnauthorised only) the profile.maxWidth property is set  
 /// </summary>
-public class InfoJson2Constructor : InfoJsonConstructorTemplate<ImageService2>
+public class InfoJson2Constructor(
+    IIIIFAuthBuilder iiifAuthBuilder,
+    IIIFAuth1Builder iiifAuth1Builder,
+    IImageServerClient imageServerClient,
+    IThumbRepository thumbRepository,
+    ILogger<InfoJson2Constructor> logger)
+    : InfoJsonConstructorTemplate<ImageService2>(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
 {
     // We want to include both Auth1 + 2 on info.json to allow for transition to auth2
-    private readonly IIIFAuth1Builder iiifAuth1Builder;
-
-    public InfoJson2Constructor(
-        IIIIFAuthBuilder iiifAuthBuilder,
-        IIIFAuth1Builder iiifAuth1Builder,
-        IImageServerClient imageServerClient,
-        IThumbRepository thumbRepository,
-        ILogger<InfoJson2Constructor> logger) : base(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
-    {
-        this.iiifAuth1Builder = iiifAuth1Builder;
-    }
 
     protected override Version ImageApiVersion => Version.V2;
     
@@ -50,7 +43,7 @@ public class InfoJson2Constructor : InfoJsonConstructorTemplate<ImageService2>
         imageService.ProfileDescription ??= new ProfileDescription();
         imageService.ProfileDescription.MaxArea = null;
         imageService.ProfileDescription.MaxHeight = null;
-        imageService.ProfileDescription.MaxWidth = orchestrationImage.MaxUnauthorised;
+        imageService.ProfileDescription.MaxWidth = orchestrationImage.MaxWidth;
     }
 
     protected override void SetImageServiceStubId(ImageService2 imageService, OrchestrationImage orchestrationImage) 
@@ -59,15 +52,10 @@ public class InfoJson2Constructor : InfoJsonConstructorTemplate<ImageService2>
     protected override void SetImageServiceSizes(ImageService2 imageService, List<Size> sizes)
         => imageService.Sizes = sizes;
     
-    protected override void SetImageServiceTiles (ImageService2 imageService, OrchestrationImage orchestrationImage)
+    protected override void TrySetImageServiceTiles(ImageService2 imageService, OrchestrationImage orchestrationImage)
     {
-        if (imageService.Tiles.IsNullOrEmpty() || imageService.Tiles
-                .Select(s => s.Width).Max() > orchestrationImage.MaxUnauthorised)
-        {
-            var tiles = GetTiles(orchestrationImage);
-
-            imageService.Tiles = tiles;
-        }
+        if (!ShouldUpdateTiles(imageService.Tiles, orchestrationImage)) return;
+        imageService.Tiles = GetTiles(orchestrationImage);
     }
 
     private async Task<List<IService>> GetAuthAllServices(OrchestrationImage orchestrationImage, CancellationToken cancellationToken)

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using IIIF;
 using IIIF.ImageApi.V3;
@@ -15,21 +13,18 @@ namespace Orchestrator.Features.Images.ImageServer;
 
 /// <summary>
 /// Implementation of <see cref="InfoJsonConstructorTemplate{T}"/> responsible for building IIIF ImageService3
-/// info.json. Assets requiring auth will have the following updates:
-///  If Roles are present, Auth v2 services are added + context updated
-///  If no Roles (ie MaxUnauthorised only) the maxWidth property is set  
+/// info.json.
+///  If Roles are present, Auth v2 services are added + context updated, unless it is 'unobtainable' role only
+///  The maxWidth property is set in all instances  
 /// </summary>
-public class InfoJson3Constructor : InfoJsonConstructorTemplate<ImageService3>
+public class InfoJson3Constructor(
+    IIIIFAuthBuilder iiifAuthBuilder,
+    IImageServerClient imageServerClient,
+    IThumbRepository thumbRepository,
+    ILogger<InfoJson3Constructor> logger)
+    : InfoJsonConstructorTemplate<ImageService3>(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
 {
     protected override Version ImageApiVersion => Version.V3;
-
-    public InfoJson3Constructor(
-        IIIIFAuthBuilder iiifAuthBuilder,
-        IImageServerClient imageServerClient,
-        IThumbRepository thumbRepository,
-        ILogger<InfoJson3Constructor> logger) : base(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
-    {
-    }
 
     protected override async Task SetImageServiceAuthServices(ImageService3 imageService, OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)
@@ -47,7 +42,7 @@ public class InfoJson3Constructor : InfoJsonConstructorTemplate<ImageService3>
     {
         imageService.MaxArea = null;
         imageService.MaxHeight = null;
-        imageService.MaxWidth = orchestrationImage.MaxUnauthorised;
+        imageService.MaxWidth = orchestrationImage.MaxWidth;
     }
 
     protected override void SetImageServiceStubId(ImageService3 imageService, OrchestrationImage orchestrationImage) 
@@ -56,14 +51,9 @@ public class InfoJson3Constructor : InfoJsonConstructorTemplate<ImageService3>
     protected override void SetImageServiceSizes(ImageService3 imageService, List<Size> sizes) 
         => imageService.Sizes = sizes;
 
-    protected override void SetImageServiceTiles (ImageService3 imageService, OrchestrationImage orchestrationImage)
+    protected override void TrySetImageServiceTiles(ImageService3 imageService, OrchestrationImage orchestrationImage)
     {
-        if (imageService.Tiles.IsNullOrEmpty() || imageService.Tiles
-                .Select(s => s.Width).Max() > orchestrationImage.MaxUnauthorised)
-        {
-            var tiles = GetTiles(orchestrationImage);
-
-            imageService.Tiles = tiles;
-        }
+        if (!ShouldUpdateTiles(imageService.Tiles, orchestrationImage)) return;
+        imageService.Tiles = GetTiles(orchestrationImage);
     }
 }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
@@ -14,8 +14,8 @@ namespace Orchestrator.Features.Images.ImageServer;
 /// <summary>
 /// Implementation of <see cref="InfoJsonConstructorTemplate{T}"/> responsible for building IIIF ImageService3
 /// info.json.
-///  If Roles are present, Auth v2 services are added + context updated, unless it is 'unobtainable' role only
-///  The maxWidth property is set in all instances  
+/// If Roles are present, Auth v2 services are added + context updated, unless it is 'unobtainable' role only
+/// The maxWidth property is set in all instances  
 /// </summary>
 public class InfoJson3Constructor(
     IIIIFAuthBuilder iiifAuthBuilder,

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
@@ -154,7 +154,7 @@ public abstract class InfoJsonConstructorTemplate<T>(
         // for example, if maxWidth is 500, the tile size will be updated to 256
         var tileSize = Math.Pow(2, (int)Math.Log2(orchestrationImage.MaxWidth)); // Casting as it truncates
 
-        var tiles = InfoJsonBuilder.GetTiles(orchestrationImage.Width, orchestrationImage.Height,
+        var tiles = InfoJsonBuilder.GetTiles(orchestrationImage.Size.Width, orchestrationImage.Size.Height,
             (int)tileSize);
         return tiles;
     }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
@@ -17,26 +17,14 @@ namespace Orchestrator.Features.Images.ImageServer;
 /// Template base class responsible for orchestrating image, calling IImageServerClient to get info.json and update with
 /// required information that image-server will be unaware of (e.g. Auth, Id).
 /// </summary>
-public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
-    where T : JsonLdBase
+public abstract class InfoJsonConstructorTemplate<T>(
+    IImageServerClient imageServerClient,
+    IThumbRepository thumbRepository,
+    IIIIFAuthBuilder iiifAuthBuilder,
+    ILogger logger) : IInfoJsonConstructor where T : JsonLdBase
 {
     protected abstract IIIF.ImageApi.Version ImageApiVersion { get; }
-    protected readonly ILogger Logger;
-    private readonly IImageServerClient imageServerClient;
-    private readonly IThumbRepository thumbRepository;
-    private readonly IIIIFAuthBuilder iiifAuthBuilder;
-
-    protected InfoJsonConstructorTemplate(
-        IImageServerClient imageServerClient,
-        IThumbRepository thumbRepository,
-        IIIIFAuthBuilder iiifAuthBuilder,
-        ILogger logger)
-    {
-        this.imageServerClient = imageServerClient;
-        this.thumbRepository = thumbRepository;
-        Logger = logger;
-        this.iiifAuthBuilder = iiifAuthBuilder;
-    }
+    protected readonly ILogger Logger = logger;
 
     public async Task<JsonLdBase?> BuildInfoJsonFromImageServer(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default)
@@ -65,15 +53,17 @@ public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
         if (imageService == null) return;
 
         SetImageServiceStubId(imageService, orchestrationImage);
+        
+        // Set the maxWidth - we will always have a value, regardless of asset specified or system default
+        SetImageServiceMaxWidth(imageService, orchestrationImage);
 
         if (orchestrationImage.RequiresAuth)
         {
-            if (orchestrationImage.Roles.IsNullOrEmpty())
+            // If the only role is the internal 'unobtainable' role, don't add auth-services as we won't advertise this
+            if (orchestrationImage.Roles.ContainsOnly(Asset.UnobtainableRole))
             {
-                Logger.LogDebug("Asset {AssetId} requires auth but no roles, adding maxWidth",
+                Logger.LogDebug("Asset {AssetId} requires auth but has unobtainable roles.",
                     orchestrationImage.AssetId);
-
-                SetImageServiceMaxWidth(imageService, orchestrationImage);
             }
             else
             {
@@ -82,11 +72,9 @@ public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
                 await SetImageServiceAuthServices(imageService, orchestrationImage, cancellationToken);
             }
         }
-        
-        if (orchestrationImage.MaxUnauthorised > 0)
-        {
-            SetImageServiceTiles(imageService, orchestrationImage);
-        }
+
+
+        TrySetImageServiceTiles(imageService, orchestrationImage);
     }
 
     /// <summary>
@@ -94,29 +82,30 @@ public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
     /// </summary>
     protected abstract Task SetImageServiceAuthServices(T imageService, OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken);
-    
+
     /// <summary>
     /// Set maxWidth property on ImageService
     /// </summary>
     protected abstract void SetImageServiceMaxWidth(T imageService, OrchestrationImage orchestrationImage);
-    
+
     /// <summary>
     /// Set the stub Id property, this will be overwritten further downstream
     /// </summary>
     protected abstract void SetImageServiceStubId(T imageService, OrchestrationImage orchestrationImage);
-    
+
     /// <summary>
     /// Overwrite the "sizes" property on info.json with given sizes
     /// </summary>
     protected abstract void SetImageServiceSizes(T imageService, List<Size> sizes);
-    
+
     /// <summary>
-    /// Overwrite the "tiles" property on info.json with given tile sizes
+    /// Overwrite the "tiles" property on info.json with given tile sizes if required.
+    /// This will happen if there are no tiles, or the advertised tile would be smaller than maxWidth.
     /// </summary>
     /// <param name="imageService">The image service</param>
     /// <param name="orchestrationImage">The image being orchestrated</param>
-    protected abstract void SetImageServiceTiles (T imageService, OrchestrationImage orchestrationImage);
-
+    protected abstract void TrySetImageServiceTiles(T imageService, OrchestrationImage orchestrationImage);
+    
     protected async Task<IService?> GetAuth2Service(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)
     {
@@ -142,8 +131,8 @@ public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
                 Logger.LogInformation("No thumbnails found for {Asset}", orchestrationImage.AssetId);
                 return Enumerable.Empty<Size>().ToList();
             }
-            
-            return thumbs.Select(s => Size.FromArray(s)).ToList();
+
+            return thumbs.Select(Size.FromArray).ToList();
         }
         catch (Exception ex)
         {
@@ -151,14 +140,19 @@ public abstract class InfoJsonConstructorTemplate<T> : IInfoJsonConstructor
             return Enumerable.Empty<Size>().ToList();
         }
     }
-    
+
+    /// <summary>
+    /// Check whether tiles should be updated - true if there are no Tiles, or the Tiles size exceeds the MaxWidth
+    /// </summary>
+    protected bool ShouldUpdateTiles(List<Tile> existingTiles, OrchestrationImage orchestrationImage) =>
+        existingTiles.IsNullOrEmpty() || existingTiles.Select(s => s.Width).Max() > orchestrationImage.MaxWidth;
+
     protected static List<Tile> GetTiles(OrchestrationImage orchestrationImage)
     {
-        // This code is working out the max tiles size based on max unauthorised.
-        // The tile size must be a power of 2 and less than maxUnauthorised
-        // for example, if maxUnauthorised is 500, the tile size will be updated to 256
-        var tileSize =
-            Math.Pow(2, (int)Math.Log2(orchestrationImage.MaxUnauthorised)); // Casting as it truncates
+        // Work out the max tiles size based on maxWidth.
+        // The tile size must be a power of 2 and less than maxWidth
+        // for example, if maxWidth is 500, the tile size will be updated to 256
+        var tileSize = Math.Pow(2, (int)Math.Log2(orchestrationImage.MaxWidth)); // Casting as it truncates
 
         var tiles = InfoJsonBuilder.GetTiles(orchestrationImage.Width, orchestrationImage.Height,
             (int)tileSize);

--- a/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
+++ b/src/protagonist/Orchestrator/Features/TimeBased/TimeBasedRequestHandler.cs
@@ -97,7 +97,7 @@ public class TimeBasedRequestHandler
     private async Task<bool> IsAuthenticated(TimeBasedAssetDeliveryRequest assetRequest, OrchestrationAsset asset,
         HttpRequest httpRequest)
     {
-        // IAssetAccessValidator is in container with a Lifetime.Scope
+        // IAssetAccessValidator is in container with a ServiceLifetime.Scoped
         using var scope = scopeFactory.CreateScope();
         var assetAccessValidator = scope.ServiceProvider.GetRequiredService<IAssetAccessValidator>();
 

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/AssetAccessValidator.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core.Collections;
 using DLCS.Core.Strings;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Web;
 using DLCS.Web.Auth;
 using Microsoft.AspNetCore.Http;
@@ -15,30 +17,22 @@ namespace Orchestrator.Infrastructure.Auth;
 /// Unified access validator that can check access via Auth v0/1 (ie Orchestrator managed) or Auth v2 (external
 /// services). This may result in multiple checks being made
 /// </summary>
-public class AssetAccessValidator : IAssetAccessValidator
+public class AssetAccessValidator(
+    Auth1AccessValidator auth1AccessValidator,
+    Auth2AccessValidator auth2AccessValidator,
+    AuthCookieManager authCookieManager,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<AssetAccessValidator> logger)
+    : IAssetAccessValidator
 {
-    private readonly Auth1AccessValidator auth1AccessValidator;
-    private readonly Auth2AccessValidator auth2AccessValidator;
-    private readonly AuthCookieManager authCookieManager;
-    private readonly IHttpContextAccessor httpContextAccessor;
-    private readonly ILogger<AssetAccessValidator> logger;
-
-    public AssetAccessValidator(
-        Auth1AccessValidator auth1AccessValidator, 
-        Auth2AccessValidator auth2AccessValidator,
-        AuthCookieManager authCookieManager,
-        IHttpContextAccessor httpContextAccessor,
-        ILogger<AssetAccessValidator> logger)
+    public async Task<AssetAccessResult> TryValidate(AssetId assetId, IReadOnlyList<string> roles, AuthMechanism mechanism, CancellationToken cancellationToken = default)
     {
-        this.auth1AccessValidator = auth1AccessValidator;
-        this.auth2AccessValidator = auth2AccessValidator;
-        this.authCookieManager = authCookieManager;
-        this.httpContextAccessor = httpContextAccessor;
-        this.logger = logger;
-    }
-
-    public async Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism, CancellationToken cancellationToken = default)
-    {
+        if (roles.ContainsOnly(Asset.UnobtainableRole))
+        {
+            logger.LogTrace("{AssetId} only has unobtainable role, shortcutting check", assetId);
+            return AssetAccessResult.Unauthorized;
+        }
+        
         if (ShouldAttemptAuth1(assetId.Customer, mechanism))
         {
             var auth1Status = await auth1AccessValidator.TryValidate(assetId, roles, mechanism, cancellationToken);
@@ -78,7 +72,6 @@ public class AssetAccessValidator : IAssetAccessValidator
     private bool HasBearerToken()
         => httpContextAccessor.SafeHttpContext().Request
             .GetAuthHeaderValue(AuthenticationHeaderUtils.BearerTokenScheme) != null;
-
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth1AccessValidator.cs
@@ -16,26 +16,14 @@ namespace Orchestrator.Infrastructure.Auth;
 /// Contains logic to validate passed BearerTokens and Cookies with a request for an asset.
 /// Setting status code and cookies depending on result of verification.
 /// </summary>
-public class Auth1AccessValidator : IAssetAccessValidator
+public class Auth1AccessValidator(
+    ISessionAuthService sessionAuthService,
+    AccessChecker accessChecker,
+    AuthCookieManager authCookieManager,
+    IHttpContextAccessor httpContextAccessor)
+    : IAssetAccessValidator
 {
-    private readonly ISessionAuthService sessionAuthService;
-    private readonly AccessChecker accessChecker;
-    private readonly AuthCookieManager authCookieManager;
-    private readonly IHttpContextAccessor httpContextAccessor;
-
-    public Auth1AccessValidator(
-        ISessionAuthService sessionAuthService,
-        AccessChecker accessChecker,
-        AuthCookieManager authCookieManager,
-        IHttpContextAccessor httpContextAccessor)
-    {
-        this.sessionAuthService = sessionAuthService;
-        this.accessChecker = accessChecker;
-        this.authCookieManager = authCookieManager;
-        this.httpContextAccessor = httpContextAccessor;
-    }
-
-    public Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+    public Task<AssetAccessResult> TryValidate(AssetId assetId, IReadOnlyList<string> roles, AuthMechanism mechanism,
         CancellationToken cancellationToken = default) => mechanism switch
     {
         AuthMechanism.All => TryValidateAll(assetId.Customer, roles),
@@ -44,19 +32,18 @@ public class Auth1AccessValidator : IAssetAccessValidator
         _ => throw new ArgumentOutOfRangeException(nameof(mechanism), mechanism, null)
     };
 
-    private async Task<AssetAccessResult> TryValidateAll(int customer, IEnumerable<string> roles)
+    private async Task<AssetAccessResult> TryValidateAll(int customer, IReadOnlyList<string> roles)
     {
-        var enumeratedRoles = roles.ToList();
-        var validateCookieResult = await TryValidateCookie(customer, enumeratedRoles);
+        var validateCookieResult = await TryValidateCookie(customer, roles);
         if (validateCookieResult is AssetAccessResult.Open or AssetAccessResult.Authorized)
         {
             return validateCookieResult;
         }
 
-        return await TryValidateBearerToken(customer, enumeratedRoles);
+        return await TryValidateBearerToken(customer, roles);
     }
     
-    private Task<AssetAccessResult> TryValidateBearerToken(int customer, IEnumerable<string> roles)
+    private Task<AssetAccessResult> TryValidateBearerToken(int customer, IReadOnlyList<string> roles)
         => ValidateAccess(customer, roles, () =>
         {
             var httpContext = httpContextAccessor.SafeHttpContext();
@@ -68,7 +55,7 @@ public class Auth1AccessValidator : IAssetAccessValidator
                 : sessionAuthService.GetAuthTokenForBearerId(customer, bearerToken);
         }, false);
 
-    private Task<AssetAccessResult> TryValidateCookie(int customer, IEnumerable<string> roles)
+    private Task<AssetAccessResult> TryValidateCookie(int customer, IReadOnlyList<string> roles)
         => ValidateAccess(customer, roles, () =>
         {
             var cookieId = GetCookieId(customer);
@@ -77,10 +64,9 @@ public class Auth1AccessValidator : IAssetAccessValidator
                 : sessionAuthService.GetAuthTokenForCookieId(customer, cookieId);
         }, true);
 
-    private async Task<AssetAccessResult> ValidateAccess(int customer, IEnumerable<string> roles,
+    private async Task<AssetAccessResult> ValidateAccess(int customer, IReadOnlyList<string> roles,
         Func<Task<AuthToken?>> getAuthToken, bool setCookieInResponse)
     {
-        var assetRoles = roles.ToList();
         var authToken = await getAuthToken();
         
         if (authToken?.SessionUser == null)
@@ -90,7 +76,7 @@ public class Auth1AccessValidator : IAssetAccessValidator
         }
         
         // Validate current user has access for roles for requested asset
-        var canAccess = await accessChecker.CanSessionUserAccessRoles(authToken.SessionUser, customer, assetRoles);
+        var canAccess = await accessChecker.CanSessionUserAccessRoles(authToken.SessionUser, customer, roles);
         if (canAccess)
         {
             if (setCookieInResponse)

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/Auth2AccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/Auth2AccessValidator.cs
@@ -9,16 +9,9 @@ namespace Orchestrator.Infrastructure.Auth;
 /// <summary>
 /// <see cref="IAssetAccessValidator"/> that uses external service to validate access via IIIF Auth v2
 /// </summary>
-public class Auth2AccessValidator : IAssetAccessValidator
+public class Auth2AccessValidator(IIIFAuth2Client iiifAuth2Client) : IAssetAccessValidator
 {
-    private readonly IIIFAuth2Client iiifAuth2Client;
-
-    public Auth2AccessValidator(IIIFAuth2Client iiifAuth2Client)
-    {
-        this.iiifAuth2Client = iiifAuth2Client;
-    }
-    
-    public async Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+    public async Task<AssetAccessResult> TryValidate(AssetId assetId, IReadOnlyList<string> roles, AuthMechanism mechanism,
         CancellationToken cancellationToken = default)
     {
         // NOTE(DG) - caller of this has checked appropriate cookie exists

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/IAssetAccessValidator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/IAssetAccessValidator.cs
@@ -15,6 +15,6 @@ public interface IAssetAccessValidator
     /// <param name="roles">Roles associated with Asset</param>
     /// <param name="mechanism">Which mechanism to use to authorize user</param>
     /// <returns><see cref="AssetAccessResult"/> enum representing result of validation</returns>
-    Task<AssetAccessResult> TryValidate(AssetId assetId, List<string> roles, AuthMechanism mechanism,
+    Task<AssetAccessResult> TryValidate(AssetId assetId, IReadOnlyList<string> roles, AuthMechanism mechanism,
         CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/V2/AuthProbeResult2Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/V2/AuthProbeResult2Builder.cs
@@ -5,12 +5,30 @@ namespace Orchestrator.Infrastructure.Auth.V2;
 
 public static class AuthProbeResult2Builder
 {
-    public static AuthProbeResult2 MissingCredentials =
+    /// <summary>
+    /// Returns 401 response with "Missing Credentials" message
+    /// </summary>
+    public static readonly AuthProbeResult2 MissingCredentials =
         BuildProbeResult(401, "Missing credentials", "Authorising credentials not found");
-    public static AuthProbeResult2 UnexpectedError = BuildProbeResult(500, "Unexpected Error", "Unexpected Error");
-    public static AuthProbeResult2 Okay => new() { Status = 200 };
+
+    /// <summary>
+    /// Returns 401 response with "Unobtainable Role" message
+    /// </summary>
+    public static readonly AuthProbeResult2 UnobtainableRole =
+        BuildProbeResult(401, "Unobtainable Role", "Asset role is unobtainable");
+
+    /// <summary>
+    /// Returns 500 response with "Unexpected Error" message
+    /// </summary>
+    public static readonly AuthProbeResult2 UnexpectedError =
+        BuildProbeResult(500, "Unexpected Error", "Unexpected Error");
     
-    public static AuthProbeResult2 BuildProbeResult(int status, string heading, string note)
+    /// <summary>
+    /// Returns empty 200 response without heading or note
+    /// </summary>
+    public static readonly AuthProbeResult2 Okay = new() { Status = 200 };
+
+    private static AuthProbeResult2 BuildProbeResult(int status, string heading, string note)
         => new()
         {
             Status = status,

--- a/src/protagonist/Orchestrator/Infrastructure/Auth/V2/IIIFAuth2Client.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/Auth/V2/IIIFAuth2Client.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using IIIF;
 using IIIF.Auth.V2;
 using IIIF.Serialisation;
@@ -16,22 +19,15 @@ namespace Orchestrator.Infrastructure.Auth.V2;
 /// <summary>
 /// Client for interactions with IIIF Authorization Flow 2 services
 /// </summary>
-public class IIIFAuth2Client : IIIIFAuthBuilder
+public class IIIFAuth2Client(HttpClient httpClient, ILogger<IIIFAuth2Client> logger) : IIIIFAuthBuilder
 {
-    private readonly HttpClient httpClient;
-    private readonly ILogger<IIIFAuth2Client> logger;
-
-    public IIIFAuth2Client(HttpClient httpClient, ILogger<IIIFAuth2Client> logger)
-    {
-        this.httpClient = httpClient;
-        this.logger = logger;
-    }
-    
-    public async Task<IService?> GetAuthServicesForAsset(AssetId assetId, List<string> roles, CancellationToken cancellationToken = default)
+    public async Task<IService?> GetAuthServicesForAsset(AssetId assetId, IReadOnlyList<string> roles, CancellationToken cancellationToken = default)
     {
         logger.LogTrace("Getting auth 2 services description for {AssetId}, {@Roles}", assetId, roles);
+        
+        if (roles.ContainsOnly(Asset.UnobtainableRole)) return null;
+        
         var path = $"services/{assetId}?roles={GetRolesString(roles)}";
-
         try
         {
             await using var authServices = await httpClient.GetStreamAsync(path, cancellationToken);
@@ -45,7 +41,7 @@ public class IIIFAuth2Client : IIIIFAuthBuilder
         }
     }
 
-    public async Task<AuthProbeResult2> GetProbeServiceResult(AssetId assetId, List<string> roles, string accessToken,
+    public async Task<AuthProbeResult2> GetProbeServiceResult(AssetId assetId, IReadOnlyList<string> roles, string accessToken,
         CancellationToken cancellationToken)
     {
         var path = $"probe_internal/{assetId}?roles={GetRolesString(roles)}";
@@ -67,7 +63,7 @@ public class IIIFAuth2Client : IIIIFAuthBuilder
         }
     }
 
-    public async Task<bool> VerifyAccess(AssetId assetId, List<string> roles, CancellationToken cancellationToken)
+    public async Task<bool> VerifyAccess(AssetId assetId, IReadOnlyList<string> roles, CancellationToken cancellationToken)
     {
         var path = $"verifyaccess/{assetId}?roles={GetRolesString(roles)}";
         try
@@ -82,6 +78,8 @@ public class IIIFAuth2Client : IIIIFAuthBuilder
         }   
     }
 
-    private static string GetRolesString(IList<string> roles)
-        => roles.Count == 1 ? roles[0] : string.Join(",", roles);
+    private static string GetRolesString(IReadOnlyList<string> roles)
+        => roles.Count == 1
+            ? roles[0]
+            : string.Join(",", roles.Where(r => !r.Equals(Asset.UnobtainableRole, StringComparison.OrdinalIgnoreCase)));
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFAuth1Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIFAuth1Builder.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
 using DLCS.Core.Types;
+using DLCS.Model.Assets;
 using DLCS.Model.Auth;
 using DLCS.Model.Auth.Entities;
 using IIIF;
@@ -19,28 +21,20 @@ namespace Orchestrator.Infrastructure.IIIF;
 /// Implementation of <see cref="IIIIFAuthBuilder"/> for IIIF Auth 0.9 and 1.0
 /// </summary>
 /// <remarks>This is legacy and will be retired in the future</remarks>
-public class IIIFAuth1Builder : IIIIFAuthBuilder
+public class IIIFAuth1Builder(
+    IAuthServicesRepository authServicesRepository,
+    IOptions<AuthSettings> authOptions,
+    ILogger<IIIFAuth1Builder> logger)
+    : IIIIFAuthBuilder
 {
-    private readonly IAuthServicesRepository authServicesRepository;
-    private readonly AuthSettings authSettings;
-    private readonly ILogger<IIIFAuth1Builder> logger;
-
-    public IIIFAuth1Builder(
-        IAuthServicesRepository authServicesRepository,
-        IOptions<AuthSettings> authOptions,
-        ILogger<IIIFAuth1Builder> logger)
-    {
-        this.authServicesRepository = authServicesRepository;
-        authSettings = authOptions.Value;
-        this.logger = logger;
-    }
+    private readonly AuthSettings authSettings = authOptions.Value;
 
     /// <summary>
     /// Generate a IIIF <see cref="IService"/> for specified asset.
     /// The 'id'/'@id' parameters will the the name of the auth service only
     /// </summary>
     /// <returns><see cref="IService"/> if found, else null</returns>
-    public async Task<IService?> GetAuthServicesForAsset(AssetId assetId, List<string> roles, CancellationToken cancellationToken = default)
+    public async Task<IService?> GetAuthServicesForAsset(AssetId assetId, IReadOnlyList<string> roles, CancellationToken cancellationToken = default)
     {
         var authServices = await GetAuthServices(assetId, roles, cancellationToken);
 
@@ -95,7 +89,9 @@ public class IIIFAuth1Builder : IIIIFAuthBuilder
         CancellationToken cancellationToken)
     {
         var authServices = new List<AuthService>();
-        foreach (var role in rolesList)
+        var obtainableRoles =
+            rolesList.Where(r => !r.Equals(Asset.UnobtainableRole, StringComparison.OrdinalIgnoreCase));
+        foreach (var role in obtainableRoles)
         {
             cancellationToken.ThrowIfCancellationRequested();
             authServices.AddRange(await authServicesRepository.GetAuthServicesForRole(assetId.Customer, role));

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIIFAuthBuilder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/IIIIFAuthBuilder.cs
@@ -15,6 +15,6 @@ public interface IIIIFAuthBuilder
     /// Generate a IIIF <see cref="IService"/> for authorisation services for specified asset.
     /// </summary>
     /// <returns><see cref="IService"/> if found, else null</returns>
-    Task<IService?> GetAuthServicesForAsset(AssetId assetId, List<string> roles,
+    Task<IService?> GetAuthServicesForAsset(AssetId assetId, IReadOnlyList<string> roles,
         CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -441,7 +441,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
     private async Task<Dictionary<AssetId, AuthProbeService2>?> GetProbeServices(IReadOnlyCollection<Asset> assets,
         CancellationToken cancellationToken)
     {
-        var assetsRequiringAuth = assets.Where(a => a.RequiresAuth && !string.IsNullOrEmpty(a.Roles)).ToList();
+        var assetsRequiringAuth = assets.Where(a => a.HasRoles).ToList();
 
         var assetsRequiringAuthCount = assetsRequiringAuth.Count;
         if (assetsRequiringAuthCount == 0) return null;

--- a/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/MetadataWithFallbackThumbSizeCalculator.cs
@@ -23,22 +23,15 @@ public interface IThumbSizeProvider
     Task<ThumbnailSizes> GetThumbSizesForImage(Asset asset, CancellationToken cancellationToken = default);
 }
 
-public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
+public class MetadataWithFallbackThumbSizeProvider(
+    IPolicyRepository policyRepository,
+    IOptions<OrchestratorSettings> orchestratorOptions,
+    ILogger<MetadataWithFallbackThumbSizeProvider> logger)
+    : IThumbSizeProvider
 {
-    private readonly IPolicyRepository policyRepository;
-    private readonly ILogger<MetadataWithFallbackThumbSizeProvider> logger;
-    private readonly OrchestratorSettings orchestratorSettings;
+    private readonly OrchestratorSettings orchestratorSettings = orchestratorOptions.Value;
     private readonly Dictionary<int, List<ImageApi.SizeParameter>> thumbnailPolicies = new();
 
-    public MetadataWithFallbackThumbSizeProvider(IPolicyRepository policyRepository, 
-        IOptions<OrchestratorSettings> orchestratorOptions,
-        ILogger<MetadataWithFallbackThumbSizeProvider> logger)
-    {
-        this.policyRepository = policyRepository;
-        this.logger = logger;
-        orchestratorSettings = orchestratorOptions.Value;
-    }
-    
     /// <summary>
     /// Get available sizes for thumbnails
     /// 
@@ -73,7 +66,7 @@ public class MetadataWithFallbackThumbSizeProvider : IThumbSizeProvider
         
         if (sizeParameters.IsNullOrEmpty()) return ThumbnailSizes.Empty;
 
-        var thumbnailSizesForImage = asset.GetAvailableThumbSizes(sizeParameters);
+        var thumbnailSizesForImage = asset.GetAvailableThumbSizes(sizeParameters, orchestratorSettings.MaxWidth);
         return thumbnailSizesForImage;
     }
 

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/PDF/FireballPdfCreator.cs
@@ -91,7 +91,7 @@ public class FireballPdfCreator(
         foreach (var i in NamedQueryProjections.GetOrderedAssets(assets, parsedNamedQuery))
         {
             Logger.LogTrace("Adding PDF page {PdfPage} to {PdfS3Key} for {Image}", pageNumber++, pdfKey, i.Id);
-            if (i.RequiresAuth && !RolesAreOnWhitelist(i, overrides))
+            if (i.HasRoles && !RolesAreOnWhitelist(i, overrides))
             {
                 Logger.LogDebug("Image {Image} on page {PdfPage} of {PdfS3Key} requires auth, redacting", i.Id,
                     pageNumber++, pdfKey);

--- a/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/NamedQueries/Zip/ImageThumbZipCreator.cs
@@ -19,21 +19,16 @@ namespace Orchestrator.Infrastructure.NamedQueries.Zip;
 /// <summary>
 /// Project assets to Zip archive.
 /// </summary>
-public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
+public class ImageThumbZipCreator(
+    IBucketReader bucketReader,
+    IBucketWriter bucketWriter,
+    IThumbSizeProvider thumbSizeProvider,
+    IOptions<NamedQuerySettings> namedQuerySettings,
+    IStorageKeyGenerator storageKeyGenerator,
+    ILogger<ImageThumbZipCreator> logger)
+    : BaseProjectionCreator<ZipParsedNamedQuery>(bucketReader, bucketWriter, namedQuerySettings, storageKeyGenerator,
+        logger)
 {
-    private readonly IThumbSizeProvider thumbSizeProvider;
-    public ImageThumbZipCreator(
-        IBucketReader bucketReader, 
-        IBucketWriter bucketWriter,
-        IThumbSizeProvider thumbSizeProvider,
-        IOptions<NamedQuerySettings> namedQuerySettings, 
-        IStorageKeyGenerator storageKeyGenerator,
-        ILogger<ImageThumbZipCreator> logger) :
-        base(bucketReader, bucketWriter, namedQuerySettings, storageKeyGenerator, logger)
-    {
-        this.thumbSizeProvider = thumbSizeProvider;
-    }
-
     protected override async Task<CreateProjectionResult> CreateFile(ZipParsedNamedQuery parsedNamedQuery,
         List<Asset> assets, CancellationToken cancellationToken)
     {
@@ -93,6 +88,7 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
                 Logger.LogWarning("Creation of zip file at {LocalPath} cancelled, aborting", zipFilePath);
                 cancellationToken.ThrowIfCancellationRequested();
             }
+
             Logger.LogTrace("Adding image {Image} to {LocalPath}", ++imageCount, zipFilePath);
             await ProcessImage(i, storageKey, zipArchive);
         }
@@ -100,9 +96,9 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
 
     private async Task ProcessImage(Asset image, string? storageKey, ZipArchive zipArchive)
     {
-        if (image.RequiresAuth)
+        if (image.HasRoles)
         {
-            Logger.LogDebug("Image {Image} of {S3Key} requires auth, redacting", image.Id, storageKey);
+            Logger.LogDebug("Image {Image} of {S3Key} has roles, redacting", image.Id, storageKey);
             return;
         }
 
@@ -133,18 +129,18 @@ public class ImageThumbZipCreator : BaseProjectionCreator<ZipParsedNamedQuery>
             .Replace("{customer}", parsedNamedQuery.Customer.ToString())
             .Replace("{storage-key}", pathSafeStorageKey);
     }
-    
+
     private async Task<Stream?> GetThumbnailStream(Asset asset)
     {
         var availableSizes = await thumbSizeProvider.GetThumbSizesForImage(asset);
-        
+
         if (availableSizes.IsEmpty()) return null;
-        
+
         var selectedSize = availableSizes.SizeClosestTo(NamedQuerySettings.ProjectionThumbsize, out var isOpen);
         Logger.LogTrace("Using thumbnail {ThumbnailSize} for asset {AssetId}. IsOpen: {ThumbnailOpen}", selectedSize,
             asset.Id, isOpen);
         var thumbnailLocation = StorageKeyGenerator.GetThumbnailLocation(asset.Id, selectedSize.MaxDimension, isOpen);
-        
+
         var thumbStream = await BucketReader.GetObjectContentFromBucket(thumbnailLocation);
         return thumbStream;
     }

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using DLCS.Model.IIIF;
 using IIIF;
 using IIIF.Exceptions;
 using IIIF.ImageApi;
+using Version = IIIF.ImageApi.Version;
 
 namespace Orchestrator.Infrastructure.ReverseProxy;
 
@@ -18,50 +20,90 @@ public static class ImageProxyPathHandler
     /// and effective maxWidth. The returned result may be invalid if request cannot be fulfilled.
     /// </summary>
     /// <param name="imageRequest">Incoming <see cref="ImageRequest"/></param>
+    /// <param name="imageVersion">IIIF ImageApi version this request is for</param>
     /// <param name="imageSize">The <see cref="Size"/> of source image</param>
     /// <param name="maxWidth">The effective maxWidth value for image</param>
+    /// <param name="strictMode">
+    /// If true, strictly process in accordance with appropriate IIIF ImageApi version. If false, use 'lax' processing
+    /// which supports 'full' request for V3 requests. See ADR 0011.
+    /// </param>
     /// <returns>
     /// <see cref="ProxyImageRequest"/> containing effective size, validity and proxy <see cref="SizeParameter"/>
     /// </returns>
-    public static ProxyImageRequest GetProxyImageRequest(this ImageRequest imageRequest, Size imageSize, int maxWidth)
+    public static ProxyImageRequest GetProxyImageRequest(this ImageRequest imageRequest, Version imageVersion,
+        Size imageSize, int maxWidth, bool strictMode = true)
+    {
+        // Safety first - gather values + validate, only carrying on with main logic if good to proceed
+        var isV2 = imageVersion == Version.V2;
+        var isExplicitFull = imageRequest.IsExplicitFullSize();
+
+        var failedValidationError = TryValidateRequest(imageRequest, isV2, isExplicitFull, strictMode);
+        if (failedValidationError != null) return failedValidationError;
+        
+        return HandleProxyLogic(imageRequest, imageSize, maxWidth, isV2, isExplicitFull);
+    }
+
+    private static ProxyImageRequest? TryValidateRequest(ImageRequest imageRequest, bool isV2, bool isExplicitFull,
+        bool strictMode)
+    {
+        // V2 doesn't support ^ character, ever
+        if (isV2)
+        {
+            if (imageRequest.Size.Upscaled)
+            {
+                return ProxyImageRequest.Invalid("Invalid size. '^' invalid for IIIF ImageApi 2.1",
+                    HttpStatusCode.BadRequest);
+            }
+        }
+        else
+        {
+            // V3 doesn't support /full/ size unless we're in 'lax' mode
+            if (isExplicitFull && (strictMode || imageRequest.Size.Upscaled))
+            {
+                return ProxyImageRequest.Invalid("Invalid size. 'full' invalid for IIIF ImageApi 3.0",
+                    HttpStatusCode.BadRequest);
+            }
+        }
+
+        return null;
+    }
+
+    private static ProxyImageRequest HandleProxyLogic(ImageRequest imageRequest, Size imageSize,
+        int maxWidth, bool isV2, bool isExplicitFull)
     {
         try
         {
-            // Get the size of the extracted region
+            // Get the size of the extracted region - we need this regardless of version
+            var sizeParameter = imageRequest.Size; 
             var extractedRegionSize = imageRequest.Region.GetExtractedRegionSize(imageSize);
-            var sizeParameter = imageRequest.Size;
-            
-            // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size 
+
+            // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size is valid
             if (!sizeParameter.Max)
             {
-                var requestedSize = sizeParameter.Resize(extractedRegionSize, InvalidUpscaleBehaviour.Throw);
-                return requestedSize.MaxDimension > maxWidth
-                    ? ProxyImageRequest.Invalid($"Requested size '{sizeParameter}' exceeds maxWidth of {maxWidth}",
-                        HttpStatusCode.Forbidden)
-                    : ProxyImageRequest.Valid(sizeParameter, requestedSize);
+                var requestedSize = GetRequestedSize(isV2, sizeParameter, extractedRegionSize);
+                if (requestedSize.MaxDimension > maxWidth)
+                {
+                    return ProxyImageRequest.Invalid(
+                        $"Requested size '{sizeParameter}' exceeds maxWidth of {maxWidth}",
+                        HttpStatusCode.Forbidden);
+                }
+
+                return ProxyImageRequest.Valid(sizeParameter, requestedSize);
+            }
+            
+            // If here, it's /full/ or /max/ size. In which case we will change size parameter in proxy request  to be
+            // the explicitly requested size (e.g. /full/ or /max/ => /1049,2033/ or /^1049,2033/)
+
+            if (!IsUpscalingAllowed(isV2, isExplicitFull, sizeParameter))
+            {
+                // If no upscaling then we can just confine the size to maxWidth without attempting to grow
+                return GetProxyImageRequest(Size.Confine(maxWidth, extractedRegionSize));
             }
 
-            // If /full/ or /max/ then we will change size-parameter to be explicit requested size
-            if (sizeParameter.Upscaled)
-            {
-                // ^full isn't valid
-                if (imageRequest.IsExplicitFullSize())
-                {
-                    return ProxyImageRequest.Invalid("'^full' size is invalid. Use 'full' or '^max' instead.",
-                        HttpStatusCode.BadRequest);
-                }
-                    
-                // Work out the final size - this will be the largest that fits withing maxWidth confinement, possibly
-                // growing
-                var finalSize = Size.FitWithin(Size.Square(maxWidth), extractedRegionSize);
-                return GetProxyImageRequest(finalSize, maxWidth > extractedRegionSize.MaxDimension);
-            }
-            else
-            {
-                // Work out the final size - this will be the extracted region size or that size confined to maxWidth 
-                var finalSize = Size.Confine(maxWidth, extractedRegionSize);
-                return GetProxyImageRequest(finalSize);
-            }
+            // If upscaling is allowed, work out the final size - the largest possible size that fits withing maxWidth
+            var finalSize = Size.FitWithin(Size.Square(maxWidth), extractedRegionSize);
+            var upscaleProxyRequest = maxWidth > extractedRegionSize.MaxDimension && !isV2;
+            return GetProxyImageRequest(finalSize, upscaleProxyRequest);
         }
         catch (RegionException ex)
         {
@@ -69,8 +111,27 @@ public static class ImageProxyPathHandler
         }
         catch (InvalidOperationException ex)
         {
-            return ProxyImageRequest.Invalid(ex.Message, HttpStatusCode.NotImplemented);
+            return ProxyImageRequest.Invalid(ex.Message, HttpStatusCode.BadRequest);
         }
+    }
+
+    // Upscaling is allowed if v3 and '^' OR v2 and 'max' 
+    private static bool IsUpscalingAllowed(bool isVersion2, bool isExplicitFullSize, SizeParameter sizeParameter) =>
+        sizeParameter.Upscaled && !isVersion2 || (!isExplicitFullSize && isVersion2);
+
+    private static Size GetRequestedSize(bool isVersion2, SizeParameter sizeParameter, Size extractedRegionSize)
+    {
+        // SizeParameter.Parse() works by V3 rules - so you need ^ to upscale. If we're version2, fake that briefly to
+        // ease calculation. Create a new copy of SizeParameter to avoid mutating the original
+        var workingSizeParam = sizeParameter;
+        if (isVersion2)
+        {
+            workingSizeParam = SizeParameter.Parse(sizeParameter.ToString());
+            workingSizeParam.Upscaled = true;
+        }
+
+        var requestedSize = workingSizeParam.Resize(extractedRegionSize);
+        return requestedSize;
     }
 
     private static ProxyImageRequest GetProxyImageRequest(Size finalSize, bool upscaled = false)
@@ -85,6 +146,7 @@ public static class ImageProxyPathHandler
 /// <summary>
 /// Class represents validated image proxy destination
 /// </summary>
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class ProxyImageRequest
 {
     /// <summary>
@@ -126,5 +188,9 @@ public class ProxyImageRequest
         ProxySizeParameter = sizeParameter,
         IsValid = true
     };
+    
+    private string DebuggerDisplay => IsValid 
+        ? $"Valid: {ProxySizeParameter}, {RequestedSize}"
+        : $"Invalid: {ErrorStatusCode}";
 }
 

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -78,7 +78,7 @@ public static class ImageProxyPathHandler
             var extractedRegionSize = imageRequest.Region.GetExtractedRegionSize(imageSize);
             var requestedFullRegion = imageRequest.Region.IsFullOrEquivalent(imageSize);
 
-            // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size is valid
+            // If this is not /full/ or /max/ then need to check the size is valid. May rewrite confined size requests
             if (!sizeParameter.Max)
             {
                 var (requestedSize, proxySizeParameter) = GetRequestedSize(isV2, sizeParameter, extractedRegionSize, maxWidth);

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using DLCS.Model.IIIF;
 using IIIF;
 using IIIF.Exceptions;
@@ -13,15 +14,16 @@ namespace Orchestrator.Infrastructure.ReverseProxy;
 public static class ImageProxyPathHandler
 {
     /// <summary>
-    /// Get the proposed final size and <see cref="SizeParameter"/> image request based on incoming imageRequest and maxWidth.
+    /// Get the proposed final size and <see cref="SizeParameter"/> for image requests based on incoming imageRequest
+    /// and effective maxWidth. The returned result may be invalid if request cannot be fulfilled.
     /// </summary>
     /// <param name="imageRequest">Incoming <see cref="ImageRequest"/></param>
     /// <param name="imageSize">The <see cref="Size"/> of source image</param>
     /// <param name="maxWidth">The effective maxWidth value for image</param>
     /// <returns>
-    /// <see cref="ProxySizeResult"/> containing effective size, validity and proxy <see cref="SizeParameter"/>
+    /// <see cref="ProxyImageRequest"/> containing effective size, validity and proxy <see cref="SizeParameter"/>
     /// </returns>
-    public static ProxySizeResult GetProposedFinalSize(this ImageRequest imageRequest, Size imageSize, int maxWidth)
+    public static ProxyImageRequest GetProxyImageRequest(this ImageRequest imageRequest, Size imageSize, int maxWidth)
     {
         try
         {
@@ -34,8 +36,9 @@ public static class ImageProxyPathHandler
             {
                 var requestedSize = sizeParameter.Resize(extractedRegionSize, InvalidUpscaleBehaviour.Throw);
                 return requestedSize.MaxDimension > maxWidth
-                    ? ProxySizeResult.Invalid($"Requested size '{sizeParameter}' exceeds maxWidth of {maxWidth}")
-                    : ProxySizeResult.Valid(sizeParameter, requestedSize);
+                    ? ProxyImageRequest.Invalid($"Requested size '{sizeParameter}' exceeds maxWidth of {maxWidth}",
+                        HttpStatusCode.Forbidden)
+                    : ProxyImageRequest.Valid(sizeParameter, requestedSize);
             }
 
             // If /full/ or /max/ then we will change size-parameter to be explicit requested size
@@ -44,33 +47,34 @@ public static class ImageProxyPathHandler
                 // ^full isn't valid
                 if (imageRequest.IsExplicitFullSize())
                 {
-                    return ProxySizeResult.Invalid("'^full' size is invalid. Use 'full' or '^max' instead.");
+                    return ProxyImageRequest.Invalid("'^full' size is invalid. Use 'full' or '^max' instead.",
+                        HttpStatusCode.BadRequest);
                 }
                     
                 // Work out the final size - this will be the largest that fits withing maxWidth confinement, possibly
                 // growing
                 var finalSize = Size.FitWithin(Size.Square(maxWidth), extractedRegionSize);
-                return GetProxySizeResult(finalSize, maxWidth > extractedRegionSize.MaxDimension);
+                return GetProxyImageRequest(finalSize, maxWidth > extractedRegionSize.MaxDimension);
             }
             else
             {
                 // Work out the final size - this will be the extracted region size or that size confined to maxWidth 
                 var finalSize = Size.Confine(maxWidth, extractedRegionSize);
-                return GetProxySizeResult(finalSize);
+                return GetProxyImageRequest(finalSize);
             }
         }
         catch (RegionException ex)
         {
-            return ProxySizeResult.Invalid(ex.Message); // TODO - differentiate between 400/403/401?
+            return ProxyImageRequest.Invalid(ex.Message, HttpStatusCode.BadRequest);
         }
         catch (InvalidOperationException ex)
         {
-            return ProxySizeResult.Invalid(ex.Message);
+            return ProxyImageRequest.Invalid(ex.Message, HttpStatusCode.NotImplemented);
         }
     }
 
-    private static ProxySizeResult GetProxySizeResult(Size finalSize, bool upscaled = false)
-        => ProxySizeResult.Valid(new SizeParameter
+    private static ProxyImageRequest GetProxyImageRequest(Size finalSize, bool upscaled = false)
+        => ProxyImageRequest.Valid(new SizeParameter
         {
             Width = finalSize.Width,
             Height = finalSize.Height,
@@ -79,36 +83,44 @@ public static class ImageProxyPathHandler
 }
 
 /// <summary>
-/// Class represents 
+/// Class represents validated image proxy destination
 /// </summary>
-public class ProxySizeResult
+public class ProxyImageRequest
 {
     /// <summary>
     /// <see cref="SizeParameter"/> that should be used to proxy image request.
     /// </summary>
-    [MemberNotNullWhen(true, nameof(IsValid))]
     public SizeParameter? ProxySizeParameter { get; private init; }
         
     /// <summary>
     /// <see cref="Size"/> that represents the final size.
     /// </summary>
-    [MemberNotNullWhen(true, nameof(IsValid))]
     public Size? RequestedSize { get; private init; }
     
     /// <summary>
     /// Whether the proxy request is valid.
     /// </summary>
+    [MemberNotNullWhen(true, nameof(ProxySizeParameter))]
+    [MemberNotNullWhen(true, nameof(RequestedSize))]
+    [MemberNotNullWhen(false, nameof(ErrorMessage))]
+    [MemberNotNullWhen(false, nameof(ErrorStatusCode))]
     public bool IsValid { get; private init; }
+    
+    /// <summary>
+    /// HTTP status code representing why request is invalid.
+    /// </summary>
+    public HttpStatusCode? ErrorStatusCode { get; private init; }
     
     /// <summary>
     /// Error message representing why request is invalid.
     /// </summary>
-    [MemberNotNullWhen(false, nameof(IsValid))]
+    
     public string? ErrorMessage { get; private init; }
 
-    public static ProxySizeResult Invalid(string message) => new() { IsValid = false, ErrorMessage = message };
+    public static ProxyImageRequest Invalid(string message, HttpStatusCode statusCode)
+        => new() { IsValid = false, ErrorMessage = message, ErrorStatusCode = statusCode };
 
-    public static ProxySizeResult Valid(SizeParameter sizeParameter, Size proposedSize) => new()
+    public static ProxyImageRequest Valid(SizeParameter sizeParameter, Size proposedSize) => new()
     {
         RequestedSize = proposedSize,
         ProxySizeParameter = sizeParameter,

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -81,7 +81,7 @@ public static class ImageProxyPathHandler
             // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size is valid
             if (!sizeParameter.Max)
             {
-                var requestedSize = GetRequestedSize(isV2, sizeParameter, extractedRegionSize);
+                var (requestedSize, proxySizeParameter) = GetRequestedSize(isV2, sizeParameter, extractedRegionSize, maxWidth);
                 if (requestedSize.MaxDimension > maxWidth)
                 {
                     return ProxyImageRequest.Invalid(
@@ -89,7 +89,7 @@ public static class ImageProxyPathHandler
                         HttpStatusCode.Forbidden);
                 }
 
-                return ProxyImageRequest.Valid(sizeParameter, requestedSize, requestedFullRegion);
+                return ProxyImageRequest.Valid(proxySizeParameter, requestedSize, requestedFullRegion);
             }
             
             // If here, it's /full/ or /max/ size. In which case we will change size parameter in proxy request to be
@@ -119,28 +119,50 @@ public static class ImageProxyPathHandler
     private static bool IsUpscalingAllowed(bool isVersion2, bool isExplicitFullSize, SizeParameter sizeParameter) =>
         sizeParameter.Upscaled && !isVersion2 || (!isExplicitFullSize && isVersion2);
 
-    private static Size GetRequestedSize(bool isVersion2, SizeParameter sizeParameter, Size extractedRegionSize)
+    private static (Size Size, SizeParameter SizeParameter) GetRequestedSize(bool isVersion2,
+        SizeParameter sizeParameter, Size extractedRegionSize, int maxWidth)
+    {
+        var workingSizeParam = GetWorkingSizeParam(isVersion2, sizeParameter);
+
+        // If it's not confined, return calculate final size and return
+        if (!sizeParameter.Confined)
+        {
+            return (workingSizeParam.Resize(extractedRegionSize), sizeParameter);
+        }
+
+        // If it's confined + would exceed the maxWidth then resize down to "as large as possible but not larger than
+        // server-imposed limits"
+        if (Math.Max(sizeParameter.Width ?? 0, sizeParameter.Height ?? 0) > maxWidth)
+        {
+            workingSizeParam.Width = maxWidth;
+            workingSizeParam.Height = maxWidth;
+        }
+
+        var requestedSize = workingSizeParam.Resize(extractedRegionSize, InvalidUpscaleBehaviour.ReturnOriginal);
+        return (requestedSize, CreateExactSizeParameter(requestedSize, sizeParameter.Upscaled));
+    }
+
+    private static SizeParameter GetWorkingSizeParam(bool isVersion2, SizeParameter sizeParameter)
     {
         // SizeParameter.Parse() works by V3 rules - so you need ^ to upscale. If we're version2, fake that briefly to
         // ease calculation. Create a new copy of SizeParameter to avoid mutating the original
-        var workingSizeParam = sizeParameter;
-        if (isVersion2)
-        {
-            workingSizeParam = SizeParameter.Parse(sizeParameter.ToString());
-            workingSizeParam.Upscaled = true;
-        }
+        if (!isVersion2) return sizeParameter;
 
-        var requestedSize = workingSizeParam.Resize(extractedRegionSize);
-        return requestedSize;
+        var workingSizeParam = SizeParameter.Parse(sizeParameter.ToString());
+        workingSizeParam.Upscaled = true;
+        return workingSizeParam;
     }
 
     private static ProxyImageRequest GetProxyImageRequest(Size finalSize, bool requestedFullRegion, bool upscaled)
-        => ProxyImageRequest.Valid(new SizeParameter
+        => ProxyImageRequest.Valid(CreateExactSizeParameter(finalSize, upscaled), finalSize, requestedFullRegion);
+
+    private static SizeParameter CreateExactSizeParameter(Size finalSize, bool upscaled) =>
+        new()
         {
             Width = finalSize.Width,
             Height = finalSize.Height,
             Upscaled = upscaled
-        }, finalSize, requestedFullRegion);
+        };
 }
 
 /// <summary>

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -37,13 +37,13 @@ public static class ImageProxyPathHandler
         var isV2 = imageVersion == Version.V2;
         var isExplicitFull = imageRequest.IsExplicitFullSize();
 
-        var failedValidationError = TryValidateRequest(imageRequest, isV2, isExplicitFull, strictMode);
+        var failedValidationError = GetValidationFailure(imageRequest, isV2, isExplicitFull, strictMode);
         if (failedValidationError != null) return failedValidationError;
         
         return HandleProxyLogic(imageRequest, imageSize, maxWidth, isV2, isExplicitFull);
     }
 
-    private static ProxyImageRequest? TryValidateRequest(ImageRequest imageRequest, bool isV2, bool isExplicitFull,
+    private static ProxyImageRequest? GetValidationFailure(ImageRequest imageRequest, bool isV2, bool isExplicitFull,
         bool strictMode)
     {
         // V2 doesn't support ^ character, ever

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using DLCS.Model.IIIF;
+using IIIF;
+using IIIF.Exceptions;
+using IIIF.ImageApi;
+
+namespace Orchestrator.Infrastructure.ReverseProxy;
+
+/// <summary>
+/// Contains decision making logic for proxying image requests.
+/// </summary>
+public static class ImageProxyPathHandler
+{
+    /// <summary>
+    /// Get the proposed final size and <see cref="SizeParameter"/> image request based on incoming imageRequest and maxWidth.
+    /// </summary>
+    /// <param name="imageRequest">Incoming <see cref="ImageRequest"/></param>
+    /// <param name="imageSize">The <see cref="Size"/> of source image</param>
+    /// <param name="maxWidth">The effective maxWidth value for image</param>
+    /// <returns>
+    /// <see cref="ProxySizeResult"/> containing effective size, validity and proxy <see cref="SizeParameter"/>
+    /// </returns>
+    public static ProxySizeResult GetProposedFinalSize(this ImageRequest imageRequest, Size imageSize, int maxWidth)
+    {
+        try
+        {
+            // Get the size of the extracted region
+            var extractedRegionSize = imageRequest.Region.GetExtractedRegionSize(imageSize);
+            var sizeParameter = imageRequest.Size;
+            
+            // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size 
+            if (!sizeParameter.Max)
+            {
+                var requestedSize = sizeParameter.Resize(extractedRegionSize, InvalidUpscaleBehaviour.Throw);
+                return requestedSize.MaxDimension > maxWidth
+                    ? ProxySizeResult.Invalid($"Requested size '{sizeParameter}' exceeds maxWidth of {maxWidth}")
+                    : ProxySizeResult.Valid(sizeParameter, requestedSize);
+            }
+
+            // If /full/ or /max/ then we will change size-parameter to be explicit requested size
+            if (sizeParameter.Upscaled)
+            {
+                // ^full isn't valid
+                if (imageRequest.IsExplicitFullSize())
+                {
+                    return ProxySizeResult.Invalid("'^full' size is invalid. Use 'full' or '^max' instead.");
+                }
+                    
+                // Work out the final size - this will be the largest that fits withing maxWidth confinement, possibly
+                // growing
+                var finalSize = Size.FitWithin(Size.Square(maxWidth), extractedRegionSize);
+                return GetProxySizeResult(finalSize, maxWidth > extractedRegionSize.MaxDimension);
+            }
+            else
+            {
+                // Work out the final size - this will be the extracted region size or that size confined to maxWidth 
+                var finalSize = Size.Confine(maxWidth, extractedRegionSize);
+                return GetProxySizeResult(finalSize);
+            }
+        }
+        catch (RegionException ex)
+        {
+            return ProxySizeResult.Invalid(ex.Message); // TODO - differentiate between 400/403/401?
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ProxySizeResult.Invalid(ex.Message);
+        }
+    }
+
+    private static ProxySizeResult GetProxySizeResult(Size finalSize, bool upscaled = false)
+        => ProxySizeResult.Valid(new SizeParameter
+        {
+            Width = finalSize.Width,
+            Height = finalSize.Height,
+            Upscaled = upscaled
+        }, finalSize);
+}
+
+/// <summary>
+/// Class represents 
+/// </summary>
+public class ProxySizeResult
+{
+    /// <summary>
+    /// <see cref="SizeParameter"/> that should be used to proxy image request.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(IsValid))]
+    public SizeParameter? ProxySizeParameter { get; private init; }
+        
+    /// <summary>
+    /// <see cref="Size"/> that represents the final size.
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(IsValid))]
+    public Size? RequestedSize { get; private init; }
+    
+    /// <summary>
+    /// Whether the proxy request is valid.
+    /// </summary>
+    public bool IsValid { get; private init; }
+    
+    /// <summary>
+    /// Error message representing why request is invalid.
+    /// </summary>
+    [MemberNotNullWhen(false, nameof(IsValid))]
+    public string? ErrorMessage { get; private init; }
+
+    public static ProxySizeResult Invalid(string message) => new() { IsValid = false, ErrorMessage = message };
+
+    public static ProxySizeResult Valid(SizeParameter sizeParameter, Size proposedSize) => new()
+    {
+        RequestedSize = proposedSize,
+        ProxySizeParameter = sizeParameter,
+        IsValid = true
+    };
+}
+

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -91,9 +91,8 @@ public static class ImageProxyPathHandler
                 return ProxyImageRequest.Valid(sizeParameter, requestedSize);
             }
             
-            // If here, it's /full/ or /max/ size. In which case we will change size parameter in proxy request  to be
+            // If here, it's /full/ or /max/ size. In which case we will change size parameter in proxy request to be
             // the explicitly requested size (e.g. /full/ or /max/ => /1049,2033/ or /^1049,2033/)
-
             if (!IsUpscalingAllowed(isV2, isExplicitFull, sizeParameter))
             {
                 // If no upscaling then we can just confine the size to maxWidth without attempting to grow

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ImageProxyPathHandler.cs
@@ -76,6 +76,7 @@ public static class ImageProxyPathHandler
             // Get the size of the extracted region - we need this regardless of version
             var sizeParameter = imageRequest.Size; 
             var extractedRegionSize = imageRequest.Region.GetExtractedRegionSize(imageSize);
+            var requestedFullRegion = imageRequest.Region.IsFullOrEquivalent(imageSize);
 
             // If this is not /full/ or /max/ then we won't change the size parameter, only need to check the size is valid
             if (!sizeParameter.Max)
@@ -88,7 +89,7 @@ public static class ImageProxyPathHandler
                         HttpStatusCode.Forbidden);
                 }
 
-                return ProxyImageRequest.Valid(sizeParameter, requestedSize);
+                return ProxyImageRequest.Valid(sizeParameter, requestedSize, requestedFullRegion);
             }
             
             // If here, it's /full/ or /max/ size. In which case we will change size parameter in proxy request to be
@@ -96,13 +97,13 @@ public static class ImageProxyPathHandler
             if (!IsUpscalingAllowed(isV2, isExplicitFull, sizeParameter))
             {
                 // If no upscaling then we can just confine the size to maxWidth without attempting to grow
-                return GetProxyImageRequest(Size.Confine(maxWidth, extractedRegionSize));
+                return GetProxyImageRequest(Size.Confine(maxWidth, extractedRegionSize), requestedFullRegion, false);
             }
 
             // If upscaling is allowed, work out the final size - the largest possible size that fits withing maxWidth
             var finalSize = Size.FitWithin(Size.Square(maxWidth), extractedRegionSize);
             var upscaleProxyRequest = maxWidth > extractedRegionSize.MaxDimension && !isV2;
-            return GetProxyImageRequest(finalSize, upscaleProxyRequest);
+            return GetProxyImageRequest(finalSize, requestedFullRegion, upscaleProxyRequest);
         }
         catch (RegionException ex)
         {
@@ -133,13 +134,13 @@ public static class ImageProxyPathHandler
         return requestedSize;
     }
 
-    private static ProxyImageRequest GetProxyImageRequest(Size finalSize, bool upscaled = false)
+    private static ProxyImageRequest GetProxyImageRequest(Size finalSize, bool requestedFullRegion, bool upscaled)
         => ProxyImageRequest.Valid(new SizeParameter
         {
             Width = finalSize.Width,
             Height = finalSize.Height,
             Upscaled = upscaled
-        }, finalSize);
+        }, finalSize, requestedFullRegion);
 }
 
 /// <summary>
@@ -175,18 +176,24 @@ public class ProxyImageRequest
     /// <summary>
     /// Error message representing why request is invalid.
     /// </summary>
-    
     public string? ErrorMessage { get; private init; }
-
+    
+    /// <summary>
+    /// True if the request region represents the full image size.
+    /// </summary>
+    public bool RepresentsFullRegion { get; private init; }
+    
     public static ProxyImageRequest Invalid(string message, HttpStatusCode statusCode)
         => new() { IsValid = false, ErrorMessage = message, ErrorStatusCode = statusCode };
 
-    public static ProxyImageRequest Valid(SizeParameter sizeParameter, Size proposedSize) => new()
-    {
-        RequestedSize = proposedSize,
-        ProxySizeParameter = sizeParameter,
-        IsValid = true
-    };
+    public static ProxyImageRequest Valid(SizeParameter sizeParameter, Size proposedSize, bool representsFullRegion) =>
+        new()
+        {
+            RequestedSize = proposedSize,
+            ProxySizeParameter = sizeParameter,
+            IsValid = true,
+            RepresentsFullRegion = representsFullRegion,
+        };
     
     private string DebuggerDisplay => IsValid 
         ? $"Valid: {ProxySizeParameter}, {RequestedSize}"

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
@@ -77,12 +77,17 @@ public class ProxyActionResult : IProxyActionResult
 /// <summary>
 /// Result for proxy actions that should be shortcut to return status code.
 /// </summary>
-public class StatusCodeResult(HttpStatusCode statusCode) : IProxyActionResult
+public class StatusCodeResult(HttpStatusCode statusCode, string? message = null) : IProxyActionResult
 {
     /// <summary>
     /// StatusCode to return
     /// </summary>
     public HttpStatusCode StatusCode { get; } = statusCode;
+    
+    /// <summary>
+    /// Optional message to return with status code
+    /// </summary>
+    public string? Message { get; } = message;
 
     /// <summary>
     /// A collection of any Headers to set on response object. 

--- a/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ReverseProxy/ProxyActionResult.cs
@@ -77,34 +77,26 @@ public class ProxyActionResult : IProxyActionResult
 /// <summary>
 /// Result for proxy actions that should be shortcut to return status code.
 /// </summary>
-public class StatusCodeResult : IProxyActionResult
+public class StatusCodeResult(HttpStatusCode statusCode) : IProxyActionResult
 {
     /// <summary>
     /// StatusCode to return
     /// </summary>
-    public HttpStatusCode StatusCode { get; }
-    
+    public HttpStatusCode StatusCode { get; } = statusCode;
+
     /// <summary>
     /// A collection of any Headers to set on response object. 
     /// </summary>
     public Dictionary<string, StringValues> Headers { get; } = new();
 
-    public StatusCodeResult(HttpStatusCode statusCode)
-    {
-        StatusCode = statusCode;
-    }
-    
     public static StatusCodeResult NotFound => new(HttpStatusCode.NotFound);
 }
 
 public static class ProxyActionResultsX
 {
     /// <summary>
-    /// Set header to return alongside statusCode
+    /// Add headers to <see cref="IProxyActionResult"/> object.
     /// </summary>
-    /// <param name="key"></param>
-    /// <param name="value"></param>
-    /// <returns></returns>
     public static IProxyActionResult WithHeader(this IProxyActionResult result, string key, string value)
     {
         result.Headers[key] = value;

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -18,6 +18,11 @@ public class OrchestratorSettings
     /// Regex for S3-origin, for objects uploaded directly to DLCS.
     /// </summary>
     public string S3OriginRegex { get; set; }
+    
+    /// <summary>
+    /// The system maximum width value. Images will not be generated that exceed this.
+    /// </summary>
+    public int MaxWidth { get; set; } = SystemDefaults.MaxWidth;
 
     /// <summary>
     /// Which image-server is handling downstream tile requests

--- a/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
+++ b/src/protagonist/Orchestrator/Settings/OrchestratorSettings.cs
@@ -23,6 +23,13 @@ public class OrchestratorSettings
     /// The system maximum width value. Images will not be generated that exceed this.
     /// </summary>
     public int MaxWidth { get; set; } = SystemDefaults.MaxWidth;
+    
+    /// <summary>
+    /// Whether to enforce strict image request validation, rejecting requests that are not in the expected format for
+    /// IIIF ImageApi version.
+    /// </summary>
+    /// <summary>See ADR 0011 for more details</summary>
+    public bool StrictImageRequestParsing { get; set; } = true;
 
     /// <summary>
     /// Which image-server is handling downstream tile requests

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -30,7 +30,6 @@ public static class DatabaseTestDataPopulation
         string origin = "http://test",
         string roles = "",
         string mediaType = "image/jpeg",
-        int maxUnauthorised = -1,
         int maxWidth = 0,
         int openFullMax = 0,
         int width = 8000,
@@ -56,7 +55,7 @@ public static class DatabaseTestDataPopulation
         {
             Created = DateTime.UtcNow, Customer = customer, Space = space, Id = id, Origin = origin,
             Width = width, Height = height, Roles = roles, Family = family, MediaType = mediaType,
-            ThumbnailPolicy = thumbnailPolicy, MaxUnauthorised = maxUnauthorised,
+            ThumbnailPolicy = thumbnailPolicy, MaxUnauthorised = -1,
             MaxWidth = maxWidth, OpenFullMax = openFullMax,
             Reference1 = ref1, Reference2 = ref2, Reference3 = ref3,
             NumberReference1 = num1, NumberReference2 = num2, NumberReference3 = num3,


### PR DESCRIPTION
Resolves #1095

Update Orchestrator to use `maxWidth` and `openFullMax` in image processing, rather than `maxUnauthorised`.

> [!WARNING]
> This change moves more IIIF ImageApi parsing logic into Orchestrator.
> Previously we relied on downstream image servers for this but now more Region + Size parameter processing is in Orchestrator.
> It also changes IIIF ImageApi parameters when making downstream proxy requests, which is a change in behaviour.

Included ADR outlines ImageApi parsing, how it differs per version and the possibility for "strict" and "lax" modes.

Biggest change is introduction of `ImageProxyPathHandler` class. This takes incoming IIIF ImageApi request and parses it to work out the resulting image size, whether this is valid and what the downstream request would be (via https://github.com/digirati-co-uk/iiif-net/pull/86). In the event of a `/max/`, or equivalent, size it will return the new SizeParameter to proxy to. Also - `/max/`, or equivalent sizes will be checked to see if they can be served by thumbs. This wasn't done previously as it would involve rewriting the size parameter but we now have values to do this. The tests for this class are verbose but pretty cumbersome - any suggestions to improve welcome!

> [!CAUTION]
> Orchestrator now has `MaxWidth` property - downstream image-server may need altered to allow requests through OR to support existing images.

Extended `IsFullOrEquivalent` logic to handle `/pct:0,0,100,100/` as full request.

Info.json construction logic is updated, `maxWidth` will be output in all info.json requests.

> [!WARNING]
> To view these changes all cached info.json files will need to be recreated by setting the `OldestAllowedInfoJson` appSetting value.
> Recreating info.json requires orchestration.

Special handling was added for "unobtainable" role introduce in earlier PR. We won't advertise access-services for this role and will shortcut some requests if this is the only role for an image.

Updated cleanup-handler to delete info.json if the `maxWidth` value has changed as this will need to be reflected in info.json (previously this only happened if `roles` changed).

Thumbnails that exceed `maxWidth` are not saved at all.