### PR TITLE
Allow create batch of images to work with a minimal payload in the stub asset space

### DIFF
--- a/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Images/Validation/HydraImageValidatorTests.cs
@@ -355,6 +355,21 @@ public class HydraImageValidatorTests
         var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default", "create"));
         result.ShouldNotHaveValidationErrorFor(a => a.MediaType);
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void MediaType_CanBeNullOrEmpty_OnCreateWhenStubAsset(string mediaType)
+    {
+        var model = new Image
+        {
+            MediaType = mediaType,
+            Space = AssetDeliveryChannels.StubAssetSpace
+        };
+        var result = Sut.TestValidate(model, options => options.IncludeRuleSets("default", "create"));
+        result.ShouldNotHaveValidationErrorFor(a => a.MediaType);
+    }
     
     [Fact]
     public void PlaceHolderValues_NotAllowed_WhenNotNoneChannel()

--- a/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
@@ -134,6 +134,30 @@ public class QueuePostValidatorTests
         result.ShouldNotHaveValidationErrorFor("Members[0].Space");
         result.ShouldNotHaveValidationErrorFor("Members[0].MediaType");
     }
+
+    [Fact]
+    public void Member_Space_Negative_Invalid()
+    {
+        var sut = GetSut();
+        var model = new HydraCollection<Image> { Members = new[] { new Image { Space = -1, ModelId = "foo", MediaType = "image/jpeg" } } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].Space");
+    }
+
+    [Fact]
+    public void Member_MediaType_Required_ForSpaceZero_WhenDeliveryChannelsPresent()
+    {
+        var sut = GetSut();
+        var model = new HydraCollection<Image>
+        {
+            Members = new[]
+            {
+                new Image { Space = 0, ModelId = "foo", DeliveryChannels = [new DeliveryChannel { Channel = "file" }] }
+            }
+        };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].MediaType");
+    }
     
     [Theory]
     [InlineData(null)]

--- a/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
@@ -136,12 +136,23 @@ public class QueuePostValidatorTests
     }
 
     [Fact]
+    public void Member_Space_NotProvided_Invalid()
+    {
+        var sut = GetSut();
+        var model = new HydraCollection<Image> { Members = new[] { new Image { ModelId = "foo" } } };
+        var result = sut.TestValidate(model);
+        result.ShouldHaveValidationErrorFor("Members[0].Space")
+            .WithErrorMessage("Space must be specified");
+    }
+
+    [Fact]
     public void Member_Space_Negative_Invalid()
     {
         var sut = GetSut();
         var model = new HydraCollection<Image> { Members = new[] { new Image { Space = -1, ModelId = "foo", MediaType = "image/jpeg" } } };
         var result = sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor("Members[0].Space");
+        result.ShouldHaveValidationErrorFor("Members[0].Space")
+            .WithErrorMessage("Space must be 0 or greater");
     }
 
     [Fact]

--- a/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
+++ b/src/protagonist/API.Tests/Features/Queues/Validation/QueuePostValidatorTests.cs
@@ -126,12 +126,13 @@ public class QueuePostValidatorTests
     }
     
     [Fact]
-    public void Member_Space_Default()
+    public void Member_Space_Default_Valid()
     {
         var sut = GetSut();
-        var model = new HydraCollection<Image> { Members = new[] { new Image { Space = 0 } } };
+        var model = new HydraCollection<Image> { Members = new[] { new Image { Space = 0, ModelId = "foo" } } };
         var result = sut.TestValidate(model);
-        result.ShouldHaveValidationErrorFor("Members[0].Space");
+        result.ShouldNotHaveValidationErrorFor("Members[0].Space");
+        result.ShouldNotHaveValidationErrorFor("Members[0].MediaType");
     }
     
     [Theory]
@@ -141,7 +142,7 @@ public class QueuePostValidatorTests
     public void Member_MediaType_NullOrEmpty(string mediaType)
     {
         var sut = GetSut();
-        var model = new HydraCollection<Image> { Members = new[] { new Image { MediaType = mediaType } } };
+        var model = new HydraCollection<Image> { Members = new[] { new Image { MediaType = mediaType, Space = 1 } } };
         var result = sut.TestValidate(model);
         result.ShouldHaveValidationErrorFor("Members[0].MediaType");
     }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -1972,6 +1972,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         const int customerId = 1901;
         var assetId = AssetIdGenerator.GetAssetId(customerId, 0);
         await dbContext.Customers.AddTestCustomer(customerId);
+        await dbContext.DefaultDeliveryChannels.AddTestDefaultDeliveryChannels(customerId);
         await dbContext.Spaces.AddTestSpace(customerId, 0, "stub-assets");
         await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
         await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -2019,4 +2019,36 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
                     A<CancellationToken>._))
             .MustHaveHappened();
     }
+
+    [Fact]
+    public async Task Post_CreateBatch_400_IfSpaceNotProvided()
+    {
+        // Arrange
+        const int customerId = 1902;
+        await dbContext.Customers.AddTestCustomer(customerId);
+        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
+        await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });
+        await dbContext.SaveChangesAsync();
+
+        var hydraImageBody = """
+        {
+            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+            "@type": "Collection",
+            "member": [
+                {
+                  "id": "my-asset"
+                }
+            ]
+        }
+        """;
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var path = $"/customers/{customerId}/queue";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -2025,12 +2025,6 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Post_CreateBatch_400_IfSpaceNotProvided()
     {
         // Arrange
-        const int customerId = 1902;
-        await dbContext.Customers.AddTestCustomer(customerId);
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
-        await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });
-        await dbContext.SaveChangesAsync();
-
         var hydraImageBody = """
         {
             "@context": "http://www.w3.org/ns/hydra/context.jsonld",
@@ -2044,10 +2038,10 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         """;
 
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var path = $"/customers/{customerId}/queue";
+        var path = $"/customers/2/queue";
 
         // Act
-        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+        var response = await httpClient.AsCustomer().PostAsync(path, content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -1964,4 +1964,59 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task Post_CreateBatch_201_IfMinimalStubAsset()
+    {
+        // Arrange
+        const int customerId = 1901;
+        var assetId = AssetIdGenerator.GetAssetId(customerId, 0);
+        await dbContext.Customers.AddTestCustomer(customerId);
+        await dbContext.Spaces.AddTestSpace(customerId, 0, "stub-assets");
+        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId);
+        await dbContext.Queues.AddAsync(new Queue { Customer = customerId, Name = "default", Size = 0 });
+        await dbContext.SaveChangesAsync();
+
+        var hydraImageBody = $$"""
+        {
+            "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+            "@type": "Collection",
+            "member": [
+                {
+                  "id": "{{assetId.Asset}}",
+                  "space": 0
+                }
+            ]
+        }
+        """;
+
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var path = $"/customers/{customerId}/queue";
+
+        // Act
+        var response = await httpClient.AsCustomer(customerId).PostAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var model = await response.ReadAsHydraResponseAsync<DLCS.HydraModel.CustomerQueue>();
+        var assetInDatabase = dbContext.Images
+            .Include(a => a.ImageDeliveryChannels)
+            .First(a => a.Batch == model.Id.GetLastPathElementAsInt());
+        assetInDatabase.Id.Should().Be(assetId);
+        assetInDatabase.ImageDeliveryChannels.Should().ContainSingle(dc => dc.Channel == AssetDeliveryChannels.None);
+
+        // None-channel assets don't require engine processing
+        A.CallTo(() =>
+            EngineClient.AsynchronousIngestBatch(
+                A<IReadOnlyCollection<Asset>>.That.Matches(i => i.First().Id == assetId), true,
+                A<CancellationToken>._)).MustNotHaveHappened();
+
+        // Batch completes immediately since no engine processing is needed
+        A.CallTo(() =>
+                NotificationSender.SendBatchCompletedMessage(
+                    A<Batch>.That.Matches(b => b.Id == model.Id.GetLastPathElementAsInt()),
+                    A<CancellationToken>._))
+            .MustHaveHappened();
+    }
 }

--- a/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
+++ b/src/protagonist/API.Tests/Integration/CustomerQueueTests.cs
@@ -2002,7 +2002,7 @@ public class CustomerQueueTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var model = await response.ReadAsHydraResponseAsync<DLCS.HydraModel.CustomerQueue>();
         var assetInDatabase = dbContext.Images
             .Include(a => a.ImageDeliveryChannels)
-            .First(a => a.Batch == model.Id.GetLastPathElementAsInt());
+            .Single(a => a.Batch == model.Id.GetLastPathElementAsInt());
         assetInDatabase.Id.Should().Be(assetId);
         assetInDatabase.ImageDeliveryChannels.Should().ContainSingle(dc => dc.Channel == AssetDeliveryChannels.None);
 

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using Amazon.S3;
 using API.Client;
 using API.Infrastructure;
-using API.Infrastructure.Messaging;
 using API.Infrastructure.Messaging.General;
 using API.Tests.Integration.Infrastructure;
 using DLCS.Core.Types;
@@ -260,13 +259,12 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Put_CreateAsset_InSpaceZero_WithNoDeliveryChannel_CreatesAssetWithNoneChannelAndPlaceholders()
     {
         // Arrange - minimal stub asset payload: no origin, no mediaType, no deliveryChannels
-        var customerAndSpace = await CreateCustomerAndSpace();
-        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, 0);
+        var assetId = AssetIdGenerator.GetAssetId(space: 0); 
         var hydraImageBody = @"{ ""@type"": ""Image"" }";
 
         // Act
         var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
-        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+        var response = await httpClient.AsCustomer().PutAsync(assetId.ToApiResourcePath(), content);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.Created);

--- a/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
+++ b/src/protagonist/API.Tests/Integration/ModifyAssetTests.cs
@@ -257,6 +257,26 @@ public class ModifyAssetTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
+    public async Task Put_CreateAsset_InSpaceZero_WithNoDeliveryChannel_CreatesAssetWithNoneChannelAndPlaceholders()
+    {
+        // Arrange - minimal stub asset payload: no origin, no mediaType, no deliveryChannels
+        var customerAndSpace = await CreateCustomerAndSpace();
+        var assetId = AssetIdGenerator.GetAssetId(customerAndSpace.customer, 0);
+        var hydraImageBody = @"{ ""@type"": ""Image"" }";
+
+        // Act
+        var content = new StringContent(hydraImageBody, Encoding.UTF8, "application/json");
+        var response = await httpClient.AsCustomer(customerAndSpace.customer).PutAsync(assetId.ToApiResourcePath(), content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var asset = dbContext.Images.Include(i => i.ImageDeliveryChannels).Single(x => x.Id == assetId);
+        asset.ImageDeliveryChannels.Should().ContainSingle(x => x.Channel == AssetDeliveryChannels.None);
+        asset.Origin.Should().Be(AssetDeliveryChannels.NoneChannelOriginPlaceholder);
+        asset.MediaType.Should().Be(AssetDeliveryChannels.NoneChannelMediaTypePlaceholder);
+    }
+
+    [Fact]
     public async Task Put_UpdateAsset_InSpaceZero_WithNoSpecifiedDeliveryChannel_UpdatesAssetWithNoneChannelSuccessfully()
     {
         // Arrange

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -256,15 +256,19 @@ public static class AssetConverter
         
         hydraImage.CustomerId = customerId;
 
-        if (hydraImage.Space > 0 && spaceId.HasValue && spaceId.Value != hydraImage.Space)
+        if (hydraImage.Space.HasValue && spaceId.HasValue && spaceId.Value != hydraImage.Space.Value)
         {
             throw new BadRequestException("Asserted space does not agree with supplied space.");
         }
 
-        if (hydraImage.Space == 0 && spaceId.HasValue)
+        if (!hydraImage.Space.HasValue && spaceId.HasValue)
         {
-            // Space was not explicitly provided in body; take space from route if available
+            // Space was not provided in body; take space from route
             hydraImage.Space = spaceId.Value;
+        }
+        else if (!hydraImage.Space.HasValue)
+        {
+            throw new BadRequestException("No Space provided for this Asset.");
         }
         else if (hydraImage.Space < 0)
         {
@@ -288,7 +292,7 @@ public static class AssetConverter
         
         // This is a silent test for backwards compatibility with Deliverator.
         // DDS sends Patch ModelIDs in full ID form:
-        var testPrefix = $"{hydraImage.CustomerId}/{hydraImage.Space}/";
+        var testPrefix = $"{hydraImage.CustomerId}/{hydraImage.Space.Value}/";
         if (modelId.StartsWith(testPrefix))
         {
             modelId = modelId.Substring(testPrefix.Length);
@@ -299,14 +303,14 @@ public static class AssetConverter
         {
             Id = assetId,
             Customer = hydraImage.CustomerId,
-            Space = hydraImage.Space
+            Space = hydraImage.Space.Value
         };
         return asset;
     }
     
     private static AssetId GetValidAssetId(Image hydraImage, string modelId)
     {
-        var assetId = new AssetId(hydraImage.CustomerId, hydraImage.Space, modelId);
+        var assetId = new AssetId(hydraImage.CustomerId, hydraImage.Space!.Value, modelId);
         if (!hydraImage.Id.HasText()) return assetId;
 
         var idParts = hydraImage.Id.Split("/");

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -260,17 +260,15 @@ public static class AssetConverter
         {
             throw new BadRequestException("Asserted space does not agree with supplied space.");
         }
-        
-        if (hydraImage.Space <= 0)
+
+        if (hydraImage.Space == 0 && spaceId.HasValue)
         {
-            if (spaceId.HasValue)
-            {
-                hydraImage.Space = spaceId.Value;
-            }
-            else
-            {
-                throw new BadRequestException("No Space provided for this Asset.");
-            }
+            // Space was not explicitly provided in body; take space from route if available
+            hydraImage.Space = spaceId.Value;
+        }
+        else if (hydraImage.Space < 0)
+        {
+            throw new BadRequestException("No Space provided for this Asset.");
         }
         
         if (modelId.IsNullOrEmpty())

--- a/src/protagonist/API/Converters/AssetConverter.cs
+++ b/src/protagonist/API/Converters/AssetConverter.cs
@@ -268,7 +268,7 @@ public static class AssetConverter
         }
         else if (hydraImage.Space < 0)
         {
-            throw new BadRequestException("No Space provided for this Asset.");
+            throw new BadRequestException("Space must be 0 or greater.");
         }
         
         if (modelId.IsNullOrEmpty())

--- a/src/protagonist/API/Features/Image/ImageController.cs
+++ b/src/protagonist/API/Features/Image/ImageController.cs
@@ -115,6 +115,9 @@ public class ImageController : HydraController
             hydraAsset.ModelId = imageId;
         }
 
+        // make sure the space id is set for the validator
+        hydraAsset.Space ??= spaceId;
+
         var validationResult = await validator.ValidateAsync(hydraAsset,
             strategy => strategy.IncludeRuleSets("default", "create"), cancellationToken);
         

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -79,12 +79,12 @@ public class AssetProcessor(
 
                 counts.CustomerStorage.NumberOfStoredImages++;
             }
-
+            
             var existingAsset = assetFromDatabase?.Clone();
-            var isNoneChannel = AssetDeliveryChannels.IsNoneOnly(
-                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel))
-                || AssetDeliveryChannels.IsStubAsset(assetBeforeProcessing.Asset.Space,
-                    assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel));
+
+            var assetDeliveryChannels = assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel).ToList();
+            var isNoneChannel = AssetDeliveryChannels.IsNoneOnly( assetDeliveryChannels)
+                || AssetDeliveryChannels.IsStubAsset(assetBeforeProcessing.Asset.Space, assetDeliveryChannels);
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
                     settings.RestrictedResourceIdCharacters, isNoneChannel);

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -84,7 +84,7 @@ public class AssetProcessor(
 
             var assetDeliveryChannels = assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel).ToList();
             var isNoneChannel = AssetDeliveryChannels.IsNoneOnly( assetDeliveryChannels)
-                || AssetDeliveryChannels.IsStubAsset(assetBeforeProcessing.Asset.Space, assetDeliveryChannels);
+                || AssetDeliveryChannels.IsPotentialStubAsset(assetBeforeProcessing.Asset.Space, assetDeliveryChannels);
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
                     settings.RestrictedResourceIdCharacters, isNoneChannel);

--- a/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
+++ b/src/protagonist/API/Features/Image/Ingest/AssetProcessor.cs
@@ -82,7 +82,9 @@ public class AssetProcessor(
 
             var existingAsset = assetFromDatabase?.Clone();
             var isNoneChannel = AssetDeliveryChannels.IsNoneOnly(
-                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel));
+                assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel))
+                || AssetDeliveryChannels.IsStubAsset(assetBeforeProcessing.Asset.Space,
+                    assetBeforeProcessing.DeliveryChannelsBeforeProcessing?.Select(dcp => dcp.Channel));
             var assetPreparationResult =
                 AssetPreparer.PrepareAssetForUpsert(assetFromDatabase, assetBeforeProcessing.Asset, false, isBatchUpdate,
                     settings.RestrictedResourceIdCharacters, isNoneChannel);

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -74,7 +74,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         => AssetDeliveryChannels.IsNoneOnly(image.DeliveryChannels?.Select(dc => dc.Channel));
 
     private static bool IsStubAsset(DLCS.HydraModel.Image image)
-        => AssetDeliveryChannels.IsStubAsset(image.Space, image.DeliveryChannels?.Select(dc => dc.Channel));
+        => AssetDeliveryChannels.IsPotentialStubAsset(image.Space, image.DeliveryChannels?.Select(dc => dc.Channel));
 
     private void ImageDeliveryChannelDependantValidation()
     {

--- a/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
+++ b/src/protagonist/API/Features/Image/Validation/HydraImageValidator.cs
@@ -22,7 +22,7 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
         {
             RuleFor(a => a.MediaType)
                 .NotEmpty()
-                .When(a => !IsNoneOnly(a))
+                .Unless(a => IsNoneOnly(a) || IsStubAsset(a))
                 .WithMessage("Media type must be specified");
         });
 
@@ -72,6 +72,9 @@ public class HydraImageValidator : AbstractValidator<DLCS.HydraModel.Image>
     
     private static bool IsNoneOnly(DLCS.HydraModel.Image image)
         => AssetDeliveryChannels.IsNoneOnly(image.DeliveryChannels?.Select(dc => dc.Channel));
+
+    private static bool IsStubAsset(DLCS.HydraModel.Image image)
+        => AssetDeliveryChannels.IsStubAsset(image.Space, image.DeliveryChannels?.Select(dc => dc.Channel));
 
     private void ImageDeliveryChannelDependantValidation()
     {

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -425,9 +425,9 @@ public class CustomerQueueController : HydraController
     private static DeliveryChannelsBeforeProcessing[]? GetDeliveryChannelsForAsset(DLCS.HydraModel.Image image)
     {
         // Space 0 assets with no delivery channels are stub assets - treat as 'none' channel implicitly
-        if (image.Space == 0 && image.DeliveryChannels.IsNullOrEmpty())
+        if (image.Space == AssetDeliveryChannels.StubAssetSpace && image.DeliveryChannels.IsNullOrEmpty())
         {
-            return [new DeliveryChannelsBeforeProcessing(AssetDeliveryChannels.None, "none")];
+            return [new DeliveryChannelsBeforeProcessing(AssetDeliveryChannels.None, AssetDeliveryChannels.None)];
         }
         return image.DeliveryChannels.ToInterimModel();
     }

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -418,18 +418,8 @@ public class CustomerQueueController : HydraController
     {
         var assetsBeforeProcessing = images.Members!
             .Select(i => new AssetBeforeProcessing(i.ToDlcsModel(customerId),
-                GetDeliveryChannelsForAsset(i))).ToList();
+                i.DeliveryChannels.ToInterimModel())).ToList();
         return assetsBeforeProcessing;
-    }
-
-    private static DeliveryChannelsBeforeProcessing[]? GetDeliveryChannelsForAsset(DLCS.HydraModel.Image image)
-    {
-        // Space 0 assets with no delivery channels are stub assets - treat as 'none' channel implicitly
-        if (image.Space == AssetDeliveryChannels.StubAssetSpace && image.DeliveryChannels.IsNullOrEmpty())
-        {
-            return [new DeliveryChannelsBeforeProcessing(AssetDeliveryChannels.None, AssetDeliveryChannels.None)];
-        }
-        return image.DeliveryChannels.ToInterimModel();
     }
     
     /// <summary>

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -418,8 +418,18 @@ public class CustomerQueueController : HydraController
     {
         var assetsBeforeProcessing = images.Members!
             .Select(i => new AssetBeforeProcessing(i.ToDlcsModel(customerId),
-                i.DeliveryChannels.ToInterimModel())).ToList();
+                GetDeliveryChannelsForAsset(i))).ToList();
         return assetsBeforeProcessing;
+    }
+
+    private static DeliveryChannelsBeforeProcessing[]? GetDeliveryChannelsForAsset(DLCS.HydraModel.Image image)
+    {
+        // Space 0 assets with no delivery channels are stub assets - treat as 'none' channel implicitly
+        if (image.Space == 0 && image.DeliveryChannels.IsNullOrEmpty())
+        {
+            return [new DeliveryChannelsBeforeProcessing(AssetDeliveryChannels.None, "none")];
+        }
+        return image.DeliveryChannels.ToInterimModel();
     }
     
     /// <summary>

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -445,9 +445,9 @@ public class CustomerQueueController : HydraController
         {
             for (int i = 0; i < members.Count; i++)
             {
-                if (Settings.LegacyModeEnabledForSpace(customerId, members[i].Space))
+                if (Settings.LegacyModeEnabledForSpace(customerId, members[i].Space.GetValueOrDefault()))
                 {
-                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i], members[i].Space);
+                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i], members[i].Space.GetValueOrDefault());
                 }
             }
         }

--- a/src/protagonist/API/Features/Queues/CustomerQueueController.cs
+++ b/src/protagonist/API/Features/Queues/CustomerQueueController.cs
@@ -435,9 +435,11 @@ public class CustomerQueueController : HydraController
         {
             for (int i = 0; i < members.Count; i++)
             {
-                if (Settings.LegacyModeEnabledForSpace(customerId, members[i].Space.GetValueOrDefault()))
+                var space = members[i].Space ?? 0;
+                
+                if (Settings.LegacyModeEnabledForSpace(customerId, space))
                 {
-                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i], members[i].Space.GetValueOrDefault());
+                    members[i] = LegacyModeConverter.VerifyAndConvertToModernFormat(members[i], space);
                 }
             }
         }

--- a/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
+++ b/src/protagonist/API/Features/Queues/Requests/CreateBatchOfImages.cs
@@ -155,17 +155,6 @@ public class CreateBatchOfImagesHandler(
         return ModifyEntityResult<Batch>.Success(batch, WriteResult.Created);
     }
 
-    private static ModifyEntityResult<Batch>? ValidateSpaceZeroDeliveryChannels(CreateBatchOfImages request)
-    {
-        var hasInvalidSpaceZeroAsset = request.AssetsBeforeProcessing.Any(a => !a.IsValidForSpaceZero());
-
-        if (!hasInvalidSpaceZeroAsset) return null;
-
-        return ModifyEntityResult<Batch>.Failure(
-            "Assets in space 0 can only use the 'none' delivery channel",
-            WriteResult.FailedValidation);
-    }
-
     private ModifyEntityResult<Batch>? ValidatePriorityQueueRequest(CreateBatchOfImages request)
     {
         if (!request.IsPriority) return null;

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -1,6 +1,7 @@
 ﻿using API.Features.Image.Validation;
 using API.Settings;
 using DLCS.Core.Collections;
+using DLCS.Model.Assets;
 using FluentValidation;
 using Hydra.Collections;
 using Microsoft.Extensions.Options;
@@ -33,15 +34,20 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
             .Must(m => (m?.Length ?? 0) <= maxBatch)
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
 
-        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(apiSettings),
-            "default", "create");
-        
+        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(apiSettings), "default");
+
         // In addition to above validation, batched updates must have ModelId + Space as this can't be taken from
-        // path
+        // path. MediaType is required unless the asset is a 'none' channel or a space-0 stub asset (which gets
+        // 'none' assigned implicitly)
         RuleForEach(c => c.Members).ChildRules(members =>
         {
             members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("Asset Id cannot be empty");
-            members.RuleFor(a => a.Space).NotEmpty().WithMessage("Space cannot be empty");
+            members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).WithMessage("Space cannot be empty");
+            members.RuleFor(a => a.MediaType)
+                .NotEmpty()
+                .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)) &&
+                           !(a.Space == 0 && a.DeliveryChannels.IsNullOrEmpty()))
+                .WithMessage("Media type must be specified");
         });
     }
 }

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -42,11 +42,11 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
         RuleForEach(c => c.Members).ChildRules(members =>
         {
             members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("Asset Id cannot be empty");
-            members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).WithMessage("Space cannot be empty");
+            members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).WithMessage("Space must be 0 or greater");
             members.RuleFor(a => a.MediaType)
                 .NotEmpty()
-                .When(a => !AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)) &&
-                           !(a.Space == 0 && a.DeliveryChannels.IsNullOrEmpty()))
+                .Unless(a => AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)) ||
+                             (a.Space == AssetDeliveryChannels.StubAssetSpace && a.DeliveryChannels.IsNullOrEmpty()))
                 .WithMessage("Media type must be specified");
         });
     }

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -1,7 +1,6 @@
 ﻿using API.Features.Image.Validation;
 using API.Settings;
 using DLCS.Core.Collections;
-using DLCS.Model.Assets;
 using FluentValidation;
 using Hydra.Collections;
 using Microsoft.Extensions.Options;
@@ -34,21 +33,14 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
             .Must(m => (m?.Length ?? 0) <= maxBatch)
             .WithMessage($"Maximum assets in single batch is {maxBatch}");
 
-        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(apiSettings), "default");
+        RuleForEach(c => c.Members).SetValidator(new HydraImageValidator(apiSettings), "default", "create");
 
-        // In addition to above validation, batched updates must have ModelId + Space as this can't be taken from
-        // path. MediaType is required unless the asset is a 'none' channel or a space-0 stub asset (which gets
-        // 'none' assigned implicitly)
+        // In addition to above validation, batched updates must have ModelId + Space as these can't be taken from path
         RuleForEach(c => c.Members).ChildRules(members =>
         {
             members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("Asset Id cannot be empty");
             members.RuleFor(a => a.Space).NotNull().WithMessage("Space must be specified");
             members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).When(a => a.Space.HasValue).WithMessage("Space must be 0 or greater");
-            members.RuleFor(a => a.MediaType)
-                .NotEmpty()
-                .Unless(a => AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)) ||
-                             (a.Space == AssetDeliveryChannels.StubAssetSpace && a.DeliveryChannels.IsNullOrEmpty()))
-                .WithMessage("Media type must be specified");
         });
     }
 }

--- a/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
+++ b/src/protagonist/API/Features/Queues/Validation/QueuePostValidator.cs
@@ -42,7 +42,8 @@ public class QueuePostValidator : AbstractValidator<HydraCollection<DLCS.HydraMo
         RuleForEach(c => c.Members).ChildRules(members =>
         {
             members.RuleFor(a => a.ModelId).NotEmpty().WithMessage("Asset Id cannot be empty");
-            members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).WithMessage("Space must be 0 or greater");
+            members.RuleFor(a => a.Space).NotNull().WithMessage("Space must be specified");
+            members.RuleFor(a => a.Space).GreaterThanOrEqualTo(0).When(a => a.Space.HasValue).WithMessage("Space must be 0 or greater");
             members.RuleFor(a => a.MediaType)
                 .NotEmpty()
                 .Unless(a => AssetDeliveryChannels.IsNoneOnly(a.DeliveryChannels?.Select(dc => dc.Channel)) ||

--- a/src/protagonist/DLCS.HydraModel/Image.cs
+++ b/src/protagonist/DLCS.HydraModel/Image.cs
@@ -38,7 +38,7 @@ public class Image : DlcsResource
     public string? ModelId { get; set; }
     
     [JsonProperty(Order = 10, PropertyName = "space")]
-    public int Space { get; set; }
+    public int? Space { get; set; }
 
     [RdfProperty(Description = "image service URI - where the IIIF Image API is exposed for this image",
         Range = Names.XmlSchema.String, ReadOnly = false, WriteOnly = false)]

--- a/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
@@ -13,7 +13,7 @@ public class ImageWithFile : Image
     
     public byte[]? File { get; set; }
     
-    public Image ToImage() => new Image(BaseUrl, CustomerId, Space, ModelId!)
+    public Image ToImage() => new Image(BaseUrl, CustomerId, Space.GetValueOrDefault(), ModelId!)
     {
         StorageIdentifier = StorageIdentifier,
         Created = Created,

--- a/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
+++ b/src/protagonist/DLCS.HydraModel/ImageWithFile.cs
@@ -13,7 +13,7 @@ public class ImageWithFile : Image
     
     public byte[]? File { get; set; }
     
-    public Image ToImage() => new Image(BaseUrl, CustomerId, Space.GetValueOrDefault(), ModelId!)
+    public Image ToImage() => new Image(BaseUrl, CustomerId, Space ?? 0, ModelId!)
     {
         StorageIdentifier = StorageIdentifier,
         Created = Created,

--- a/src/protagonist/DLCS.Mock/Controllers/QueueController.cs
+++ b/src/protagonist/DLCS.Mock/Controllers/QueueController.cs
@@ -42,7 +42,7 @@ public class QueueController : ControllerBase
         model.Batches.Add(batch);
         foreach (var incomingImage in images.Members)
         {
-            var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, incomingImage.Space, incomingImage.ModelId, 
+            var newImage = MockHelp.MakeImage(model.BaseUrl, customerId, incomingImage.Space.GetValueOrDefault(), incomingImage.ModelId,
                 DateTime.UtcNow, incomingImage.Origin, 
                 0, 0, incomingImage.MaxUnauthorised, null, null, null, true, null, 
                 incomingImage.Tags, incomingImage.String1, incomingImage.String2, incomingImage.String3,

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -87,8 +87,11 @@ public static class AssetDeliveryChannels
 
     /// <summary>
     /// Checks if an asset is a stub asset: in space 0 with no delivery channels specified
+    ///
+    /// Note: having "deliveryChannels": ["none"] would also be a valid stub asset, but this should be picked up with
+    /// <see cref="IsNoneOnly"/>
     /// </summary>
-    public static bool IsStubAsset(int? space, IEnumerable<string>? channels)
+    public static bool IsPotentialStubAsset(int? space, IEnumerable<string>? channels)
         => space == StubAssetSpace && channels.IsNullOrEmpty();
 
     /// <summary>

--- a/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
+++ b/src/protagonist/DLCS.Model/Assets/AssetDeliveryChannels.cs
@@ -80,10 +80,16 @@ public static class AssetDeliveryChannels
     public static bool IsNoneOnly(IEnumerable<string>? channels)
     {
         if (channels == null) return false;
-        
+
         using var e = channels.GetEnumerator();
         return e.MoveNext() && e.Current == None && !e.MoveNext();
     }
+
+    /// <summary>
+    /// Checks if an asset is a stub asset: in space 0 with no delivery channels specified
+    /// </summary>
+    public static bool IsStubAsset(int? space, IEnumerable<string>? channels)
+        => space == StubAssetSpace && channels.IsNullOrEmpty();
 
     /// <summary>
     /// Checks if string is a valid delivery channel

--- a/src/protagonist/Portal/Features/Spaces/Requests/GetImage.cs
+++ b/src/protagonist/Portal/Features/Spaces/Requests/GetImage.cs
@@ -88,7 +88,7 @@ public class GetImageHandler : IRequestHandler<GetImage, GetImageResult?>
     {
         try
         {
-            return await dlcsClient.GetImageStorage(image.Space.GetValueOrDefault(), image.ModelId);
+            return await dlcsClient.GetImageStorage(image.Space ?? 0, image.ModelId);
         }
         catch (Exception ex) 
         {  

--- a/src/protagonist/Portal/Features/Spaces/Requests/GetImage.cs
+++ b/src/protagonist/Portal/Features/Spaces/Requests/GetImage.cs
@@ -88,7 +88,7 @@ public class GetImageHandler : IRequestHandler<GetImage, GetImageResult?>
     {
         try
         {
-            return await dlcsClient.GetImageStorage(image.Space, image.ModelId);
+            return await dlcsClient.GetImageStorage(image.Space.GetValueOrDefault(), image.ModelId);
         }
         catch (Exception ex) 
         {  


### PR DESCRIPTION
## What does this change?

This PR fixes some issues identified with `createBatchOfImages` to work with a minimal payload in the stub asset space, which is used by iiif-presentation for manifest level adjuncts

Original PR here - #1191
