### PR TITLE
Add InlineAnnotation to the API

### DIFF
--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -231,6 +231,6 @@ public class HydraAdjunctValidatorTests
         };
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.Type)
-            .WithErrorMessage("When the 'iiifLink' is 'annotations', the '@type' must be 'AnnotationPage'");
+            .WithErrorMessage("When 'iiifLink' is 'annotations', the '@type' must be 'AnnotationPage'");
     }
 }

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -108,7 +108,7 @@ public class HydraAdjunctValidatorTests
         };
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.IIIFLink)
-            .WithErrorMessage("Valid values for 'iiifLink' are 'seeAlso', 'annotations', 'rendering'");
+            .WithErrorMessage("Valid values for 'iiifLink' are 'seeAlso', 'annotations', 'rendering', 'inlineAnnotation'");
     }
     
     [Fact]
@@ -218,5 +218,20 @@ public class HydraAdjunctValidatorTests
         var result = sut.TestValidate(adjunct);
         result.ShouldHaveValidationErrorFor(r => r.Language)
             .WithErrorMessage("All 'language' values must be 10 characters or less. e.g. ISO language codes, sub-codes or 'none'");
+    }
+    
+    [Fact]
+    public void Motivation_Error_NotAnnotationPage()
+    {
+        var adjunct = new Adjunct
+        {
+            MediaType = "mediaType",
+            IIIFLink = "seeAlso",
+            Type = "Annotation",
+            Motivation = "some motivation"
+        };
+        var result = sut.TestValidate(adjunct);
+        result.ShouldHaveValidationErrorFor(r => r.Motivation)
+            .WithErrorMessage("The 'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
     }
 }

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -221,7 +221,7 @@ public class HydraAdjunctValidatorTests
     }
     
     [Fact]
-    public void Motivation_Error_NotAnnotationPage()
+    public void Type_Error_NotAnnotationPage()
     {
         var adjunct = new Adjunct
         {

--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/HydraAdjunctValidatorTests.cs
@@ -226,12 +226,11 @@ public class HydraAdjunctValidatorTests
         var adjunct = new Adjunct
         {
             MediaType = "mediaType",
-            IIIFLink = "seeAlso",
+            IIIFLink = "annotations",
             Type = "Annotation",
-            Motivation = "some motivation"
         };
         var result = sut.TestValidate(adjunct);
-        result.ShouldHaveValidationErrorFor(r => r.Motivation)
-            .WithErrorMessage("The 'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
+        result.ShouldHaveValidationErrorFor(r => r.Type)
+            .WithErrorMessage("When the 'iiifLink' is 'annotations', the '@type' must be 'AnnotationPage'");
     }
 }

--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -44,11 +44,12 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const string newAdjunctJson = """
                                       {
                                                 "id": "someAdjunctId",
-                                                "@type": "Image",
+                                                "@type": "AnnotationPage",
                                                 "externalId": "https://some-location.com/an-adjunct",
                                                 "iiifLink": "seeAlso",
                                                 "mediaType": "a-mediaType",
                                                 "label": {"label": ["value"]},
+                                                "motivation": "a motivation",
                                                 "language": ["en"],
                                               }
                                       """;
@@ -71,6 +72,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.Language.Should().Contain(l => l == "en").And.HaveCount(1);
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
+        adjunct.Motivation.Should().Be("a motivation");
         
         response.Headers.Location.Should()
             .Be(
@@ -283,7 +285,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var assetId = AssetIdGenerator.GetAssetId();
 
         await dbContext.Images.AddTestAsset(assetId)
-            .WithTestAdjunct("someAdjunctId");
+            .WithTestAdjunct("someAdjunctId", motivation: "a motivation");
         await dbContext.SaveChangesAsync();
         
         var path = $"{assetId.ToApiResourcePath()}/adjuncts/someAdjunctId";
@@ -299,6 +301,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
             .Be(
                 $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/someAdjunctId");
         adjunct.IIIFLink.Should().Be("seeAlso");
+        adjunct.Motivation.Should().Be("a motivation");
     }
     
     [Fact]

--- a/src/protagonist/API/Converters/AdjunctConverter.cs
+++ b/src/protagonist/API/Converters/AdjunctConverter.cs
@@ -47,6 +47,7 @@ public static class AdjunctConverter
             Label =  hydraAdjunct.Label.ToLanguageMap(),
             Language = hydraAdjunct.Language,
             Size = hydraAdjunct.Size,
+            Motivation = hydraAdjunct.Motivation,
         };
         
         if (hydraAdjunct.Origin is not null)
@@ -85,6 +86,7 @@ public static class AdjunctConverter
             Finished = adjunct.Finished,
             Size = adjunct.Size,
             Error = adjunct.Error,
+            Motivation = adjunct.Motivation,
             Ingesting = adjunct.Ingesting
         };
 }

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -58,7 +58,7 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.Type)
             .Must(t =>  t == "AnnotationPage")
             .When(a => a.IIIFLink == IIIFLinkType.Annotations.GetDescription())
-            .WithMessage($"When the 'iiifLink' is '{IIIFLinkType.Annotations.GetDescription()}', the '@type' must be 'AnnotationPage'");
+            .WithMessage($"When 'iiifLink' is '{IIIFLinkType.Annotations.GetDescription()}', the '@type' must be 'AnnotationPage'");
     }
 
     private readonly List<string> validIIIFLinkTypes =

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -49,6 +49,10 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.Type)
             .NotEmpty()
             .WithMessage("'@type' is required");
+        
+        RuleFor(a => a.Motivation).Empty()
+            .When(a => a.Type != "AnnotationPage")
+            .WithMessage("'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
 
         const int maximumLength = 10;
         RuleForEach(a => a.Language)

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -55,9 +55,10 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
             .MaximumLength(maximumLength)
             .WithMessage($"All 'language' values must be {maximumLength} characters or less. e.g. ISO language codes, sub-codes or 'none'");
         
-        RuleFor(a => a.Motivation).Empty()
-            .When(a => a.Type != "AnnotationPage")
-            .WithMessage("The 'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
+        RuleFor(a => a.Type)
+            .Must(t =>  t == "AnnotationPage")
+            .When(a => a.IIIFLink == IIIFLinkType.Annotations.GetDescription())
+            .WithMessage($"When the 'iiifLink' is '{IIIFLinkType.Annotations.GetDescription()}', the '@type' must be 'AnnotationPage'");
     }
 
     private readonly List<string> validIIIFLinkTypes =

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -49,15 +49,15 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         RuleFor(a => a.Type)
             .NotEmpty()
             .WithMessage("'@type' is required");
-        
-        RuleFor(a => a.Motivation).Empty()
-            .When(a => a.Type != "AnnotationPage")
-            .WithMessage("'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
 
         const int maximumLength = 10;
         RuleForEach(a => a.Language)
             .MaximumLength(maximumLength)
             .WithMessage($"All 'language' values must be {maximumLength} characters or less. e.g. ISO language codes, sub-codes or 'none'");
+        
+        RuleFor(a => a.Motivation).Empty()
+            .When(a => a.Type != "AnnotationPage")
+            .WithMessage("The 'motivation' is not allowed when the '@type' is not 'AnnotationPage'");
     }
 
     private readonly List<string> validIIIFLinkTypes =

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -86,7 +86,7 @@ public class Adjunct : DlcsResource
     [JsonProperty(Order = 23, PropertyName = "origin")]
     public string? Origin { get; set; }
     
-    [RdfProperty(Description = "Why this adjunct exists.",
+    [RdfProperty(Description = "he reason why this adjunct exists.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 24, PropertyName = "motivation")]
     public string? Motivation { get; set; }

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -81,18 +81,23 @@ public class Adjunct : DlcsResource
     [JsonProperty(Order = 22, PropertyName = "finished")]
     public DateTime? Finished { get; set; }
     
-    [RdfProperty(Description = "Origin endpoint from where the original adjunct can be acquired (or was acquired)",
+    [RdfProperty(Description = "Origin endpoint from where the original adjunct can be acquired (or was acquired).",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 23, PropertyName = "origin")]
     public string? Origin { get; set; }
     
-    [RdfProperty(Description = "Is the adjunct currently being ingested?",
+    [RdfProperty(Description = "Why this adjunct exists.",
+        Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
+    [JsonProperty(Order = 24, PropertyName = "motivation")]
+    public string? Motivation { get; set; }
+    
+    [RdfProperty(Description = "Whether the adjunct is currently being ingested.",
         Range = Names.XmlSchema.Boolean, ReadOnly = true, WriteOnly = false)]
-    [JsonProperty(Order = 24, PropertyName = "ingesting")]
+    [JsonProperty(Order = 25, PropertyName = "ingesting")]
     public bool? Ingesting { get; set; }
     
-    [RdfProperty(Description = "Reported errors with this adjunct",
+    [RdfProperty(Description = "Reported errors with this adjunct.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
-    [JsonProperty(Order = 25, PropertyName = "error")]
+    [JsonProperty(Order = 26, PropertyName = "error")]
     public string? Error { get; set; }
 }

--- a/src/protagonist/DLCS.HydraModel/Adjunct.cs
+++ b/src/protagonist/DLCS.HydraModel/Adjunct.cs
@@ -86,7 +86,7 @@ public class Adjunct : DlcsResource
     [JsonProperty(Order = 23, PropertyName = "origin")]
     public string? Origin { get; set; }
     
-    [RdfProperty(Description = "he reason why this adjunct exists.",
+    [RdfProperty(Description = "The reason why this adjunct exists.",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]
     [JsonProperty(Order = 24, PropertyName = "motivation")]
     public string? Motivation { get; set; }

--- a/src/protagonist/DLCS.Model/Assets/Adjunct.cs
+++ b/src/protagonist/DLCS.Model/Assets/Adjunct.cs
@@ -99,5 +99,7 @@ public enum IIIFLinkType
     [Description("annotations")]
     Annotations,
     [Description("rendering")]
-    Rendering
+    Rendering,
+    [Description("inlineAnnotation")]
+    InlineAnnotation
 }

--- a/src/protagonist/DLCS.Model/Assets/Adjunct.cs
+++ b/src/protagonist/DLCS.Model/Assets/Adjunct.cs
@@ -85,6 +85,11 @@ public class Adjunct : IDeliverable
     /// The size in bytes of the adjunct
     /// </summary>
     public long? Size { get; set; }
+    
+    /// <summary>
+    /// The reason why this adjunct exists.
+    /// </summary>
+    public string? Motivation { get; set; }
 
     public Asset Asset { get; set; } = null!;
 }

--- a/src/protagonist/DLCS.Repository/Migrations/20260302120251_Add motivation to adjuncts table.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260302120251_Add motivation to adjuncts table.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20260302120251_Add motivation to adjuncts table")]
+    partial class Addmotivationtoadjunctstable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/protagonist/DLCS.Repository/Migrations/20260302120251_Add motivation to adjuncts table.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260302120251_Add motivation to adjuncts table.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    /// <inheritdoc />
+    public partial class Addmotivationtoadjunctstable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Motivation",
+                table: "Adjuncts",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Motivation",
+                table: "Adjuncts");
+        }
+    }
+}

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -72,7 +72,7 @@ public static class DatabaseTestDataPopulation
         IIIFLinkType iiifLinkType = IIIFLinkType.SeeAlso,
         string profile = null, LanguageMap label = null,
         string[] language = null, string externalId = "https://someHost.com/someUri", DateTime? created = null,
-        long? size = null)
+        long? size = null, string? motivation = null)
     {
         asset.Result.Entity.Adjuncts ??= [];
         asset.Result.Entity.Adjuncts.Add(new Adjunct
@@ -87,7 +87,8 @@ public static class DatabaseTestDataPopulation
             Language = language,
             ExternalId = new Uri(externalId),
             Created = created ?? DateTime.UtcNow,
-            Size = size
+            Size = size,
+            Motivation = motivation
         });
 
         return asset;


### PR DESCRIPTION
Resolves #1112 


This PR adds the `InlineAnnotation` iiif link type to the API.  Additionally, `motivation` is now supported, along with a migration to add this to the database

> [!Note]
> This PR contains a migration