### PR TITLE
Handle bucket copy for files greater than 50GB

### DIFF
--- a/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
@@ -2,8 +2,10 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
+using DLCS.AWS.Settings;
 using FakeItEasy;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace DLCS.AWS.Tests.S3;
 
@@ -15,14 +17,15 @@ public class S3BucketWriterTests
     public S3BucketWriterTests()
     {
         s3Client = A.Fake<IAmazonS3>();
-        sut = new S3BucketWriter(s3Client, new NullLogger<S3BucketWriter>());
+        var awsOptions = Options.Create(new AWSSettings { S3 = new S3Settings { CopyPartConcurrency = 4 } });
+        sut = new S3BucketWriter(s3Client, awsOptions, new NullLogger<S3BucketWriter>());
     }
 
     [Theory]
-    [InlineData(10L * 1024 * 1024, 2)] // 10 MB, 2 × 5MB parts (minimum part size)
-    [InlineData(50L * 1024 * 1024 * 1024, 10000)] // 50 GB, 10000 parts (boundary: just forces scale-up)
-    [InlineData(100L * 1024 * 1024 * 1024, 10000)] // 100 GB, 10000 parts (~10MB each)
-    [InlineData(500L * 1024 * 1024 * 1024, 10000)] // 500 GB, 10000 parts (~50MB each)
+    [InlineData(32L * 1024 * 1024, 2)] // 32 MB , 2 × 16MB parts (minimum part size)
+    [InlineData(50L * 1024 * 1024 * 1024, 3200)]  // 50 GB , 3200 × 16MB parts
+    [InlineData(100L * 1024 * 1024 * 1024, 6400)] // 100 GB, 6400 × 16MB parts
+    [InlineData(500L * 1024 * 1024 * 1024, 10000)] // 500 GB, 10000 parts (scale-up kicks in ~53MB each)
     public async Task CopyLargeObject_NeverExceeds10000Parts(long fileSize, int expectedPartCount)
     {
         SetupS3ForCopy(fileSize);
@@ -41,9 +44,9 @@ public class S3BucketWriterTests
     }
 
     [Fact]
-    public async Task CopyLargeObject_Uses5MBParts_ForSmallFile()
+    public async Task CopyLargeObject_Uses16MBParts_ForSmallFile()
     {
-        const long fileSize = 10L * 1024 * 1024; // 10 MB, 2 parts at 5 MB each
+        const long fileSize = 32L * 1024 * 1024; // 32 MB, 2 × 16MB parts
         SetupS3ForCopy(fileSize);
         var source = new ObjectInBucket("src-bucket", "src-key");
         var destination = new ObjectInBucket("dst-bucket", "dst-key");
@@ -58,9 +61,36 @@ public class S3BucketWriterTests
             .ToList();
 
         partRequests.Should().HaveCount(2);
-        (partRequests[0]!.LastByte - partRequests[0]!.FirstByte + 1).Should().Be(5 * 1024 * 1024);
+        (partRequests[0]!.LastByte - partRequests[0]!.FirstByte + 1).Should().Be(16 * 1024 * 1024);
     }
-    
+
+    [Fact]
+    public async Task CopyLargeObject_CopiesPartsInParallel()
+    {
+        const long fileSize = 64L * 1024 * 1024; // 64 MB, 4 × 16MB parts, matches CopyPartConcurrency of 4
+        SetupS3ForCopy(fileSize);
+        var source = new ObjectInBucket("src-bucket", "src-key");
+        var destination = new ObjectInBucket("dst-bucket", "dst-key");
+
+        var currentConcurrent = 0;
+        var maxConcurrent = 0;
+
+        A.CallTo(() => s3Client.CopyPartAsync(A<CopyPartRequest>.Ignored, A<CancellationToken>.Ignored))
+            .ReturnsLazily(async _ =>
+            {
+                var current = Interlocked.Increment(ref currentConcurrent);
+                InterlockedMax(ref maxConcurrent, current);
+                await Task.Delay(50);
+                Interlocked.Decrement(ref currentConcurrent);
+                return new CopyPartResponse();
+            });
+
+        var result = await sut.CopyLargeObject(source, destination);
+
+        result.Result.Should().Be(LargeObjectStatus.Success);
+        maxConcurrent.Should().BeGreaterThan(1, "parts should be copied in parallel");
+    }
+
     private void SetupS3ForCopy(long fileSize, string uploadId = "upload-id")
     {
         A.CallTo(() => s3Client.GetObjectMetadataAsync(
@@ -78,5 +108,16 @@ public class S3BucketWriterTests
         A.CallTo(() => s3Client.CompleteMultipartUploadAsync(
                 A<CompleteMultipartUploadRequest>.Ignored, A<CancellationToken>.Ignored))
             .Returns(new CompleteMultipartUploadResponse());
+    }
+
+    // Thread-safe max update — Interlocked.Max is .NET 9+, so use a compare-and-swap loop on .NET 8
+    private static void InterlockedMax(ref int location, int candidate)
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref location);
+            if (candidate <= current) return;
+        } while (Interlocked.CompareExchange(ref location, candidate, current) != current);
     }
 }

--- a/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
@@ -91,6 +91,33 @@ public class S3BucketWriterTests
         maxConcurrent.Should().BeGreaterThan(1, "parts should be copied in parallel");
     }
 
+    [Fact]
+    public async Task CopyLargeObject_AbortsAndReturnsCancelled_WhenCancelled()
+    {
+        const string uploadId = "upload-id";
+        const long fileSize = 32L * 1024 * 1024; // 32 MB, 2 parts
+        SetupS3ForCopy(fileSize, uploadId);
+        var source = new ObjectInBucket("src-bucket", "src-key");
+        var destination = new ObjectInBucket("dst-bucket", "dst-key");
+
+        var cts = new CancellationTokenSource();
+
+        A.CallTo(() => s3Client.CopyPartAsync(A<CopyPartRequest>.Ignored, A<CancellationToken>.Ignored))
+            .ReturnsLazily(_ =>
+            {
+                // Cancel the operation after the first part is copied
+                cts.Cancel();
+                return Task.FromCanceled<CopyPartResponse>(cts.Token);
+            });
+
+        var result = await sut.CopyLargeObject(source, destination, token: cts.Token);
+
+        result.Result.Should().Be(LargeObjectStatus.Cancelled);
+        A.CallTo(() => s3Client.AbortMultipartUploadAsync(destination.Bucket, destination.Key, uploadId,
+                CancellationToken.None))
+            .MustHaveHappenedOnceExactly();
+    }
+
     private void SetupS3ForCopy(long fileSize, string uploadId = "upload-id")
     {
         A.CallTo(() => s3Client.GetObjectMetadataAsync(

--- a/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
+++ b/src/protagonist/DLCS.AWS.Tests/S3/S3BucketWriterTests.cs
@@ -1,0 +1,82 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using DLCS.AWS.S3;
+using DLCS.AWS.S3.Models;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DLCS.AWS.Tests.S3;
+
+public class S3BucketWriterTests
+{
+    private readonly IAmazonS3 s3Client;
+    private readonly S3BucketWriter sut;
+
+    public S3BucketWriterTests()
+    {
+        s3Client = A.Fake<IAmazonS3>();
+        sut = new S3BucketWriter(s3Client, new NullLogger<S3BucketWriter>());
+    }
+
+    [Theory]
+    [InlineData(10L * 1024 * 1024, 2)] // 10 MB, 2 × 5MB parts (minimum part size)
+    [InlineData(50L * 1024 * 1024 * 1024, 10000)] // 50 GB, 10000 parts (boundary: just forces scale-up)
+    [InlineData(100L * 1024 * 1024 * 1024, 10000)] // 100 GB, 10000 parts (~10MB each)
+    [InlineData(500L * 1024 * 1024 * 1024, 10000)] // 500 GB, 10000 parts (~50MB each)
+    public async Task CopyLargeObject_NeverExceeds10000Parts(long fileSize, int expectedPartCount)
+    {
+        SetupS3ForCopy(fileSize);
+        var source = new ObjectInBucket("src-bucket", "src-key");
+        var destination = new ObjectInBucket("dst-bucket", "dst-key");
+
+        var result = await sut.CopyLargeObject(source, destination);
+
+        result.Result.Should().Be(LargeObjectStatus.Success);
+
+        A.CallTo(() => s3Client.CopyPartAsync(A<CopyPartRequest>.Ignored, A<CancellationToken>.Ignored))
+            .MustHaveHappened(expectedPartCount, Times.Exactly);
+        A.CallTo(() => s3Client.CopyPartAsync(
+                A<CopyPartRequest>.That.Matches(r => r.PartNumber > 10000), A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task CopyLargeObject_Uses5MBParts_ForSmallFile()
+    {
+        const long fileSize = 10L * 1024 * 1024; // 10 MB, 2 parts at 5 MB each
+        SetupS3ForCopy(fileSize);
+        var source = new ObjectInBucket("src-bucket", "src-key");
+        var destination = new ObjectInBucket("dst-bucket", "dst-key");
+
+        var result = await sut.CopyLargeObject(source, destination);
+
+        result.Result.Should().Be(LargeObjectStatus.Success);
+
+        var partRequests = Fake.GetCalls(s3Client)
+            .Where(c => c.Method.Name == nameof(IAmazonS3.CopyPartAsync))
+            .Select(c => (CopyPartRequest)c.Arguments[0]!)
+            .ToList();
+
+        partRequests.Should().HaveCount(2);
+        (partRequests[0]!.LastByte - partRequests[0]!.FirstByte + 1).Should().Be(5 * 1024 * 1024);
+    }
+    
+    private void SetupS3ForCopy(long fileSize, string uploadId = "upload-id")
+    {
+        A.CallTo(() => s3Client.GetObjectMetadataAsync(
+                A<GetObjectMetadataRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new GetObjectMetadataResponse { ContentLength = fileSize });
+
+        A.CallTo(() => s3Client.InitiateMultipartUploadAsync(
+                A<InitiateMultipartUploadRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new InitiateMultipartUploadResponse { UploadId = uploadId });
+
+        A.CallTo(() => s3Client.CopyPartAsync(
+                A<CopyPartRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CopyPartResponse());
+
+        A.CallTo(() => s3Client.CompleteMultipartUploadAsync(
+                A<CompleteMultipartUploadRequest>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(new CompleteMultipartUploadResponse());
+    }
+}

--- a/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
@@ -4,20 +4,16 @@ using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
 using DLCS.AWS.S3.Models;
+using DLCS.AWS.Settings;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace DLCS.AWS.S3;
 
-public class S3BucketWriter : IBucketWriter
+public class S3BucketWriter(IAmazonS3 s3Client, IOptions<AWSSettings> awsOptions, ILogger<S3BucketWriter> logger)
+    : IBucketWriter
 {
-    private readonly IAmazonS3 s3Client;
-    private readonly ILogger<S3BucketWriter> logger;
-
-    public S3BucketWriter(IAmazonS3 s3Client, ILogger<S3BucketWriter> logger)
-    {
-        this.s3Client = s3Client;
-        this.logger = logger;
-    }
+    private readonly S3Settings s3Settings = awsOptions.Value.S3;
 
     public async Task CopyObject(ObjectInBucket source, ObjectInBucket destination)
     {
@@ -57,10 +53,10 @@ public class S3BucketWriter : IBucketWriter
     /// <returns>ResultStatus signifying success or failure alongside ContentSize</returns>
     /// <remarks>See https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjctsUsingLLNetMPUapi.html </remarks>
     public async Task<LargeObjectCopyResult> CopyLargeObject(ObjectInBucket source, ObjectInBucket destination,
-        Func<long, Task<bool>>? verifySize = null, string? contentType = null,
-        CancellationToken token = default)
+        Func<long, Task<bool>>? verifySize = null, string? contentType = null, CancellationToken token = default)
     {
         long? objectSize = null;
+        string? uploadId = null;
         var success = false;
         var timer = Stopwatch.StartNew();
 
@@ -74,57 +70,42 @@ public class S3BucketWriter : IBucketWriter
                 notFoundResponse.DestinationExists = destinationMetadata != null;
                 return notFoundResponse;
             }
-            
+
             objectSize = sourceMetadata.ContentLength;
-            
+            var notNullObjectSize = objectSize.Value;
+
             if (verifySize != null)
             {
-                if (!await verifySize.Invoke(objectSize.Value))
+                if (!await verifySize.Invoke(notNullObjectSize))
                 {
                     logger.LogInformation("Aborting multipart upload for {Target} as size verification failed",
                         destination);
-                    return new LargeObjectCopyResult(LargeObjectStatus.FileTooLarge, objectSize);
+                    return new LargeObjectCopyResult(LargeObjectStatus.FileTooLarge, notNullObjectSize);
                 }
             }
 
-            var partSize = GetPartSize(objectSize.Value);
-            var numberOfParts = (int)Math.Ceiling((double)objectSize / partSize);
-            var copyResponses = new List<CopyPartResponse>(numberOfParts);
+            var partSize = GetPartSize(notNullObjectSize);
+            var numberOfParts = (int)Math.Ceiling((double)notNullObjectSize / partSize);
 
-            var uploadId = await InitiateMultipartUpload(destination, contentType);
+            uploadId = await InitiateMultipartUpload(destination, contentType);
             logger.LogDebug("Starting copying {UploadId} in {Parts} parts of size {PartSize}", uploadId, numberOfParts,
                 partSize);
 
-            long bytePosition = 0;
-            for (int i = 1; bytePosition < objectSize; i++)
-            {
-                if (token.IsCancellationRequested)
-                {
-                    logger.LogInformation("Cancellation requested, aborting multipart upload for {Target}",
-                        destination);
-                    await s3Client.AbortMultipartUploadAsync(destination.Bucket, destination.Key, uploadId, token);
-                    return new LargeObjectCopyResult(LargeObjectStatus.Cancelled, objectSize);
-                }
-                
-                var copyRequest = new CopyPartRequest
-                {
-                    DestinationBucket = destination.Bucket,
-                    DestinationKey = destination.Key,
-                    SourceBucket = source.Bucket,
-                    SourceKey = source.Key,
-                    UploadId = uploadId,
-                    FirstByte = bytePosition,
-                    LastByte = bytePosition + partSize - 1 >= objectSize.Value
-                        ? objectSize.Value - 1
-                        : bytePosition + partSize - 1,
-                    PartNumber = i
-                };
-                
-                copyResponses.Add(await s3Client.CopyPartAsync(copyRequest, token));
-                bytePosition += partSize;
-            }
+            // Build all part requests
+            var partRequests =
+                GetCopyPartRequests(source, destination, numberOfParts, notNullObjectSize, uploadId, partSize);
 
-            // Complete the request
+            // Copy parts in parallel with bounded concurrency
+            var copyResponses = new CopyPartResponse[numberOfParts];
+            await Parallel.ForEachAsync(
+                partRequests,
+                new ParallelOptions
+                    { MaxDegreeOfParallelism = s3Settings.CopyPartConcurrency, CancellationToken = token },
+                async (request, ct) =>
+                {
+                    copyResponses[request.PartNumber - 1] = await s3Client.CopyPartAsync(request, ct);
+                });
+
             var completeRequest = new CompleteMultipartUploadRequest
             {
                 Key = destination.Key,
@@ -136,11 +117,15 @@ public class S3BucketWriter : IBucketWriter
             success = true;
             return new LargeObjectCopyResult(LargeObjectStatus.Success, objectSize);
         }
-        catch (OverflowException e)
+        catch (OperationCanceledException)
         {
-            logger.LogError(e,
-                "Error getting number of parts to copy. From '{Source}' to '{Destination}'. Size {Size}", source,
-                destination, objectSize);
+            logger.LogInformation("Cancellation requested, aborting multipart upload for {Target}", destination);
+            if (uploadId != null)
+            {
+                await s3Client.AbortMultipartUploadAsync(destination.Bucket, destination.Key, uploadId,
+                    CancellationToken.None);
+            }
+            return new LargeObjectCopyResult(LargeObjectStatus.Cancelled, objectSize);
         }
         catch (AmazonS3Exception e)
         {
@@ -171,11 +156,38 @@ public class S3BucketWriter : IBucketWriter
         return new LargeObjectCopyResult(LargeObjectStatus.Error, objectSize);
     }
 
+    private static List<CopyPartRequest> GetCopyPartRequests(ObjectInBucket source, ObjectInBucket destination,
+        int numberOfParts, long objectSize, string uploadId, long partSize)
+    {
+        var partRequests = new List<CopyPartRequest>(numberOfParts);
+        long bytePosition = 0;
+        for (var i = 1; bytePosition < objectSize; i++)
+        {
+            partRequests.Add(new CopyPartRequest
+            {
+                DestinationBucket = destination.Bucket,
+                DestinationKey = destination.Key,
+                SourceBucket = source.Bucket,
+                SourceKey = source.Key,
+                UploadId = uploadId,
+                FirstByte = bytePosition,
+                LastByte = bytePosition + partSize - 1 >= objectSize
+                    ? objectSize - 1
+                    : bytePosition + partSize - 1,
+                PartNumber = i
+            });
+            bytePosition += partSize;
+        }
+
+        return partRequests;
+    }
+
     private static long GetPartSize(long objectSize)
     {
-        // 5 MB (S3 minimum per part)
-        const long minPartSize = 5 * 1024 * 1024;
-        var partSize = Math.Max(minPartSize, (long)Math.Ceiling((double)objectSize / 10000));
+        // 16 MB matches TransferUtility's default and reduces API call overhead vs the 5 MB S3 minimum
+        const long minPartSize = 16 * 1024 * 1024;
+        const double maxParts = 10000;
+        var partSize = Math.Max(minPartSize, (long)Math.Ceiling(objectSize / maxParts));
         return partSize;
     }
 

--- a/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
+++ b/src/protagonist/DLCS.AWS/S3/S3BucketWriter.cs
@@ -61,7 +61,6 @@ public class S3BucketWriter : IBucketWriter
         CancellationToken token = default)
     {
         long? objectSize = null;
-        var partSize = 5 * (long)Math.Pow(2, 20); // 5 MB
         var success = false;
         var timer = Stopwatch.StartNew();
 
@@ -77,7 +76,7 @@ public class S3BucketWriter : IBucketWriter
             }
             
             objectSize = sourceMetadata.ContentLength;
-
+            
             if (verifySize != null)
             {
                 if (!await verifySize.Invoke(objectSize.Value))
@@ -88,10 +87,13 @@ public class S3BucketWriter : IBucketWriter
                 }
             }
 
-            var numberOfParts = Convert.ToInt32(objectSize / partSize);
+            var partSize = GetPartSize(objectSize.Value);
+            var numberOfParts = (int)Math.Ceiling((double)objectSize / partSize);
             var copyResponses = new List<CopyPartResponse>(numberOfParts);
 
             var uploadId = await InitiateMultipartUpload(destination, contentType);
+            logger.LogDebug("Starting copying {UploadId} in {Parts} parts of size {PartSize}", uploadId, numberOfParts,
+                partSize);
 
             long bytePosition = 0;
             for (int i = 1; bytePosition < objectSize; i++)
@@ -167,6 +169,14 @@ public class S3BucketWriter : IBucketWriter
         }
         
         return new LargeObjectCopyResult(LargeObjectStatus.Error, objectSize);
+    }
+
+    private static long GetPartSize(long objectSize)
+    {
+        // 5 MB (S3 minimum per part)
+        const long minPartSize = 5 * 1024 * 1024;
+        var partSize = Math.Max(minPartSize, (long)Math.Ceiling((double)objectSize / 10000));
+        return partSize;
     }
 
     public async Task WriteToBucket(ObjectInBucket dest, string content, string contentType,

--- a/src/protagonist/DLCS.AWS/Settings/S3Settings.cs
+++ b/src/protagonist/DLCS.AWS/Settings/S3Settings.cs
@@ -46,4 +46,9 @@ public class S3Settings
     /// Service root for S3. Only used if running LocalStack
     /// </summary>
     public string ServiceUrl { get; set; } = "http://localhost:4566/";
+
+    /// <summary>
+    /// Maximum number of concurrent part-copy operations when performing a multipart bucket-to-bucket copy.
+    /// </summary>
+    public int CopyPartConcurrency { get; set; } = 4;
 }


### PR DESCRIPTION
## What does this change?

Fixes #1200 

Fixes issue in s3 -> s3 copy operations and optimises it. Summary of changes

* Dynamic part sizing - replaces hardcoded 5MB part size. Size of origin file is read from metadata and part-size determined based on that, with a default of 16MB (matching `TransferUtility` from AWS which I'm assuming was optimised). Part size increases for files over 160GB to stay within S3's 10,000-part limit
* Parallel part copying - `Parallel.ForEachAsync` with bounded concurrency (default 4, configurable via appsetting) replaces sequential loop
* Cancellation handling - `OperationCanceledException` now caught explicitly, aborting the multipart upload before returning
* Removed `OverflowException` handling as this was due to too many parts, which is now prevented.

## Infrastructure Changes

> [!NOTE]
> This PR requires infrastructure changes.
>
> - **Optional:** For environments where larger AV files are expected, timebased queue `visibility_timeout` could be increased to allow for handling. In practice this won't have much affect as messages are only retried once.

## Configuration Changes

> [!NOTE]
> This PR introduces configuration changes.
>
> |Service | AppSetting | Required? | Description | Default |
> |---|---|---|---|---|
> | Engine | `AWS:S3:CopyPartConcurrency` | N | Number of concurrent part uploads | 4 |