### PR TITLE
Add support to orchestrator for inline annotations

### DIFF
--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -12,7 +12,6 @@ public static class AssetDeliveryChannels
     public const string File = "file";
     public const string None = "none";
     public const string Default = "default";
-    public const string Adjunct = "adjunct-annotations";
 
     /// <summary>
     /// All possible delivery channels

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -12,6 +12,7 @@ public static class AssetDeliveryChannels
     public const string File = "file";
     public const string None = "none";
     public const string Default = "default";
+    public const string Adjunct = "adjunct-annotations";
 
     /// <summary>
     /// All possible delivery channels

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -6,13 +6,14 @@ using DLCS.Core.Collections;
 using DLCS.Model.Assets;
 using DLCS.Model.Assets.Metadata;
 using DLCS.Model.PathElements;
+using DLCS.Web.Requests.AssetDelivery;
 using DLCS.Web.Response;
 using IIIF;
 using IIIF.ImageApi.V3;
 using IIIF.Presentation.V3.Annotation;
 using IIIF.Presentation.V3.Content;
+using IIIF.Presentation.V3.Strings;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Orchestrator.Infrastructure.IIIF;
 using Orchestrator.Infrastructure.IIIF.Manifests;
 using Test.Helpers;
@@ -24,13 +25,14 @@ public class ManifestV3BuilderTests
 {
     private readonly IManifestBuilderUtils builderUtils;
     private readonly CustomerPathElement pathElement = new(99, "test");
+    private readonly IAssetPathGenerator assetPathGenerator;
 
     private readonly ManifestV3Builder sut;
     
     public ManifestV3BuilderTests()
     {
         builderUtils = A.Fake<IManifestBuilderUtils>();
-        var assetPathGenerator = A.Fake<IAssetPathGenerator>();
+        assetPathGenerator = A.Fake<IAssetPathGenerator>();
         var authBuilder = A.Fake<IIIIFAuthBuilder>();
 
         A.CallTo(() => builderUtils.RetrieveThumbnails(A<Asset>._, A<CancellationToken>._))
@@ -512,6 +514,76 @@ public class ManifestV3BuilderTests
         image.Height.Should().Be(1000, "Height of static placeholder");
         image.Format.Should().Be("image/png", "Type of static placeholder");
         image.Service.Should().BeNull("No image service");
+    }
+    
+    [Fact]
+    public async Task BuildManifest_InlineAnnotation()
+    {
+        var asset = GetImageAsset("iiif-img");
+        asset.Adjuncts =
+        [
+            new Adjunct
+            {
+                Id = "first",
+                IIIFLink = IIIFLinkType.InlineAnnotation,
+                MediaType = "text/plain",
+                AssetId = AssetIdGenerator.GetAssetId(),
+                Type = "AnnotationPage",
+                ExternalId = new Uri("http://some.id/first")
+            },
+            new Adjunct
+            {
+                Id = "second",
+                IIIFLink = IIIFLinkType.InlineAnnotation,
+                MediaType = "text/plain",
+                AssetId = AssetIdGenerator.GetAssetId(),
+                Type = "AnnotationPage",
+                Label = new LanguageMap("en", "first"),
+                Motivation = "something",
+                Language = ["en"],
+                Profile = "some profile",
+                ExternalId = new Uri("http://some.id/second")
+            }
+        ];
+        
+        var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
+        A.CallTo(() => builderUtils.GetFullQualifiedImagePath(asset, pathElement, A<Size>._, false))
+            .Returns("https://dlcs.test/image-url/");
+        A.CallTo(() => builderUtils.GetCanvasId(asset, pathElement, A<int>._))
+            .Returns("https://dlcs.test/canvas/0");
+        A.CallTo(() => assetPathGenerator.GetFullPathForRequest(A<BasicPathElements>._, A<bool>._, A<bool>._))
+            .Returns($"https://dlcs.test/adjunct-annotations/{asset.Id}");
+
+        var manifest = await sut.BuildManifest(manifestId, "testLabel", asset.AsList(), pathElement,
+            ManifestType.NamedQuery, CancellationToken.None);
+
+        manifest.Id.Should().Be(manifestId);
+        var annotations = manifest.Items![0].Annotations;
+        annotations.Should().HaveCount(1);
+        var annotation = annotations!.First();
+        annotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset");
+        annotation.Label!.Should().BeEquivalentTo(new LanguageMap("en", "Inline annotations"));
+        annotation.Items.Should().HaveCount(2);
+        
+        var minimalInlinePaintingAnnotation =  annotation.Items!.First().As<GeneralAnnotation>();
+        minimalInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/first");
+        minimalInlinePaintingAnnotation.Motivation.Should().Be(null);
+        var minimalInlinePaintingAnnotationBody = minimalInlinePaintingAnnotation.Body!.First().As<AdjunctOutput>();
+        minimalInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/first");
+        minimalInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
+        minimalInlinePaintingAnnotationBody.Profile.Should().BeNull();
+        minimalInlinePaintingAnnotationBody.Label.Should().BeNull();
+        minimalInlinePaintingAnnotationBody.Language.Should().BeNull();
+        
+        var fullInlinePaintingAnnotation =  annotation.Items!.Last().As<GeneralAnnotation>();
+        fullInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/second");
+        fullInlinePaintingAnnotation.Motivation.Should().Be("something");
+        var fullInlinePaintingAnnotationBody = fullInlinePaintingAnnotation.Body!.First().As<AdjunctOutput>();
+        fullInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/second");
+        fullInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
+        fullInlinePaintingAnnotationBody.Profile.Should().Be("some profile");
+        fullInlinePaintingAnnotationBody.Label!.Should().BeEquivalentTo(new LanguageMap("en", "first"));
+        fullInlinePaintingAnnotationBody.Language.Should().OnlyContain(l => l == "en");
     }
     
     private static Asset GetImageAsset(string deliveryChannels) =>

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -568,7 +568,7 @@ public class ManifestV3BuilderTests
         var minimalInlinePaintingAnnotation =  annotation.Items!.First().As<GeneralAnnotation>();
         minimalInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/first");
         minimalInlinePaintingAnnotation.Motivation.Should().Be(null);
-        var minimalInlinePaintingAnnotationBody = minimalInlinePaintingAnnotation.Body!.First().As<AdjunctOutput>();
+        var minimalInlinePaintingAnnotationBody = minimalInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
         minimalInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/first");
         minimalInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
         minimalInlinePaintingAnnotationBody.Profile.Should().BeNull();
@@ -578,7 +578,7 @@ public class ManifestV3BuilderTests
         var fullInlinePaintingAnnotation =  annotation.Items!.Last().As<GeneralAnnotation>();
         fullInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/second");
         fullInlinePaintingAnnotation.Motivation.Should().Be("something");
-        var fullInlinePaintingAnnotationBody = fullInlinePaintingAnnotation.Body!.First().As<AdjunctOutput>();
+        var fullInlinePaintingAnnotationBody = fullInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
         fullInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/second");
         fullInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
         fullInlinePaintingAnnotationBody.Profile.Should().Be("some profile");

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -815,7 +815,7 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             .WithTestAdjunct("seeAlso2", type: "Text", mediaType: "text/xml", iiifLinkType: IIIFLinkType.SeeAlso,
                 externalId: "https://other.example/2")
             .WithTestAdjunct("inlineAnnotation1", type: "AnnotationPage", mediaType: "text/xml", iiifLinkType: IIIFLinkType.InlineAnnotation,
-                externalId: "https://inline.example/1")
+                externalId: "https://inline.example/1", motivation: "something")
             .WithTestAdjunct("inlineAnnotation2", type: "AnnotationPage", mediaType: "text/xml", iiifLinkType: IIIFLinkType.InlineAnnotation,
                 externalId: "https://inline.example/2");
         
@@ -827,8 +827,8 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             new() { Id = $"http://localhost/adjunct-annotations/{id}", Label = new LanguageMap("en", "Inline annotations"), 
                 Items = 
                 [
-                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation1", Body = [new AdjunctOutput("AnnotationPage"){ Id = "https://inline.example/1", Format = "text/xml"}]},
-                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation2", Body = [new AdjunctOutput("AnnotationPage"){ Id = "https://inline.example/2", Format = "text/xml"}]}
+                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation1", Motivation = "something", Body = [new ExternalResource("AnnotationPage"){ Id = "https://inline.example/1", Format = "text/xml"}]},
+                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation2", Body = [new ExternalResource("AnnotationPage"){ Id = "https://inline.example/2", Format = "text/xml"}]}
                 ]}
         ];
 

--- a/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ManifestHandlingTests.cs
@@ -14,6 +14,7 @@ using IIIF.Serialisation;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using Orchestrator.Infrastructure.IIIF;
+using Orchestrator.Infrastructure.IIIF.Manifests;
 using Orchestrator.Tests.Integration.Infrastructure;
 using Test.Helpers;
 using Test.Helpers.Data;
@@ -812,13 +813,23 @@ public class ManifestHandlingTests : IClassFixture<ProtagonistAppFactory<Startup
             .WithTestAdjunct("rendering1", type: "Text", mediaType: "application/pdf", iiifLinkType: IIIFLinkType.Rendering,
                 label: new LanguageMap("none", "PDF of image"), externalId: "https://pdf.example/1", language: ["fr"])
             .WithTestAdjunct("seeAlso2", type: "Text", mediaType: "text/xml", iiifLinkType: IIIFLinkType.SeeAlso,
-                externalId: "https://other.example/2");
+                externalId: "https://other.example/2")
+            .WithTestAdjunct("inlineAnnotation1", type: "AnnotationPage", mediaType: "text/xml", iiifLinkType: IIIFLinkType.InlineAnnotation,
+                externalId: "https://inline.example/1")
+            .WithTestAdjunct("inlineAnnotation2", type: "AnnotationPage", mediaType: "text/xml", iiifLinkType: IIIFLinkType.InlineAnnotation,
+                externalId: "https://inline.example/2");
         
         await dbFixture.DbContext.SaveChangesAsync();
 
         List<AnnotationPage> expectedAnnos =
         [
-            new() { Id = "https://mets.example/w3c", Label = new LanguageMap("en", "Line-level annos") }
+            new() { Id = "https://mets.example/w3c", Label = new LanguageMap("en", "Line-level annos") },
+            new() { Id = $"http://localhost/adjunct-annotations/{id}", Label = new LanguageMap("en", "Inline annotations"), 
+                Items = 
+                [
+                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation1", Body = [new AdjunctOutput("AnnotationPage"){ Id = "https://inline.example/1", Format = "text/xml"}]},
+                    new GeneralAnnotation(null){Id = $"http://localhost/adjunct-annotations/{id}/inlineAnnotation2", Body = [new AdjunctOutput("AnnotationPage"){ Id = "https://inline.example/2", Format = "text/xml"}]}
+                ]}
         ];
 
         List<ExternalResource> expectedSeeAlso =

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -509,6 +509,29 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                     canvas.Rendering ??= [];
                     canvas.Rendering.Add(CreateExternalResource(adjunct));
                     break;
+                case IIIFLinkType.InlineAnnotation:
+                    canvas.Annotations ??= [];
+                    canvas.Annotations.Add(new AnnotationPage
+                    {
+                        Id = GetPathForAdjunct(adjunct, asset.Customer),
+                        Label = new LanguageMap("en", "Inline annotations"),
+                        Items = [
+                            new PaintingAnnotation
+                            {
+                                Id = $"{GetPathForAdjunct(adjunct, asset.Customer)}/{adjunct.Id}",
+                                Motivation = adjunct.Motivation,
+                                Body = new AdjunctAnnotation(adjunct.Type)
+                                {
+                                    Id = adjunct.ExternalId.ToString(),
+                                    Format = adjunct.MediaType,
+                                    Profile = adjunct.Profile,
+                                    Label = adjunct.Label,
+                                    Language = adjunct.Language?.ToList(),
+                                }
+                            }
+                        ]
+                    });
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(adjunct.IIIFLink), adjunct.IIIFLink,
                         "IIIFLink type not supported");
@@ -525,4 +548,18 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             Language = adjunct.Language?.ToList(),
         };
     }
+    
+    private string GetPathForAdjunct(Adjunct adjunct, int customerId)
+    {
+        var transcodeRequest = new BasicPathElements
+        {
+            Space = adjunct.Asset.Space,
+            AssetPath = adjunct.Asset.Id.Asset,
+            RoutePrefix = AssetDeliveryChannels.Adjunct,
+            CustomerPathValue = customerId.ToString(),
+        };
+        return assetPathGenerator.GetFullPathForRequest(transcodeRequest, BuilderUtils.UseNativeFormatForAssets, false);
+    }
 }
+
+public class AdjunctAnnotation(string type) : ExternalResource(type), IPaintable;

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -510,27 +510,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                     canvas.Rendering.Add(CreateExternalResource(adjunct));
                     break;
                 case IIIFLinkType.InlineAnnotation:
-                    canvas.Annotations ??= [];
-                    canvas.Annotations.Add(new AnnotationPage
-                    {
-                        Id = GetPathForAdjunct(adjunct, asset.Customer),
-                        Label = new LanguageMap("en", "Inline annotations"),
-                        Items = [
-                            new PaintingAnnotation
-                            {
-                                Id = $"{GetPathForAdjunct(adjunct, asset.Customer)}/{adjunct.Id}",
-                                Motivation = adjunct.Motivation,
-                                Body = new AdjunctAnnotation(adjunct.Type)
-                                {
-                                    Id = adjunct.ExternalId.ToString(),
-                                    Format = adjunct.MediaType,
-                                    Profile = adjunct.Profile,
-                                    Label = adjunct.Label,
-                                    Language = adjunct.Language?.ToList(),
-                                }
-                            }
-                        ]
-                    });
+                    CreateInlineAnnotation(canvas, adjunct);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(adjunct.IIIFLink), adjunct.IIIFLink,
@@ -538,28 +518,64 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             }
         }
 
-        // "rendering" and "seeAlso" are ExternalResources
-        ExternalResource CreateExternalResource(Adjunct adjunct) => new(adjunct.Type)
+        return;
+
+        // generates inline annotation output for adjuncts
+        void CreateInlineAnnotation(Canvas currentCanvas, Adjunct adjunct)
         {
-            Id = adjunct.ExternalId.ToString(),
-            Format = adjunct.MediaType,
-            Profile = adjunct.Profile,
-            Label = adjunct.Label,
-            Language = adjunct.Language?.ToList(),
-        };
+            var inlineAnnotationPage = currentCanvas.Annotations?.FirstOrDefault(a => !a.Items.IsNullOrEmpty());
+        
+            if (inlineAnnotationPage == null)
+            {
+                currentCanvas.Annotations ??= [];
+                currentCanvas.Annotations.Add(new AnnotationPage
+                {
+                    Id = GetPathForAdjunct(adjunct),
+                    Label = new LanguageMap("en", "Inline annotations"),
+                    Items =
+                    [
+                        new GeneralAnnotation(adjunct.Motivation)
+                        {
+                            Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
+                            Body = [CreateExternalResource(adjunct)]
+                        }
+                    ]
+                });
+            }
+            else
+            {
+                inlineAnnotationPage.Items!.Add(new GeneralAnnotation(adjunct.Motivation)
+                {
+                    Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
+                    Body = [CreateExternalResource(adjunct)]
+                });
+            }
+        }
+
+        // "rendering", "seeAlso" and "inline annotations" are the same style of output
+        AdjunctOutput CreateExternalResource(Adjunct adjunct) =>
+            new(adjunct.Type)
+            {
+                Id = adjunct.ExternalId.ToString(),
+                Format = adjunct.MediaType,
+                Profile = adjunct.Profile,
+                Label = adjunct.Label,
+                Language = adjunct.Language?.ToList(),
+            };
     }
-    
-    private string GetPathForAdjunct(Adjunct adjunct, int customerId)
+
+
+    private string GetPathForAdjunct(Adjunct adjunct)
     {
         var transcodeRequest = new BasicPathElements
         {
-            Space = adjunct.Asset.Space,
-            AssetPath = adjunct.Asset.Id.Asset,
+            Space = adjunct.AssetId.Space,
+            AssetPath = adjunct.AssetId.Asset,
             RoutePrefix = AssetDeliveryChannels.Adjunct,
-            CustomerPathValue = customerId.ToString(),
+            CustomerPathValue = adjunct.AssetId.Customer.ToString(),
         };
         return assetPathGenerator.GetFullPathForRequest(transcodeRequest, BuilderUtils.UseNativeFormatForAssets, false);
     }
 }
 
-public class AdjunctAnnotation(string type) : ExternalResource(type), IPaintable;
+public class AdjunctOutput(string type) : ExternalResource(type), IPaintable;

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -35,6 +35,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
     private readonly IAssetPathGenerator assetPathGenerator;
     private readonly IIIIFAuthBuilder authBuilder;
     private readonly ILogger<ManifestV3Builder> logger;
+    private const string AdjunctRoutePrefix = "adjunct-annotations";
 
     /// <summary>
     /// Implementation of <see cref="IBuildManifests{T}"/> responsible for generating IIIF v3 manifest
@@ -530,30 +531,23 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                 currentCanvas.Annotations ??= [];
                 currentCanvas.Annotations.Add(new AnnotationPage
                 {
-                    Id = GetPathForAdjunct(adjunct),
+                   Id = GetPathForAdjunct(adjunct),
                     Label = new LanguageMap("en", "Inline annotations"),
-                    Items =
-                    [
-                        new GeneralAnnotation(adjunct.Motivation)
-                        {
-                            Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
-                            Body = [CreateExternalResource(adjunct)]
-                        }
-                    ]
+                    Items = []
                 });
+
+                inlineAnnotationPage = currentCanvas.Annotations.Last();
             }
-            else
+            
+            inlineAnnotationPage.Items!.Add(new GeneralAnnotation(adjunct.Motivation)
             {
-                inlineAnnotationPage.Items!.Add(new GeneralAnnotation(adjunct.Motivation)
-                {
-                    Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
-                    Body = [CreateExternalResource(adjunct)]
-                });
-            }
+                Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
+                Body = [CreateExternalResource(adjunct)]
+            });
         }
 
         // "rendering", "seeAlso" and "inline annotations" are the same style of output
-        AdjunctOutput CreateExternalResource(Adjunct adjunct) =>
+        ExternalResource CreateExternalResource(Adjunct adjunct) =>
             new(adjunct.Type)
             {
                 Id = adjunct.ExternalId.ToString(),
@@ -564,18 +558,15 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             };
     }
 
-
     private string GetPathForAdjunct(Adjunct adjunct)
     {
-        var transcodeRequest = new BasicPathElements
+        var adjunctRequest = new BasicPathElements
         {
             Space = adjunct.AssetId.Space,
             AssetPath = adjunct.AssetId.Asset,
-            RoutePrefix = AssetDeliveryChannels.Adjunct,
+            RoutePrefix = AdjunctRoutePrefix,
             CustomerPathValue = adjunct.AssetId.Customer.ToString(),
         };
-        return assetPathGenerator.GetFullPathForRequest(transcodeRequest, BuilderUtils.UseNativeFormatForAssets, false);
+        return assetPathGenerator.GetFullPathForRequest(adjunctRequest, true, false);
     }
 }
-
-public class AdjunctOutput(string type) : ExternalResource(type), IPaintable;

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -35,7 +35,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
     private readonly IAssetPathGenerator assetPathGenerator;
     private readonly IIIIFAuthBuilder authBuilder;
     private readonly ILogger<ManifestV3Builder> logger;
-    private const string AdjunctRoutePrefix = "adjunct-annotations";
+    private const string AdjunctAnnotationRoutePrefix = "adjunct-annotations";
 
     /// <summary>
     /// Implementation of <see cref="IBuildManifests{T}"/> responsible for generating IIIF v3 manifest
@@ -532,8 +532,8 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                 currentCanvas.Annotations.Add(new AnnotationPage
                 {
                    Id = GetPathForAdjunct(adjunct),
-                    Label = new LanguageMap("en", "Inline annotations"),
-                    Items = []
+                   Label = new LanguageMap("en", "Inline annotations"),
+                   Items = []
                 });
 
                 inlineAnnotationPage = currentCanvas.Annotations.Last();
@@ -564,7 +564,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
         {
             Space = adjunct.AssetId.Space,
             AssetPath = adjunct.AssetId.Asset,
-            RoutePrefix = AdjunctRoutePrefix,
+            RoutePrefix = AdjunctAnnotationRoutePrefix,
             CustomerPathValue = adjunct.AssetId.Customer.ToString(),
         };
         return assetPathGenerator.GetFullPathForRequest(adjunctRequest, true, false);


### PR DESCRIPTION
Resolves #1113 

This PR adds inline annotation adjuncts to the output from orchestrator.  It will collect all `inlineAnnotations` into a single annotation and makes the assumption that if there is an `annotation.Items` property available, that this is a collection of `inlineAnnotations`

This will create output like the below on a manifest:

```json
"annotations": [
                {
                    "id": "https://localhost:5003/adjunct-annotations/26/1/test-image",
                    "type": "AnnotationPage",
                    "label": {
                        "en": [
                            "Inline annotations"
                        ]
                    },
                    "items": [
                        {
                            "id": "https://localhost:5003/adjunct-annotations/26/1/test-image/anotherAdjunct",
                            "type": "Annotation",
                            "motivation": "something",
                            "body": {
                                "id": "https://some-location.com/an-adjunct",
                                "type": "Image",
                                "label": {
                                    "label": [
                                        "value"
                                    ]
                                },
                                "format": "a-mediaType",
                                "language": [
                                    "en"
                                ]
                            }
                        },
                        {
                            "id": "https://localhost:5003/adjunct-annotations/26/1/test-image/anotherAdjunct2",
                            "type": "Annotation",
                            "motivation": "something",
                            "body": {
                                "id": "https://some-location.com/an-adjunct",
                                "type": "Image",
                                "label": {
                                    "label": [
                                        "value"
                                    ]
                                },
                                "format": "a-mediaType",
                                "language": [
                                    "en"
                                ]
                            }
                        }
                    ]
                }
            ]
```