### PR TITLE
Add /version endpoint to API and Orchestrator

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -48,3 +48,5 @@ runs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         push: ${{ github.actor != 'dependabot[bot]' }}
+        build-args: |
+          APP_VERSION=${{ steps.docker-meta.outputs.version }}

--- a/Dockerfile.API
+++ b/Dockerfile.API
@@ -23,6 +23,8 @@ FROM build AS publish
 RUN dotnet publish "API.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.CleanupHandler
+++ b/Dockerfile.CleanupHandler
@@ -17,6 +17,8 @@ FROM build AS publish
 RUN dotnet publish "CleanupHandler.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Engine
+++ b/Dockerfile.Engine
@@ -19,6 +19,8 @@ FROM build AS publish
 RUN dotnet publish "Engine.csproj" --no-restore -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Migrator
+++ b/Dockerfile.Migrator
@@ -18,6 +18,8 @@ FROM build AS publish
 RUN dotnet publish "Migrator.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Orchestrator
+++ b/Dockerfile.Orchestrator
@@ -23,6 +23,8 @@ FROM build AS publish
 RUN dotnet publish "Orchestrator.csproj" --no-restore -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Portal
+++ b/Dockerfile.Portal
@@ -24,6 +24,8 @@ FROM build AS publish
 RUN dotnet publish "Portal.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/Dockerfile.Thumbs
+++ b/Dockerfile.Thumbs
@@ -19,6 +19,8 @@ FROM build AS publish
 RUN dotnet publish "Thumbs.csproj" -c Release -o /app/publish
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim AS base
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>,Tom Crane <tom.crane@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/protagonist

--- a/src/protagonist/API/Startup.cs
+++ b/src/protagonist/API/Startup.cs
@@ -17,6 +17,7 @@ using DLCS.Repository;
 using DLCS.Repository.Messaging;
 using DLCS.Repository.NamedQueries;
 using DLCS.Repository.NamedQueries.Infrastructure;
+using DLCS.Web;
 using DLCS.Web.Auth;
 using DLCS.Web.Configuration;
 using DLCS.Web.Handlers;
@@ -162,6 +163,7 @@ public class Startup
                     .MapControllers()
                     .RequireAuthorization();
                 endpoints.MapHealthChecks("/ping").AllowAnonymous();
+                endpoints.AddVersionEndpoint();
             });
     }
 }

--- a/src/protagonist/DLCS.Web/EndpointBuilderX.cs
+++ b/src/protagonist/DLCS.Web/EndpointBuilderX.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace DLCS.Web;
+
+public static class EndpointBuilderX
+{
+    /// <summary>
+    /// Add end endpoint that outputs a simple {"version": "x.y.z"} response
+    /// </summary>
+    public static RouteHandlerBuilder AddVersionEndpoint(this IEndpointRouteBuilder endpoints, string path = "/version",
+        string fallback = "unknown") =>
+        endpoints.MapGet(path, () => new
+        {
+            version = Environment.GetEnvironmentVariable("APP_VERSION") ?? fallback
+        });
+}

--- a/src/protagonist/Orchestrator/Startup.cs
+++ b/src/protagonist/Orchestrator/Startup.cs
@@ -4,6 +4,7 @@ using DLCS.Core.Caching;
 using DLCS.Repository;
 using DLCS.Repository.NamedQueries;
 using DLCS.Repository.Strategy.DependencyInjection;
+using DLCS.Web;
 using DLCS.Web.Configuration;
 using DLCS.Web.Handlers;
 using DLCS.Web.Logging;
@@ -158,6 +159,7 @@ public class Startup
                 endpoints.MapTimeBasedHandling();
                 endpoints.MapFileHandling();
                 endpoints.MapConfiguredHealthChecks();
+                endpoints.AddVersionEndpoint();
             });
     }
 }


### PR DESCRIPTION
## What does this change?

Bakes the `APP_VERSION` build-arg into each Docker image as an env var. Passes tag through from gh action.

Only output these on api and orchestrator, at `/version`. This will easier (automated) check of which version is running in particular environments.