### PR TITLE
Set certain fields to optional for the 'None' channel

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -345,7 +345,7 @@ public class HydraImageValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public void MediaType_NullOrEmpty_OnCreateWhenNoneDeliveryChannel(string mediaType)
+    public void MediaType_CanBeNullOrEmpty_OnCreateWhenNoneDeliveryChannel(string mediaType)
     {
         var model = new Image
         {
@@ -354,5 +354,33 @@ public class HydraImageValidatorTests
         };
         var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default", "create"));
         result.ShouldNotHaveValidationErrorFor(a => a.MediaType);
+    }
+    
+    [Fact]
+    public void PlaceHolderValues_NotAllowed_WhenNotNoneChannel()
+    {
+        var model = new Image
+        {
+            MediaType = AssetDeliveryChannels.NoneChannelMediaTypePlaceholder,
+            Origin = AssetDeliveryChannels.NoneChannelOriginPlaceholder,
+            DeliveryChannels = [new DeliveryChannel {Channel = AssetDeliveryChannels.Image }]
+        };
+        var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default"));
+        result.ShouldHaveValidationErrorFor(a => a.MediaType).WithErrorMessage("'example/example' is not a valid mediaType");
+        result.ShouldHaveValidationErrorFor(a => a.Origin).WithErrorMessage("'https://example.org/origin' is not a valid origin");
+    }
+    
+    [Fact]
+    public void PlaceHolderValues_Allowed_WhenNoneChannel()
+    {
+        var model = new Image
+        {
+            MediaType = AssetDeliveryChannels.NoneChannelMediaTypePlaceholder,
+            Origin = AssetDeliveryChannels.NoneChannelOriginPlaceholder,
+            DeliveryChannels = [new DeliveryChannel {Channel = AssetDeliveryChannels.None }]
+        };
+        var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default"));
+        result.ShouldNotHaveValidationErrorFor(a => a.MediaType);
+        result.ShouldNotHaveValidationErrorFor(a => a.Origin);
     }
 }

--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -2,6 +2,7 @@
 using API.Features.Image.Validation;
 using API.Settings;
 using DLCS.HydraModel;
+using DLCS.Model.Assets;
 using FluentValidation.TestHelper;
 using Microsoft.Extensions.Options;
 
@@ -338,5 +339,20 @@ public class HydraImageValidatorTests
         };
         var result = Sut.TestValidate(model);
         result.ShouldNotHaveValidationErrorFor(a => a.MaxWidth);
+    }
+    
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void MediaType_NullOrEmpty_OnCreateWhenNoneDeliveryChannel(string mediaType)
+    {
+        var model = new Image
+        {
+            MediaType = mediaType,
+            DeliveryChannels = [new DeliveryChannel {Channel = AssetDeliveryChannels.None }]
+        };
+        var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default", "create"));
+        result.ShouldNotHaveValidationErrorFor(a => a.MediaType);
     }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerAdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerAdjunctTests.cs
@@ -294,7 +294,7 @@ public class CustomerAdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>
         var deleteAdjunctsJson = $$"""
                                    {
                                        "@type": "Collection",
-                                       "member": [ 
+                                       "member": [
                                          { "id": "this/is/not/a/valid/asset/id", "adjunct": [ "{{adjunctId}}" ] }
                                        ]
                                    };
@@ -310,10 +310,34 @@ public class CustomerAdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>
 
         var error = await response.ReadAsJsonAsync<Error>(ensureSuccess: false);
         error.Description.Should().Be("AssetId 'this/is/not/a/valid/asset/id' is invalid. Must be in format customer/space/asset");
-        
+
         A.CallTo(() => DeliverableNotificationSender.SendDeliverableModifiedMessage(
             A<IReadOnlyCollection<NotificationRecord<DLCS.Model.Assets.Adjunct>>>.That.Matches(r =>
                 r.First().ChangeType == ChangeType.Delete && r.First().Before.Id == adjunctId),
+            A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task DeleteMultipleAdjuncts_Returns400_WhenMemberBodyContainsInvalidPropertyNames()
+    {
+        // Arrange - payload uses "idx" instead of "id" and "adjunctx" instead of "adjunct",
+        const string deleteAdjunctsJson = """
+                                          {
+                                              "member": [
+                                                { "idx": "1/1/foo", "adjunctx": ["ocr.txt", "mets.xml"] }
+                                              ]
+                                          }
+                                          """;
+
+        var content = new StringContent(deleteAdjunctsJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(99).PostAsync("/customers/99/deleteAdjuncts", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        A.CallTo(() => DeliverableNotificationSender.SendDeliverableModifiedMessage(
+            A<IReadOnlyCollection<NotificationRecord<DLCS.Model.Assets.Adjunct>>>.Ignored,
             A<CancellationToken>._)).MustNotHaveHappened();
     }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerAdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerAdjunctTests.cs
@@ -336,8 +336,5 @@ public class CustomerAdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        A.CallTo(() => DeliverableNotificationSender.SendDeliverableModifiedMessage(
-            A<IReadOnlyCollection<NotificationRecord<DLCS.Model.Assets.Adjunct>>>.Ignored,
-            A<CancellationToken>._)).MustNotHaveHappened();
     }
 }

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -3250,6 +3250,22 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task Put_LegacyMode_BadRequest_WhenMediaTypeOmittedUnknownOriginExtension()
+    {
+        // legacy mode cannot specify deliveryChannels, so none-optional logic does not apply - mediaType is still required
+        var assetId = AssetIdGenerator.GetAssetId(LegacyModeHelpers.LegacyCustomer, LegacyModeHelpers.LegacySpace);
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.unknown""
+        }}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private byte[] StreamToBytes(Stream input)
     {
         using MemoryStream ms = new MemoryStream();

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -3123,6 +3123,133 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(api);
     }
     
+    [Fact]
+    public async Task Put_NoneChannel_CreatesAsset_WhenOriginOmitted()
+    {
+        // origin is optional for none delivery channel, defaults to https://example.org/origin
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, customerAndSpace.space);
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [{{
+                ""channel"": ""none"",
+                ""policy"": ""none""
+            }}]
+        }}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = dbContext.Images.Single(x => x.Id == assetId);
+        asset.Origin.Should().Be("https://example.org/origin");
+    }
+
+    [Fact]
+    public async Task Put_NoneChannel_CreatesAsset_WhenMediaTypeOmitted()
+    {
+        // mediaType is optional for none delivery channel, defaults to example/example
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, customerAndSpace.space);
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""deliveryChannels"": [{{
+                ""channel"": ""none"",
+                ""policy"": ""none""
+            }}]
+        }}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = dbContext.Images.Single(x => x.Id == assetId);
+        asset.MediaType.Should().Be("example/example");
+    }
+
+    [Fact]
+    public async Task Put_NoneChannel_CreatesAsset_WhenBothOriginAndMediaTypeOmitted()
+    {
+        // both origin and mediaType are optional for none delivery channel
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, customerAndSpace.space);
+        var hydraImageBody = @"{
+            ""@type"": ""Image"",
+            ""deliveryChannels"": [{
+                ""channel"": ""none"",
+                ""policy"": ""none""
+            }]
+        }";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = dbContext.Images.Single(x => x.Id == assetId);
+        asset.Origin.Should().Be("https://example.org/origin");
+        asset.MediaType.Should().Be("example/example");
+    }
+
+    [Fact]
+    public async Task Put_BadRequest_WhenOriginIsNonePlaceholder_AndDeliveryChannelIsNotNone()
+    {
+        // https://example.org/origin is not a valid origin for non-none delivery channels
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, customerAndSpace.space);
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/origin"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [{{
+                ""channel"": ""iiif-img""
+            }}]
+        }}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Put_BadRequest_WhenMediaTypeIsNonePlaceholder_AndDeliveryChannelIsNotNone()
+    {
+        // example/example is not a valid mediaType for non-none delivery channels
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, customerAndSpace.space);
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""mediaType"": ""example/example"",
+            ""deliveryChannels"": [{{
+                ""channel"": ""iiif-img""
+            }}]
+        }}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Put_LegacyMode_BadRequest_WhenOriginOmitted()
+    {
+        // legacy mode cannot specify deliveryChannels, so none-optional logic does not apply - origin is still required
+        var assetId = AssetIdGenerator.GetAssetId(LegacyModeHelpers.LegacyCustomer, LegacyModeHelpers.LegacySpace);
+        var hydraImageBody = @"{
+            ""@type"": ""Image"",
+            ""mediaType"": ""image/tiff""
+        }";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     private byte[] StreamToBytes(Stream input)
     {
         using MemoryStream ms = new MemoryStream();

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -3250,22 +3250,6 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    [Fact]
-    public async Task Put_LegacyMode_BadRequest_WhenMediaTypeOmittedUnknownOriginExtension()
-    {
-        // legacy mode cannot specify deliveryChannels, so none-optional logic does not apply - mediaType is still required
-        var assetId = AssetIdGenerator.GetAssetId(LegacyModeHelpers.LegacyCustomer, LegacyModeHelpers.LegacySpace);
-        var hydraImageBody = $@"{{
-            ""@type"": ""Image"",
-            ""origin"": ""https://example.org/{assetId.Asset}.unknown""
-        }}";
-
-        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var response = await httpClient.AsCustomer(LegacyModeHelpers.LegacyCustomer).PutAsync(assetId.ToApiResourcePath(), content);
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-    }
-
     private byte[] StreamToBytes(Stream input)
     {
         using MemoryStream ms = new MemoryStream();

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -33,11 +33,9 @@ public static class LegacyModeConverter
         if (image.MediaType.IsNullOrEmpty())
         {
             logger?.LogLegacyUsage("Null or empty media type");
-            
-            var contentType = image.Origin.Split('.').Last();
-            image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ??
-                              throw new BadRequestException(
-                                  "Media type is omitted and could not be inferred from origin. This is required when legacy mode is enabled");
+            var contentType = image.Origin?.Split('.').Last() ?? string.Empty;
+
+            image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ?? MIMEHelper.UnknownImage;
             image.Family ??= AssetFamily.Image;
         }
         

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -33,9 +33,11 @@ public static class LegacyModeConverter
         if (image.MediaType.IsNullOrEmpty())
         {
             logger?.LogLegacyUsage("Null or empty media type");
-            var contentType = image.Origin?.Split('.').Last() ?? string.Empty;
-         
-            image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ?? MIMEHelper.UnknownImage;
+            
+            var contentType = image.Origin.Split('.').Last();
+            image.MediaType = MIMEHelper.GetContentTypeForExtension(contentType) ??
+                              throw new BadRequestException(
+                                  "Media type is omitted and could not be inferred from origin. This is required when legacy mode is enabled");
             image.Family ??= AssetFamily.Image;
         }
         

--- a/src/protagonist/API/Features/Customer/CustomerAdjunctsController.cs
+++ b/src/protagonist/API/Features/Customer/CustomerAdjunctsController.cs
@@ -1,21 +1,15 @@
-﻿using System.Collections.Generic;
-using AngleSharp.Attributes;
-using API.Converters;
-using API.Exceptions;
+﻿using API.Converters;
 using API.Features.Customer.Infrastructure;
 using API.Features.Customer.Requests;
 using API.Features.Customer.Validation;
 using API.Infrastructure;
 using API.Settings;
-using DLCS.Core.Types;
 using DLCS.Model;
 using Hydra.Collections;
 using Hydra.Model;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Serilog;
 
 namespace API.Features.Customer;
 
@@ -23,7 +17,8 @@ namespace API.Features.Customer;
 /// Controller for handling bulk requests for adjuncts associated with a customer 
 /// </summary>
 [Route("/customers/{customerId}")]
-public class CustomerAdjunctsController(IOptions<ApiSettings> settings, IMediator mediator, ILogger<CustomerAdjunctsController> logger)
+[ApiController]
+public class CustomerAdjunctsController(IOptions<ApiSettings> settings, IMediator mediator)
     : HydraController(settings.Value, mediator)
 {
     /// <summary>

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -114,8 +114,8 @@ public class ImageController : HydraController
         {
             hydraAsset.ModelId = imageId;
         }
-        
-        var validationResult = await validator.ValidateAsync(hydraAsset, 
+
+        var validationResult = await validator.ValidateAsync(hydraAsset,
             strategy => strategy.IncludeRuleSets("default", "create"), cancellationToken);
         
         if (!validationResult.IsValid)

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -81,9 +81,11 @@ public class AssetProcessor(
             }
 
             var existingAsset = assetFromDatabase?.Clone();
+            var isNoneChannel = assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Length > 0 &&
+                                assetBeforeProcessing.DeliveryChannelsBeforeProcessing.All(dcp => dcp.Channel == AssetDeliveryChannels.None);
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
-                    settings.RestrictedResourceIdCharacters, assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Any(dcp => dcp.Channel == AssetDeliveryChannels.None) ?? false);
+                    settings.RestrictedResourceIdCharacters, isNoneChannel);
 
             if (!assetPreparationResult.Success)
             {

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -5,8 +5,6 @@ using API.Settings;
 using DLCS.Core;
 using DLCS.Model.Assets;
 using DLCS.Model.Storage;
-using DLCS.Repository;
-using DLCS.Repository.Storage;
 using Microsoft.Extensions.Options;
 
 namespace API.Features.Image.Ingest;
@@ -85,7 +83,7 @@ public class AssetProcessor(
             var existingAsset = assetFromDatabase?.Clone();
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
-                    settings.RestrictedResourceIdCharacters);
+                    settings.RestrictedResourceIdCharacters, assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Any(dcp => dcp.Channel == AssetDeliveryChannels.None) ?? false);
 
             if (!assetPreparationResult.Success)
             {

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -81,8 +81,8 @@ public class AssetProcessor(
             }
 
             var existingAsset = assetFromDatabase?.Clone();
-            var isNoneChannel = assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Length > 0 &&
-                                assetBeforeProcessing.DeliveryChannelsBeforeProcessing.All(dcp => dcp.Channel == AssetDeliveryChannels.None);
+            var isNoneChannel = AssetDeliveryChannels.IsNoneOnly(
+                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel));
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
                     settings.RestrictedResourceIdCharacters, isNoneChannel);

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -21,18 +21,18 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleSet("create", () =>
         {
             RuleFor(a => a.MediaType).NotEmpty()
-                .When(a => !a.DeliveryChannels?.Any(dc => dc.Channel == AssetDeliveryChannels.None) ?? true)
+                .When(a => !IsNoneOnly(a))
                 .WithMessage("Media type must be specified");
         });
 
         RuleFor(a => a.Origin)
-            .Must(o => o != AssetDeliveryChannels.NoneChannelOriginPlaceholder)
-            .When(a => !(a.DeliveryChannels?.All(dc => dc.Channel == AssetDeliveryChannels.None) ?? false))
+            .Must(o => !string.Equals(o, AssetDeliveryChannels.NoneChannelOriginPlaceholder, StringComparison.OrdinalIgnoreCase))
+            .When(a => !IsNoneOnly(a))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelOriginPlaceholder}' is not a valid origin");
 
         RuleFor(a => a.MediaType)
-            .Must(m => m != AssetDeliveryChannels.NoneChannelMediaTypePlaceholder)
-            .When(a => !(a.DeliveryChannels?.All(dc => dc.Channel == AssetDeliveryChannels.None) ?? false))
+            .Must(m => !string.Equals(m, AssetDeliveryChannels.NoneChannelMediaTypePlaceholder, StringComparison.OrdinalIgnoreCase))
+            .When(a => !IsNoneOnly(a))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelMediaTypePlaceholder}' is not a valid mediaType");
 
         When(a => !a.DeliveryChannels.IsNullOrEmpty(), ImageDeliveryChannelDependantValidation);
@@ -68,6 +68,10 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Finished).Empty().WithMessage("Should not include finished");
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
     }
+
+    private static bool IsNoneOnly(DLCS.HydraModel.Image a) =>
+        a.DeliveryChannels?.Length > 0 &&
+        a.DeliveryChannels.All(dc => dc.Channel == AssetDeliveryChannels.None);
 
     private void ImageDeliveryChannelDependantValidation()
     {

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -21,18 +21,18 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleSet("create", () =>
         {
             RuleFor(a => a.MediaType).NotEmpty()
-                .When(a => !IsNoneOnly(a))
+                .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
                 .WithMessage("Media type must be specified");
         });
 
         RuleFor(a => a.Origin)
             .Must(o => !string.Equals(o, AssetDeliveryChannels.NoneChannelOriginPlaceholder, StringComparison.OrdinalIgnoreCase))
-            .When(a => !IsNoneOnly(a))
+            .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelOriginPlaceholder}' is not a valid origin");
 
         RuleFor(a => a.MediaType)
             .Must(m => !string.Equals(m, AssetDeliveryChannels.NoneChannelMediaTypePlaceholder, StringComparison.OrdinalIgnoreCase))
-            .When(a => !IsNoneOnly(a))
+            .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelMediaTypePlaceholder}' is not a valid mediaType");
 
         When(a => !a.DeliveryChannels.IsNullOrEmpty(), ImageDeliveryChannelDependantValidation);
@@ -68,10 +68,6 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Finished).Empty().WithMessage("Should not include finished");
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
     }
-
-    private static bool IsNoneOnly(DLCS.HydraModel.Image a) =>
-        a.DeliveryChannels?.Length > 0 &&
-        a.DeliveryChannels.All(dc => dc.Channel == AssetDeliveryChannels.None);
 
     private void ImageDeliveryChannelDependantValidation()
     {

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -20,7 +20,8 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         
         RuleSet("create", () =>
         {
-            RuleFor(a => a.MediaType).NotEmpty()
+            RuleFor(a => a.MediaType)
+                .NotEmpty()
                 .When(a => !IsNoneOnly(a))
                 .WithMessage("Media type must be specified");
         });
@@ -69,7 +70,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
     }
     
-    static bool IsNoneOnly(DLCS.HydraModel.Image image)
+    private static bool IsNoneOnly(DLCS.HydraModel.Image image)
         => AssetDeliveryChannels.IsNoneOnly(image.DeliveryChannels?.Select(dc => dc.Channel));
 
     private void ImageDeliveryChannelDependantValidation()

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -20,9 +20,21 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         
         RuleSet("create", () =>
         {
-            RuleFor(a => a.MediaType).NotEmpty().WithMessage("Media type must be specified");
+            RuleFor(a => a.MediaType).NotEmpty()
+                .When(a => !a.DeliveryChannels?.Any(dc => dc.Channel == AssetDeliveryChannels.None) ?? true)
+                .WithMessage("Media type must be specified");
         });
-        
+
+        RuleFor(a => a.Origin)
+            .Must(o => o != AssetDeliveryChannels.NoneChannelOriginPlaceholder)
+            .When(a => !(a.DeliveryChannels?.All(dc => dc.Channel == AssetDeliveryChannels.None) ?? false))
+            .WithMessage($"'{AssetDeliveryChannels.NoneChannelOriginPlaceholder}' is not a valid origin");
+
+        RuleFor(a => a.MediaType)
+            .Must(m => m != AssetDeliveryChannels.NoneChannelMediaTypePlaceholder)
+            .When(a => !(a.DeliveryChannels?.All(dc => dc.Channel == AssetDeliveryChannels.None) ?? false))
+            .WithMessage($"'{AssetDeliveryChannels.NoneChannelMediaTypePlaceholder}' is not a valid mediaType");
+
         When(a => !a.DeliveryChannels.IsNullOrEmpty(), ImageDeliveryChannelDependantValidation);
         
         RuleFor(a => a.MaxUnauthorised)

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -21,18 +21,18 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleSet("create", () =>
         {
             RuleFor(a => a.MediaType).NotEmpty()
-                .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
+                .When(a => !IsNoneOnly(a))
                 .WithMessage("Media type must be specified");
         });
 
         RuleFor(a => a.Origin)
             .Must(o => !string.Equals(o, AssetDeliveryChannels.NoneChannelOriginPlaceholder, StringComparison.OrdinalIgnoreCase))
-            .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
+            .When(a => !IsNoneOnly(a))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelOriginPlaceholder}' is not a valid origin");
 
         RuleFor(a => a.MediaType)
             .Must(m => !string.Equals(m, AssetDeliveryChannels.NoneChannelMediaTypePlaceholder, StringComparison.OrdinalIgnoreCase))
-            .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)))
+            .When(a => !IsNoneOnly(a))
             .WithMessage($"'{AssetDeliveryChannels.NoneChannelMediaTypePlaceholder}' is not a valid mediaType");
 
         When(a => !a.DeliveryChannels.IsNullOrEmpty(), ImageDeliveryChannelDependantValidation);
@@ -68,6 +68,9 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         RuleFor(a => a.Finished).Empty().WithMessage("Should not include finished");
         RuleFor(a => a.Created).Empty().WithMessage("Should not include created");
     }
+    
+    static bool IsNoneOnly(DLCS.HydraModel.Image image)
+        => AssetDeliveryChannels.IsNoneOnly(image.DeliveryChannels?.Select(dc => dc.Channel));
 
     private void ImageDeliveryChannelDependantValidation()
     {

--- a/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
+++ b/src/protagonist/DLCS.Model.Tests/Assets/AssetDeliveryChannelsTests.cs
@@ -137,4 +137,34 @@ public class AssetDeliveryChannelsTests
 
         asset.HasAnyDeliveryChannel(AssetDeliveryChannels.All).Should().BeFalse();
     }
+    
+    [Fact]
+    public void IsNoneOnly_True_IfOnlyNoneChannel()
+    {
+        AssetDeliveryChannels.IsNoneOnly(["none"]).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNoneOnly_False_IfNull()
+    {
+        AssetDeliveryChannels.IsNoneOnly(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsNoneOnly_False_IfEmpty()
+    {
+        AssetDeliveryChannels.IsNoneOnly([]).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("iiif-img")]
+    [InlineData("file")]
+    [InlineData("iiif-av")]
+    [InlineData("thumbs")]
+    [InlineData("none,iiif-img")]
+    [InlineData("none,none")]
+    public void IsNoneOnly_False_IfInvalidChannelCombinations(string channelsCsv)
+    {
+        AssetDeliveryChannels.IsNoneOnly(channelsCsv.Split(',')).Should().BeFalse();
+    }
 }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -73,18 +73,14 @@ public static class AssetDeliveryChannels
         => !asset.HasDeliveryChannel(deliveryChannel);
     
     /// <summary>
-    /// Checks if all specified channels are the 'none' channel (and at least one is present)
+    /// Checks if the 'none' channel is the only channel specified (exactly one entry, equal to 'none')
     /// </summary>
     public static bool IsNoneOnly(IEnumerable<string>? channels)
     {
         if (channels == null) return false;
-        var isNoneOnly = false;
-        foreach (var channel in channels)
-        {
-            isNoneOnly = true;
-            if (channel != None) return false;
-        }
-        return isNoneOnly;
+        
+        using var e = channels.GetEnumerator();
+        return e.MoveNext() && e.Current == None && !e.MoveNext();
     }
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DLCS.Core.Collections;
 
@@ -71,6 +72,16 @@ public static class AssetDeliveryChannels
     public static bool DoesNotHaveDeliveryChannel(this Asset asset, string deliveryChannel)
         => !asset.HasDeliveryChannel(deliveryChannel);
     
+    /// <summary>
+    /// Checks if all specified channels are the 'none' channel (and at least one is present)
+    /// </summary>
+    public static bool IsNoneOnly(IEnumerable<string>? channels)
+    {
+        if (channels == null) return false;
+        var list = channels.ToList();
+        return list.Count > 0 && list.All(c => c == None);
+    }
+
     /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -13,6 +13,9 @@ public static class AssetDeliveryChannels
     public const string None = "none";
     public const string Default = "default";
 
+    public const string NoneChannelOriginPlaceholder = "https://example.org/origin";
+    public const string NoneChannelMediaTypePlaceholder = "example/example";
+
     /// <summary>
     /// All possible delivery channels
     /// </summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -78,8 +78,13 @@ public static class AssetDeliveryChannels
     public static bool IsNoneOnly(IEnumerable<string>? channels)
     {
         if (channels == null) return false;
-        var list = channels.ToList();
-        return list.Count > 0 && list.All(c => c == None);
+        var isNoneOnly = false;
+        foreach (var channel in channels)
+        {
+            isNoneOnly = true;
+            if (channel != None) return false;
+        }
+        return isNoneOnly;
     }
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -72,7 +72,7 @@ public static class AssetPreparer
     /// </param>
     /// <param name="isBatchUpdate">True if this is part of batch creation - allows Batch value to be set.</param>
     /// <param name="disallowedCharacters">List of characters that are not allowed to be used in AssetId</param>
-    /// <param name="isNoneChannel">Whther this asset is being delivered by the none channel</param>
+    /// <param name="isNoneChannel">Whether this asset is being delivered by the none channel only</param>
     /// <returns>A validation result</returns>
     public static AssetPreparationResult PrepareAssetForUpsert(
         Asset? existingAsset,
@@ -97,8 +97,8 @@ public static class AssetPreparer
         // For "none" delivery channel, fill in placeholder origin/mediaType if absent
         if (isNoneChannel)
         {
-           updateAsset.Origin ??= AssetDeliveryChannels.NoneChannelOriginPlaceholder;
-           updateAsset.MediaType ??= AssetDeliveryChannels.NoneChannelMediaTypePlaceholder;
+            updateAsset.Origin ??= AssetDeliveryChannels.NoneChannelOriginPlaceholder;
+            updateAsset.MediaType ??= AssetDeliveryChannels.NoneChannelMediaTypePlaceholder;
         }
 
         bool reCalculateFamily = false;

--- a/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetPreparer.cs
@@ -64,21 +64,23 @@ public static class AssetPreparer
     /// </remarks>
     /// <param name="existingAsset">If this is an update, the current version of the asset</param>
     /// <param name="updateAsset">
-    /// The new or updated asset - this is the submitted list of changes
+    ///     The new or updated asset - this is the submitted list of changes
     /// </param>
     /// <param name="allowNonApiUpdates">
-    /// Permit setting of fields that would not be allowed on API calls. Use with caution - all values submitted will
-    /// be saved as this effectively drops validation.
+    ///     Permit setting of fields that would not be allowed on API calls. Use with caution - all values submitted will
+    ///     be saved as this effectively drops validation.
     /// </param>
     /// <param name="isBatchUpdate">True if this is part of batch creation - allows Batch value to be set.</param>
     /// <param name="disallowedCharacters">List of characters that are not allowed to be used in AssetId</param>
+    /// <param name="isNoneChannel">Whther this asset is being delivered by the none channel</param>
     /// <returns>A validation result</returns>
     public static AssetPreparationResult PrepareAssetForUpsert(
         Asset? existingAsset,
         Asset updateAsset,
         bool allowNonApiUpdates,
         bool isBatchUpdate,
-        char[] disallowedCharacters)
+        char[] disallowedCharacters,
+        bool isNoneChannel = false)
     {
         bool requiresReingest = existingAsset == null;
         
@@ -91,6 +93,13 @@ public static class AssetPreparer
         // Validate there are no issues
         var prepareAssetForUpsert = ValidateRequests(existingAsset, updateAsset, allowNonApiUpdates, isBatchUpdate, disallowedCharacters);
         if (prepareAssetForUpsert != null) return prepareAssetForUpsert;
+        
+        // For "none" delivery channel, fill in placeholder origin/mediaType if absent
+        if (isNoneChannel)
+        {
+           updateAsset.Origin ??= AssetDeliveryChannels.NoneChannelOriginPlaceholder;
+           updateAsset.MediaType ??= AssetDeliveryChannels.NoneChannelMediaTypePlaceholder;
+        }
 
         bool reCalculateFamily = false;
         if (existingAsset != null)


### PR DESCRIPTION
## What does this change?

Resolves #1155
Resolves #1182

This PR modifies the `none` channel to make the `mediaType` and `origin` optional when specified.  

It will also update the origin to be `https://example.org/origin` and the mediatype to `example/example` if they haven't been set.

However, if the `none` channel isn't specified, the code will act the same way, outside of activwely rejecting any asset qwith the placeholder values set

Additionally, the bug around returning `500` when deleting adjuncts with incorrect fields has been fixed by adding`[ApiController]` to the `CustomerAdjunctController` class, so it should now return a `400` response

