### PR TITLE
Improve OrchestrationImage caching - avoid unnecessary proxying

### DIFF
--- a/src/protagonist/DLCS.Repository/Policies/PolicyRepository.cs
+++ b/src/protagonist/DLCS.Repository/Policies/PolicyRepository.cs
@@ -96,18 +96,6 @@ public class PolicyRepository : IPolicyRepository
         }, cacheSettings.GetMemoryCacheOptions(CacheDuration.Long));
     }
 
-    private Task<List<ThumbnailPolicy>> GetThumbnailPolicies(CancellationToken cancellationToken)
-    {
-        const string key = "ThumbnailPolicies";
-        return appCache.GetOrAddAsync(key, async () =>
-        {
-            logger.LogDebug("Refreshing ThumbnailPolicies from database");
-            var thumbnailPolicies =
-                await dlcsContext.ThumbnailPolicies.AsNoTracking().ToListAsync(cancellationToken: cancellationToken);
-            return thumbnailPolicies;
-        }, cacheSettings.GetMemoryCacheOptions());
-    }
-    
     private async Task<List<DeliveryChannelPolicy>> GetThumbnailDeliveryChannelPolicies(int customerId, CancellationToken cancellationToken)
     {
         string key = $"ThumbnailDeliveryChannelPolicies:{customerId}";

--- a/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
@@ -61,7 +61,8 @@ public class ImageOrchestratorTests
     public async Task EnsureImageOrchestrated_DoesNotCheckFileSystem_IfObjectInCache()
     {
         // Arrange
-        A.CallTo(() => fakedCache.GetOrAddAsync(CacheKey, A<Func<ICacheEntry, Task<bool>>>._)).Returns(true);
+        A.CallTo(() => fakedCache.GetOrAddAsync(CacheKey, A<Func<ICacheEntry, Task<OrchestrationResult>>>._, A<MemoryCacheEntryOptions>._))
+            .Returns(OrchestrationResult.Orchestrated);
         var sut = GetSystemUnderTest(true);
 
         // Act
@@ -269,10 +270,11 @@ public class ImageOrchestratorTests
     }
 
     private void SetupCacheToInvokeFactory(TestCacheEntry testEntry)
-        => A.CallTo(() => fakedCache.GetOrAddAsync(CacheKey, A<Func<ICacheEntry, Task<bool>>>._, A<MemoryCacheEntryOptions>._))
+        => A.CallTo(() => fakedCache.GetOrAddAsync(CacheKey, A<Func<ICacheEntry, Task<OrchestrationResult>>>._,
+                A<MemoryCacheEntryOptions>._))
             .ReturnsLazily(call =>
             {
-                var factory = call.GetArgument<Func<ICacheEntry, Task<bool>>>(1)!;
+                var factory = call.GetArgument<Func<ICacheEntry, Task<OrchestrationResult>>>(1)!;
                 return factory(testEntry);
             });
 

--- a/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
+++ b/src/protagonist/Orchestrator.Tests/Features/Images/Orchestration/ImageOrchestratorTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using DLCS.Core.Caching;
 using DLCS.Core.FileSystem;
 using DLCS.Core.Types;
@@ -10,6 +12,7 @@ using DLCS.Repository.Strategy.Utils;
 using LazyCache;
 using LazyCache.Mocks;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Orchestrator.Assets;
@@ -208,8 +211,87 @@ public class ImageOrchestratorTests
         result.Should().Be(OrchestrationResult.NotFound);
     }
 
+    [Fact]
+    public async Task EnsureImageOrchestrated_SetsShortTtlAndLowPriority_WhenOrchestrationErrors()
+    {
+        // Arrange
+        var testEntry = new TestCacheEntry();
+        SetupCacheToInvokeFactory(testEntry);
+        A.CallTo(() => originStrategy.LoadFromOrigin(orchestrationImage, null, CancellationToken.None))
+            .Returns(new OriginResponse(Stream.Null));
+
+        var sut = GetSystemUnderTest(true);
+
+        // Act
+        await sut.EnsureImageOrchestrated(orchestrationImage, CancellationToken.None);
+
+        // Assert
+        testEntry.AbsoluteExpirationRelativeToNow.Should().Be(TimeSpan.FromSeconds(60));
+        testEntry.Priority.Should().Be(CacheItemPriority.Low);
+    }
+
+    [Fact]
+    public async Task EnsureImageOrchestrated_SetsShortTtlAndLowPriority_WhenAssetNotFound()
+    {
+        // Arrange
+        var image = new OrchestrationImage { AssetId = new AssetId(1, 10, "test") };
+        var testEntry = new TestCacheEntry();
+        SetupCacheToInvokeFactory(testEntry);
+
+        var sut = GetSystemUnderTest(true);
+
+        // Act
+        await sut.EnsureImageOrchestrated(image, CancellationToken.None);
+
+        // Assert
+        testEntry.AbsoluteExpirationRelativeToNow.Should().Be(TimeSpan.FromSeconds(60));
+        testEntry.Priority.Should().Be(CacheItemPriority.Low);
+    }
+
+    [Fact]
+    public async Task EnsureImageOrchestrated_DoesNotOverrideCacheEntry_WhenSuccessful()
+    {
+        // Arrange
+        var testEntry = new TestCacheEntry();
+        SetupCacheToInvokeFactory(testEntry);
+        var originResponse = new OriginResponse("test".ToMemoryStream());
+        A.CallTo(() => originStrategy.LoadFromOrigin(orchestrationImage, null, CancellationToken.None))
+            .Returns(originResponse);
+
+        var sut = GetSystemUnderTest(true);
+
+        // Act
+        await sut.EnsureImageOrchestrated(orchestrationImage, CancellationToken.None);
+
+        // Assert - factory did not override entry (options on GetOrAddAsync handle the High priority default)
+        testEntry.AbsoluteExpirationRelativeToNow.Should().BeNull();
+        testEntry.Priority.Should().NotBe(CacheItemPriority.Low);
+    }
+
+    private void SetupCacheToInvokeFactory(TestCacheEntry testEntry)
+        => A.CallTo(() => fakedCache.GetOrAddAsync(CacheKey, A<Func<ICacheEntry, Task<bool>>>._, A<MemoryCacheEntryOptions>._))
+            .ReturnsLazily(call =>
+            {
+                var factory = call.GetArgument<Func<ICacheEntry, Task<bool>>>(1)!;
+                return factory(testEntry);
+            });
+
     // if fakeCache = true then use A.Fake<IAppCache>, else use provided MockCachingService
     private ImageOrchestrator GetSystemUnderTest(bool fakeCache = false)
         => new(assetTracker, orchestratorSettings, originStrategy, fakeCache ? fakedCache : new MockCachingService(),
             fileSaver, fileSystem, dlcsApiClient, new NullLogger<ImageOrchestrator>());
+
+    private class TestCacheEntry : ICacheEntry
+    {
+        public object Key => throw new NotImplementedException();
+        public object? Value { get; set; }
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+        public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+        public TimeSpan? SlidingExpiration { get; set; }
+        public IList<IChangeToken> ExpirationTokens { get; } = new List<IChangeToken>();
+        public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; } = new List<PostEvictionCallbackRegistration>();
+        public CacheItemPriority Priority { get; set; } = CacheItemPriority.Normal;
+        public long? Size { get; set; }
+        public void Dispose() { }
+    }
 }

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -49,45 +49,30 @@ public enum OrchestrationResult
 /// <summary>
 /// Class that contains logic for copying images from slow object-storage to fast-disk storage
 /// </summary>
-public class ImageOrchestrator : IImageOrchestrator
+public class ImageOrchestrator(
+    IAssetTracker assetTracker,
+    IOptionsMonitor<OrchestratorSettings> orchestratorSettings,
+    IOriginStrategy originStrategy,
+    IAppCache appCache,
+    IFileSaver fileSaver,
+    IFileSystem fileSystem,
+    IDlcsApiClient dlcsApiClient,
+    ILogger<ImageOrchestrator> logger)
+    : IImageOrchestrator
 {
-    private readonly IAssetTracker assetTracker;
-    private readonly IOptionsMonitor<OrchestratorSettings> orchestratorSettings;
-    private readonly IOriginStrategy originStrategy;
-    private readonly IAppCache appCache;
-    private readonly IFileSaver fileSaver;
-    private readonly IFileSystem fileSystem;
-    private readonly IDlcsApiClient dlcsApiClient;
-    private readonly ILogger<ImageOrchestrator> logger;
-
-    public ImageOrchestrator(IAssetTracker assetTracker,
-        IOptionsMonitor<OrchestratorSettings> orchestratorSettings,
-        IOriginStrategy originStrategy,
-        IAppCache appCache,
-        IFileSaver fileSaver,
-        IFileSystem fileSystem,
-        IDlcsApiClient dlcsApiClient,
-        ILogger<ImageOrchestrator> logger)
-    {
-        this.assetTracker = assetTracker;
-        this.orchestratorSettings = orchestratorSettings;
-        this.originStrategy = originStrategy;
-        this.appCache = appCache;
-        this.fileSaver = fileSaver;
-        this.fileSystem = fileSystem;
-        this.dlcsApiClient = dlcsApiClient;
-        this.logger = logger;
-    }
-
     public async Task<OrchestrationResult> EnsureImageOrchestrated(OrchestrationImage orchestrationImage,
         CancellationToken cancellationToken = default)
     {
         var assetId = orchestrationImage.AssetId;
+        
+        // "workDone" is used to differentiate between an image being already orchestrated and cache delegate being
+        // called to do the orchestration 
+        var workDone = false;
 
-        var orchestrationResult = OrchestrationResult.AlreadyOrchestrated;
-
-        await appCache.GetOrAddAsync(CacheKeys.GetOrchestrationCacheKey(assetId), async entry =>
+        var orchestrationResult = await appCache.GetOrAddAsync(CacheKeys.GetOrchestrationCacheKey(assetId), async entry =>
         {
+            workDone = true;
+            OrchestrationResult orchestrationResult;
             try
             {
                 orchestrationResult = await OrchestrateImageInternal(orchestrationImage, assetId, cancellationToken);
@@ -104,10 +89,12 @@ public class ImageOrchestrator : IImageOrchestrator
                 entry.Priority = CacheItemPriority.Low;
             }
 
-            return true;
+            return orchestrationResult;
         }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(priority: CacheItemPriority.High));
-
-        return orchestrationResult;
+        
+        return orchestrationResult == OrchestrationResult.Orchestrated && !workDone
+            ? OrchestrationResult.AlreadyOrchestrated
+            : orchestrationResult;
     }
 
     private async Task<OrchestrationResult> OrchestrateImageInternal(OrchestrationImage orchestrationImage,

--- a/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
+++ b/src/protagonist/Orchestrator/Features/Images/Orchestration/ImageOrchestrator.cs
@@ -86,7 +86,7 @@ public class ImageOrchestrator : IImageOrchestrator
 
         var orchestrationResult = OrchestrationResult.AlreadyOrchestrated;
 
-        await appCache.GetOrAddAsync(CacheKeys.GetOrchestrationCacheKey(assetId), async _ =>
+        await appCache.GetOrAddAsync(CacheKeys.GetOrchestrationCacheKey(assetId), async entry =>
         {
             try
             {
@@ -97,14 +97,15 @@ public class ImageOrchestrator : IImageOrchestrator
                 orchestrationResult = OrchestrationResult.Error;
             }
 
+            if (orchestrationResult is OrchestrationResult.Error or OrchestrationResult.NotFound)
+            {
+                var cacheSettings = orchestratorSettings.CurrentValue.Caching;
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(cacheSettings.GetTtl(CacheDuration.Short));
+                entry.Priority = CacheItemPriority.Low;
+            }
+
             return true;
-        }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(
-            duration: orchestrationResult is OrchestrationResult.Error or OrchestrationResult.NotFound
-                ? CacheDuration.Short
-                : CacheDuration.Default,
-            priority: orchestrationResult is OrchestrationResult.Error or OrchestrationResult.NotFound
-                ? CacheItemPriority.Low
-                : CacheItemPriority.High));
+        }, orchestratorSettings.CurrentValue.Caching.GetMemoryCacheOptions(priority: CacheItemPriority.High));
 
         return orchestrationResult;
     }


### PR DESCRIPTION
## What does this change?

Resolves #1197

Fixes 2 issues in `ImageOrchestrator`
1. Don't cache a boolean, cache status enum. This makes it impossible to differentiate between assets that failed to orchestrate and those that orchestrated okay after first request.
2. Set CacheDuration and Priority inside lambda, not outside as that is evaluated before entering the lambda (and as such always used defaults).

Additional change was to remove unused method from `PolicyRepository` - spotted when checking all other usages of lazy cache to ensure this was handled correctly elsewhere.