### PR TITLE
Generated manifests include adjuncts for 'none'

### DIFF
--- a/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Infrastructure/IIIF/Manifests/ManifestV3BuilderTests.cs
@@ -592,6 +592,62 @@ public class ManifestV3BuilderTests
         fullInlinePaintingAnnotationBody.Language.Should().OnlyContain(l => l == "en");
     }
     
+    [Fact]
+    public async Task BuildManifest_NoneChannel_WithAdjuncts_CreatesCanvas()
+    {
+        var asset = new Asset
+        {
+            Id = AssetIdGenerator.GetAssetId(),
+            MediaType = "example/example",
+            ImageDeliveryChannels = "none".GenerateDeliveryChannels(),
+            Adjuncts =
+            [
+                new Adjunct
+                {
+                    Id = "dataset",
+                    IIIFLink = IIIFLinkType.SeeAlso,
+                    MediaType = "application/json",
+                    AssetId = AssetIdGenerator.GetAssetId(),
+                    Type = "Dataset",
+                    ExternalId = new Uri("http://some.id/dataset")
+                }
+            ]
+        };
+
+        var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
+        A.CallTo(() => builderUtils.GetCanvasId(asset, pathElement, A<int>._))
+            .Returns("https://dlcs.test/canvas/0");
+
+        var manifest = await sut.BuildManifest(manifestId, "testLabel", asset.AsList(), pathElement,
+            ManifestType.NamedQuery, CancellationToken.None);
+
+        manifest.Items.Should().HaveCount(1);
+        var canvas = manifest.Items!.Single();
+        canvas.Items.Should().BeNull("No painting annotation for none channel");
+        canvas.SeeAlso.Should().HaveCount(1);
+        var seeAlso = canvas.SeeAlso!.Single();
+        seeAlso.Id.Should().Be("http://some.id/dataset");
+        seeAlso.Format.Should().Be("application/json");
+    }
+
+    [Fact]
+    public async Task BuildManifest_NoneChannel_WithoutAdjuncts_NoCanvas()
+    {
+        var asset = new Asset
+        {
+            Id = AssetIdGenerator.GetAssetId(),
+            MediaType = "example/example",
+            ImageDeliveryChannels = "none".GenerateDeliveryChannels()
+        };
+
+        var manifestId = $"https://dlcs.test/iiif-manifest/{asset}";
+
+        var manifest = await sut.BuildManifest(manifestId, "testLabel", asset.AsList(), pathElement,
+            ManifestType.NamedQuery, CancellationToken.None);
+
+        manifest.Items.Should().BeNullOrEmpty();
+    }
+
     private static Asset GetImageAsset(string deliveryChannels) =>
         new()
         {

--- a/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
+++ b/src/protagonist/Orchestrator/Infrastructure/IIIF/Manifests/ManifestV3Builder.cs
@@ -202,9 +202,15 @@ public class ManifestV3Builder : ManifestBuilderBase<Manifest>
 
         if (annotationPage == null)
         {
+            if (asset.HasSingleDeliveryChannel(AssetDeliveryChannels.None) && !asset.Adjuncts.IsNullOrEmpty())
+            {
+                logger.LogDebug("{AssetId} has 'none' channel and adjuncts - adding Canvas", asset.Id);
+                AddAdjunctsToCanvas(canvas, asset);
+                return new AssetCanvas(canvas, additionalContexts);
+            }
             return new AssetCanvas(null, null);
         }
-        
+
         canvas.Items = annotationPage.AsList();
 
         if (thumbnail != null)


### PR DESCRIPTION
## What does this change?

Resolves #1188

Generated single-item and named-query Manifests will now output adjuncts for any Assets that have 'none' channel. Assets with 'none' channel and no adjuncts will continue to be ignored.