### PR TITLE
Allow for stub assets to be added to space 0

### DIFF
--- a/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
+++ b/src/protagonist/API.Tests/Converters/LegacyModeConverterTests.cs
@@ -9,6 +9,8 @@ namespace API.Tests.Converters;
 
 public class LegacyModeConverterTests
 {
+    private const int defaultSpace = 1;
+    
     [Fact]
     public void VerifyAndConvertToModernFormat_ChangesNothing_WithNewFormat()
     {
@@ -20,7 +22,7 @@ public class LegacyModeConverterTests
         };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be(hydraImage.MediaType);
@@ -36,7 +38,7 @@ public class LegacyModeConverterTests
 
         // Act
         Action action = () =>
-            LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+            LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         action.Should()
@@ -53,7 +55,7 @@ public class LegacyModeConverterTests
             { MaxUnauthorised = 5, Family = AssetFamily.File, Origin = "https://example.org/my-asset" };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be("image/unknown");
@@ -68,7 +70,7 @@ public class LegacyModeConverterTests
         var hydraImage = new Image { Origin = "something.jpg", MaxUnauthorised = 5, Family = AssetFamily.File };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be("image/jpeg");
@@ -83,7 +85,7 @@ public class LegacyModeConverterTests
         var hydraImage = new Image { Origin = "something.jpg", MaxUnauthorised = 0, Family = AssetFamily.File };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be("image/jpeg");
@@ -98,7 +100,7 @@ public class LegacyModeConverterTests
         var hydraImage = new Image { Origin = "something.jpg" };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be("image/jpeg");
@@ -113,7 +115,7 @@ public class LegacyModeConverterTests
         var hydraImage = new Image { Origin = "something.jpg", Roles = ["some role"] };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.MediaType.Should().Be("image/jpeg");
@@ -132,7 +134,7 @@ public class LegacyModeConverterTests
         };
         
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.ModelId.Should().Be("someId");
@@ -149,7 +151,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -175,7 +177,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -196,7 +198,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -215,7 +217,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -234,7 +236,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -255,7 +257,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -277,7 +279,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -301,7 +303,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -327,7 +329,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -352,7 +354,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -375,7 +377,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        var convertedImage = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         convertedImage.DeliveryChannels.Should().Satisfy(
@@ -394,7 +396,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         action.Should()
@@ -414,7 +416,7 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         action.Should()
@@ -435,12 +437,32 @@ public class LegacyModeConverterTests
         };
 
         // Act
-        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage);
+        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, defaultSpace);
 
         // Assert
         action.Should()
             .Throw<APIException>()
             .WithMessage("'not-a-policy' is not a valid imageOptimisationPolicy for a timebased asset")
+            .And.StatusCode.Should().Be(400);
+    }
+    
+    [Fact]
+    public void VerifyAndConvertToModernFormat_Fails_WhenStubAssetSpaceUsed()
+    {
+        // Arrange
+        var hydraImage = new Image
+        {
+            MediaType = "type", Origin = "https://example.org/my-asset",
+            MaxUnauthorised = 5, Family = AssetFamily.File
+        };
+        
+        // Act
+        Action action = () => LegacyModeConverter.VerifyAndConvertToModernFormat(hydraImage, AssetDeliveryChannels.StubAssetSpace);
+        
+        // Assert
+        action.Should()
+            .Throw<APIException>()
+            .WithMessage("The stub asset space is not valid when legacy mode is enabled")
             .And.StatusCode.Should().Be(400);
     }
 }

--- a/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelHelperTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelHelperTests.cs
@@ -1,0 +1,32 @@
+using API.Features.DeliveryChannels.Helpers;
+
+namespace API.Tests.Features.DeliveryChannels;
+
+public class DefaultDeliveryChannelHelperTests
+{
+    [Fact]
+    public void GetSpaceZeroErrorMessage_ReturnsNull_WhenSpaceIsNull()
+    {
+        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(null, SpaceZeroOperation.Create);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetSpaceZeroErrorMessage_ReturnsNull_WhenSpaceIsNonZero()
+    {
+        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(5, SpaceZeroOperation.Create);
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(SpaceZeroOperation.Create, "create")]
+    [InlineData(SpaceZeroOperation.Modify, "modify")]
+    [InlineData(SpaceZeroOperation.Delete, "delete")]
+    public void GetSpaceZeroErrorMessage_ReturnsError_WhenSpaceIsZero(SpaceZeroOperation operation, string expectedOpName)
+    {
+        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(0, operation);
+        result.Should().NotBeNull();
+        result.Should().Contain("space 0");
+        result.Should().Contain(expectedOpName);
+    }
+}

--- a/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelHelperTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelHelperTests.cs
@@ -7,26 +7,14 @@ public class DefaultDeliveryChannelHelperTests
     [Fact]
     public void GetSpaceZeroErrorMessage_ReturnsNull_WhenSpaceIsNull()
     {
-        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(null, SpaceZeroOperation.Create);
+        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(null);
         result.Should().BeNull();
     }
 
     [Fact]
     public void GetSpaceZeroErrorMessage_ReturnsNull_WhenSpaceIsNonZero()
     {
-        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(5, SpaceZeroOperation.Create);
+        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(5);
         result.Should().BeNull();
-    }
-
-    [Theory]
-    [InlineData(SpaceZeroOperation.Create, "create")]
-    [InlineData(SpaceZeroOperation.Modify, "modify")]
-    [InlineData(SpaceZeroOperation.Delete, "delete")]
-    public void GetSpaceZeroErrorMessage_ReturnsError_WhenSpaceIsZero(SpaceZeroOperation operation, string expectedOpName)
-    {
-        var result = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(0, operation);
-        result.Should().NotBeNull();
-        result.Should().Contain("space 0");
-        result.Should().Contain(expectedOpName);
     }
 }

--- a/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelRepositoryTests.cs
@@ -49,7 +49,7 @@ public class DefaultDeliveryChannelRepositoryTests
        
        dbContext.DefaultDeliveryChannels.Add(new DefaultDeliveryChannel
        {
-           Space = 0,
+           Space = null,
            Customer = 2,
            DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.ImageDefault,
            MediaType = "image/*"

--- a/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelRepositoryTests.cs
+++ b/src/protagonist/API.Tests/Features/DeliveryChannels/DefaultDeliveryChannelRepositoryTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Linq;
+using API.Features.Assets.Query;
 using API.Features.DeliveryChannels.DataAccess;
 using API.Tests.Integration.Infrastructure;
 using DLCS.Core.Caching;
+using DLCS.Model.Assets;
 using DLCS.Model.DeliveryChannels;
 using DLCS.Model.Policies;
 using DLCS.Repository;
@@ -55,6 +57,14 @@ public class DefaultDeliveryChannelRepositoryTests
            MediaType = "image/*"
        });
        
+       dbContext.DefaultDeliveryChannels.Add(new DefaultDeliveryChannel
+       {
+           Space = AssetDeliveryChannels.StubAssetSpace,
+           Customer = 2,
+           DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.None,
+           MediaType = "*/*"
+       });
+       
        dbContext.SaveChanges();
     }
 
@@ -97,5 +107,16 @@ public class DefaultDeliveryChannelRepositoryTests
 
         // Assert
         await action.Should().ThrowExactlyAsync<InvalidOperationException>();
+    }
+    
+    [Fact]
+    public async Task MatchedDeliveryChannels_ReturnsOnlyNoneDeliveryChannelPolicy_WhenCalledFromStubAssetSpace()
+    {
+        // Arrange and Act
+        var matches = await sut.MatchedDeliveryChannels("image/tiff", AssetDeliveryChannels.StubAssetSpace, 2);
+
+        // Assert
+        matches.Count.Should().Be(1);
+        matches.Count(x => x.Channel == "none").Should().Be(1);
     }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -1922,4 +1922,46 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
             dc => dc.Channel == AssetDeliveryChannels.Timebased &&
                   dc.DeliveryChannelPolicy.Name == "default-audio");
     }
+
+    [Fact]
+    public async Task Post_CreateBatch_400_IfSpaceZeroAssetHasNonNoneDeliveryChannel()
+    {
+        // Arrange
+        const int customerId = 1900;
+        await dbContext.Customers.AddTestCustomer(customerId);
+        await dbContext.Spaces.AddTestSpace(customerId, 0, "stub-space");
+        await dbContext.Spaces.AddTestSpace(customerId, 1);
+        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
+        await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });
+        await dbContext.SaveChangesAsync();
+
+        var hydraImageBody = @"{
+    ""@context"": ""http://www.w3.org/ns/hydra/context.jsonld"",
+    ""@type"": ""Collection"",
+    ""member"": [
+        {
+          ""id"": ""stub-asset"",
+          ""origin"": ""https://example.org/image.jpg"",
+          ""space"": 0,
+          ""family"": ""I"",
+          ""mediaType"": ""image/jpeg"",
+          ""deliveryChannels"": [
+            {
+              ""channel"": ""iiif-img"",
+              ""policy"": ""default""
+            }
+          ]
+        }
+    ]
+}";
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var path = $"/customers/{customerId}/queue";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -1929,7 +1929,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange
         const int customerId = 1900;
         await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.Spaces.AddTestSpace(customerId, 0, "stub-space");
+        await dbContext.Spaces.AddTestSpace(customerId, 0, "stub-assets");
         await dbContext.Spaces.AddTestSpace(customerId, 1);
         await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
         await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });

--- a/src/protagonist/API.Tests/Integration/CustomerTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerTests.cs
@@ -193,7 +193,7 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
 
         var spaceZero = await dbContext.Spaces.SingleOrDefaultAsync(s => s.Customer == newCustomerId && s.Id == 0);
         spaceZero.Should().NotBeNull();
-        spaceZero!.Name.Should().Be("stub-space");
+        spaceZero!.Name.Should().Be("stub-assets");
     }
 
     [Fact]

--- a/src/protagonist/API.Tests/Integration/CustomerTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerTests.cs
@@ -163,13 +163,37 @@ public class CustomerTests : IClassFixture<ProtagonistAppFactory<Startup>>
         priorityQueue.Size.Should().Be(0);
         
         dbContext.DeliveryChannelPolicies.Count(d => d.Customer == newDbCustomer.Id).Should().Be(3);
-        dbContext.DefaultDeliveryChannels.Count(d => d.Customer == newDbCustomer.Id).Should().Be(5);
+        dbContext.DefaultDeliveryChannels.Count(d => d.Customer == newDbCustomer.Id).Should().Be(6);
 
         A.CallTo(() =>
                 NotificationSender.SendCustomerCreatedMessage(
                     A<DLCS.Model.Customers.Customer>.That.Matches(c => c.Id == newDbCustomer.Id),
                     A<CancellationToken>._))
             .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task CreateNewCustomer_CreatesSpaceZero()
+    {
+        // Arrange
+        const string newCustomerJson = @"{
+  ""@type"": ""Customer"",
+  ""name"": ""api-test-space-zero"",
+  ""displayName"": ""Space Zero Customer""
+}";
+        var content = new StringContent(newCustomerJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsAdmin().PostAsync("/customers", content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var newCustomer = await response.ReadAsHydraResponseAsync<Customer>();
+        var newCustomerId = int.Parse(newCustomer.Id!.Split('/').Last());
+
+        var spaceZero = await dbContext.Spaces.SingleOrDefaultAsync(s => s.Customer == newCustomerId && s.Id == 0);
+        spaceZero.Should().NotBeNull();
+        spaceZero!.Name.Should().Be("stub-space");
     }
 
     [Fact]

--- a/src/protagonist/API.Tests/Integration/DefaultDeliveryChannelsTests.cs
+++ b/src/protagonist/API.Tests/Integration/DefaultDeliveryChannelsTests.cs
@@ -701,6 +701,75 @@ public class DefaultDeliveryChannelsTests : IClassFixture<ProtagonistAppFactory<
     }
     
     [Fact]
+    public async Task Post_CreateDefaultDeliveryChannel_ForSpaceZero_Returns400()
+    {
+        // Arrange
+        const int customerId = 1;
+        var path = $"customers/{customerId}/spaces/0/defaultDeliveryChannels";
+
+        string newDefaultDeliveryChannelJson = JsonConvert.SerializeObject(new DefaultDeliveryChannel()
+        {
+            MediaType = "image/tiff",
+            Policy = "default",
+            Channel = "iiif-img"
+        });
+
+        // Act
+        var content = new StringContent(newDefaultDeliveryChannelJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+
+        var data = JsonConvert.DeserializeObject<Error>(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        data!.Description.Should().Contain("space 0");
+    }
+
+    [Fact]
+    public async Task Put_UpdateDefaultDeliveryChannel_ForSpaceZero_Returns400()
+    {
+        // Arrange
+        const int customerId = 1;
+        var existingDdc = dlcsContext.DefaultDeliveryChannels.First(d => d.Customer == customerId && d.Space == 0);
+        var path = $"customers/{customerId}/spaces/0/defaultDeliveryChannels/{existingDdc.Id}";
+
+        string updateJson = JsonConvert.SerializeObject(new DefaultDeliveryChannel()
+        {
+            MediaType = "image/*",
+            Policy = "default",
+            Channel = "iiif-img"
+        });
+
+        // Act
+        var content = new StringContent(updateJson, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerId).PutAsync(path, content);
+
+        var data = JsonConvert.DeserializeObject<Error>(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        data!.Description.Should().Contain("space 0");
+    }
+
+    [Fact]
+    public async Task Delete_DeleteDefaultDeliveryChannel_ForSpaceZero_Returns409()
+    {
+        // Arrange
+        const int customerId = 1;
+        var existingDdc = dlcsContext.DefaultDeliveryChannels.First(d => d.Customer == customerId && d.Space == 0);
+        var path = $"customers/{customerId}/spaces/0/defaultDeliveryChannels/{existingDdc.Id}";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).DeleteAsync(path);
+
+        var data = JsonConvert.DeserializeObject<Error>(await response.Content.ReadAsStringAsync());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        data!.Description.Should().Contain("space 0");
+    }
+
+    [Fact]
     public async Task Delete_DeleteADefaultDeliveryChannelForCustomerAndSpace_200()
     {
         // Arrange

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -207,7 +207,7 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     {
         // Arrange
         var customerAndSpace = await CreateCustomerAndSpace();
-        var assetId = new AssetId(customerAndSpace.customer, 0, nameof(Put_Asset_InSpaceZero_WithNonNoneDeliveryChannel_Returns400));
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, 0);
         var hydraImageBody = $@"{{
             ""@type"": ""Image"",
             ""origin"": ""https://example.org/{assetId.Asset}.tiff"",

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -255,6 +255,44 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels).Single(x => x.Id == assetId);
         asset.ImageDeliveryChannels.Should().ContainSingle(x => x.Channel == AssetDeliveryChannels.None);
     }
+    
+    [Fact]
+    public async Task Put_UpdateAsset_InSpaceZero_WithNoSpecifiedDeliveryChannel_UpdatesAssetWithNoneChannelSuccessfully()
+    {
+        // Arrange
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customer: customerAndSpace.customer, space: AssetDeliveryChannels.StubAssetSpace);
+    
+        var noneDeliveryChannel = new List<ImageDeliveryChannel>
+        {
+            new()
+            {
+                Channel = AssetDeliveryChannels.None,
+                DeliveryChannelPolicyId = KnownDeliveryChannelPolicies.None
+            }
+        };
+        
+        await dbContext.Images.AddTestAsset(assetId, customer: customerAndSpace.customer, space: AssetDeliveryChannels.StubAssetSpace, 
+            origin: $"https://example.org/{assetId.Asset}.tiff", imageDeliveryChannels: noneDeliveryChannel);
+        
+        await dbContext.SaveChangesAsync();
+        
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff""
+        }}";
+
+        // Act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels).Single(x => x.Id == assetId);
+        asset.ImageDeliveryChannels.Should().ContainSingle(x => x.Channel == AssetDeliveryChannels.None);
+    }
 
     [Fact]
     public async Task Put_NewImageAsset_Creates_Asset_WithDeliveryChannelsSetToDefault()

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -203,6 +203,60 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_Asset_InSpaceZero_WithNonNoneDeliveryChannel_Returns400()
+    {
+        // Arrange
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = new AssetId(customerAndSpace.customer, 0, nameof(Put_Asset_InSpaceZero_WithNonNoneDeliveryChannel_Returns400));
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+            {{
+                ""channel"": ""iiif-img"",
+                ""policy"": ""default""
+            }}]
+        }}";
+
+        // Act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Put_Asset_InSpaceZero_WithNoneDeliveryChannel_CreatesAsset()
+    {
+        // Arrange
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = new AssetId(customerAndSpace.customer, 0, nameof(Put_Asset_InSpaceZero_WithNoneDeliveryChannel_CreatesAsset));
+        var hydraImageBody = $@"{{
+            ""@type"": ""Image"",
+            ""origin"": ""https://example.org/{assetId.Asset}.tiff"",
+            ""family"": ""I"",
+            ""mediaType"": ""image/tiff"",
+            ""deliveryChannels"": [
+            {{
+                ""channel"": ""none"",
+                ""policy"": ""none""
+            }}]
+        }}";
+
+        // Act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels).Single(x => x.Id == assetId);
+        asset.ImageDeliveryChannels.Should().ContainSingle(x => x.Channel == AssetDeliveryChannels.None);
+    }
+
+    [Fact]
     public async Task Put_NewImageAsset_Creates_Asset_WithDeliveryChannelsSetToDefault()
     {
         var customerAndSpace = await CreateCustomerAndSpace();

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -594,6 +594,6 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var space = await response.ReadAsHydraResponseAsync<HydraCollection<Space>>();
         space.Members.Should().NotContain(s => s.ModelId == 0);
-        space.TotalItems.Should().Be(0, "new customer has no user-created spaces, only stub-space which is excluded");
+        space.TotalItems.Should().Be(0, "new customer has no user-created spaces, only stub-assets which is excluded");
     }
 }

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -562,8 +562,38 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Arrange & Act
         int? customerId = await EnsureCustomerForSpaceTests("Patch_Space_Updates_Name");
         var deleteResponse = await httpClient.AsCustomer().DeleteAsync($"/customers/{customerId}/spaces/456453");
-        
+
         // Assert
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteSpace_Returns_Conflict_ForSpaceZero()
+    {
+        // Arrange
+        const int customerId = 99;
+
+        // Act
+        var deleteResponse = await httpClient.AsCustomer(customerId).DeleteAsync($"/customers/{customerId}/spaces/0");
+
+        // Assert
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task GetSpaces_DoesNotReturn_SpaceZero()
+    {
+        // Arrange
+        var customerId = await EnsureCustomerForSpaceTests("GetSpaces_DoesNotReturn_SpaceZero");
+        var spacesUrl = $"/customers/{customerId}/spaces";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId.Value).GetAsync(spacesUrl);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var space = await response.ReadAsHydraResponseAsync<HydraCollection<Space>>();
+        space.Members.Should().NotContain(s => s.ModelId == 0);
+        space.TotalItems.Should().Be(0, "new customer has no user-created spaces, only stub-space which is excluded");
     }
 }

--- a/src/protagonist/API/Converters/LegacyModeConverter.cs
+++ b/src/protagonist/API/Converters/LegacyModeConverter.cs
@@ -16,15 +16,21 @@ public static class LegacyModeConverter
 {
     internal static void LogLegacyUsage(this ILogger logger, string message, params object?[] args)
         => logger.LogWarning("LEGACY USE:" + message, args);
-    
+
     /// <summary>
     /// Converts from legacy format to new format
     /// </summary>
     /// <param name="image">The image to convert should be emulated and translated into delivery channels</param>
+    /// <param name="space">The space this image is attached to</param>
     /// <returns>A converted image</returns>
-    public static T VerifyAndConvertToModernFormat<T>(T image, ILogger? logger = null)
+    public static T VerifyAndConvertToModernFormat<T>(T image, int space, ILogger? logger = null)
         where T : Image
     {
+        if (space == AssetDeliveryChannels.StubAssetSpace)
+        {
+            throw new BadRequestException("The stub asset space is not valid when legacy mode is enabled");
+        }
+        
         if (image.Origin.IsNullOrEmpty())
         {
             throw new BadRequestException("An origin is required when legacy mode is enabled");  

--- a/src/protagonist/API/Features/Customer/DapperNewCustomerDeliveryChannelRepository.cs
+++ b/src/protagonist/API/Features/Customer/DapperNewCustomerDeliveryChannelRepository.cs
@@ -57,7 +57,7 @@ where dcp.""Customer"" = 1
 insert into ""DefaultDeliveryChannels"" (""Id"", ""Customer"", ""Space"", ""MediaType"", ""DeliveryChannelPolicyId"")
 select gen_random_uuid(),
        @Customer,
-       0,
+       ddc.""Space"",
        ddc.""MediaType"",
        case
            when ddc.""DeliveryChannelPolicyId"" = 5 then (select ""Id"" from ""DeliveryChannelPolicies"" where ""Channel"" = 'iiif-av' and ""Name"" = 'default-audio' and ""Customer"" = @Customer)
@@ -67,6 +67,6 @@ select gen_random_uuid(),
        end as policyId
 from ""DefaultDeliveryChannels"" ddc
 where ddc.""Customer"" = 1
-  and ddc.""Space"" = 0;
+  and (ddc.""Space"" IS NULL OR ddc.""Space"" = 0);
 ";
 }

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -102,7 +102,7 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEnti
             {
                 Customer = newCustomerId,
                 Id = 0,
-                Name = "stub-space",
+                Name = "stub-assets",
                 Created = DateTime.UtcNow,
                 ImageBucket = string.Empty,
                 Tags = Array.Empty<string>(),

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -6,6 +6,7 @@ using DLCS.Core;
 using DLCS.Model;
 using DLCS.Model.Auth;
 using DLCS.Model.Processing;
+using DLCS.Model.Spaces;
 using DLCS.Repository;
 using DLCS.Repository.Entities;
 using DLCS.Repository.Exceptions;
@@ -95,6 +96,19 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEnti
                 new Queue { Customer = newCustomerId, Name = QueueNames.Default, Size = 0 },
                 new Queue { Customer = newCustomerId, Name = QueueNames.Priority, Size = 0 }
             );
+
+            // Create space 0 for stub assets
+            await dbContext.Spaces.AddAsync(new DLCS.Model.Spaces.Space
+            {
+                Customer = newCustomerId,
+                Id = 0,
+                Name = "stub-space",
+                Created = DateTime.UtcNow,
+                ImageBucket = string.Empty,
+                Tags = Array.Empty<string>(),
+                Roles = Array.Empty<string>(),
+                MaxUnauthorised = -1
+            }, cancellationToken);
 
             await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
@@ -32,10 +32,11 @@ public class DefaultDeliveryChannelRepository : IDefaultDeliveryChannelRepositor
 
     public async Task<List<DeliveryChannelPolicy>> MatchedDeliveryChannels(string mediaType, int space, int customerId)
     {
-        
         var orderedDefaultDeliveryChannels = await OrderedDefaultDeliveryChannels(space, customerId);
 
-        // this is the stub asset space, which is handled differently
+        // this is the stub asset space, which is handled differently as it's used to hold assets
+        // without any delivery channels which is effectively used to store adjuncts that can be outputted on
+        // named queries
         if (space == AssetDeliveryChannels.StubAssetSpace)
         {
             return orderedDefaultDeliveryChannels.Where(dc => dc.Space == AssetDeliveryChannels.StubAssetSpace)

--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
@@ -87,7 +87,7 @@ public class DefaultDeliveryChannelRepository : IDefaultDeliveryChannelRepositor
             return defaultDeliveryChannels;
         }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long));
 
-        return defaultDeliveryChannels.Where(d => d.Space == space || d.Space == 0).ToList();
+        return defaultDeliveryChannels.Where(d => d.Space == space || d.Space == null).ToList();
     }
     
     private async Task<List<DefaultDeliveryChannel>> OrderedDefaultDeliveryChannels(int space, int customerId, string? channel = null)

--- a/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DataAccess/DefaultDeliveryChannelRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO.Enumeration;
 using DLCS.Core.Caching;
+using DLCS.Model.Assets;
 using DLCS.Model.DeliveryChannels;
 using DLCS.Model.Policies;
 using DLCS.Repository;
@@ -31,9 +32,17 @@ public class DefaultDeliveryChannelRepository : IDefaultDeliveryChannelRepositor
 
     public async Task<List<DeliveryChannelPolicy>> MatchedDeliveryChannels(string mediaType, int space, int customerId)
     {
-        var completedMatch = new List<DeliveryChannelPolicy>();
         
         var orderedDefaultDeliveryChannels = await OrderedDefaultDeliveryChannels(space, customerId);
+
+        // this is the stub asset space, which is handled differently
+        if (space == AssetDeliveryChannels.StubAssetSpace)
+        {
+            return orderedDefaultDeliveryChannels.Where(dc => dc.Space == AssetDeliveryChannels.StubAssetSpace)
+                .Select(dc => dc.DeliveryChannelPolicy).ToList();
+        } 
+        
+        var completedMatch = new List<DeliveryChannelPolicy>();
         
         foreach (var defaultDeliveryChannel in orderedDefaultDeliveryChannels)
         {

--- a/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/DefaultDeliveryChannelsController.cs
@@ -37,7 +37,7 @@ public class DefaultDeliveryChannelsController : HydraController
     public async Task<IActionResult> GetCustomerDefaultDeliveryChannels(
         [FromRoute] int customerId,
         CancellationToken cancellationToken,
-        [FromRoute] int space = 0)
+        [FromRoute] int? space = null)
     {
         var getCustomerDefaultDeliveryChannels = new GetDefaultDeliveryChannels(customerId, space);
 
@@ -61,11 +61,11 @@ public class DefaultDeliveryChannelsController : HydraController
         [FromRoute] int customerId,
         Guid defaultDeliveryChannelId,
         CancellationToken cancellationToken,
-        [FromRoute] int space = 0)
+        [FromRoute] int? space = null)
     {
         var getCustomerDefaultDeliveryChannel = new GetDefaultDeliveryChannel(
-            customerId, 
-            space, 
+            customerId,
+            space,
             defaultDeliveryChannelId);
 
         return await HandleFetch(
@@ -88,7 +88,7 @@ public class DefaultDeliveryChannelsController : HydraController
         [FromBody] DefaultDeliveryChannel defaultDeliveryChannel,
         [FromServices] HydraDefaultDeliveryChannelValidator validator,
         CancellationToken cancellationToken,
-        [FromRoute] int space = 0)
+        [FromRoute] int? space = null)
     {
         var validationResult = await validator.ValidateAsync(defaultDeliveryChannel, cancellationToken);
         if (!validationResult.IsValid)
@@ -100,9 +100,9 @@ public class DefaultDeliveryChannelsController : HydraController
         {
             var command = new CreateDefaultDeliveryChannel(customerId,
                 space,
-                defaultDeliveryChannel.Policy,
-                defaultDeliveryChannel.Channel,
-                defaultDeliveryChannel.MediaType);
+                defaultDeliveryChannel.Policy!,
+                defaultDeliveryChannel.Channel!,
+                defaultDeliveryChannel.MediaType!);
             
             return await HandleUpsert(command,
                 s => s.ToHydra(GetUrlRoots().BaseUrl),
@@ -127,7 +127,7 @@ public class DefaultDeliveryChannelsController : HydraController
         [FromServices] HydraDefaultDeliveryChannelValidator validator,
         Guid defaultDeliveryChannelId,
         CancellationToken cancellationToken,
-        [FromRoute] int space = 0)
+        [FromRoute] int? space = null)
     {
         var validationResult = await validator.ValidateAsync(defaultDeliveryChannel, cancellationToken);
         if (!validationResult.IsValid)
@@ -135,11 +135,11 @@ public class DefaultDeliveryChannelsController : HydraController
             return this.ValidationFailed(validationResult);
         }
 
-        var command = new UpdateDefaultDeliveryChannel(customerId, 
-            space, 
-            defaultDeliveryChannel.Policy,
-            defaultDeliveryChannel.Channel,
-            defaultDeliveryChannel.MediaType, 
+        var command = new UpdateDefaultDeliveryChannel(customerId,
+            space,
+            defaultDeliveryChannel.Policy!,
+            defaultDeliveryChannel.Channel!,
+            defaultDeliveryChannel.MediaType!,
             defaultDeliveryChannelId);
 
         return await HandleUpsert(command, 
@@ -160,10 +160,10 @@ public class DefaultDeliveryChannelsController : HydraController
         [FromRoute] int customerId,
         Guid defaultDeliveryChannelId,
         CancellationToken cancellationToken,
-        [FromRoute] int space = 0)
+        [FromRoute] int? space = null)
     {
         var deleteCustomerDefaultDeliveryChannel = new DeleteDefaultDeliveryChannel(
-            customerId, 
+            customerId,
             space,
             defaultDeliveryChannelId);
     

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
@@ -1,0 +1,13 @@
+namespace API.Features.DeliveryChannels.Helpers;
+
+public enum SpaceZeroOperation { Create, Modify, Delete }
+
+public static class DefaultDeliveryChannelHelper
+{
+    /// <summary>
+    /// Returns an error message if <paramref name="space"/> is 0, otherwise null.
+    /// The <paramref name="operation"/> controls which message is returned.
+    /// </summary>
+    public static string? GetSpaceZeroErrorMessage(int? space, SpaceZeroOperation operation)
+        => space == 0 ? $"Default delivery channels for space 0 cannot be changed for the {operation.ToString().ToLower()} operation" : null;
+}

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
@@ -9,5 +9,5 @@ public static class DefaultDeliveryChannelHelper
     /// The <paramref name="operation"/> controls which message is returned.
     /// </summary>
     public static string? GetSpaceZeroErrorMessage(int? space, SpaceZeroOperation operation)
-        => space == 0 ? $"Default delivery channels for space 0 cannot be changed for the {operation.ToString().ToLower()} operation" : null;
+        => space == 0 ? $"Default delivery channels for space 0 cannot be changed for the {operation.ToString().ToLowerInvariant()} operation" : null;
 }

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/DefaultDeliveryChannelHelper.cs
@@ -1,13 +1,10 @@
 namespace API.Features.DeliveryChannels.Helpers;
 
-public enum SpaceZeroOperation { Create, Modify, Delete }
-
 public static class DefaultDeliveryChannelHelper
 {
     /// <summary>
     /// Returns an error message if <paramref name="space"/> is 0, otherwise null.
-    /// The <paramref name="operation"/> controls which message is returned.
     /// </summary>
-    public static string? GetSpaceZeroErrorMessage(int? space, SpaceZeroOperation operation)
-        => space == 0 ? $"Default delivery channels for space 0 cannot be changed for the {operation.ToString().ToLowerInvariant()} operation" : null;
+    public static string? GetSpaceZeroErrorMessage(int? space)
+        => space == 0 ? "Default delivery channels for space 0 cannot be changed" : null;
 }

--- a/src/protagonist/API/Features/DeliveryChannels/Helpers/SpaceZeroValidator.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Helpers/SpaceZeroValidator.cs
@@ -1,0 +1,45 @@
+﻿using API.Features.Image;
+using API.Features.Image.Requests;
+using API.Features.Queues.Requests;
+using API.Infrastructure.Requests;
+using DLCS.Core;
+using DLCS.Model.Assets;
+using MediatR;
+
+namespace API.Features.DeliveryChannels.Helpers;
+
+public static class SpaceZeroValidator
+{
+    public static ModifyEntityResult<T>? Validate<T>(IRequest<ModifyEntityResult<T>> request) where T : class
+    {
+        var failedValidation = false;
+        
+        switch (typeof(T))
+        {
+            case
+                var cls when cls == typeof(Asset):
+            {
+                var converted = (CreateOrUpdateImage)request;
+                if (!converted.AssetBeforeProcessing!.IsValidForSpaceZero()) failedValidation = true;
+                break;
+            }
+            case
+                var cls when cls == typeof(Batch):
+            {
+                var converted = (CreateBatchOfImages)request;
+                var hasInvalidSpaceZeroAsset = converted.AssetsBeforeProcessing.Any(a => !a.IsValidForSpaceZero());
+                if (hasInvalidSpaceZeroAsset) failedValidation = true;
+                break;
+            } 
+        }
+
+        if (failedValidation)
+        {
+            return ModifyEntityResult<T>.Failure(
+                "Assets in space 0 can only use the 'none' delivery channel",
+                WriteResult.FailedValidation);
+        }
+
+        return null;
+    }
+}

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
@@ -54,7 +54,7 @@ public class CreateDefaultDeliveryChannelHandler : IRequestHandler<CreateDefault
     public async Task<ModifyEntityResult<DefaultDeliveryChannel>> Handle(
         CreateDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
-        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Create);
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space);
         if (spaceZeroError != null) return ModifyEntityResult<DefaultDeliveryChannel>.Failure(spaceZeroError, WriteResult.BadRequest);
 
         var defaultDeliveryChannel = new DefaultDeliveryChannel()

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
@@ -8,6 +8,7 @@ using DLCS.Repository;
 using DLCS.Repository.Exceptions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace API.Features.DeliveryChannels.Requests.DefaultDeliveryChannels;
 
@@ -42,10 +43,12 @@ public class CreateDefaultDeliveryChannelHandler : IRequestHandler<CreateDefault
     ModifyEntityResult<DefaultDeliveryChannel>>
 {
     private readonly DlcsContext dbContext;
+    private readonly ILogger<CreateDefaultDeliveryChannelHandler> logger;
 
-    public CreateDefaultDeliveryChannelHandler(DlcsContext dbContext)
+    public CreateDefaultDeliveryChannelHandler(DlcsContext dbContext, ILogger<CreateDefaultDeliveryChannelHandler> logger)
     {
         this.dbContext = dbContext;
+        this.logger = logger;
     }
 
     public async Task<ModifyEntityResult<DefaultDeliveryChannel>> Handle(
@@ -96,10 +99,18 @@ public class CreateDefaultDeliveryChannelHandler : IRequestHandler<CreateDefault
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
+        catch (DbUpdateException ex) when (ex.GetDatabaseError() is UniqueConstraintError)
+        {
+            // Race condition: duplicate slipped through the pre-check
+            return ModifyEntityResult<DefaultDeliveryChannel>.Failure(
+                $"A default delivery channel for the requested media type '{defaultDeliveryChannel.MediaType}' already exists",
+                WriteResult.Conflict);
+        }
         catch (DbUpdateException ex)
         {
+            logger.LogError(ex, "Failed to save default delivery channel for customer {Customer}", request.Customer);
             return ModifyEntityResult<DefaultDeliveryChannel>.Failure(
-                $"Unknown error trying to save the default delivery channel",
+                "Unknown error trying to save the default delivery channel",
                 WriteResult.Error);
         }
 

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/CreateDefaultDeliveryChannel.cs
@@ -18,15 +18,15 @@ public class CreateDefaultDeliveryChannel : IRequest<ModifyEntityResult<DefaultD
 {
     public int Customer { get; }
     
-    public int Space { get; }
-    
+    public int? Space { get; }
+
     public string Policy { get; }
-    
+
     public string Channel { get; }
-    
+
     public string MediaType { get; }
-    
-    public CreateDefaultDeliveryChannel(int customer, int space, string policy, string channel, string mediaType)
+
+    public CreateDefaultDeliveryChannel(int customer, int? space, string policy, string channel, string mediaType)
     {
         Customer = customer;
         Policy = policy;
@@ -51,6 +51,9 @@ public class CreateDefaultDeliveryChannelHandler : IRequestHandler<CreateDefault
     public async Task<ModifyEntityResult<DefaultDeliveryChannel>> Handle(
         CreateDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Create);
+        if (spaceZeroError != null) return ModifyEntityResult<DefaultDeliveryChannel>.Failure(spaceZeroError, WriteResult.BadRequest);
+
         var defaultDeliveryChannel = new DefaultDeliveryChannel()
         {
             Customer = request.Customer,
@@ -72,17 +75,32 @@ public class CreateDefaultDeliveryChannelHandler : IRequestHandler<CreateDefault
             return ModifyEntityResult<DefaultDeliveryChannel>.Failure("Failed to find linked delivery channel policy", WriteResult.BadRequest);
         }
 
+        var space = request.Space;
+        var duplicate = await dbContext.DefaultDeliveryChannels.AnyAsync(
+            d => d.Customer == request.Customer &&
+                 d.Space == space &&
+                 d.MediaType == request.MediaType &&
+                 d.DeliveryChannelPolicyId == defaultDeliveryChannel.DeliveryChannelPolicyId,
+            cancellationToken);
+
+        if (duplicate)
+        {
+            return ModifyEntityResult<DefaultDeliveryChannel>.Failure(
+                $"A default delivery channel for the requested media type '{defaultDeliveryChannel.MediaType}' already exists",
+                WriteResult.Conflict);
+        }
+
         dbContext.DefaultDeliveryChannels.Add(defaultDeliveryChannel);
 
         try
         {
             await dbContext.SaveChangesAsync(cancellationToken);
         }
-        catch (DbUpdateException ex) when (ex.GetDatabaseError() is UniqueConstraintError)
+        catch (DbUpdateException ex)
         {
             return ModifyEntityResult<DefaultDeliveryChannel>.Failure(
-                $"A default delivery channel for the requested media type '{defaultDeliveryChannel.MediaType}' already exists",
-                WriteResult.Conflict);
+                $"Unknown error trying to save the default delivery channel",
+                WriteResult.Error);
         }
 
         return ModifyEntityResult<DefaultDeliveryChannel>.Success(defaultDeliveryChannel, WriteResult.Created);

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
@@ -41,7 +41,7 @@ public class DeleteDefaultDeliveryChannelHandler : IRequestHandler<DeleteDefault
 
     public async Task<DeleteEntityResult> Handle(DeleteDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
-        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Delete);
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space);
         if (spaceZeroError != null) return DeleteEntityResult.Failure(spaceZeroError, DeleteResult.Conflict);
 
         var defaultDeliveryChannel = await dbContext.DefaultDeliveryChannels.SingleOrDefaultAsync(

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/DeleteDefaultDeliveryChannel.cs
@@ -1,4 +1,5 @@
-﻿using API.Infrastructure.Requests;
+﻿using API.Features.DeliveryChannels.Helpers;
+using API.Infrastructure.Requests;
 using API.Infrastructure.Requests.Pipelines;
 using DLCS.Core;
 using DLCS.Core.Collections;
@@ -13,17 +14,17 @@ namespace API.Features.DeliveryChannels.Requests.DefaultDeliveryChannels;
 /// </summary>
 public class DeleteDefaultDeliveryChannel : IRequest<DeleteEntityResult>, IInvalidateCaches
 {
-    public DeleteDefaultDeliveryChannel(int customer, int space, Guid defaultDeliveryChannelId)
+    public DeleteDefaultDeliveryChannel(int customer, int? space, Guid defaultDeliveryChannelId)
     {
         Customer = customer;
         Space = space;
         DefaultDeliveryChannelId = defaultDeliveryChannelId;
     }
-    
+
     public int Customer { get; }
-    
-    public int Space { get; }
-    
+
+    public int? Space { get; }
+
     public Guid DefaultDeliveryChannelId { get; }
     
     public string[] InvalidatedCacheKeys => CacheKeys.DefaultDeliveryChannels(Customer).AsArray();
@@ -40,8 +41,11 @@ public class DeleteDefaultDeliveryChannelHandler : IRequestHandler<DeleteDefault
 
     public async Task<DeleteEntityResult> Handle(DeleteDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Delete);
+        if (spaceZeroError != null) return DeleteEntityResult.Failure(spaceZeroError, DeleteResult.Conflict);
+
         var defaultDeliveryChannel = await dbContext.DefaultDeliveryChannels.SingleOrDefaultAsync(
-            ch => ch.Customer == request.Customer && 
+            ch => ch.Customer == request.Customer &&
                   ch.Id == request.DefaultDeliveryChannelId &&
                   ch.Space == request.Space,
             cancellationToken: cancellationToken);

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannel.cs
@@ -10,11 +10,11 @@ public class GetDefaultDeliveryChannel : IRequest<FetchEntityResult<DefaultDeliv
 {
     public int Customer { get; }
     
-    public int Space { get; }
-    
+    public int? Space { get; }
+
     public Guid DefaultDeliveryChannelId { get; }
 
-    public GetDefaultDeliveryChannel(int customer, int space, Guid defaultDeliveryChannelId)
+    public GetDefaultDeliveryChannel(int customer, int? space, Guid defaultDeliveryChannelId)
     {
         Customer = customer;
         Space = space;

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannels.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/GetDefaultDeliveryChannels.cs
@@ -12,9 +12,9 @@ public class GetDefaultDeliveryChannels: IRequest<FetchEntityResult<PageOf<Defau
     public int Page { get; set; }
     public int PageSize { get; set; }
     public int Customer { get; }
-    public int Space { get; }
-    
-    public GetDefaultDeliveryChannels(int customer, int space)
+    public int? Space { get; }
+
+    public GetDefaultDeliveryChannels(int customer, int? space)
     {
         Customer = customer;
         Space = space;

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/UpdateDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/UpdateDefaultDeliveryChannel.cs
@@ -57,7 +57,7 @@ public class UpdateDefaultDeliveryChannelHandler : IRequestHandler<UpdateDefault
     
     public async Task<ModifyEntityResult<DefaultDeliveryChannel>> Handle(UpdateDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
-        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Modify);
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space);
         if (spaceZeroError != null) return ModifyEntityResult<DefaultDeliveryChannel>.Failure(spaceZeroError, WriteResult.BadRequest);
 
         var defaultDeliveryChannel = await dbContext.DefaultDeliveryChannels.SingleOrDefaultAsync(

--- a/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/UpdateDefaultDeliveryChannel.cs
+++ b/src/protagonist/API/Features/DeliveryChannels/Requests/DefaultDeliveryChannels/UpdateDefaultDeliveryChannel.cs
@@ -17,21 +17,21 @@ public class UpdateDefaultDeliveryChannel : IRequest<ModifyEntityResult<DefaultD
 {
     public int Customer { get; }
 
-    public int Space { get; }
-    
+    public int? Space { get; }
+
     public string Policy { get; }
-    
+
     public string Channel { get; }
-    
+
     public string MediaType { get; }
-    
+
     public Guid Id { get; }
 
     public UpdateDefaultDeliveryChannel(
-        int customerId, 
-        int space, 
-        string policy, 
-        string channel, 
+        int customerId,
+        int? space,
+        string policy,
+        string channel,
         string mediaType,
         Guid id)
     {
@@ -41,7 +41,6 @@ public class UpdateDefaultDeliveryChannel : IRequest<ModifyEntityResult<DefaultD
         Policy = policy;
         Channel = channel;
         Id = id;
-        Space = space;
     }
 
     public string[] InvalidatedCacheKeys => CacheKeys.DefaultDeliveryChannels(Customer).AsArray();
@@ -58,6 +57,9 @@ public class UpdateDefaultDeliveryChannelHandler : IRequestHandler<UpdateDefault
     
     public async Task<ModifyEntityResult<DefaultDeliveryChannel>> Handle(UpdateDefaultDeliveryChannel request, CancellationToken cancellationToken)
     {
+        var spaceZeroError = DefaultDeliveryChannelHelper.GetSpaceZeroErrorMessage(request.Space, SpaceZeroOperation.Modify);
+        if (spaceZeroError != null) return ModifyEntityResult<DefaultDeliveryChannel>.Failure(spaceZeroError, WriteResult.BadRequest);
+
         var defaultDeliveryChannel = await dbContext.DefaultDeliveryChannels.SingleOrDefaultAsync(
             d => d.Customer == request.Customer && d.Id == request.Id, cancellationToken);
         

--- a/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
+++ b/src/protagonist/API/Features/Image/AssetBeforeProcessing.cs
@@ -20,3 +20,15 @@ public class AssetBeforeProcessing(Asset asset, DeliveryChannelsBeforeProcessing
 /// <param name="Channel">Channel (e.g. 'iiif-img', 'file' etc)</param>
 /// <param name="Policy">Name of policy (e.g. 'default', 'video-mp4-480p')</param>
 public record DeliveryChannelsBeforeProcessing(string Channel, string? Policy);
+
+public static class AssetBeforeProcessingX
+{
+    /// <summary>
+    /// Returns true if the asset's delivery channels are valid for space 0 (only 'none' allowed),
+    /// or if the asset is not in space 0.
+    /// </summary>
+    public static bool IsValidForSpaceZero(this AssetBeforeProcessing assetBeforeProcessing)
+        => assetBeforeProcessing.Asset.Space != 0 || assetBeforeProcessing.DeliveryChannelsBeforeProcessing == null ||
+           AssetDeliveryChannels.IsNoneOnly(
+               assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel));
+}

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -101,7 +101,7 @@ public class ImageController : HydraController
         {
             try
             {
-                hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset);
+                hydraAsset = LegacyModeConverter.VerifyAndConvertToModernFormat(hydraAsset, spaceId);
             }
             catch (APIException apiEx)
             {

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -107,15 +107,15 @@ public class AssetProcessor(
                 {
                     requiresEngineNotification = true;
                 }
-
-                if (updatedAsset.HasSingleDeliveryChannel(AssetDeliveryChannels.None))
-                {
-                    // no need to notify the engine with the none channel
-                    requiresEngineNotification = false;
+            }
+            
+            if (updatedAsset.HasSingleDeliveryChannel(AssetDeliveryChannels.None))
+            {
+                // no need to notify the engine with the none channel
+                requiresEngineNotification = false;
                     
-                    // no engine notification, so 0 out the image storage record
-                    await assetRepository.ResetImageStorage(updatedAsset.GetAssetId(), cancellationToken);
-                }
+                // no engine notification, so 0 out the image storage record
+                await assetRepository.ResetImageStorage(updatedAsset.GetAssetId(), cancellationToken);
             }
 
             if (requiresEngineNotification)

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Net;
 using API.Exceptions;
 using API.Features.Assets;
+using API.Features.DeliveryChannels.Helpers;
 using API.Features.Image.Ingest;
 using API.Infrastructure;
 using API.Infrastructure.Messaging.General;
@@ -75,16 +76,10 @@ public class CreateOrUpdateImageHandler(
                 $"Target space for asset does not exist: {assetBeforeProcessing.Asset.Customer}/{assetBeforeProcessing.Asset.Space}",
                 WriteResult.FailedValidation);
         }
-
-        if (!AssetDeliveryChannels.IsValidForSpaceZero(
-                assetBeforeProcessing.Asset.Space,
-                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel)))
-        {
-            return ModifyEntityResult<Asset>.Failure(
-                "Assets in space 0 can only use the 'none' delivery channel",
-                WriteResult.FailedValidation);
-        }
-
+        
+        var space0Validation = SpaceZeroValidator.Validate(request);
+        if (space0Validation != null) return space0Validation;
+        
         await using var transaction = 
             await dlcsContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -76,9 +76,9 @@ public class CreateOrUpdateImageHandler(
                 WriteResult.FailedValidation);
         }
 
-        if (assetBeforeProcessing.Asset.Space == 0 &&
-            assetBeforeProcessing.DeliveryChannelsBeforeProcessing != null &&
-            !AssetDeliveryChannels.IsNoneOnly(assetBeforeProcessing.DeliveryChannelsBeforeProcessing.Select(dc => dc.Channel)))
+        if (!AssetDeliveryChannels.IsValidForSpaceZero(
+                assetBeforeProcessing.Asset.Space,
+                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel)))
         {
             return ModifyEntityResult<Asset>.Failure(
                 "Assets in space 0 must use the 'none' delivery channel only",

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -81,7 +81,7 @@ public class CreateOrUpdateImageHandler(
                 assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel)))
         {
             return ModifyEntityResult<Asset>.Failure(
-                "Assets in space 0 must use the 'none' delivery channel only",
+                "Assets in space 0 can only use the 'none' delivery channel",
                 WriteResult.FailedValidation);
         }
 

--- a/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
+++ b/src/protagonist/API/Features/Image/Requests/CreateOrUpdateImage.cs
@@ -76,6 +76,15 @@ public class CreateOrUpdateImageHandler(
                 WriteResult.FailedValidation);
         }
 
+        if (assetBeforeProcessing.Asset.Space == 0 &&
+            assetBeforeProcessing.DeliveryChannelsBeforeProcessing != null &&
+            !AssetDeliveryChannels.IsNoneOnly(assetBeforeProcessing.DeliveryChannelsBeforeProcessing.Select(dc => dc.Channel)))
+        {
+            return ModifyEntityResult<Asset>.Failure(
+                "Assets in space 0 must use the 'none' delivery channel only",
+                WriteResult.FailedValidation);
+        }
+
         await using var transaction = 
             await dlcsContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -437,7 +437,7 @@ public class CustomerQueueController : HydraController
             {
                 if (Settings.LegacyModeEnabledForSpace(customerId, members[i].Space))
                 {
-                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i]);
+                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i], members[i].Space);
                 }
             }
         }

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -49,9 +49,12 @@ public class CreateBatchOfImagesHandler(
     {
         var priorityValidation = ValidatePriorityQueueRequest(request);
         if (priorityValidation != null) return priorityValidation;
-        
+
         var spaceValidation = await ValidateAllSpaces(request, cancellationToken);
-        if (spaceValidation != null) return spaceValidation; 
+        if (spaceValidation != null) return spaceValidation;
+
+        var space0Validation = ValidateSpace0DeliveryChannels(request);
+        if (space0Validation != null) return space0Validation;
 
         bool updateFailed = false;
         var failureMessage = string.Empty;
@@ -149,6 +152,20 @@ public class CreateBatchOfImagesHandler(
         }
 
         return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);
+    }
+
+    private static ModifyEntityResult<Batch>? ValidateSpace0DeliveryChannels(CreateBatchOfImages request)
+    {
+        var hasInvalidSpace0Asset = request.AssetsBeforeProcessing.Any(a =>
+            a.Asset.Space == 0 &&
+            a.DeliveryChannelsBeforeProcessing != null &&
+            !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannelsBeforeProcessing.Select(dc => dc.Channel)));
+
+        if (!hasInvalidSpace0Asset) return null;
+
+        return ModifyEntityResult<Batch>.Failure(
+            "Assets in space 0 must use the 'none' delivery channel only",
+            WriteResult.FailedValidation);
     }
 
     private ModifyEntityResult<Batch>? ValidatePriorityQueueRequest(CreateBatchOfImages request)

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Data;
+using API.Features.DeliveryChannels.Helpers;
 using API.Features.Image;
 using API.Features.Image.Ingest;
 using API.Infrastructure;
@@ -53,7 +54,7 @@ public class CreateBatchOfImagesHandler(
         var spaceValidation = await ValidateAllSpaces(request, cancellationToken);
         if (spaceValidation != null) return spaceValidation;
 
-        var space0Validation = ValidateSpace0DeliveryChannels(request);
+        var space0Validation = SpaceZeroValidator.Validate(request);
         if (space0Validation != null) return space0Validation;
 
         bool updateFailed = false;
@@ -154,14 +155,11 @@ public class CreateBatchOfImagesHandler(
         return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);
     }
 
-    private static ModifyEntityResult<Batch>? ValidateSpace0DeliveryChannels(CreateBatchOfImages request)
+    private static ModifyEntityResult<Batch>? ValidateSpaceZeroDeliveryChannels(CreateBatchOfImages request)
     {
-        var hasInvalidSpace0Asset = request.AssetsBeforeProcessing.Any(a =>
-            !AssetDeliveryChannels.IsValidForSpaceZero(
-                a.Asset.Space,
-                a.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel)));
+        var hasInvalidSpaceZeroAsset = request.AssetsBeforeProcessing.Any(a => !a.IsValidForSpaceZero());
 
-        if (!hasInvalidSpace0Asset) return null;
+        if (!hasInvalidSpaceZeroAsset) return null;
 
         return ModifyEntityResult<Batch>.Failure(
             "Assets in space 0 can only use the 'none' delivery channel",

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -157,9 +157,9 @@ public class CreateBatchOfImagesHandler(
     private static ModifyEntityResult<Batch>? ValidateSpace0DeliveryChannels(CreateBatchOfImages request)
     {
         var hasInvalidSpace0Asset = request.AssetsBeforeProcessing.Any(a =>
-            a.Asset.Space == 0 &&
-            a.DeliveryChannelsBeforeProcessing != null &&
-            !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannelsBeforeProcessing.Select(dc => dc.Channel)));
+            !AssetDeliveryChannels.IsValidForSpaceZero(
+                a.Asset.Space,
+                a.DeliveryChannelsBeforeProcessing?.Select(dc => dc.Channel)));
 
         if (!hasInvalidSpace0Asset) return null;
 

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -164,7 +164,7 @@ public class CreateBatchOfImagesHandler(
         if (!hasInvalidSpace0Asset) return null;
 
         return ModifyEntityResult<Batch>.Failure(
-            "Assets in space 0 must use the 'none' delivery channel only",
+            "Assets in space 0 can only use the 'none' delivery channel",
             WriteResult.FailedValidation);
     }
 

--- a/src/protagonist/API/Features/Space/Requests/DeleteSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/DeleteSpace.cs
@@ -35,6 +35,11 @@ public class DeleteSpaceHandler : IRequestHandler<DeleteSpace, ResultMessage<Del
     
     public async Task<ResultMessage<DeleteResult>> Handle(DeleteSpace request, CancellationToken cancellationToken)
     {
+        if (request.SpaceId == 0)
+        {
+            return new ResultMessage<DeleteResult>("Space 0 cannot be deleted", DeleteResult.Conflict);
+        }
+
         logger.LogDebug("Deleting Space {SpaceId}", request.SpaceId);
         var deleteResult = await spaceRepository.DeleteSpace(request.CustomerId, request.SpaceId, cancellationToken);
 

--- a/src/protagonist/DLCS.HydraModel/DefaultDeliveryChannel.cs
+++ b/src/protagonist/DLCS.HydraModel/DefaultDeliveryChannel.cs
@@ -14,13 +14,13 @@ public class DefaultDeliveryChannel : DlcsResource
     {
     }
     
-    public DefaultDeliveryChannel(string baseUrl, int customerId, string channel, string? policy, string mediaType, string id, int space)
+    public DefaultDeliveryChannel(string baseUrl, int customerId, string channel, string? policy, string mediaType, string id, int? space)
     {
         Channel = channel;
         Policy = policy;
         MediaType = mediaType;
 
-        if (space == 0)
+        if (space == null)
         {
             Init(baseUrl, true, customerId, id);
         }

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -84,6 +84,13 @@ public static class AssetDeliveryChannels
     }
 
     /// <summary>
+    /// Returns true if the asset's delivery channels are valid for space 0 (only 'none' allowed),
+    /// or if the asset is not in space 0.
+    /// </summary>
+    public static bool IsValidForSpaceZero(int space, IEnumerable<string>? channels)
+        => space != 0 || channels == null || IsNoneOnly(channels);
+
+    /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
     public static bool IsValidChannel(string? deliveryChannel)

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -86,13 +86,6 @@ public static class AssetDeliveryChannels
     }
 
     /// <summary>
-    /// Returns true if the asset's delivery channels are valid for space 0 (only 'none' allowed),
-    /// or if the asset is not in space 0.
-    /// </summary>
-    public static bool IsValidForSpaceZero(int space, IEnumerable<string>? channels)
-        => space != 0 || channels == null || IsNoneOnly(channels);
-
-    /// <summary>
     /// Checks if string is a valid delivery channel
     /// </summary>
     public static bool IsValidChannel(string? deliveryChannel)

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -16,6 +16,8 @@ public static class AssetDeliveryChannels
 
     public const string NoneChannelOriginPlaceholder = "https://example.org/origin";
     public const string NoneChannelMediaTypePlaceholder = "example/example";
+    
+    public const int StubAssetSpace = 0;
 
     /// <summary>
     /// All possible delivery channels

--- a/src/protagonist/DLCS.Model/DeliveryChannels/DefaultDeliveryChannel.cs
+++ b/src/protagonist/DLCS.Model/DeliveryChannels/DefaultDeliveryChannel.cs
@@ -20,7 +20,7 @@ public class DefaultDeliveryChannel
     /// <summary>
     /// The space this delivery channel will be applied to
     /// </summary>
-    public int Space { get; set; }
+    public int? Space { get; set; }
     
     /// <summary>
     /// The media type this policy will apply to.  This value can use wildcards

--- a/src/protagonist/DLCS.Repository/DlcsContext.cs
+++ b/src/protagonist/DLCS.Repository/DlcsContext.cs
@@ -688,7 +688,6 @@ public partial class DlcsContext : DbContext
         {
             entity.HasIndex(e => new {e.Customer, e.Space, e.MediaType, e.DeliveryChannelPolicyId}).IsUnique();
             entity.Property(e => e.Customer).IsRequired();
-            entity.Property(e => e.Space).IsRequired();
             entity.Property(e => e.DeliveryChannelPolicyId).IsRequired();
             
             entity.Property(e => e.MediaType).IsRequired().HasMaxLength(255);

--- a/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.Designer.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DLCS.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DLCS.Repository.Migrations
 {
     [DbContext(typeof(DlcsContext))]
-    partial class DlcsContextModelSnapshot : ModelSnapshot
+    [Migration("20260501110241_SpaceZeroHandling")]
+    partial class SpaceZeroHandling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1347,3 +1350,4 @@ namespace DLCS.Repository.Migrations
         }
     }
 }
+

--- a/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
@@ -24,8 +24,8 @@ namespace DLCS.Repository.Migrations
 
             // Add space 0 (stub-space) for all existing customers that don't already have one
             migrationBuilder.Sql(@"
-INSERT INTO ""Spaces"" (""Id"", ""Customer"", ""Name"", ""Created"", ""ImageBucket"", ""Tags"", ""Roles"", ""MaxUnauthorised"")
-SELECT 0, c.""Id"", 'stub-space', NOW(), '', ARRAY[]::text[], ARRAY[]::text[], -1
+INSERT INTO ""Spaces"" (""Id"", ""Customer"", ""Name"", ""Created"", ""ImageBucket"", ""Tags"", ""Roles"", ""MaxUnauthorised"", ""Keep"", ""Transform"")
+SELECT 0, c.""Id"", 'stub-space', NOW(), '', ARRAY[]::text[], ARRAY[]::text[], -1, false, false
 FROM ""Customers"" c
 WHERE NOT EXISTS (
     SELECT 1 FROM ""Spaces"" s WHERE s.""Customer"" = c.""Id"" AND s.""Id"" = 0

--- a/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
@@ -32,18 +32,32 @@ WHERE NOT EXISTS (
 );
 ");
 
-            // Add 'none' default delivery channel for customer 1 space 0 (the template used for new customers)
-            migrationBuilder.InsertData(
-                table: "DefaultDeliveryChannels",
-                columns: new[] { "Id", "Customer", "DeliveryChannelPolicyId", "MediaType", "Space" },
-                values: new object[] { Guid.NewGuid(), 1, Ids.None, "*/*", 0 });
+            // Add 'none' default delivery channel at space 0 for customer 1 (template for new customers).
+            migrationBuilder.Sql(@"
+INSERT INTO ""DefaultDeliveryChannels"" (""Id"", ""Customer"", ""DeliveryChannelPolicyId"", ""MediaType"", ""Space"")
+SELECT gen_random_uuid(), 1, " + Ids.None + @", '*/*', 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM ""DefaultDeliveryChannels"" ddc
+    WHERE ddc.""Customer"" = 1
+      AND ddc.""Space"" = 0
+      AND ddc.""MediaType"" = '*/*'
+      AND ddc.""DeliveryChannelPolicyId"" = " + Ids.None + @"
+);
+");
 
-            // Add 'none' default delivery channel for all existing non-customer-1 customers
+            // Add 'none' default delivery channel at space 0 for all other existing customers
             migrationBuilder.Sql(@"
 INSERT INTO ""DefaultDeliveryChannels"" (""Id"", ""Customer"", ""DeliveryChannelPolicyId"", ""MediaType"", ""Space"")
 SELECT gen_random_uuid(), c.""Id"", " + Ids.None + @", '*/*', 0
 FROM ""Customers"" c
-WHERE c.""Id"" != 1;
+WHERE c.""Id"" != 1
+  AND NOT EXISTS (
+    SELECT 1 FROM ""DefaultDeliveryChannels"" ddc
+    WHERE ddc.""Customer"" = c.""Id""
+      AND ddc.""Space"" = 0
+      AND ddc.""MediaType"" = '*/*'
+      AND ddc.""DeliveryChannelPolicyId"" = " + Ids.None + @"
+);
 ");
         }
 

--- a/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Ids = DLCS.Model.Policies.KnownDeliveryChannelPolicies;
+
+#nullable disable
+
+namespace DLCS.Repository.Migrations
+{
+    public partial class SpaceZeroHandling : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Make Space nullable so NULL can represent customer-wide defaults
+            migrationBuilder.AlterColumn<int>(
+                name: "Space",
+                table: "DefaultDeliveryChannels",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            // Existing Space=0 rows were the customer-wide defaults; move them to NULL
+            migrationBuilder.Sql(@"UPDATE ""DefaultDeliveryChannels"" SET ""Space"" = NULL WHERE ""Space"" = 0;");
+
+            // Add space 0 (stub-space) for all existing customers that don't already have one
+            migrationBuilder.Sql(@"
+INSERT INTO ""Spaces"" (""Id"", ""Customer"", ""Name"", ""Created"", ""ImageBucket"", ""Tags"", ""Roles"", ""MaxUnauthorised"")
+SELECT 0, c.""Id"", 'stub-space', NOW(), '', ARRAY[]::text[], ARRAY[]::text[], -1
+FROM ""Customers"" c
+WHERE NOT EXISTS (
+    SELECT 1 FROM ""Spaces"" s WHERE s.""Customer"" = c.""Id"" AND s.""Id"" = 0
+);
+");
+
+            // Add 'none' default delivery channel for customer 1 space 0 (the template used for new customers)
+            migrationBuilder.InsertData(
+                table: "DefaultDeliveryChannels",
+                columns: new[] { "Id", "Customer", "DeliveryChannelPolicyId", "MediaType", "Space" },
+                values: new object[] { Guid.NewGuid(), 1, Ids.None, "*/*", 0 });
+
+            // Add 'none' default delivery channel for all existing non-customer-1 customers
+            migrationBuilder.Sql(@"
+INSERT INTO ""DefaultDeliveryChannels"" (""Id"", ""Customer"", ""DeliveryChannelPolicyId"", ""MediaType"", ""Space"")
+SELECT gen_random_uuid(), c.""Id"", " + Ids.None + @", '*/*', 0
+FROM ""Customers"" c
+WHERE c.""Id"" != 1;
+");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Remove 'none' default delivery channel entries for space 0
+            migrationBuilder.Sql(@"
+DELETE FROM ""DefaultDeliveryChannels""
+WHERE ""DeliveryChannelPolicyId"" = " + Ids.None + @" AND ""Space"" = 0 AND ""MediaType"" = '*/*';
+");
+
+            // Remove space 0 for all customers (stub-space entries added by this migration)
+            migrationBuilder.Sql(@"
+DELETE FROM ""Spaces"" WHERE ""Id"" = 0 AND ""Name"" = 'stub-space';
+");
+
+            // Restore NULL back to 0 for the customer-wide defaults
+            migrationBuilder.Sql(@"UPDATE ""DefaultDeliveryChannels"" SET ""Space"" = 0 WHERE ""Space"" IS NULL;");
+
+            // Restore column to NOT NULL
+            migrationBuilder.AlterColumn<int>(
+                name: "Space",
+                table: "DefaultDeliveryChannels",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldNullable: true,
+                oldType: "integer");
+        }
+    }
+}

--- a/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
+++ b/src/protagonist/DLCS.Repository/Migrations/20260501110241_SpaceZeroHandling.cs
@@ -22,10 +22,10 @@ namespace DLCS.Repository.Migrations
             // Existing Space=0 rows were the customer-wide defaults; move them to NULL
             migrationBuilder.Sql(@"UPDATE ""DefaultDeliveryChannels"" SET ""Space"" = NULL WHERE ""Space"" = 0;");
 
-            // Add space 0 (stub-space) for all existing customers that don't already have one
+            // Add space 0 (stub-assets) for all existing customers that don't already have one
             migrationBuilder.Sql(@"
 INSERT INTO ""Spaces"" (""Id"", ""Customer"", ""Name"", ""Created"", ""ImageBucket"", ""Tags"", ""Roles"", ""MaxUnauthorised"", ""Keep"", ""Transform"")
-SELECT 0, c.""Id"", 'stub-space', NOW(), '', ARRAY[]::text[], ARRAY[]::text[], -1, false, false
+SELECT 0, c.""Id"", 'stub-assets', NOW(), '', ARRAY[]::text[], ARRAY[]::text[], -1, false, false
 FROM ""Customers"" c
 WHERE NOT EXISTS (
     SELECT 1 FROM ""Spaces"" s WHERE s.""Customer"" = c.""Id"" AND s.""Id"" = 0
@@ -69,9 +69,9 @@ DELETE FROM ""DefaultDeliveryChannels""
 WHERE ""DeliveryChannelPolicyId"" = " + Ids.None + @" AND ""Space"" = 0 AND ""MediaType"" = '*/*';
 ");
 
-            // Remove space 0 for all customers (stub-space entries added by this migration)
+            // Remove space 0 for all customers (stub-assets entries added by this migration)
             migrationBuilder.Sql(@"
-DELETE FROM ""Spaces"" WHERE ""Id"" = 0 AND ""Name"" = 'stub-space';
+DELETE FROM ""Spaces"" WHERE ""Id"" = 0 AND ""Name"" = 'stub-assets';
 ");
 
             // Restore NULL back to 0 for the customer-wide defaults

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -158,9 +158,9 @@ public class SpaceRepository : ISpaceRepository
         var result = new PageOfSpaces
         {
             Page = page,
-            Total = await dlcsContext.Spaces.CountAsync(s => s.Customer == customerId, cancellationToken: cancellationToken),
+            Total = await dlcsContext.Spaces.CountAsync(s => s.Customer == customerId && s.Id != 0, cancellationToken: cancellationToken),
             Spaces = await dlcsContext.Spaces.AsNoTracking()
-                .Where(s => s.Customer == customerId)
+                .Where(s => s.Customer == customerId && s.Id != 0)
                 .AsOrderedSpaceQuery(orderBy, descending)
                 .Skip((page - 1) * pageSize)
                 .Take(pageSize)

--- a/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
+++ b/src/protagonist/Test.Helpers/Integration/DatabaseTestDataPopulation.cs
@@ -165,7 +165,7 @@ public static class DatabaseTestDataPopulation
 
     public static Task AddTestDefaultDeliveryChannels(this DbSet<DefaultDeliveryChannel> defaultDeliveryChannels,
         int customerId) =>
-        defaultDeliveryChannels.AddRangeAsync(defaultDeliveryChannels.Where(d => d.Customer == 1 && d.Space == 0)
+        defaultDeliveryChannels.AddRangeAsync(defaultDeliveryChannels.Where(d => d.Customer == 1 && (d.Space == null || d.Space == 0))
             .Select(x => new DefaultDeliveryChannel
             {
                 Customer = customerId,

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -121,7 +121,7 @@ public class DlcsDatabaseFixture : DlcsDefaultDatabaseFixture
             Next = 1
         });
         await DbContext.Spaces.AddAsync(new Space
-            { Created = DateTime.UtcNow, Id = 0, Customer = customer, Name = "stub-space", ImageBucket = string.Empty, Tags = Array.Empty<string>(), Roles = Array.Empty<string>(), MaxUnauthorised = -1 });
+            { Created = DateTime.UtcNow, Id = 0, Customer = customer, Name = "stub-assets", ImageBucket = string.Empty, Tags = Array.Empty<string>(), Roles = Array.Empty<string>(), MaxUnauthorised = -1 });
         await DbContext.Spaces.AddAsync(new Space
             { Created = DateTime.UtcNow, Id = 1, Customer = customer, Name = "space-1" });
         await DbContext.ThumbnailPolicies.AddAsync(new ThumbnailPolicy

--- a/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
+++ b/src/protagonist/Test.Helpers/Integration/DlcsDatabaseFixture.cs
@@ -121,6 +121,8 @@ public class DlcsDatabaseFixture : DlcsDefaultDatabaseFixture
             Next = 1
         });
         await DbContext.Spaces.AddAsync(new Space
+            { Created = DateTime.UtcNow, Id = 0, Customer = customer, Name = "stub-space", ImageBucket = string.Empty, Tags = Array.Empty<string>(), Roles = Array.Empty<string>(), MaxUnauthorised = -1 });
+        await DbContext.Spaces.AddAsync(new Space
             { Created = DateTime.UtcNow, Id = 1, Customer = customer, Name = "space-1" });
         await DbContext.ThumbnailPolicies.AddAsync(new ThumbnailPolicy
             { Id = "default", Name = "default", Sizes = "800,400,200" });


### PR DESCRIPTION
## What does this change?

Resolves #1186

Allows space 0 to be used for stub assets, while disallowing the use of space 0 for any delivery channel which isn't `none`.  This additionally adds a migration to make sure default delivery channels will automatically specify the `none` channel if space 0 is selected.

Additionally, due to space now being `null` for setting global delivery channels, there's essentially a new set of endpoints for `DefaultDeliverChannel` management to omit the space.

| Operation | Route |                                                                                                                                                                                                                                                                                                                                                                                                          
  |---|---|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  | Get one | `GET /customers/{id}/defaultDeliveryChannels/{ddcId}` |
  | Create | `POST /customers/{id}/defaultDeliveryChannels` |                                                                                                                                                                                                                                                                                                                                                                    
  | Update | `PUT /customers/{id}/defaultDeliveryChannels/{ddcId}` |
  | Delete | `DELETE /customers/{id}/defaultDeliveryChannels/{ddcId}` |

> [!Note]
> These endpoints work the exact same way as the previous endpoints, and go through the same code as the previous space-based endpoints

### Requirements

| # | Requirement | Covered? | Where | Tests |                                                                                                                                                                                                                                                                                                                                                                                 
  |---|---|---|---|---|      
  | 1 | `none` is the only accepted delivery channel for space 0 assets | ✅ | `CreateOrUpdateImage.cs`, `CreateBatchOfImages.cs` | `Put_Asset_InSpaceZero_WithNonNoneDeliveryChannel_Returns400`, `Put_Asset_InSpaceZero_WithNoneDeliveryChannel_CreatesAsset`, `Post_CreateBatch_400_IfSpaceZeroAssetHasNonNoneDeliveryChannel` |                                                                                              ─
  | 2 | Space 0 uses `none` DDC by default; new and existing customers receive it | ✅ | Migration (`SpaceZeroHandling`), `DapperNewCustomerDeliveryChannelRepository` | `CreateNewCustomer_CreatesSpaceZero`, `Post_CreateDefaultDeliveryChannel_ForSpaceZero_Returns400` (verifies row exists) |
  | 3 | All existing customers have a space 0 | ✅ | Migration (`SpaceZeroHandling`) | Covered by migration; `CreateNewCustomer_CreatesSpaceZero` validates new customer path |                                                                                                                                                                                                                                                  ─
  | 4 | New customers receive a space 0 | ✅ | `CreateCustomer.cs` | `CreateNewCustomer_CreatesSpaceZero` |
  | 5 | Prevent deletion of space 0 | ✅ | `DeleteSpace.cs` | `DeleteSpace_Returns_Conflict_ForSpaceZero` |
  | 6 | Space 0 not returned in API space listings | ✅ | `SpaceRepository.GetPageOfSpaces` | `GetSpaces_DoesNotReturn_SpaceZero` |
  | 7 | _(Stretch)_ Prevent changing DDCs for space 0 | ✅ | `DefaultDeliveryChannelHelper` | `Post_CreateDefaultDeliveryChannel_ForSpaceZero_Returns400`, `Put_UpdateDefaultDeliveryChannel_ForSpaceZero_Returns400`, `Delete_DeleteDefaultDeliveryChannel_ForSpaceZero_Returns409`, `GetSpaceZeroErrorMessage_ReturnsError_WhenSpaceIsZero` |

## Database Migration

> [!NOTE]
> - **Migration name:** `20260501110241_SpaceZeroHandling`
> - **What it does:**
>   - Makes `space` nullable in the `DefaultDeliveryChannel` table
>   - Modifies the "global" space in the `DefaultDeliveryChannel` table to be `null` instead of `0`
>   - Adds space `0` to all existing customers
>   - Adds a new template `DefaultDeliveryChannel` that sets the `none` channel if space `0` is specified (used for new customers)
>   - Updates all existing customers with the new `DefaultDeliveryChannel`
> - **Breaking Change?** Yes - would break API in this case