### PR TITLE
Add concurrency to github action

### DIFF
--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -10,6 +10,10 @@ on:
       - "docs/**"
       - "scripts/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-dotnet:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update github action to have concurrency. If a second, duplicate build is started it will cancel the currently running build.