### PR TITLE
Handle very small maxWidth values and "sizes" in info.json

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -80,17 +80,19 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_DeliveryChannelMissingChannel()
     {
-        var model = new Image { DeliveryChannels =
-        [
-            new DeliveryChannel
-            {
-                Policy = "none"
-            },
-            new DeliveryChannel
-            {
-                Channel = "file"
-            }
-        ]
+        var model = new Image
+        {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                {
+                    Policy = "none"
+                },
+                new DeliveryChannel
+                {
+                    Channel = "file"
+                }
+            ]
         };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
@@ -99,17 +101,19 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenNoneAndMoreDeliveryChannels()
     {
-        var model = new Image { DeliveryChannels =
-        [
-            new DeliveryChannel
-            {
-                Channel = "none"
-            },
-            new DeliveryChannel
-            {
-                Channel = "file"
-            }
-        ]
+        var model = new Image
+        {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                {
+                    Channel = "none"
+                },
+                new DeliveryChannel
+                {
+                    Channel = "file"
+                }
+            ]
         };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
@@ -118,17 +122,19 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenDefaultAndMoreDeliveryChannels()
     {
-        var model = new Image { DeliveryChannels =
-        [
-            new DeliveryChannel
-            {
-                Channel = "default"
-            },
-            new DeliveryChannel
-            {
-                Channel = "file"
-            }
-        ]
+        var model = new Image
+        {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                {
+                    Channel = "default"
+                },
+                new DeliveryChannel
+                {
+                    Channel = "file"
+                }
+            ]
         };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
@@ -137,17 +143,19 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsWithNoNone()
     {
-        var model = new Image { DeliveryChannels =
-        [
-            new DeliveryChannel
-            {
-                Channel = "iiif-img"
-            },
-            new DeliveryChannel
-            {
-                Channel = "file"
-            }
-        ]
+        var model = new Image
+        {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                    {
+                        Channel = "iiif-img"
+                    },
+                    new DeliveryChannel
+                    {
+                        Channel = "file"
+                    }
+            ]
         };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
@@ -156,13 +164,15 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenOnlyNone()
     {
-        var model = new Image { DeliveryChannels =
-        [
-            new DeliveryChannel
-            {
-                Channel = "none"
-            }
-        ]
+        var model = new Image
+        {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                {
+                    Channel = "none"
+                }
+            ]
         };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
@@ -183,7 +193,8 @@ public class HydraImageValidatorTests
     [InlineData("application/pdf", "none")]
     public void DeliveryChannel_NoValidationError_WhenChannelValidForMediaType(string mediaType, string channel)
     {
-        var model = new Image { 
+        var model = new Image
+        {
             MediaType = mediaType,
             DeliveryChannels =
             [
@@ -206,14 +217,15 @@ public class HydraImageValidatorTests
     [InlineData("application/pdf", "iiif-av")]
     public void DeliveryChannel_ValidationError_WhenWrongChannelForMediaType(string mediaType, string channel)
     {
-        var model = new Image { 
+        var model = new Image
+        {
             MediaType = mediaType,
             DeliveryChannels =
             [
                 new DeliveryChannel
-                {
-                Channel = channel,
-            }
+                    {
+                        Channel = channel,
+                    }
             ]
         };
         var result = Sut.TestValidate(model);

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -273,4 +273,28 @@ public class HydraImageValidatorTests
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.MaxWidth);
     }
+    
+    [Fact]
+    public void MaxWidth_TooSmall()
+    {
+        var model = new Image
+        {
+            MaxWidth = new ApiSettings().MinimumMaxWidth - 1
+        };
+        var result = Sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(a => a.MaxWidth);
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData(-1)]
+    public void MaxWidth_CanBeZeroOrNegative(int? maxWidth)
+    {
+        var model = new Image
+        {
+            MaxWidth = maxWidth
+        };
+        var result = Sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.MaxWidth);
+    }
 }

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -9,7 +9,8 @@ namespace API.Tests.Features.Images.Validation;
 
 public class HydraImageValidatorTests
 {
-    private static HydraImageValidator Sut => new(Options.Create(new ApiSettings()));
+    private static readonly ApiSettings apiSettings = new();
+    private static HydraImageValidator Sut => new(Options.Create(apiSettings));
 
     [Theory]
     [InlineData(null)]
@@ -79,17 +80,18 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_DeliveryChannelMissingChannel()
     {
-        var model = new Image { DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
+        var model = new Image { DeliveryChannels =
+        [
+            new DeliveryChannel
             {
                 Policy = "none"
             },
-            new DeliveryChannel()
+            new DeliveryChannel
             {
                 Channel = "file"
             }
-        } };
+        ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -97,17 +99,18 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenNoneAndMoreDeliveryChannels()
     {
-        var model = new Image { DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
+        var model = new Image { DeliveryChannels =
+        [
+            new DeliveryChannel
             {
                 Channel = "none"
             },
-            new DeliveryChannel()
+            new DeliveryChannel
             {
                 Channel = "file"
             }
-        } };
+        ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -115,17 +118,18 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_ValidationError_WhenDefaultAndMoreDeliveryChannels()
     {
-        var model = new Image { DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
+        var model = new Image { DeliveryChannels =
+        [
+            new DeliveryChannel
             {
                 Channel = "default"
             },
-            new DeliveryChannel()
+            new DeliveryChannel
             {
                 Channel = "file"
             }
-        } };
+        ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -133,17 +137,18 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenDeliveryChannelsWithNoNone()
     {
-        var model = new Image { DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
+        var model = new Image { DeliveryChannels =
+        [
+            new DeliveryChannel
             {
                 Channel = "iiif-img"
             },
-            new DeliveryChannel()
+            new DeliveryChannel
             {
                 Channel = "file"
             }
-        } };
+        ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -151,13 +156,14 @@ public class HydraImageValidatorTests
     [Fact]
     public void DeliveryChannel_NoValidationError_WhenOnlyNone()
     {
-        var model = new Image { DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
+        var model = new Image { DeliveryChannels =
+        [
+            new DeliveryChannel
             {
                 Channel = "none"
             }
-        } };
+        ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -179,13 +185,14 @@ public class HydraImageValidatorTests
     {
         var model = new Image { 
             MediaType = mediaType,
-            DeliveryChannels = new[]
-            {
-                new DeliveryChannel()
+            DeliveryChannels =
+            [
+                new DeliveryChannel
                 {
                     Channel = channel,
                 }
-            } };
+            ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -201,13 +208,14 @@ public class HydraImageValidatorTests
     {
         var model = new Image { 
             MediaType = mediaType,
-            DeliveryChannels = new[]
-        {
-            new DeliveryChannel()
-            {
+            DeliveryChannels =
+            [
+                new DeliveryChannel
+                {
                 Channel = channel,
             }
-        } };
+            ]
+        };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.DeliveryChannels);
     }
@@ -217,7 +225,7 @@ public class HydraImageValidatorTests
     {
         var model = new Image
         {
-            DeliveryChannels = Array.Empty<DeliveryChannel>()
+            DeliveryChannels = []
         };
         var result = Sut.TestValidate(model, options => 
             options.IncludeRuleSets("default", "patch"));
@@ -268,7 +276,7 @@ public class HydraImageValidatorTests
     {
         var model = new Image
         {
-            MaxWidth = new ApiSettings().MaxWidth + 1
+            MaxWidth = apiSettings.MaxWidth + 1
         };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.MaxWidth);
@@ -279,7 +287,7 @@ public class HydraImageValidatorTests
     {
         var model = new Image
         {
-            MaxWidth = new ApiSettings().MinimumMaxWidth - 1
+            MaxWidth = apiSettings.MinimumMaxWidth - 1
         };
         var result = Sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor(a => a.MaxWidth);
@@ -293,6 +301,28 @@ public class HydraImageValidatorTests
         var model = new Image
         {
             MaxWidth = maxWidth
+        };
+        var result = Sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.MaxWidth);
+    }
+    
+    [Fact]
+    public void MaxWidth_CanBeMinSize()
+    {
+        var model = new Image
+        {
+            MaxWidth = apiSettings.MinimumMaxWidth
+        };
+        var result = Sut.TestValidate(model);
+        result.ShouldNotHaveValidationErrorFor(a => a.MaxWidth);
+    }
+    
+    [Fact]
+    public void MaxWidth_CanBeMaxSize()
+    {
+        var model = new Image
+        {
+            MaxWidth = apiSettings.MaxWidth
         };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.MaxWidth);

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -30,9 +30,16 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .When(a => a.MaxWidth.HasValue || a.OpenFullMax.HasValue)
             .WithMessage("'maxUnauthorised' cannot be set when 'maxWidth' or 'openFullMax' is set");
         
+        // MaxWidth must be negative or null (ie unset) or, if it is set it mj
         RuleFor(a => a.MaxWidth)
-            .Must(mw => (mw ?? 0) <= apiSettings.Value.MaxWidth)
-            .WithMessage($"'maxWidth' cannot exceed system-default {apiSettings.Value.MaxWidth}.");
+            .Must(mw =>
+            {
+                var maxWidthValue = mw ?? apiSettings.Value.MinimumMaxWidth;
+                return maxWidthValue >= apiSettings.Value.MinimumMaxWidth && maxWidthValue < apiSettings.Value.MaxWidth;
+            })
+            .When(asset => asset.MaxWidth is > 0)
+            .WithMessage(
+                $"'maxWidth' must be between {apiSettings.Value.MinimumMaxWidth} and {apiSettings.Value.MaxWidth}.");
         
         // Legacy policy fields
         RuleFor(a => a.ImageOptimisationPolicy).Null()

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -30,12 +30,12 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
             .When(a => a.MaxWidth.HasValue || a.OpenFullMax.HasValue)
             .WithMessage("'maxUnauthorised' cannot be set when 'maxWidth' or 'openFullMax' is set");
         
-        // MaxWidth must be negative or null (ie unset) or, if it is set it mj
+        // MaxWidth must be negative or null (ie unset) or, if it is set it must be between the min and max values
         RuleFor(a => a.MaxWidth)
             .Must(mw =>
             {
                 var maxWidthValue = mw ?? apiSettings.Value.MinimumMaxWidth;
-                return maxWidthValue >= apiSettings.Value.MinimumMaxWidth && maxWidthValue < apiSettings.Value.MaxWidth;
+                return maxWidthValue >= apiSettings.Value.MinimumMaxWidth && maxWidthValue <= apiSettings.Value.MaxWidth;
             })
             .When(asset => asset.MaxWidth is > 0)
             .WithMessage(

--- a/src/protagonist/API/Settings/ApiSettings.cs
+++ b/src/protagonist/API/Settings/ApiSettings.cs
@@ -25,6 +25,11 @@ public class ApiSettings
     public int MaxWidth { get; set; } = SystemDefaults.MaxWidth;
     
     /// <summary>
+    /// The lowest possible maxWidth value
+    /// </summary>
+    public int MinimumMaxWidth { get; set; } = SystemDefaults.MinimumMaxWidth;
+    
+    /// <summary>
     /// The default PageSize for endpoints that support paging 
     /// </summary>
     public int PageSize { get; set; }

--- a/src/protagonist/DLCS.Core/Settings/SystemDefaults.cs
+++ b/src/protagonist/DLCS.Core/Settings/SystemDefaults.cs
@@ -10,4 +10,9 @@ public static class SystemDefaults
     /// that exceed this.
     /// </remarks>
     public const int MaxWidth = 5000;
+
+    /// <summary>
+    /// The system default minimum allowed value for the maxWidth property.
+    /// </summary>
+    public const int MinimumMaxWidth = 256;
 }

--- a/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Integration/ImageHandlingTests.cs
@@ -356,6 +356,46 @@ public class ImageHandlingTests : IClassFixture<ProtagonistAppFactory<Startup>>
         infoJson.MaxWidth.Should().Be(5000, "Fallback to system-default");
     }
     
+    [Fact]
+    public async Task GetInfoJson_RemovesSizesLargerThanMaxWidth_IfNoThumbsFound()
+    {
+        // This should be an uncommon scenario, see https://github.com/dlcs/protagonist/issues/1123#issuecomment-4010901536
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, maxWidth: 75,
+            imageDeliveryChannels: deliveryChannelsForImage); 
+        // NOTE - no s3 thumbs data setup
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService3>();
+
+        var sizes = new List<Size> { new(25, 25), new(1, 1) };
+        infoJson.Sizes.Should().BeEquivalentTo(sizes, "100 size removed as greater than maxWidth");
+    }
+    
+    [Fact]
+    public async Task GetInfoJsonV2_RemovesSizesLargerThanMaxWidth_IfNoThumbsFound()
+    {
+        // This should be an uncommon scenario, see https://github.com/dlcs/protagonist/issues/1123#issuecomment-4010901536
+        var id = AssetIdGenerator.GetAssetId();
+        await dbFixture.DbContext.Images.AddTestAsset(id, maxWidth: 75,
+            imageDeliveryChannels: deliveryChannelsForImage); 
+        // NOTE - no s3 thumbs data setup
+        await dbFixture.DbContext.SaveChangesAsync();
+
+        // Act
+        var response = await httpClient.GetAsync($"iiif-img/v2/{id}/info.json");
+
+        // Assert
+        var infoJson = (await response.Content.ReadAsStreamAsync()).FromJsonStream<ImageService2>();
+
+        var sizes = new List<Size> { new(25, 25), new(1, 1) };
+        infoJson.Sizes.Should().BeEquivalentTo(sizes, "100 size removed as greater than maxWidth");
+    }
+    
     [Theory]
     [InlineData(500, 256)]
     [InlineData(512, 512)]

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson2Constructor.cs
@@ -31,6 +31,8 @@ public class InfoJson2Constructor(
 
     protected override Version ImageApiVersion => Version.V2;
 
+    protected override List<Size> GetImageServiceSizes(ImageService2 imageService) => imageService.Sizes;
+
     protected override async Task SetImageServiceAuthServices(ImageService2 imageService,
         OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJson3Constructor.cs
@@ -28,6 +28,8 @@ public class InfoJson3Constructor(
 {
     protected override Version ImageApiVersion => Version.V3;
 
+    protected override List<Size> GetImageServiceSizes(ImageService3 imageService) => imageService.Sizes;
+
     protected override async Task SetImageServiceAuthServices(ImageService3 imageService,
         OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken)

--- a/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
+++ b/src/protagonist/Orchestrator/Features/Images/ImageServer/InfoJsonConstructorTemplate.cs
@@ -34,24 +34,37 @@ public abstract class InfoJsonConstructorTemplate<T>(
     {
         var orchestrationImage = await GetRefreshedOrchestrationImage(assetId);
 
-        var getSizesTask = GetSizes(orchestrationImage);
+        // Start task to get "sizes" from thumbnails - the vast majority of cases will have set sizes
+        var getSizesFromThumbnailsTask = GetSizes(orchestrationImage);
 
         // Get info.json from downstream image server and add dlcs-known elements (services, thumbs) to it
-        // TODO - handle 501 etc from downstream image-server
         var imageService =
             await imageServerClient.GetInfoJson<T>(orchestrationImage, ImageApiVersion, cancellationToken);
         if (imageService == null) return null;
 
         await UpdateImageService(imageService, orchestrationImage, cancellationToken);
-        var sizes = await getSizesTask;
-        if (!sizes.IsNullOrEmpty())
-        {
-            SetImageServiceSizes(imageService, sizes);
-        }
+        var sizesFromThumbnails = await getSizesFromThumbnailsTask;
+        SetInfoJsonSizes(imageService, orchestrationImage, sizesFromThumbnails);
 
         return imageService;
     }
 
+    private void SetInfoJsonSizes(T imageService, OrchestrationImage orchestrationImage, List<Size> sizesFromThumbnails)
+    {
+        if (!sizesFromThumbnails.IsNullOrEmpty())
+        {
+            SetImageServiceSizes(imageService, sizesFromThumbnails);
+            return;
+        }
+
+        // If we didn't get any sizes from thumbnails, filter those from image-service
+        logger.LogInformation("No sizes found for {AssetId}, filtering those from image-server",
+            orchestrationImage.AssetId);
+        var imageServerSizes = GetImageServiceSizes(imageService);
+        var correctedSizes = imageServerSizes.Where(sz => sz.MaxDimension <= orchestrationImage.MaxWidth).ToList();
+        SetImageServiceSizes(imageService, correctedSizes);
+    }
+    
     // We always want to generate info.json using a fresh OrchestrationImage. If it's stale we could set an invalid
     // property (e.g. maxWidth or roles that have very recently been updated in API)
     private async Task<OrchestrationImage> GetRefreshedOrchestrationImage(AssetId assetId)
@@ -90,6 +103,11 @@ public abstract class InfoJsonConstructorTemplate<T>(
         TrySetImageServiceTiles(imageService, orchestrationImage);
     }
 
+    /// <summary>
+    /// Get "sizes" from image service
+    /// </summary>
+    protected abstract List<Size> GetImageServiceSizes(T imageService);
+    
     /// <summary>
     /// Add required auth services to "services" property
     /// </summary>


### PR DESCRIPTION
## What does this change?

Fixes #1123 . See final comment, logic is:

* Prevent creation of image with `maxWidth` < 256
* If building info.json and no thumbnails found, use those from image-server but filter out any that exceed `maxWidth`.