### PR TITLE
Support ?include on POST allImages

### DIFF
--- a/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerImageTests.cs
@@ -119,7 +119,98 @@ public class CustomerImageTests : IClassFixture<ProtagonistAppFactory<Startup>>
         collection.PageSize.Should().Be(3);
         collection.TotalItems.Should().Be(3);
     }
-    
+
+    [Fact]
+    public async Task Post_AllImages_Adjuncts_IsUriString_WhenNoIncludeParam()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("adj1");
+        await dbContext.SaveChangesAsync();
+
+        const string allImagesJson = @"{{ ""@type"": ""Collection"", ""member"": [ {{ ""id"": ""{0}"" }} ] }}";
+        var content = new StringContent(string.Format(allImagesJson, assetId.ToString()), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        var asset = collection.Members.Single(m => m.ModelId == assetId.Asset);
+        asset.Adjuncts!.Type.Should().Be(JTokenType.String);
+        asset.Adjuncts.ToString().Should().EndWith($"/images/{assetId.Asset}/adjuncts");
+    }
+
+    [Fact]
+    public async Task Post_AllImages_Adjuncts_IsUriString_WhenUnknownIncludeParam()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("adj1");
+        await dbContext.SaveChangesAsync();
+
+        const string allImagesJson = @"{{ ""@type"": ""Collection"", ""member"": [ {{ ""id"": ""{0}"" }} ] }}";
+        var content = new StringContent(string.Format(allImagesJson, assetId.ToString()), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages?include=something", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        var asset = collection.Members.Single(m => m.ModelId == assetId.Asset);
+        asset.Adjuncts!.Type.Should().Be(JTokenType.String);
+    }
+
+    [Fact]
+    public async Task Post_AllImages_Adjuncts_IsEmptyArray_WhenIncludeAdjunctsButNoneExist()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId);
+        await dbContext.SaveChangesAsync();
+
+        const string allImagesJson = @"{{ ""@type"": ""Collection"", ""member"": [ {{ ""id"": ""{0}"" }} ] }}";
+        var content = new StringContent(string.Format(allImagesJson, assetId.ToString()), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages?include=adjuncts", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        var asset = collection.Members.Single(m => m.ModelId == assetId.Asset);
+        asset.Adjuncts!.Type.Should().Be(JTokenType.Array);
+        ((JArray)asset.Adjuncts).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Post_AllImages_Adjuncts_IsInlineArray_WhenIncludeAdjunctsAndAdjunctsExist()
+    {
+        // Arrange
+        var assetId = AssetIdGenerator.GetAssetId();
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct("adj1")
+            .WithTestAdjunct("adj2");
+        await dbContext.SaveChangesAsync();
+
+        const string allImagesJson = @"{{ ""@type"": ""Collection"", ""member"": [ {{ ""id"": ""{0}"" }} ] }}";
+        var content = new StringContent(string.Format(allImagesJson, assetId.ToString()), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer().PostAsync("/customers/99/allImages?include=adjuncts", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var collection = await response.ReadAsHydraResponseAsync<HydraCollection<Image>>();
+        var asset = collection.Members.Single(m => m.ModelId == assetId.Asset);
+        asset.Adjuncts!.Type.Should().Be(JTokenType.Array);
+        ((JArray)asset.Adjuncts).Should().HaveCount(2);
+    }
+
     [Fact]
     public async Task Post_DeleteImages_400_IfInvalidFormatId()
     {

--- a/src/protagonist/API/Features/Customer/CustomerImagesController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerImagesController.cs
@@ -61,11 +61,13 @@ public class CustomerImagesController(IOptions<ApiSettings> settings, IMediator 
             return this.ValidationFailed(validationResult);
         }
 
-        var request = new GetMultipleImagesById(imageIdentifiers.Members!.Select(m => m.Id).ToList(), customerId);
+        var assetQueryModel = Request.GetAssetQuery();
+        var request = new GetMultipleImagesById(imageIdentifiers.Members!.Select(m => m.Id).ToList(), customerId,
+            assetQueryModel.Include);
 
         return await HandleListFetch<Asset, GetMultipleImagesById, DLCS.HydraModel.Image>(
             request,
-            a => a.ToHydra(GetUrlRoots()),
+            a => a.ToHydra(GetUrlRoots(), assetQueryModel.IncludesField(IncludeFields.Adjuncts)),
             "Get customer images failed",
             cancellationToken: cancellationToken);
     }

--- a/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
+++ b/src/protagonist/API/Features/Customer/Requests/GetMultipleImagesById.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using API.Features.Assets.Query;
 using API.Features.Customer.Validation;
 using API.Infrastructure.Requests;
 using DLCS.Model.Assets;
@@ -12,16 +13,12 @@ namespace API.Features.Customer.Requests;
 /// <summary>
 /// Get a list of all images whose id is in ImageIds list
 /// </summary>
-public class GetMultipleImagesById : IRequest<FetchEntityResult<IReadOnlyCollection<Asset>>>
+public class GetMultipleImagesById(IReadOnlyCollection<string> assetIds, int customerId, AssetInclude? include)
+    : IRequest<FetchEntityResult<IReadOnlyCollection<Asset>>>
 {
-    public IReadOnlyCollection<string> AssetIds { get; }
-    public int CustomerId { get; }
-
-    public GetMultipleImagesById(IReadOnlyCollection<string> assetIds, int customerId)
-    {
-        AssetIds = assetIds;
-        CustomerId = customerId;
-    }
+    public IReadOnlyCollection<string> AssetIds { get; } = assetIds;
+    public int CustomerId { get; } = customerId;
+    public AssetInclude? Include { get; } = include;
 }
 
 public class GetMultipleImagesByIdHandler 
@@ -42,6 +39,7 @@ public class GetMultipleImagesByIdHandler
         var results = await dlcsContext.Images.AsNoTracking()
             .Where(i => i.Customer == request.CustomerId && assetIds.Contains(i.Id))
             .IncludeDeliveryChannelsWithPolicy()
+            .IncludeRelated(request.Include)
             .AsSingleQuery()
             .ToListAsync(cancellationToken);
 


### PR DESCRIPTION
## What does this change?

Resolves #1184.

Adds support for `?include=adjuncts` to `POST /allImages` endpoint. The logic will attempt to parse full asset-query syntax but only use the "include" as it didn't feel worth refactoring to extract this out.