### PR TITLE
Bugfixes for inline annotation work

### DIFF
--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -563,7 +563,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
         await dbContext.Images.AddTestAsset(assetId)
-            .WithTestAdjunct("someAdjunctId", created: DateTime.UtcNow.AddDays(-2));
+            .WithTestAdjunct("someAdjunctId", created: DateTime.UtcNow.AddDays(-2), motivation: "something");
         await dbContext.SaveChangesAsync();
         
         const string updateAdjunctJson = """
@@ -575,6 +575,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
                                                    "mediaType": "a-mediaType",
                                                    "label": {"label": ["value"]},
                                                    "language": ["en"],
+                                                   "motivation": "changed"
                                                  }
                                          """;
         
@@ -598,6 +599,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         adjunct.Finished.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         adjunct.ExternalId.Should().Be("https://some-location.com/an-adjunct");
         adjunct.PublicId.Should().Be("https://some-location.com/an-adjunct");
+        adjunct.Motivation.Should().Be("changed");
     }
     
     [Fact]

--- a/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
+++ b/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
@@ -76,6 +76,7 @@ public class CreateOrUpdateAdjunctHandler(DlcsContext dbContext, IIngestNotifica
             dbAdjunct.Origin = adjunct.Origin;
             dbAdjunct.Error = adjunct.Error;
             dbAdjunct.Type = adjunct.Type;
+            dbAdjunct.Motivation =  adjunct.Motivation;
             dbAdjunct.Ingesting = adjunct.Ingesting;
         }
         else

--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -568,6 +568,7 @@ public class ManifestV3BuilderTests
         var minimalInlinePaintingAnnotation =  annotation.Items!.First().As<GeneralAnnotation>();
         minimalInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/first");
         minimalInlinePaintingAnnotation.Motivation.Should().Be(null);
+        minimalInlinePaintingAnnotation.Target.Id.Should().Be("https://dlcs.test/canvas/0");
         var minimalInlinePaintingAnnotationBody = minimalInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
         minimalInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/first");
         minimalInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
@@ -578,6 +579,7 @@ public class ManifestV3BuilderTests
         var fullInlinePaintingAnnotation =  annotation.Items!.Last().As<GeneralAnnotation>();
         fullInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/second");
         fullInlinePaintingAnnotation.Motivation.Should().Be("something");
+        fullInlinePaintingAnnotation.Target.Id.Should().Be("https://dlcs.test/canvas/0");
         var fullInlinePaintingAnnotationBody = fullInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
         fullInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/second");
         fullInlinePaintingAnnotationBody.Format.Should().Be("text/plain");

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -542,7 +542,8 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             inlineAnnotationPage.Items!.Add(new GeneralAnnotation(adjunct.Motivation)
             {
                 Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
-                Body = [CreateExternalResource(adjunct)]
+                Body = [CreateExternalResource(adjunct)],
+                Target = new Canvas { Id = currentCanvas.Id }
             });
         }
 


### PR DESCRIPTION
## What does this change?

Resolves #1135 
Resolves #1137

This PR contains a pair of bugfixes picked up in automated testing for inline annotations

1. motivation wasn't being updated in `PUT`
2. Allow target to be output on a manifest