### PR TITLE
UpdateHandlers abort if item not in DB

### DIFF
--- a/src/protagonist/CleanupHandler/Adjunct/AdjunctUpdatedHandler.cs
+++ b/src/protagonist/CleanupHandler/Adjunct/AdjunctUpdatedHandler.cs
@@ -31,9 +31,9 @@ public class AdjunctUpdatedHandler(
 
             if (adjunctAfter == null)
             {
-                logger.LogInformation("Adjunct {Asset}/{Id} was not found in the database for use in after calculation",
+                logger.LogInformation("Adjunct {Asset}/{Id} not in database, aborting",
                     adjunctBefore.AssetId, adjunctBefore.Id);
-                return false;
+                return true;
             }
             
             logger.LogDebug("Processing update adjunct notification for {Asset}/{Id}", adjunctBefore.AssetId, adjunctBefore.Id);
@@ -51,6 +51,6 @@ public class AdjunctUpdatedHandler(
     }
 
     // We only cleanup when the adjunct has moved from hosted to unhosted
-    private bool NoCleanupRequired(DLCS.Model.Assets.Adjunct adjunctBefore, DLCS.Model.Assets.Adjunct adjunctAfter) =>
+    private static bool NoCleanupRequired(DLCS.Model.Assets.Adjunct adjunctBefore, DLCS.Model.Assets.Adjunct adjunctAfter) =>
         adjunctBefore.ExternalId != null || !adjunctAfter.Origin.IsNullOrEmpty();
 }

--- a/src/protagonist/CleanupHandler/Asset/AssetUpdatedHandler.cs
+++ b/src/protagonist/CleanupHandler/Asset/AssetUpdatedHandler.cs
@@ -49,12 +49,12 @@ public class AssetUpdatedHandler(
 
             if (assetAfter == null)
             {
-                logger.LogInformation("Asset {AssetId} was not found in the database for use in after calculation",
+                logger.LogInformation("Asset {AssetId} not in database, aborting",
                     assetBefore.Id);
-                return false;
+                return true;
             }
             
-            logger.LogDebug("Processing update DLCS.Model.Assets.Asset notification for {AssetId}", assetBefore.Id);
+            logger.LogDebug("Processing update Asset notification for {AssetId}", assetBefore.Id);
 
             if (NoCleanupRequired(message, assetAfter, assetBefore))
             {
@@ -73,7 +73,7 @@ public class AssetUpdatedHandler(
 
             if (handlerSettings.AssetModifiedSettings.DryRun)
             {
-                logger.LogInformation("Dry run enabled. DLCS.Model.Assets.Asset {AssetId} will log deletions, but not remove them",
+                logger.LogInformation("Dry run enabled. Asset {AssetId} will log deletions, but not remove them",
                     assetBefore.Id);
             }
 
@@ -208,7 +208,7 @@ public class AssetUpdatedHandler(
                 CleanupFileDeliveryChannel(assetAfter, s3Objects.objectsToRemove);
                 break;
             default:
-                logger.LogDebug("policy {PolicyName} does not require any changes for asset {AssetId}",
+                logger.LogDebug("Policy {PolicyName} does not require any changes for asset {AssetId}",
                     deliveryChannelRemoved.DeliveryChannelPolicy.Name, assetAfter.Id);
                 break;
         }

--- a/src/protagonist/CleanupHandlerTests/Adjuncts/AdjunctUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/Adjuncts/AdjunctUpdatedHandlerTests.cs
@@ -77,7 +77,7 @@ public class AdjunctUpdatedHandlerTests
     }
     
     [Fact]
-    public async Task Handle_ReturnsFalse_IfNoMatchingAdjunct()
+    public async Task Handle_ReturnsFalse_IfNoDeliverableBeforeUpdate_InMessage()
     {
         // Arrange
         var assetId = AssetIdGenerator.GetAssetId();
@@ -108,6 +108,46 @@ public class AdjunctUpdatedHandlerTests
         
         // Assert
         response.Should().BeFalse();
+        A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
+    }
+    
+    [Fact]
+    public async Task Handle_ReturnsTrue_IfAdjunctNotFoundInDatabase()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        var adjunctId = "someAdjunct";
+        await dbContext.Images.AddTestAsset(assetId);
+        await dbContext.SaveChangesAsync();
+        
+        var adjunct = new Adjunct
+        {
+            Id = adjunctId,
+            MediaType = "a-mediaType",
+            IIIFLink = IIIFLinkType.Annotations,
+            Type = "a-type",
+            AssetId = assetId,
+            Origin = "https://some.origin"
+        };
+        var cleanupRequest = new DeliverableUpdatedNotification<Adjunct>
+        {
+            DeliverableBeforeUpdate = adjunct,
+            DeliverableAfterUpdate = adjunct
+        };
+        
+        var serialized = JsonSerializer.Serialize(cleanupRequest, settings);
+        
+        var queueMessage = new QueueMessage
+        {
+            Body = JsonNode.Parse(serialized)!.AsObject()
+        };
+
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
         A.CallTo(() => bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>._)).MustNotHaveHappened();
     }
     

--- a/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
+++ b/src/protagonist/CleanupHandlerTests/AssetUpdatedHandlerTests.cs
@@ -156,6 +156,27 @@ public class AssetUpdatedHandlerTests
         A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
     }
     
+    [Fact]
+    public async Task Handle_ReturnsTrue_IfAssetNotInDatabase()
+    {
+        // Arrange
+        var requestDetails = CreateMinimalRequestDetails([imageDeliveryChannelFile], []);
+        
+        A.CallTo(() => cleanupHandlerAssetRepository.RetrieveAssetWithDeliveryChannels(A<AssetId>._))
+            .Returns<Asset?>(null);
+        
+        // Act
+        var sut = GetSut();
+        var response = await sut.HandleMessage(requestDetails.queueMessage);
+        
+        // Assert
+        response.Should().BeTrue();
+        A.CallTo(() =>
+                bucketWriter.DeleteFromBucket(A<ObjectInBucket[]>.That.Matches(o => o[0].Key == "1/99/foo/original")))
+            .MustNotHaveHappened();
+        A.CallTo(() => bucketWriter.DeleteFolder(A<ObjectInBucket>._, A<bool>._)).MustNotHaveHappened();
+    }
+    
     // removed
     
     [Fact]


### PR DESCRIPTION
## What does this change?

Alter `AdjunctUpdateHandler` and `AssetUpdateHandler` to return `true` rather than `false`. By returning `false` the item is requeued and then moved to DLQ, whereas returning `true` marks the message as handled.

This can only happen if an item is Updated then Deleted prior to being picked up by Updated handler. In this case the `*DeleteHandler` will have handled removing derivatives.