### PR TITLE
Specify actual type when serialising completion

### DIFF
--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -313,6 +313,35 @@ public class TopicPublisherTests
                 r.MessageAttributes["CustomerId"].StringValue == "99"),
             A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
+    
+    [Fact]
+    public async Task PublishToBatchCompletedTopic_Correctly_Serialises()
+    {
+        // Arrange
+        const string arn = "arn:aws:sns:us-east-1:000000000000:batchCompleted";
+        var batch = new Batch
+        {
+            Id = 1, Customer = 99, Count = 5, Completed = 5, Errors = 0, Submitted = DateTime.UtcNow, Superseded = true
+        };
+        var notification = new BatchCompletedNotification(batch);
+        var settings = Options.Create(new AWSSettings
+        {
+            SNS = new SNSSettings { BatchCompletedTopicArn = arn }
+        });
+        var arnSut = new TopicPublisher(snsClient, settings, new NullLogger<TopicPublisher>());
+
+        // Act
+        await arnSut.PublishToBatchCompletedTopic(notification, CancellationToken.None);
+
+        // Check that 'superseded' is correctly serialised to the message, this is on concrete type only, not interface
+        // so verifies that it's not only the interface props that are being serialised. 
+        A.CallTo(() => snsClient.PublishAsync(
+            A<PublishRequest>.That.Matches(r =>
+                r.TopicArn == arn &&
+                r.MessageAttributes["CustomerId"].StringValue == "99" &&
+                r.Message.Contains("superseded")),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
 
     [Theory]
     [InlineData(HttpStatusCode.Accepted, true)]

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -151,11 +151,11 @@ public class TopicPublisher(
             logger.LogWarning("{TopicName} is not set - cannot publish batch completed notification", topicName);
             return false;
         }
-
+        
         var request = new PublishRequest
         {
             TopicArn = topicArn,
-            Message = JsonSerializer.Serialize(message, settings),
+            Message = JsonSerializer.Serialize(message, message.GetType(), settings),
             MessageAttributes = new Dictionary<string, MessageAttributeValue>
             {
                 ["CustomerId"] = new()


### PR DESCRIPTION
## What does this change?

PublishBatchCompleted method takes `IBatchCompletedNotification`, which contains details of the completed batch. There are 2 implementations (`Batch` and `AdjunctBatch`). 

This was using `JsonSerializer.Serialize(message, settings)` which uses the static type (`IBatchCompletedNotification`) to determine which properties to serialize, so it skips any properties only in the concrete implementation. Fix was to use pass the runtime type to the serialiser.