### PR TITLE
Use orchestrator url for hosted adjuncts id in manifest builder

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -542,7 +542,7 @@ public class ManifestV3BuilderTests
                 Motivation = "something",
                 Language = ["en"],
                 Profile = "some profile",
-                ExternalId = new Uri("http://some.id/second")
+                Origin = "http://some.id/second"
             }
         ];
         
@@ -552,7 +552,11 @@ public class ManifestV3BuilderTests
         A.CallTo(() => builderUtils.GetCanvasId(asset, pathElement, A<int>._))
             .Returns("https://dlcs.test/canvas/0");
         A.CallTo(() => assetPathGenerator.GetFullPathForRequest(A<BasicPathElements>._, A<bool>._, A<bool>._))
-            .Returns($"https://dlcs.test/adjunct-annotations/{asset.Id}");
+            .ReturnsLazily(c =>
+            {
+                var e = (BasicPathElements) c.Arguments[0];
+                return $"https://dlcs.test/{e.RoutePrefix}/{e.CustomerPathValue}/{e.Space}/{e.AssetPath}";
+            });
 
         var manifest = await sut.BuildManifest(manifestId, "testLabel", asset.AsList(), pathElement,
             ManifestType.NamedQuery, CancellationToken.None);
@@ -561,12 +565,12 @@ public class ManifestV3BuilderTests
         var annotations = manifest.Items![0].Annotations;
         annotations.Should().HaveCount(1);
         var annotation = annotations!.First();
-        annotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset");
+        annotation.Id.Should().Be($"https://dlcs.test/adjunct-annotations/99/1/{nameof(BuildManifest_InlineAnnotation)}");
         annotation.Label!.Should().BeEquivalentTo(new LanguageMap("en", "Inline annotations"));
         annotation.Items.Should().HaveCount(2);
         
         var minimalInlinePaintingAnnotation =  annotation.Items!.First().As<GeneralAnnotation>();
-        minimalInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/first");
+        minimalInlinePaintingAnnotation.Id.Should().Be($"https://dlcs.test/adjunct-annotations/99/1/{nameof(BuildManifest_InlineAnnotation)}/first");
         minimalInlinePaintingAnnotation.Motivation.Should().Be(null);
         minimalInlinePaintingAnnotation.Target.Id.Should().Be("https://dlcs.test/canvas/0");
         var minimalInlinePaintingAnnotationBody = minimalInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
@@ -577,11 +581,11 @@ public class ManifestV3BuilderTests
         minimalInlinePaintingAnnotationBody.Language.Should().BeNull();
         
         var fullInlinePaintingAnnotation =  annotation.Items!.Last().As<GeneralAnnotation>();
-        fullInlinePaintingAnnotation.Id.Should().Be("https://dlcs.test/adjunct-annotations/99/1/GetImageAsset/second");
+        fullInlinePaintingAnnotation.Id.Should().Be($"https://dlcs.test/adjunct-annotations/99/1/{nameof(BuildManifest_InlineAnnotation)}/second");
         fullInlinePaintingAnnotation.Motivation.Should().Be("something");
         fullInlinePaintingAnnotation.Target.Id.Should().Be("https://dlcs.test/canvas/0");
         var fullInlinePaintingAnnotationBody = fullInlinePaintingAnnotation.Body!.First().As<ExternalResource>();
-        fullInlinePaintingAnnotationBody.Id.Should().Be("http://some.id/second");
+        fullInlinePaintingAnnotationBody.Id.Should().Be($"https://dlcs.test/adjuncts/99/1/{nameof(BuildManifest_InlineAnnotation)}/second");
         fullInlinePaintingAnnotationBody.Format.Should().Be("text/plain");
         fullInlinePaintingAnnotationBody.Profile.Should().Be("some profile");
         fullInlinePaintingAnnotationBody.Label!.Should().BeEquivalentTo(new LanguageMap("en", "first"));

--- a/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/AssetQueryableX.cs
@@ -22,6 +22,5 @@ public static class AssetQueryableX
                     md.MetadataType == AssetApplicationMetadataTypes.ThumbSizes ||
                     md.MetadataType == AssetApplicationMetadataTypes.AVTranscodes))
             .Include(a => a.ImageDeliveryChannels)
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
-            .Include(a => a.Adjuncts!.Where(adj => adj.ExternalId != null).OrderBy(ad => ad.Id));
+            .Include(a => a.Adjuncts!.Where(adj => adj.ExternalId != null || adj.Origin != null).OrderBy(ad => ad.Id));
 }

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -36,6 +36,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
     private readonly IIIIFAuthBuilder authBuilder;
     private readonly ILogger<ManifestV3Builder> logger;
     private const string AdjunctAnnotationRoutePrefix = "adjunct-annotations";
+    private const string AdjunctRoutePrefix = "adjuncts";
 
     /// <summary>
     /// Implementation of <see cref="IBuildManifests{T}"/> responsible for generating IIIF v3 manifest
@@ -502,7 +503,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                     canvas.Annotations ??= [];
                     canvas.Annotations.Add(new AnnotationPage
                     {
-                        Id = adjunct.ExternalId.ToString(),
+                        Id = GetAdjunctId(adjunct),
                         Label = adjunct.Label,
                     });
                     break;
@@ -531,7 +532,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
                 currentCanvas.Annotations ??= [];
                 currentCanvas.Annotations.Add(new AnnotationPage
                 {
-                   Id = GetPathForAdjunct(adjunct),
+                   Id = GetPathForAdjunctAnnotation(adjunct),
                    Label = new LanguageMap("en", "Inline annotations"),
                    Items = []
                 });
@@ -541,7 +542,7 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
             
             inlineAnnotationPage.Items!.Add(new GeneralAnnotation(adjunct.Motivation)
             {
-                Id = $"{GetPathForAdjunct(adjunct)}/{adjunct.Id}",
+                Id = $"{GetPathForAdjunctAnnotation(adjunct)}/{adjunct.Id}",
                 Body = [CreateExternalResource(adjunct)],
                 Target = new Canvas { Id = currentCanvas.Id }
             });
@@ -551,15 +552,29 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
         ExternalResource CreateExternalResource(Adjunct adjunct) =>
             new(adjunct.Type)
             {
-                Id = adjunct.ExternalId.ToString(),
+                Id = GetAdjunctId(adjunct),
                 Format = adjunct.MediaType,
                 Profile = adjunct.Profile,
                 Label = adjunct.Label,
                 Language = adjunct.Language?.ToList(),
             };
+
+        string? GetAdjunctId(Adjunct adjunct)
+            => adjunct switch
+            {
+                { Origin: null, ExternalId: { } externalUri } => externalUri.ToString(),
+                { Origin: not null, ExternalId: null } => assetPathGenerator.GetFullPathForRequest(new BasicPathElements
+                {
+                    Space = adjunct.AssetId.Space,
+                    AssetPath = $"{adjunct.AssetId.Asset}/{adjunct.Id}",
+                    RoutePrefix = AdjunctRoutePrefix,
+                    CustomerPathValue = adjunct.AssetId.Customer.ToString(),
+                }),
+                _ => null
+            };
     }
 
-    private string GetPathForAdjunct(Adjunct adjunct)
+    private string GetPathForAdjunctAnnotation(Adjunct adjunct)
     {
         var adjunctRequest = new BasicPathElements
         {


### PR DESCRIPTION
## What does this change?

Implementes #1079 

Previously the `ManifestV3Builder` included only external adjuncts. This filters the db query for adjuncts that are either external or hosted and applies a logic split when setting the `Id` property of generated adjunct manifest objects.
