### PR TITLE
Refresh OrchestrationImage info.json create

### DIFF
--- a/src/protagonist/DLCS.Repository/Assets/AssetCachingHelper.cs
+++ b/src/protagonist/DLCS.Repository/Assets/AssetCachingHelper.cs
@@ -12,20 +12,13 @@ namespace DLCS.Repository.Assets;
 /// <summary>
 /// Helper for working with cached assets
 /// </summary>
-public class AssetCachingHelper
+public class AssetCachingHelper(
+    IAppCache appCache,
+    IOptions<CacheSettings> cacheOptions,
+    ILogger<AssetCachingHelper> logger)
 {
-    private readonly IAppCache appCache;
-    private readonly ILogger<AssetCachingHelper> logger;
-    private readonly CacheSettings cacheSettings;
+    private readonly CacheSettings cacheSettings = cacheOptions.Value;
     private static readonly Asset NullAsset = new() { Id = AssetId.Null };
-
-    public AssetCachingHelper(IAppCache appCache, IOptions<CacheSettings> cacheOptions,
-        ILogger<AssetCachingHelper> logger)
-    {
-        this.appCache = appCache;
-        this.logger = logger;
-        cacheSettings = cacheOptions.Value;
-    }
 
     /// <summary>
     /// Purge specified asset from cache
@@ -58,5 +51,5 @@ public class AssetCachingHelper
         return asset.Id == NullAsset.Id ? null : asset;
     }
 
-    private string GetCacheKey(AssetId assetId) => $"asset:{assetId}";
+    private static string GetCacheKey(AssetId assetId) => $"asset:{assetId}";
 }

--- a/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Assets/MemoryAssetTrackerTests.cs
@@ -8,6 +8,7 @@ using LazyCache.Mocks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
+using Orchestrator.Infrastructure.DataAccess;
 using Orchestrator.Settings;
 using Test.Helpers.Data;
 
@@ -15,14 +16,14 @@ namespace Orchestrator.Tests.Assets;
 
 public class MemoryAssetTrackerTests
 {
-    private readonly IAssetRepository assetRepository;
+    private readonly IOrchestratorAssetRepository assetRepository;
     private readonly IThumbRepository thumbRepository;
     private readonly ICustomerOriginStrategyRepository customerOriginStrategyRepository;
     private readonly MemoryAssetTracker sut;
 
     public MemoryAssetTrackerTests()
     {
-        assetRepository = A.Fake<IAssetRepository>();
+        assetRepository = A.Fake<IOrchestratorAssetRepository>();
         thumbRepository = A.Fake<IThumbRepository>();
         customerOriginStrategyRepository = A.Fake<ICustomerOriginStrategyRepository>();
         A.CallTo(() => customerOriginStrategyRepository.GetCustomerOriginStrategy(A<AssetId>._, A<string>._))
@@ -52,7 +53,7 @@ public class MemoryAssetTrackerTests
     {
         // Arrange
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns<Asset>(null);
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns<Asset>(null);
         
         // Act
         var result = await sut.GetOrchestrationAsset(assetId);
@@ -73,7 +74,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, Origin = "test" });
 
         // Act
@@ -96,7 +97,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, NotForDelivery = true });
         
         // Act
@@ -111,7 +112,7 @@ public class MemoryAssetTrackerTests
     {
         // Arrange
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns<Asset>(null);
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns<Asset>(null);
         
         // Act
         var result = await sut.GetOrchestrationAsset<OrchestrationAsset>(assetId);
@@ -125,7 +126,7 @@ public class MemoryAssetTrackerTests
     {
         // Arrange
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns<Asset>(null);
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns<Asset>(null);
         
         // Act
         var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
@@ -139,7 +140,7 @@ public class MemoryAssetTrackerTests
     {
         // Arrange
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset { NotForDelivery = true });
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset { NotForDelivery = true });
         
         // Act
         var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
@@ -156,7 +157,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset
             {
                 ImageDeliveryChannels = imageDeliveryChannels, Origin = "my-origin"
@@ -180,7 +181,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset
             {
                 ImageDeliveryChannels = imageDeliveryChannels, Origin = "my-origin"
@@ -206,7 +207,7 @@ public class MemoryAssetTrackerTests
         var assetId = new AssetId(1, 1, "go!");
 
         var sizes = new List<int[]> { new[] { 100, 200 } };
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels,
             Height = 10, Width = 50, Origin = "test"
@@ -234,7 +235,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, Roles = roles, OpenFullMax = openFullMax
         });
@@ -256,7 +257,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, MaxWidth = assetMaxWidth
         });
@@ -277,7 +278,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today
@@ -299,7 +300,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today.AddDays(-1)
@@ -322,7 +323,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "otis");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, Height = 10, Width = 50,
             Origin = "test", Created = DateTime.Today.AddDays(1)
@@ -346,7 +347,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels, Origin = "test" });
         
         // Act
@@ -364,7 +365,7 @@ public class MemoryAssetTrackerTests
         // Arrange
         var imageDeliveryChannels = "iiif-img".GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
-        A.CallTo(() => assetRepository.GetAsset(assetId)).Returns(new Asset
+        A.CallTo(() => assetRepository.GetAsset(assetId, false)).Returns(new Asset
         {
             ImageDeliveryChannels = imageDeliveryChannels, Roles = roles
         });
@@ -386,7 +387,7 @@ public class MemoryAssetTrackerTests
         var imageDeliveryChannels = deliveryChannels.GenerateDeliveryChannels();
         var assetId = new AssetId(1, 1, "go!");
 
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset { ImageDeliveryChannels = imageDeliveryChannels});
         
         // Act
@@ -412,7 +413,7 @@ public class MemoryAssetTrackerTests
             .Returns(Task.FromResult(new CustomerOriginStrategy
                 { Id = "_default_", Strategy = OriginStrategyType.Default, Optimised = optimised }));
         
-        A.CallTo(() => assetRepository.GetAsset(assetId))
+        A.CallTo(() => assetRepository.GetAsset(assetId, false))
             .Returns(new Asset
             {
                 ImageDeliveryChannels = imageDeliveryChannels, Origin = "test", MediaType = "audio/mpeg"
@@ -424,5 +425,33 @@ public class MemoryAssetTrackerTests
         // Assert
         result!.OptimisedOrigin.Should().Be(optimised);
         result.MediaType.ToString().Should().Be("audio/mpeg");
+    }
+    
+    [Fact]
+    public async Task RefreshCachedAsset_Null_IfNotFound()
+    {
+        // Arrange
+        var assetId = new AssetId(1, 1, "go!");
+        A.CallTo(() => assetRepository.GetAsset(assetId, true)).Returns<Asset>(null);
+        
+        // Act
+        var result = await sut.RefreshCachedAsset<OrchestrationAsset>(assetId);
+        
+        // Assert
+        result.Should().BeNull();
+    }
+    
+    [Fact]
+    public async Task RefreshCachedAsset_Null_IfAssetFoundButNotForDelivery()
+    {
+        // Arrange
+        var assetId = new AssetId(1, 1, "go!");
+        A.CallTo(() => assetRepository.GetAsset(assetId, true)).Returns(new Asset { NotForDelivery = true });
+        
+        // Act
+        var result = await sut.GetOrchestrationAsset<OrchestrationImage>(assetId);
+        
+        // Assert
+        result.Should().BeNull();
     }
 }

--- a/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
+++ b/src/protagonist/Orchestrator/Assets/MemoryAssetTracker.cs
@@ -11,6 +11,7 @@ using LazyCache;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using Orchestrator.Infrastructure.DataAccess;
 using Orchestrator.Settings;
 
 namespace Orchestrator.Assets;
@@ -19,7 +20,7 @@ namespace Orchestrator.Assets;
 /// <see cref="IAssetTracker"/> implementation using in-memory tracking
 /// </summary>
 public class MemoryAssetTracker(
-    IAssetRepository assetRepository,
+    IOrchestratorAssetRepository assetRepository,
     IAppCache appCache,
     IThumbRepository thumbRepository,
     ICustomerOriginStrategyRepository customerOriginStrategyRepository,
@@ -58,7 +59,7 @@ public class MemoryAssetTracker(
     {
         var cacheKey = GetCacheKey(assetId);
 
-        var newOrchestrationAsset = await GetOrchestrationAssetFromSource(assetId);
+        var newOrchestrationAsset = await GetOrchestrationAssetFromSource(assetId, true);
         appCache.Add(cacheKey, newOrchestrationAsset, cacheSettings.GetMemoryCacheOptions());
 
         return newOrchestrationAsset as T;
@@ -89,9 +90,9 @@ public class MemoryAssetTracker(
         }, cacheSettings.GetMemoryCacheOptions());
     }
 
-    private async Task<OrchestrationAsset?> GetOrchestrationAssetFromSource(AssetId assetId)
+    private async Task<OrchestrationAsset?> GetOrchestrationAssetFromSource(AssetId assetId, bool noCache = false)
     {
-        var asset = await assetRepository.GetAsset(assetId);
+        var asset = await assetRepository.GetAsset(assetId, noCache);
         return asset == null || asset.NotForDelivery
             ? null
             : await ConvertAssetToTrackedAsset(assetId, asset);

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
@@ -22,14 +22,17 @@ public class InfoJson2Constructor(
     IIIFAuth1Builder iiifAuth1Builder,
     IImageServerClient imageServerClient,
     IThumbRepository thumbRepository,
+    IAssetTracker assetTracker,
     ILogger<InfoJson2Constructor> logger)
-    : InfoJsonConstructorTemplate<ImageService2>(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
+    : InfoJsonConstructorTemplate<ImageService2>(imageServerClient, thumbRepository, iiifAuthBuilder, assetTracker,
+        logger)
 {
     // We want to include both Auth1 + 2 on info.json to allow for transition to auth2
 
     protected override Version ImageApiVersion => Version.V2;
-    
-    protected override async Task SetImageServiceAuthServices(ImageService2 imageService, OrchestrationImage orchestrationImage,
+
+    protected override async Task SetImageServiceAuthServices(ImageService2 imageService,
+        OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)
     {
         var authServices = await GetAuthAllServices(orchestrationImage, cancellationToken);
@@ -46,19 +49,20 @@ public class InfoJson2Constructor(
         imageService.ProfileDescription.MaxWidth = orchestrationImage.MaxWidth;
     }
 
-    protected override void SetImageServiceStubId(ImageService2 imageService, OrchestrationImage orchestrationImage) 
+    protected override void SetImageServiceStubId(ImageService2 imageService, OrchestrationImage orchestrationImage)
         => imageService.Id = $"v2/{orchestrationImage.AssetId}";
 
     protected override void SetImageServiceSizes(ImageService2 imageService, List<Size> sizes)
         => imageService.Sizes = sizes;
-    
+
     protected override void TrySetImageServiceTiles(ImageService2 imageService, OrchestrationImage orchestrationImage)
     {
         if (!ShouldUpdateTiles(imageService.Tiles, orchestrationImage)) return;
         imageService.Tiles = GetTiles(orchestrationImage);
     }
 
-    private async Task<List<IService>> GetAuthAllServices(OrchestrationImage orchestrationImage, CancellationToken cancellationToken)
+    private async Task<List<IService>> GetAuthAllServices(OrchestrationImage orchestrationImage,
+        CancellationToken cancellationToken)
     {
         var getAuthServicesForAsset = GetAuth2Service(orchestrationImage, cancellationToken);
         var getAuthCookieService = iiifAuth1Builder.GetAuthServicesForAsset(orchestrationImage.AssetId,

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
@@ -21,12 +21,15 @@ public class InfoJson3Constructor(
     IIIIFAuthBuilder iiifAuthBuilder,
     IImageServerClient imageServerClient,
     IThumbRepository thumbRepository,
+    IAssetTracker assetTracker,
     ILogger<InfoJson3Constructor> logger)
-    : InfoJsonConstructorTemplate<ImageService3>(imageServerClient, thumbRepository, iiifAuthBuilder, logger)
+    : InfoJsonConstructorTemplate<ImageService3>(imageServerClient, thumbRepository, iiifAuthBuilder, assetTracker,
+        logger)
 {
     protected override Version ImageApiVersion => Version.V3;
 
-    protected override async Task SetImageServiceAuthServices(ImageService3 imageService, OrchestrationImage orchestrationImage,
+    protected override async Task SetImageServiceAuthServices(ImageService3 imageService,
+        OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)
     {
         var authServices = await GetAuth2Service(orchestrationImage, cancellationToken);
@@ -45,10 +48,10 @@ public class InfoJson3Constructor(
         imageService.MaxWidth = orchestrationImage.MaxWidth;
     }
 
-    protected override void SetImageServiceStubId(ImageService3 imageService, OrchestrationImage orchestrationImage) 
+    protected override void SetImageServiceStubId(ImageService3 imageService, OrchestrationImage orchestrationImage)
         => imageService.Id = $"v3/{orchestrationImage.AssetId}";
 
-    protected override void SetImageServiceSizes(ImageService3 imageService, List<Size> sizes) 
+    protected override void SetImageServiceSizes(ImageService3 imageService, List<Size> sizes)
         => imageService.Sizes = sizes;
 
     protected override void TrySetImageServiceTiles(ImageService3 imageService, OrchestrationImage orchestrationImage)

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core.Collections;
+using DLCS.Core.Guard;
+using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using IIIF;
 using IIIF.ImageApi;
@@ -21,14 +23,17 @@ public abstract class InfoJsonConstructorTemplate<T>(
     IImageServerClient imageServerClient,
     IThumbRepository thumbRepository,
     IIIIFAuthBuilder iiifAuthBuilder,
+    IAssetTracker assetTracker,
     ILogger logger) : IInfoJsonConstructor where T : JsonLdBase
 {
     protected abstract IIIF.ImageApi.Version ImageApiVersion { get; }
     protected readonly ILogger Logger = logger;
 
-    public async Task<JsonLdBase?> BuildInfoJsonFromImageServer(OrchestrationImage orchestrationImage,
+    public async Task<JsonLdBase?> BuildInfoJsonFromImageServer(AssetId assetId,
         CancellationToken cancellationToken = default)
     {
+        var orchestrationImage = await GetRefreshedOrchestrationImage(assetId);
+
         var getSizesTask = GetSizes(orchestrationImage);
 
         // Get info.json from downstream image server and add dlcs-known elements (services, thumbs) to it
@@ -45,6 +50,14 @@ public abstract class InfoJsonConstructorTemplate<T>(
         }
 
         return imageService;
+    }
+
+    // We always want to generate info.json using a fresh OrchestrationImage. If it's stale we could set an invalid
+    // property (e.g. maxWidth or roles that have very recently been updated in API)
+    private async Task<OrchestrationImage> GetRefreshedOrchestrationImage(AssetId assetId)
+    {
+        var orchestrationImage = await assetTracker.RefreshCachedAsset<OrchestrationImage>(assetId);
+        return orchestrationImage.ThrowIfNull(nameof(orchestrationImage));
     }
 
     private async Task UpdateImageService(T? imageService, OrchestrationImage orchestrationImage,
@@ -162,6 +175,6 @@ public abstract class InfoJsonConstructorTemplate<T>(
 
 public interface IInfoJsonConstructor
 {
-    public Task<JsonLdBase?> BuildInfoJsonFromImageServer(OrchestrationImage orchestrationImage,
+    public Task<JsonLdBase?> BuildInfoJsonFromImageServer(AssetId assetId,
         CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonService.cs
@@ -20,30 +20,15 @@ namespace Orchestrator.Features.Images.ImageServer;
 /// <summary>
 /// Service for managing the fetching and storing of info.json requests.
 /// </summary>
-public class InfoJsonService
+public class InfoJsonService(
+    IStorageKeyGenerator storageKeyGenerator,
+    IBucketReader bucketReader,
+    IBucketWriter bucketWriter,
+    InfoJsonConstructorResolver infoJsonConstructorResolver,
+    IOptions<OrchestratorSettings> orchestratorSettings,
+    ILogger<InfoJsonService> logger)
 {
-    private readonly IStorageKeyGenerator storageKeyGenerator;
-    private readonly IBucketReader bucketReader;
-    private readonly IBucketWriter bucketWriter;
-    private readonly InfoJsonConstructorResolver infoJsonConstructorResolver;
-    private readonly OrchestratorSettings orchestratorSettings;
-    private readonly ILogger<InfoJsonService> logger;
-
-    public InfoJsonService(
-        IStorageKeyGenerator storageKeyGenerator,
-        IBucketReader bucketReader,
-        IBucketWriter bucketWriter,
-        InfoJsonConstructorResolver infoJsonConstructorResolver,
-        IOptions<OrchestratorSettings> orchestratorSettings,
-        ILogger<InfoJsonService> logger)
-    {
-        this.storageKeyGenerator = storageKeyGenerator;
-        this.bucketReader = bucketReader;
-        this.bucketWriter = bucketWriter;
-        this.infoJsonConstructorResolver = infoJsonConstructorResolver;
-        this.orchestratorSettings = orchestratorSettings.Value;
-        this.logger = logger;
-    }
+    private readonly OrchestratorSettings orchestratorSettings = orchestratorSettings.Value;
 
     public async Task<InfoJsonResponse?> GetInfoJson(OrchestrationImage orchestrationImage,
         Version version, CancellationToken cancellationToken = default)
@@ -65,7 +50,7 @@ public class InfoJsonService
         // If not found, build new copy
         var infoJsonConstructor = infoJsonConstructorResolver(version);
         var infoJsonResponse =
-            await infoJsonConstructor.BuildInfoJsonFromImageServer(orchestrationImage, cancellationToken);
+            await infoJsonConstructor.BuildInfoJsonFromImageServer(orchestrationImage.AssetId, cancellationToken);
 
         if (infoJsonResponse == null) return null;
 

--- a/src/protagonist/Orchestrator/Infrastructure/DataAccess/DapperAssetRepository.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/DataAccess/DapperAssetRepository.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
+using DLCS.Repository;
+using DLCS.Repository.Assets;
 using Microsoft.Extensions.Configuration;
 
-namespace DLCS.Repository.Assets;
+namespace Orchestrator.Infrastructure.DataAccess;
 
 /// <summary>
 /// Implementation of <see cref="IAssetRepository"/> using Dapper for data access.
@@ -13,13 +15,23 @@ namespace DLCS.Repository.Assets;
 public class DapperAssetRepository(
     IConfiguration configuration,
     AssetCachingHelper assetCachingHelper)
-    : IAssetRepository, IDapperConfigRepository
+    : IOrchestratorAssetRepository, IDapperConfigRepository
 {
     public IConfiguration Configuration { get; } = configuration;
 
     public async Task<ImageLocation?> GetImageLocation(AssetId assetId)
         => await this.QuerySingleOrDefaultAsync<ImageLocation>(ImageLocationSql, new {Id = assetId.ToString()});
-    
+
+    public Task<Asset?> GetAsset(AssetId assetId, bool noCache)
+    {
+        if (noCache)
+        {
+            assetCachingHelper.RemoveAssetFromCache(assetId);
+        }
+        
+        return GetAsset(assetId);
+    }
+
     public async Task<Asset?> GetAsset(AssetId assetId)
     {
         var asset = await assetCachingHelper.GetCachedAsset(assetId, GetAssetInternal);
@@ -31,7 +43,7 @@ public class DapperAssetRepository(
         var id = assetId.ToString();
         IEnumerable<dynamic> rawAsset = await this.QueryAsync(AssetSql, new { Id = id });
         var convertedRawAsset = rawAsset.ToList();
-        if (!convertedRawAsset.Any())
+        if (convertedRawAsset.Count == 0)
         {
             return null;
         }

--- a/src/protagonist/Orchestrator/Infrastructure/DataAccess/IOrchestratorAssetRepository.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/DataAccess/IOrchestratorAssetRepository.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+using DLCS.Core.Types;
+using DLCS.Model.Assets;
+
+namespace Orchestrator.Infrastructure.DataAccess;
+
+public interface IOrchestratorAssetRepository : IAssetRepository
+{
+    /// <summary>
+    /// Get specified asset from database
+    /// </summary>
+    /// <param name="assetId">Id of Asset to load</param>
+    /// <param name="noCache">If true the object will not be loaded from cache</param>
+    /// <returns><see cref="Asset"/> if found, or null</returns>
+    public Task<Asset?> GetAsset(AssetId assetId, bool noCache);
+}

--- a/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/ServiceCollectionX.cs
@@ -31,6 +31,7 @@ using Orchestrator.Features.Images.Orchestration;
 using Orchestrator.Infrastructure.API;
 using Orchestrator.Infrastructure.Auth;
 using Orchestrator.Infrastructure.Auth.V2;
+using Orchestrator.Infrastructure.DataAccess;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
 using Orchestrator.Infrastructure.ReverseProxy;
@@ -56,7 +57,7 @@ public static class ServiceCollectionX
             .AddSingleton<ICustomerRepository, DapperCustomerRepository>()
             .AddSingleton<IPathCustomerRepository, GranularCustomerPathElementRepository>()
             .AddSingleton<AssetCachingHelper>()
-            .AddSingleton<IAssetRepository, DapperAssetRepository>()
+            .AddSingleton<IOrchestratorAssetRepository, DapperAssetRepository>()
             .AddSingleton<IThumbRepository, ThumbRepository>()
             .AddScoped<IPolicyRepository, PolicyRepository>()
             .AddSingleton<ICredentialsRepository, DapperCredentialsRepository>()


### PR DESCRIPTION
Avoids issues where stale OrchestrationImage can be used to create info.json. We cache info.json for a long time, so created with stale data that can hang around. If info.json is missing it means the image new, or it has recently been updated and cleanup-handler has removed.

This looks like more changes than it actually is, summary:
* Add new `IOrchestratorAssetRepository : IAssetRepository`, which adds a `noCache` overload of `GetAsset()`
* `DapperAssetRepository` inherits from above, so had to move into Orchestrator (this should have been done a while ago).
* Extend `MemoryAssetTracker.RefreshCachedAsset` to call new overload with `true` (ie get a fresh asset)
* InfoJson* classes now take `AssetId` rather than `OrchestrationAsset` when building info.json.