### PR TITLE
Publish notification AdjunctBatch completion

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerAdjunctQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerAdjunctQueueTests.cs
@@ -8,6 +8,8 @@ using System.Threading;
 using API.Client;
 using API.Infrastructure;
 using API.Tests.Integration.Infrastructure;
+using DLCS.AWS.SNS.Messaging;
+using DLCS.Model.Assets;
 using DLCS.Model.Messaging;
 using DLCS.Repository;
 using DLCS.Web.Response;
@@ -31,6 +33,7 @@ public class CustomerAdjunctQueueTests : IClassFixture<ProtagonistAppFactory<Sta
     private readonly DlcsContext dbContext;
     private static readonly IDeliverableNotificationSender DeliverableNotificationSender = A.Fake<IDeliverableNotificationSender>();
     private static readonly IIngestNotificationSender IngestNotificationSender = A.Fake<IIngestNotificationSender>();
+    private static readonly IBatchCompletedNotificationSender BatchCompletedNotificationSender = A.Fake<IBatchCompletedNotificationSender>();
 
     public CustomerAdjunctQueueTests(StorageFixture storageFixture, ProtagonistAppFactory<Startup> factory)
     {
@@ -44,6 +47,7 @@ public class CustomerAdjunctQueueTests : IClassFixture<ProtagonistAppFactory<Sta
                             "API-Test", o => { });
                     services.AddSingleton(_ => DeliverableNotificationSender);
                     services.AddScoped(_ => IngestNotificationSender);
+                    services.AddScoped(_ => BatchCompletedNotificationSender);
                 }));
         dbContext = storageFixture.DbFixture.DbContext;
         storageFixture.DbFixture.CleanUp();
@@ -226,6 +230,9 @@ public class CustomerAdjunctQueueTests : IClassFixture<ProtagonistAppFactory<Sta
         A.CallTo(() => IngestNotificationSender.SendIngestAdjunctRequest(
                 A<IReadOnlyList<DLCS.Model.Assets.Adjunct>>._, A<CancellationToken>._))
             .MustNotHaveHappened();
+        A.CallTo(() => BatchCompletedNotificationSender.SendBatchCompletedMessage(
+                A<DLCS.Model.Assets.AdjunctBatch>.That.Matches(b => b.Id == batchId), A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
     }
 
     [Fact]
@@ -274,6 +281,9 @@ public class CustomerAdjunctQueueTests : IClassFixture<ProtagonistAppFactory<Sta
                 A<IReadOnlyList<DLCS.Model.Assets.Adjunct>>.That.Matches(a => a.Single().Id == "adj-hosted-1"),
                 A<CancellationToken>._))
             .MustHaveHappened(1, Times.Exactly);
+        A.CallTo(() => BatchCompletedNotificationSender.SendBatchCompletedMessage(
+                A<DLCS.Model.Assets.AdjunctBatch>.That.Matches(b => b.Id == batchId), A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]
@@ -331,6 +341,9 @@ public class CustomerAdjunctQueueTests : IClassFixture<ProtagonistAppFactory<Sta
         junctionRecords.Should().HaveCount(2);
         junctionRecords.Single(a => a.AdjunctId == "adj-ext").Status.Should().Be(DLCS.Model.Assets.BatchStatus.Completed);
         junctionRecords.Single(a => a.AdjunctId == "adj-hosted").Status.Should().Be(DLCS.Model.Assets.BatchStatus.Waiting);
+        A.CallTo(() => BatchCompletedNotificationSender.SendBatchCompletedMessage(
+                A<DLCS.Model.Assets.AdjunctBatch>.That.Matches(b => b.Id == batchId), A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]

--- a/src/protagonist/API/Features/AdjunctQueues/Requests/CreateAdjunctBatch.cs
+++ b/src/protagonist/API/Features/AdjunctQueues/Requests/CreateAdjunctBatch.cs
@@ -3,6 +3,7 @@ using System.Data;
 using API.Features.Adjuncts;
 using API.Infrastructure;
 using API.Infrastructure.Requests;
+using DLCS.AWS.SNS.Messaging;
 using DLCS.Core;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
@@ -27,6 +28,7 @@ public class CreateAdjunctBatchHandler(
     DlcsContext dbContext,
     IAdjunctBatchRepository adjunctBatchRepository,
     AdjunctUpsertService adjunctUpsertService,
+    IBatchCompletedNotificationSender batchCompletedNotificationSender,
     ILogger<CreateAdjunctBatchHandler> logger)
     : IRequestHandler<CreateAdjunctBatch, ModifyEntityResult<AdjunctBatch>>
 {
@@ -91,6 +93,11 @@ public class CreateAdjunctBatchHandler(
             logger.LogWarning(
                 "Not all engine notifications sent for adjunct batch {BatchId} (customer {CustomerId}); some adjuncts may not be ingested",
                 batch.Id, request.CustomerId);
+        }
+
+        if (batch.Finished.HasValue)
+        {
+            await batchCompletedNotificationSender.SendBatchCompletedMessage(batch, cancellationToken);
         }
 
         return ModifyEntityResult<AdjunctBatch>.Success(batch, WriteResult.Created);

--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using DLCS.AWS.Settings;
 using DLCS.AWS.SNS;
+using DLCS.Model.Assets;
 using DLCS.Model.Customers;
 using DLCS.Model.Messaging;
 using FakeItEasy;
@@ -273,6 +274,134 @@ public class TopicPublisherTests
         result.Should().Be(expected);
     }
     
+    [Fact]
+    public async Task PublishToBatchCompletedTopic_ReturnsFalse_IfNoArn()
+    {
+        // Arrange
+        var notification = new BatchCompletedNotification(new Batch { Id = 1, Customer = 99 });
+        var settings = Options.Create(new AWSSettings { SNS = new SNSSettings() });
+        var noArnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+
+        // Act
+        var result = await noArnSut.PublishToBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse("Missing Arn should result in failure");
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task PublishToBatchCompletedTopic_PublishesToCorrectArn_WithCustomerIdAttribute()
+    {
+        // Arrange
+        const string arn = "arn:aws:sns:us-east-1:000000000000:batchCompleted";
+        var batch = new Batch { Id = 1, Customer = 99, Count = 5, Completed = 5, Errors = 0, Submitted = DateTime.UtcNow };
+        var notification = new BatchCompletedNotification(batch);
+        var settings = Options.Create(new AWSSettings
+        {
+            SNS = new SNSSettings { BatchCompletedTopicArn = arn }
+        });
+        var arnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+
+        // Act
+        await arnSut.PublishToBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => snsClient.PublishAsync(
+            A<PublishRequest>.That.Matches(r =>
+                r.TopicArn == arn &&
+                r.MessageAttributes["CustomerId"].StringValue == "99"),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Accepted, true)]
+    [InlineData(HttpStatusCode.OK, true)]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    public async Task PublishToBatchCompletedTopic_ReturnsSuccessDependentOnStatusCode(HttpStatusCode statusCode, bool expected)
+    {
+        // Arrange
+        var notification = new BatchCompletedNotification(new Batch { Id = 1, Customer = 99 });
+        var settings = Options.Create(new AWSSettings
+        {
+            SNS = new SNSSettings { BatchCompletedTopicArn = "arn:aws:sns:us-east-1:000000000000:batchCompleted" }
+        });
+        var arnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
+            .Returns(new PublishResponse { HttpStatusCode = statusCode });
+
+        // Act
+        var result = await arnSut.PublishToBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task PublishToAdjunctBatchCompletedTopic_ReturnsFalse_IfNoArn()
+    {
+        // Arrange
+        var notification = new AdjunctBatchCompletedNotification(new AdjunctBatch { Id = 1, Customer = 99 });
+        var settings = Options.Create(new AWSSettings { SNS = new SNSSettings() });
+        var noArnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+
+        // Act
+        var result = await noArnSut.PublishToAdjunctBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse("Missing Arn should result in failure");
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task PublishToAdjunctBatchCompletedTopic_PublishesToCorrectArn_WithCustomerIdAttribute()
+    {
+        // Arrange
+        const string arn = "arn:aws:sns:us-east-1:000000000000:adjunctBatchCompleted";
+        var batch = new AdjunctBatch { Id = 2, Customer = 99, Count = 3, Completed = 3, Errors = 0, Submitted = DateTime.UtcNow };
+        var notification = new AdjunctBatchCompletedNotification(batch);
+        var settings = Options.Create(new AWSSettings
+        {
+            SNS = new SNSSettings { AdjunctBatchCompletedTopicArn = arn }
+        });
+        var arnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+
+        // Act
+        await arnSut.PublishToAdjunctBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => snsClient.PublishAsync(
+            A<PublishRequest>.That.Matches(r =>
+                r.TopicArn == arn &&
+                r.MessageAttributes["CustomerId"].StringValue == "99"),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Accepted, true)]
+    [InlineData(HttpStatusCode.OK, true)]
+    [InlineData(HttpStatusCode.BadRequest, false)]
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    public async Task PublishToAdjunctBatchCompletedTopic_ReturnsSuccessDependentOnStatusCode(HttpStatusCode statusCode, bool expected)
+    {
+        // Arrange
+        var notification = new AdjunctBatchCompletedNotification(new AdjunctBatch { Id = 1, Customer = 99 });
+        var settings = Options.Create(new AWSSettings
+        {
+            SNS = new SNSSettings { AdjunctBatchCompletedTopicArn = "arn:aws:sns:us-east-1:000000000000:adjunctBatchCompleted" }
+        });
+        var arnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+        A.CallTo(() => snsClient.PublishAsync(A<PublishRequest>._, A<CancellationToken>._))
+            .Returns(new PublishResponse { HttpStatusCode = statusCode });
+
+        // Act
+        var result = await arnSut.PublishToAdjunctBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(expected);
+    }
+
     [Fact]
     public async Task PublishToAssetModifiedTopicBatch_FailsToPublishTopic_WhenArnNotParsed()
     {

--- a/src/protagonist/DLCS.AWS/SNS/AdjunctBatchCompletedNotification.cs
+++ b/src/protagonist/DLCS.AWS/SNS/AdjunctBatchCompletedNotification.cs
@@ -2,7 +2,7 @@ using DLCS.Model.Assets;
 
 namespace DLCS.AWS.SNS;
 
-public class BatchCompletedNotification(Batch completedBatch) : IBatchCompletedNotification
+public class AdjunctBatchCompletedNotification(AdjunctBatch completedBatch) : IBatchCompletedNotification
 {
     public int Id { get; } = completedBatch.Id;
 
@@ -13,10 +13,8 @@ public class BatchCompletedNotification(Batch completedBatch) : IBatchCompletedN
     public int Completed { get; } = completedBatch.Completed;
 
     public int Errors { get; } = completedBatch.Errors;
-    
+
     public DateTime Submitted { get; } = completedBatch.Submitted;
 
     public DateTime? Finished { get; } = completedBatch.Finished;
-    
-    public bool Superseded { get; private set; } = completedBatch.Superseded;
 }

--- a/src/protagonist/DLCS.AWS/SNS/IBatchCompletedNotification.cs
+++ b/src/protagonist/DLCS.AWS/SNS/IBatchCompletedNotification.cs
@@ -1,0 +1,15 @@
+﻿namespace DLCS.AWS.SNS;
+
+/// <summary>
+/// Common properties for BatchCompleted notifications
+/// </summary>
+public interface IBatchCompletedNotification
+{
+    int Id { get; }
+    int Customer { get; }
+    int Count { get; }
+    int Completed { get; }
+    int Errors { get; }
+    DateTime Submitted { get; }
+    DateTime? Finished { get; }
+}

--- a/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/ITopicPublisher.cs
@@ -19,6 +19,13 @@ public interface ITopicPublisher
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Asynchronously publishes a message to the Batch completed topic for an AdjunctBatch
+    /// </summary>
+    /// <returns>Boolean representing the overall success/failure status of request</returns>
+    public Task<bool> PublishToAdjunctBatchCompletedTopic(AdjunctBatchCompletedNotification message,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Asynchronously publishes a message to deliverable modified SNS
     /// </summary>
     /// <param name="messages">A collection of notifications to send</param>

--- a/src/protagonist/DLCS.AWS/SNS/Messaging/BatchCompletedNotificationSender.cs
+++ b/src/protagonist/DLCS.AWS/SNS/Messaging/BatchCompletedNotificationSender.cs
@@ -10,7 +10,7 @@ public class BatchCompletedNotificationSender(
 {
     public async Task SendBatchCompletedMessage(IDeliverableBatch batch, CancellationToken cancellationToken = default)
     {
-        logger.LogDebug("Sending notification of creation of batch {Type} {Batch}", batch.GetType().Name, batch.Id);
+        logger.LogDebug("Sending notification of completion of batch {Type} {Batch}", batch.GetType().Name, batch.Id);
 
         switch (batch)
         {

--- a/src/protagonist/DLCS.AWS/SNS/Messaging/BatchCompletedNotificationSender.cs
+++ b/src/protagonist/DLCS.AWS/SNS/Messaging/BatchCompletedNotificationSender.cs
@@ -3,23 +3,23 @@ using Microsoft.Extensions.Logging;
 
 namespace DLCS.AWS.SNS.Messaging;
 
-public class BatchCompletedNotificationSender : IBatchCompletedNotificationSender
+public class BatchCompletedNotificationSender(
+    ITopicPublisher topicPublisher,
+    ILogger<BatchCompletedNotificationSender> logger)
+    : IBatchCompletedNotificationSender
 {
-    private readonly ITopicPublisher topicPublisher;
-    private readonly ILogger<BatchCompletedNotificationSender> logger;
-    
-    public BatchCompletedNotificationSender(ITopicPublisher topicPublisher, 
-        ILogger<BatchCompletedNotificationSender> logger)
+    public async Task SendBatchCompletedMessage(IDeliverableBatch batch, CancellationToken cancellationToken = default)
     {
-        this.topicPublisher = topicPublisher;
-        this.logger = logger;
-    }
+        logger.LogDebug("Sending notification of creation of batch {Type} {Batch}", batch.GetType().Name, batch.Id);
 
-    public async Task SendBatchCompletedMessage(Batch batch, CancellationToken cancellationToken = default)
-    {
-        logger.LogDebug("Sending notification of creation of batch {Batch}", batch.Id);
-        
-        var batchCompletedNotification = new BatchCompletedNotification(batch);
-        await topicPublisher.PublishToBatchCompletedTopic(batchCompletedNotification, cancellationToken);
+        switch (batch)
+        {
+            case Batch b:
+                await topicPublisher.PublishToBatchCompletedTopic(new BatchCompletedNotification(b), cancellationToken);
+                break;
+            case AdjunctBatch ab:
+                await topicPublisher.PublishToAdjunctBatchCompletedTopic(new AdjunctBatchCompletedNotification(ab), cancellationToken);
+                break;
+        }
     }
 }

--- a/src/protagonist/DLCS.AWS/SNS/Messaging/IBatchCompletedNotificationSender.cs
+++ b/src/protagonist/DLCS.AWS/SNS/Messaging/IBatchCompletedNotificationSender.cs
@@ -7,5 +7,5 @@ public interface IBatchCompletedNotificationSender
     /// <summary>
     /// Broadcast batch completed notification
     /// </summary>
-    Task SendBatchCompletedMessage(Batch completedBatch, CancellationToken cancellationToken = default);
+    Task SendBatchCompletedMessage(IDeliverableBatch completedBatch, CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -37,31 +37,17 @@ public class TopicPublisher(
     }
 
     /// <inheritdoc />
-    public async Task<bool> PublishToBatchCompletedTopic(BatchCompletedNotification message, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrEmpty(snsSettings.BatchCompletedTopicArn))
-        {
-            logger.LogWarning("Batch Completed Topic Arn is not set - cannot send BatchCompletedNotification");
-            return false;
-        }
-        
-        var request = new PublishRequest
-        {
-            TopicArn = snsSettings.BatchCompletedTopicArn,
-            Message = JsonSerializer.Serialize(message, settings),
-            MessageAttributes = new Dictionary<string, MessageAttributeValue>()
-            {
-                {"CustomerId", new MessageAttributeValue
-                {
-                    StringValue = message.Customer.ToString(),
-                    DataType = "String"
-                }}
-            } 
-        };
+    public Task<bool> PublishToBatchCompletedTopic(BatchCompletedNotification message,
+        CancellationToken cancellationToken)
+        => PublishBatchCompleted(message, snsSettings.BatchCompletedTopicArn,
+            nameof(snsSettings.BatchCompletedTopicArn), cancellationToken);
 
-        return await TryPublishRequest(request, cancellationToken);
-    }
-    
+    /// <inheritdoc />
+    public Task<bool> PublishToAdjunctBatchCompletedTopic(AdjunctBatchCompletedNotification message,
+        CancellationToken cancellationToken)
+        => PublishBatchCompleted(message, snsSettings.AdjunctBatchCompletedTopicArn,
+            nameof(snsSettings.AdjunctBatchCompletedTopicArn), cancellationToken);
+
     /// <inheritdoc />
     public async Task<bool> PublishToDeliverableModifiedTopic(IReadOnlyList<DeliverableModifiedNotification> messages,
         DeliverableTopicType topicType, CancellationToken cancellationToken = default)
@@ -153,18 +139,33 @@ public class TopicPublisher(
     }
 
     private static Dictionary<string, MessageAttributeValue> GetMessageAttributes(Dictionary<string, string> attributes)
+        => attributes.ToDictionary(
+            attribute => attribute.Key,
+            attribute => new MessageAttributeValue { DataType = "String", StringValue = attribute.Value });
+
+    private async Task<bool> PublishBatchCompleted(IBatchCompletedNotification message, string? topicArn, string topicName,
+        CancellationToken cancellationToken)
     {
-        var messageAttributes = new Dictionary<string, MessageAttributeValue>();
-        foreach (var attribute in attributes)
+        if (string.IsNullOrEmpty(topicArn))
         {
-            messageAttributes.Add(attribute.Key,
-                new MessageAttributeValue
-                {
-                    DataType = "String",
-                    StringValue = attribute.Value
-                });
+            logger.LogWarning("{TopicName} is not set - cannot publish batch completed notification", topicName);
+            return false;
         }
 
-        return messageAttributes;
+        var request = new PublishRequest
+        {
+            TopicArn = topicArn,
+            Message = JsonSerializer.Serialize(message, settings),
+            MessageAttributes = new Dictionary<string, MessageAttributeValue>
+            {
+                ["CustomerId"] = new()
+                {
+                    StringValue = message.Customer.ToString(),
+                    DataType = "String"
+                },
+            }
+        };
+
+        return await TryPublishRequest(request, cancellationToken);
     }
 }

--- a/src/protagonist/DLCS.AWS/Settings/SNSSettings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/SNSSettings.cs
@@ -18,9 +18,14 @@ public class SNSSettings
     public string? CustomerCreatedTopicArn { get; set; }
     
     /// <summary>
-    /// Name of the SNS topic for notifying that 
+    /// Name of the SNS topic for notifying that a batch has completed processing
     /// </summary>
     public string? BatchCompletedTopicArn { get; set; }
+    
+    /// <summary>
+    /// Name of the SNS topic for notifying that an adjunct-batch has completed processing
+    /// </summary>
+    public string? AdjunctBatchCompletedTopicArn { get; set; }
     
     /// <summary>
     /// Service root for SNS. Only used if running LocalStack

--- a/src/protagonist/DLCS.Model/Assets/IDeliverableBatch.cs
+++ b/src/protagonist/DLCS.Model/Assets/IDeliverableBatch.cs
@@ -7,6 +7,7 @@ namespace DLCS.Model.Assets;
 /// </summary>
 public interface IDeliverableBatch
 {
+    int Id { get; set; }
     int Customer { get; set; }
     DateTime Submitted { get; set; }
     int Count { get; set; }

--- a/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/DlcsContextModelSnapshot.cs
@@ -162,7 +162,7 @@ namespace DLCS.Repository.Migrations
 
                     b.HasIndex("AdjunctId", "AssetId");
 
-                    b.ToTable("AdjunctBatchAdjuncts", (string)null);
+                    b.ToTable("AdjunctBatchAdjuncts");
                 });
 
             modelBuilder.Entity("DLCS.Model.Assets.Asset", b =>

--- a/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
+++ b/src/protagonist/Engine.Tests/Data/EngineAssetRepositoryTests.cs
@@ -612,6 +612,11 @@ public class EngineAssetRepositoryTests
         updatedBatch.Completed.Should().Be(0);
         updatedBatch.Finished.Should().BeNull();
         updatedBatch.BatchAdjuncts.Single(ba => ba.AdjunctId == adjunctId).Status.Should().Be(BatchStatus.Error);
+        A.CallTo(() =>
+                batchCompletedNotificationSender.SendBatchCompletedMessage(
+                    A<AdjunctBatch>._,
+                    A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]
@@ -645,6 +650,11 @@ public class EngineAssetRepositoryTests
         updatedBatch.Completed.Should().Be(1);
         updatedBatch.Finished.Should().BeNull();
         updatedBatch.BatchAdjuncts.Single(ba => ba.AdjunctId == adjunctId).Status.Should().Be(BatchStatus.Completed);
+        A.CallTo(() =>
+                batchCompletedNotificationSender.SendBatchCompletedMessage(
+                    A<AdjunctBatch>._,
+                    A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Fact]
@@ -683,6 +693,11 @@ public class EngineAssetRepositoryTests
         var updatedAdjunct = await dbContext.Adjuncts.SingleAsync(a => a.Id == adjunctId && a.AssetId == assetId);
         updatedAdjunct.Finished.Should().BeNull();
         updatedAdjunct.Ingesting.Should().BeTrue();
+        A.CallTo(() =>
+                batchCompletedNotificationSender.SendBatchCompletedMessage(
+                    A<AdjunctBatch>._,
+                    A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 
     [Theory]
@@ -718,6 +733,11 @@ public class EngineAssetRepositoryTests
 
         var updatedBatch = await dbContext.AdjunctBatches.SingleAsync(b => b.Id == batchId);
         updatedBatch.Finished.Should().NotBeNull();
+        A.CallTo(() =>
+                batchCompletedNotificationSender.SendBatchCompletedMessage(
+                    A<AdjunctBatch>.That.Matches(b => b.Id == batchId),
+                    A<CancellationToken>._))
+            .MustHaveHappened(1, Times.Exactly);
     }
 
     [Theory]
@@ -756,5 +776,10 @@ public class EngineAssetRepositoryTests
         var updatedBatch = await dbContext.AdjunctBatches.SingleAsync(b => b.Id == batchId);
         updatedBatch.Finished.Should()
             .BeCloseTo(batchFinishedDate, TimeSpan.FromSeconds(2), "Finished date is not modified");
+        A.CallTo(() =>
+                batchCompletedNotificationSender.SendBatchCompletedMessage(
+                    A<AdjunctBatch>.That.Matches(b => b.Id == batchId),
+                    A<CancellationToken>._))
+            .MustNotHaveHappened();
     }
 }

--- a/src/protagonist/Engine/Data/EngineAssetRepository.cs
+++ b/src/protagonist/Engine/Data/EngineAssetRepository.cs
@@ -128,36 +128,13 @@ public class EngineAssetRepository(
             return rowCount > 0;
         }
 
-        switch (deliverable)
+        return deliverable switch
         {
-            case Asset asset:
-            {
-                var batchAsset = asset.BatchAssets!.Single();
-                batchAsset.FinishBatchItem(asset);
-                var updatedRows = await DlcsContext.SaveChangesAsync(cancellationToken);
-
-                var finishedBatch = await TryFinishBatch<Batch>(batchAsset.BatchId);
-                if (finishedBatch != null)
-                {
-                    updatedRows++;
-                    await batchCompletedNotificationSender.SendBatchCompletedMessage(finishedBatch, cancellationToken);
-                }
-
-                return updatedRows > 0;
-            }
-            case Adjunct adjunct:
-            {
-                var batchAdjunct = adjunct.AdjunctBatchAdjuncts!.Single();
-                batchAdjunct.FinishBatchItem(adjunct);
-                var updatedRows = await DlcsContext.SaveChangesAsync(cancellationToken);
-
-                await TryFinishBatch<AdjunctBatch>(batchAdjunct.BatchId);
-
-                return updatedRows > 0;
-            }
-            default:
-                throw new ArgumentOutOfRangeException(nameof(deliverable), deliverable, null);
-        }
+            Asset asset => await FinishBatchedItem<Batch>(asset.BatchAssets!.Single(), asset, cancellationToken),
+            Adjunct adjunct => await FinishBatchedItem<AdjunctBatch>(adjunct.AdjunctBatchAdjuncts!.Single(), adjunct,
+                cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(deliverable), deliverable, null)
+        };
     }
     
     private static void UpdateDeliverable(IDeliverable deliverable, bool ingestFinished)
@@ -166,6 +143,22 @@ public class EngineAssetRepository(
         {
             deliverable.MarkAsFinished();
         }
+    }
+
+    private async Task<bool> FinishBatchedItem<T>(IDeliverableBatchItem batchItem, IDeliverable deliverable,
+        CancellationToken cancellationToken) where T : IDeliverableBatch
+    {
+        batchItem.FinishBatchItem(deliverable);
+        var updatedRows = await DlcsContext.SaveChangesAsync(cancellationToken);
+
+        var finishedBatch = await TryFinishBatch<T>(batchItem.BatchId);
+        if (finishedBatch != null)
+        {
+            updatedRows++;
+            await batchCompletedNotificationSender.SendBatchCompletedMessage(finishedBatch, cancellationToken);
+        }
+
+        return updatedRows > 0;
     }
 
     private async Task<T?> TryFinishBatch<T>(int batchId) where T : IDeliverableBatch


### PR DESCRIPTION
## What does this change?

Resolves #1163

Update API and Engine to publish AdjunctBatch completion topic. This will happen whether the batch was successful or contains errors.

Main areas of change were:
* API - `CreateAdjunctBatchHandler` will raise if AdjunctBatch.Finished has a value
* Engine - `EngineAssetRepository` will raise if just-saved adjunct means batch is completed.

Other areas / details:
* `IBatchCompletedNotificationSender` takes a single `IDeliverableBatch` to share logic with Batch and AdjunctBatch.
* `ITopicPublisher` has and adjunct and asset "publish batch completed" overload but internally they share implementation.
* Refactored `EngineAssetRepository` to share more batch completion code, leveraging various shared interfaces `IDeliverableBatchItem`, `IDeliverable` and `IDeliverableBatch`

## Infrastructure Changes

> [!NOTE]
> This PR requires infrastructure changes.
>
> - **Required:** N/A
> - **Optional:** AdjunctBatch completion SNS topic. If present API or Engine will publish a notification when an `AdjunctBatch` is completed. If missing a warning will be logged.

## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | Engine | `AWS:SNS:AdjunctBatchCompletedTopicArn` | N | ARN for AdjunctBatch Completion SNS topic| `null` |
> | API | `AWS:SNS:AdjunctBatchCompletedTopicArn` | N | ARN for AdjunctBatch Completion SNS topic| `null` |