### PR TITLE
Include 'type' in batch completion notifications

### DIFF
--- a/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/SNS/TopicPublisherTests.cs
@@ -310,7 +310,8 @@ public class TopicPublisherTests
         A.CallTo(() => snsClient.PublishAsync(
             A<PublishRequest>.That.Matches(r =>
                 r.TopicArn == arn &&
-                r.MessageAttributes["CustomerId"].StringValue == "99"),
+                r.MessageAttributes["CustomerId"].StringValue == "99" &&
+                r.MessageAttributes["Type"].StringValue == "Batch"),
             A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
     
@@ -403,7 +404,8 @@ public class TopicPublisherTests
         A.CallTo(() => snsClient.PublishAsync(
             A<PublishRequest>.That.Matches(r =>
                 r.TopicArn == arn &&
-                r.MessageAttributes["CustomerId"].StringValue == "99"),
+                r.MessageAttributes["CustomerId"].StringValue == "99" &&
+                r.MessageAttributes["Type"].StringValue == "AdjunctBatch"),
             A<CancellationToken>._)).MustHaveHappenedOnceExactly();
     }
 

--- a/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
+++ b/src/protagonist/DLCS.AWS/SNS/TopicPublisher.cs
@@ -4,6 +4,7 @@ using Amazon.SimpleNotificationService;
 using Amazon.SimpleNotificationService.Model;
 using DLCS.AWS.Settings;
 using DLCS.Core;
+using DLCS.Model.Assets;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -151,7 +152,7 @@ public class TopicPublisher(
             logger.LogWarning("{TopicName} is not set - cannot publish batch completed notification", topicName);
             return false;
         }
-        
+
         var request = new PublishRequest
         {
             TopicArn = topicArn,
@@ -161,6 +162,11 @@ public class TopicPublisher(
                 ["CustomerId"] = new()
                 {
                     StringValue = message.Customer.ToString(),
+                    DataType = "String"
+                },
+                ["Type"] = new()
+                {
+                    StringValue = message is AdjunctBatchCompletedNotification ? nameof(AdjunctBatch) : nameof(Batch),
                     DataType = "String"
                 },
             }


### PR DESCRIPTION
## What does this change?

Add new "type" parameter to signify what type of batch is completed. Will allow for downstream filtering

