### PR TITLE
Prevent invalid adjunct ids in deletion

### DIFF
--- a/src/protagonist/API.Tests/Features/Adjuncts/Validation/AdjunctIdListValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Adjuncts/Validation/AdjunctIdListValidatorTests.cs
@@ -14,7 +14,8 @@ public class AdjunctIdListValidatorTests
     private readonly AdjunctIdListValidator sut = new(Options.Create(
         new ApiSettings
         {
-            MaxImageListSize = 4
+            MaxImageListSize = 4,
+            RestrictedResourceIdCharacterString = "\\ /"
         }));
     
     [Fact]
@@ -142,5 +143,23 @@ public class AdjunctIdListValidatorTests
         
         var result = sut.TestValidate(adjuncts);
         result.ShouldHaveAnyValidationError().WithErrorMessage("Maximum adjuncts in single batch is 4");
+    }
+    
+    [Theory]
+    [InlineData(" space")]
+    [InlineData("slash\\")]
+    [InlineData("other/slash")]
+    public void Invalid_WhenAdjunctContainsInvalidCharacters(string invalidId)
+    {
+        var assetId = AssetIdGenerator.GetAssetId();
+        var adjuncts = new Dictionary<AssetId, List<string>>
+        {
+            {assetId, ["first", "second", invalidId]}
+        };
+        
+        var result = sut.TestValidate(adjuncts);
+        result.ShouldHaveAnyValidationError()
+            .WithErrorMessage(
+                "Adjunct id contains at least one of the following restricted characters. Invalid values are: \\ /");
     }
 }

--- a/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
+++ b/src/protagonist/API/Features/Adjuncts/Validation/HydraAdjunctValidator.cs
@@ -44,7 +44,7 @@ public class HydraAdjunctValidator : AbstractValidator<DLCS.HydraModel.Adjunct>
         
         RuleFor(a => a.ModelId)
             .Must(a => !apiSettings.Value.DoesResourceIdContainRestrictedCharacters(a))
-            .WithMessage($"Adjunct id contains at least one of the following restricted characters. Invalid values are: {new string(apiSettings.Value.RestrictedResourceIdCharacters)}");
+            .WithMessage($"Adjunct id contains at least one of the following restricted characters. Invalid values are: {apiSettings.Value.RestrictedResourceIdCharacterString}");
         
         RuleFor(a => a.Type)
             .NotEmpty()

--- a/src/protagonist/API/Features/Customer/Validation/AdjunctIdListValidator.cs
+++ b/src/protagonist/API/Features/Customer/Validation/AdjunctIdListValidator.cs
@@ -24,6 +24,10 @@ public class AdjunctIdListValidator : AbstractValidator<Dictionary<AssetId, List
                 return $"Members contains {dupes.Count} duplicate Id(s): {string.Join(",", dupes.Select(d => $"asset Id: {d.Key} : adjunct id: {string.Join(',', d.Value.GroupBy(v => v).Where(v => v.Count() > 1).Select(v => v.Key))}"))}";
             });
         
+        RuleForEach(c => c)
+            .Must(kvp => kvp.Value.All(a => !apiSettings.Value.DoesResourceIdContainRestrictedCharacters(a)))
+            .WithMessage($"Adjunct id contains at least one of the following restricted characters. Invalid values are: {apiSettings.Value.RestrictedResourceIdCharacterString}");
+        
         var maxBatch = apiSettings.Value.MaxImageListSize;
         RuleFor(c => c)
             .Must(m => m!.SelectMany(a => a.Value).Count() <= maxBatch)


### PR DESCRIPTION
## What does this change?

Fixes #1180

Validate that adjunct ids sent to bulk-delete endpoint don't contain invalid characters. If they do fail fast with 400|BadRequest