### PR TITLE
Always return single adjunct on PUT

### DIFF
--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -618,12 +618,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
-
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        var adjunct = hydra.Members![0];
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
         adjunct.Id.Should()
             .Be(
                 $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/someAdjunctId");
@@ -673,12 +668,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
-
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        var adjunct = hydra.Members![0];
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
         var expectedAdjunctId = $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}";
         adjunct.Id.Should().Be(expectedAdjunctId);
         adjunct.IIIFLink.Should().Be("seeAlso");
@@ -727,12 +717,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
-
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        var adjunct = hydra.Members![0];        
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
         var expectedAdjunctId = $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}";
         
         adjunct.Id.Should().Be(expectedAdjunctId);
@@ -778,12 +763,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);
-        var hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
-
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        var adjunct = hydra.Members![0];        
+        var adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
         adjunct.Id.Should()
             .Be(
                 $"http://localhost/customers/{assetId.Customer}/spaces/{assetId.Space}/images/{assetId.Asset}/adjuncts/{adjunctId}");
@@ -1399,12 +1379,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert 2
         response.StatusCode.Should().Be(HttpStatusCode.OK); // not created, updated
-        hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
+        adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
 
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        adjunct = hydra.Members![0];
         adjunct.Size.Should().Be(1234L, "API preserves the size set by engine");
         adjunct.Ingesting.Should().Be(true, "the adjunct was sent to engine for (re)ingestion");
         adjunct.Finished.Should().NotBeNull("API doesn't touch finished, as it now states for 'last finished'");
@@ -1486,12 +1462,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert 2
         response.StatusCode.Should().Be(HttpStatusCode.OK); // not created, updated
-        hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
+        adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
 
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        adjunct = hydra.Members![0];
         adjunct.Size.Should().Be(null, "API sets to null to signify it wasn't hosted previously - so no size for our purposes");
         adjunct.Ingesting.Should().Be(true, "the adjunct was sent to engine for ingestion");
         adjunct.Finished.Should().NotBeNull("API doesn't touch finished, as it now states for 'last finished'");
@@ -1581,12 +1553,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         // Assert 2
         response.StatusCode.Should().Be(HttpStatusCode.OK); // not created, updated
-        hydra = await response.ReadAsHydraResponseAsync<HydraCollection<Adjunct>>();
+        adjunct = await response.ReadAsHydraResponseAsync<Adjunct>();
 
-        hydra.Should().NotBeNull();
-        hydra.Members.Should().HaveCount(1);
-
-        adjunct = hydra.Members![0];
         adjunct.Size.Should().Be(69L, "as this is now external adjunct, ");
         adjunct.Ingesting.Should().NotBe(true, "the adjunct was NOT sent to engine for ingestion");
         adjunct.Finished.Should().NotBeNull("API doesn't touch finished, as it now states for 'last finished'");

--- a/src/protagonist/API/Features/Adjuncts/AdjunctsController.cs
+++ b/src/protagonist/API/Features/Adjuncts/AdjunctsController.cs
@@ -5,6 +5,8 @@ using API.Infrastructure;
 using API.Settings;
 using DLCS.Core.Types;
 using DLCS.HydraModel;
+using DLCS.Web.Requests;
+using Hydra;
 using Hydra.Collections;
 using Hydra.Model;
 using MediatR;
@@ -100,8 +102,9 @@ public class AdjunctsController(
         }
         
         hydraAdjunct.ModelId = adjunctId;
-        
-        return await CreateOrUpdateAdjunct(customerId, spaceId, imageId, [hydraAdjunct], validator, false, cancellationToken);
+
+        return await CreateOrUpdateAdjunct(customerId, spaceId, imageId, [hydraAdjunct], validator, false,
+            cancellationToken);
     }
 
     /// <summary>
@@ -118,9 +121,9 @@ public class AdjunctsController(
 
         return await HandleDelete(deleteRequest);
     }
-    
-    private async Task<IActionResult> CreateOrUpdateAdjunct(int customerId, int spaceId, string imageId, Adjunct[] hydraAdjuncts,
-        HydraAdjunctValidator validator, bool createOnly, CancellationToken cancellationToken)
+
+    private async Task<IActionResult> CreateOrUpdateAdjunct(int customerId, int spaceId, string imageId,
+        Adjunct[] hydraAdjuncts, HydraAdjunctValidator validator, bool isPost, CancellationToken cancellationToken)
     {
         foreach (var hydraAdjunct in hydraAdjuncts)
         {
@@ -135,13 +138,27 @@ public class AdjunctsController(
             .Select(a => a.ToDlcsModel(customerId, spaceId, imageId))
             .ToArray();
         
-        var createOrUpdateRequest =
-            new CreateOrUpdateAdjunct(dlcsAdjuncts, createOnly);
-        
+        var createOrUpdateRequest = new CreateOrUpdateAdjunct(dlcsAdjuncts, isPost);
+
         return await HandleUpsert(
             createOrUpdateRequest,
-            a => a.ToHydra(GetUrlRoots()),
+            BuildHydraResponse,
             new AssetId(customerId, spaceId, imageId).ToString(),
-            "Create or update adjunct failed", cancellationToken);
+            "Create or update adjunct failed",
+            cancellationToken);
+
+        // If this is a PUT operation (ie !isPost) then we always want to return a single adjunct, not a collection. 
+        // else we want to return a collection always
+        JsonLdBase BuildHydraResponse(DLCS.Model.Assets.Adjunct[] adjuncts)
+            => isPost
+                ? new HydraCollection<Adjunct>
+                {
+                    WithContext = true,
+                    Members = adjuncts.Select(a => a.ToHydra(GetUrlRoots())).ToArray(),
+                    TotalItems = adjuncts.Length,
+                    PageSize = adjuncts.Length,
+                    Id = Request.GetJsonLdId()
+                }
+                : adjuncts.Single().ToHydra(GetUrlRoots());
     }
 }


### PR DESCRIPTION
## What does this change?

Fixes #1174

Always returns a single Adjunct resource for PUT. Always return HydraCollection<Adjunct> for POST.
