### PR TITLE
Validate "annotations" adjuncts are JSON

### DIFF
--- a/src/protagonist/DLCS.Repository.Tests/Strategy/S3AmbientOriginStrategyTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Strategy/S3AmbientOriginStrategyTests.cs
@@ -93,12 +93,28 @@ public class S3AmbientOriginStrategyTests
     }
 
     [Fact]
-    public async Task LoadAssetFromOrigin_ReturnsNull_IfCallFails()
+    public async Task LoadAssetFromOrigin_ReturnsEmpty_IfCallFails()
     {
         // Arrange
         const string originUri = "s3://eu-west-1/test-storage/2/1/repelish";
         A.CallTo(() => bucketReader.GetObjectFromBucket(A<ObjectInBucket>._, A<CancellationToken>._))
             .ThrowsAsync(new Exception());
+
+        // Act
+        var result = await sut.LoadFromOrigin(new Asset { Id = assetId, Origin = originUri }, customerOriginStrategy);
+
+        // Assert
+        result.Stream.Should().BeSameAs(Stream.Null);
+        result.IsEmpty.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async Task LoadAssetFromOrigin_ReturnsEmpty_IfCallReturnsNullStream()
+    {
+        // Arrange
+        const string originUri = "s3://eu-west-1/test-storage/2/1/repelish";
+        A.CallTo(() => bucketReader.GetObjectFromBucket(A<ObjectInBucket>._, A<CancellationToken>._))
+            .Returns(new ObjectFromBucket(new ObjectInBucket("bucket"), null, null));
 
         // Act
         var result = await sut.LoadFromOrigin(new Asset { Id = assetId, Origin = originUri }, customerOriginStrategy);

--- a/src/protagonist/DLCS.Repository/Strategy/OriginResponse.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/OriginResponse.cs
@@ -9,13 +9,13 @@ namespace DLCS.Repository.Strategy;
 /// <summary>
 /// Represents the result of fetching an asset from an origin.
 /// </summary>
-public class OriginResponse : IAsyncDisposable
+public class OriginResponse(Stream stream) : IAsyncDisposable
 {
     /// <summary>
     /// Stream content from origin
     /// </summary>
-    public Stream Stream { get; }
-    
+    public Stream Stream { get; } = stream.ThrowIfNull(nameof(stream));
+
     /// <summary>
     /// Get value of ContentType for content
     /// </summary>
@@ -36,11 +36,6 @@ public class OriginResponse : IAsyncDisposable
     /// </summary>
     public static readonly OriginResponse Empty = new(Stream.Null) { IsEmpty = true };
 
-    public OriginResponse(Stream stream)
-    {
-        Stream = stream.ThrowIfNull(nameof(stream));
-    }
-    
     public OriginResponse WithContentType(string? contentType)
     {
         if (IsEmpty) throw new InvalidOperationException("Cannot set ContentType for empty response");

--- a/src/protagonist/DLCS.Repository/Strategy/S3AmbientOriginStrategy.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/S3AmbientOriginStrategy.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
+using DLCS.Core.Streams;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
@@ -34,6 +35,7 @@ public class S3AmbientOriginStrategy : IOriginStrategy
         {
             var regionalisedBucket = RegionalisedObjectInBucket.Parse(originItem.Origin);
             var response = await bucketReader.GetObjectFromBucket(regionalisedBucket, cancellationToken);
+            if (response.Stream.IsNull()) return OriginResponse.Empty;
             var originResponse = CreateOriginResponse(response);
             return originResponse;
         }

--- a/src/protagonist/DLCS.Repository/Strategy/Utils/OriginFetcher.cs
+++ b/src/protagonist/DLCS.Repository/Strategy/Utils/OriginFetcher.cs
@@ -9,9 +9,7 @@ namespace DLCS.Repository.Strategy.Utils;
 /// <summary>
 /// Helper class that gets appropriate origin strategy for a resource and fetches from origin to local disk
 /// </summary>
-public class OriginFetcher(
-    ICustomerOriginStrategyRepository customerOriginStrategyRepository,
-    OriginStrategyResolver originStrategyResolver)
+public class OriginFetcher(OriginStrategyResolver originStrategyResolver)
 {
     /// <summary>
     /// Get <see cref="OriginResponse"/> object for provided asset, loading from origin passed origin strategy

--- a/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
@@ -29,7 +29,7 @@ public class FileChannelWorkerTests
         storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
         originStrategy = A.Fake<IOriginStrategy>();
         OriginStrategyResolver resolver = _ => originStrategy;
-        var originFetcher = new OriginFetcher(null, resolver);
+        var originFetcher = new OriginFetcher(resolver);
 
         sut = new FileChannelWorker(assetToS3, assetIngestorSizeCheck, storageKeyGenerator, originFetcher,
             new NullLogger<FileChannelWorker>());

--- a/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
@@ -404,6 +404,23 @@ public class FileChannelWorkerTests
         context.Adjunct.Error.Should().Be("Unable to read annotation content for validation");
     }
 
+    [Fact]
+    public async Task IngestAdjunct_Annotation_Optimised_NullStream_ReturnsFailed()
+    {
+        // OriginResponse with Stream.Null but IsEmpty=false (strategy returns null stream without using Empty static)
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = true };
+        A.CallTo(() => originStrategy.LoadFromOrigin(context.Adjunct, cos, A<CancellationToken>._))
+            .Returns(new OriginResponse(Stream.Null));
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Failed);
+        context.Adjunct.Error.Should().Be("Unable to read annotation content for validation");
+    }
+
     // Annotation adjuncts - non-Optimised path (validator callback passed to CopyOriginToStorage)
 
     [Fact]

--- a/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/File/FileChannelWorkerTests.cs
@@ -1,8 +1,12 @@
-﻿using DLCS.AWS.S3;
+﻿using System.Text;
+using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
 using DLCS.Core.Types;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
+using DLCS.Repository.Strategy;
+using DLCS.Repository.Strategy.DependencyInjection;
+using DLCS.Repository.Strategy.Utils;
 using Engine.Ingest;
 using Engine.Ingest.File;
 using Engine.Ingest.Persistence;
@@ -15,6 +19,7 @@ public class FileChannelWorkerTests
 {
     private readonly IAssetToS3 assetToS3;
     private readonly IStorageKeyGenerator storageKeyGenerator;
+    private readonly IOriginStrategy originStrategy;
     private readonly FileChannelWorker sut;
 
     public FileChannelWorkerTests()
@@ -22,8 +27,11 @@ public class FileChannelWorkerTests
         var assetIngestorSizeCheck = new HardcodedAssetIngestorSizeCheckBase(10);
         assetToS3 = A.Fake<IAssetToS3>();
         storageKeyGenerator = A.Fake<IStorageKeyGenerator>();
+        originStrategy = A.Fake<IOriginStrategy>();
+        OriginStrategyResolver resolver = _ => originStrategy;
+        var originFetcher = new OriginFetcher(null, resolver);
 
-        sut = new FileChannelWorker(assetToS3, assetIngestorSizeCheck, storageKeyGenerator,
+        sut = new FileChannelWorker(assetToS3, assetIngestorSizeCheck, storageKeyGenerator, originFetcher,
             new NullLogger<FileChannelWorker>());
     }
 
@@ -40,7 +48,7 @@ public class FileChannelWorkerTests
         // Assert
         result.Should().Be(IngestResultStatus.Success);
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -56,7 +64,7 @@ public class FileChannelWorkerTests
             .Returns(destination);
 
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AssetFromOrigin(context.AssetId, 1234L, "anywhere", "application/docx"));
 
         // Act
@@ -81,7 +89,7 @@ public class FileChannelWorkerTests
             .Returns(destination);
 
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AssetFromOrigin(context.AssetId, 1234L, "anywhere", "application/docx"));
 
         // Act
@@ -107,7 +115,7 @@ public class FileChannelWorkerTests
         var assetFromOrigin = new AssetFromOrigin(context.AssetId, 1234L, "anywhere", "application/docx");
         assetFromOrigin.FileTooLarge();
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(assetFromOrigin);
 
         // Act
@@ -135,7 +143,7 @@ public class FileChannelWorkerTests
         
         // Assert
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, false, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, false, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .MustHaveHappened();
         result.Should().Be(IngestResultStatus.Success);
     }
@@ -173,7 +181,7 @@ public class FileChannelWorkerTests
         // Assert
         result.Should().Be(IngestResultStatus.Success);
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -189,7 +197,7 @@ public class FileChannelWorkerTests
             .Returns(destination);
 
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AdjunctFromOrigin(context.Adjunct.Id, context.AssetId, 1234L, "anywhere", "application/docx"));
 
         // Act
@@ -214,7 +222,7 @@ public class FileChannelWorkerTests
             .Returns(destination);
 
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AdjunctFromOrigin(context.Adjunct.Id, context.AssetId, 1234L, "anywhere", "application/docx"));
 
         // Act
@@ -241,7 +249,7 @@ public class FileChannelWorkerTests
         assetFromOrigin.FileTooLarge();
         
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, true, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(assetFromOrigin);
 
         // Act
@@ -269,7 +277,7 @@ public class FileChannelWorkerTests
         
         // Assert
         A.CallTo(() =>
-                assetToS3.CopyOriginToStorage(destination, context, false, cos, A<CancellationToken>._))
+                assetToS3.CopyOriginToStorage(destination, context, false, cos, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .MustHaveHappened();
         result.Should().Be(IngestResultStatus.Success);
     }
@@ -309,9 +317,140 @@ public class FileChannelWorkerTests
             Id = adjunctId, AssetId = id, Asset = asset, IIIFLink = IIIFLinkType.SeeAlso,
             MediaType = "image/jpeg", Type = "Image"
         };
-        
+
         var context = new AdjunctIngestionContext(adjunct, imageStorage);
         return context;
+    }
+
+    private static AdjunctIngestionContext GetAnnotationAdjunctIngestionContext(string assetId = "/1/2/something",
+        string adjunctId = "someAdjunct", string origin = "s3://test-bucket/annotation-key")
+    {
+        var id = AssetId.FromString(assetId);
+        var asset = new Asset
+        {
+            Id = id, Customer = id.Customer, Space = id.Space,
+            DeliveryChannels = [AssetDeliveryChannels.File]
+        };
+
+        var adjunct = new Adjunct
+        {
+            Id = adjunctId, AssetId = id, Asset = asset, IIIFLink = IIIFLinkType.Annotations,
+            MediaType = "application/json", Type = "AnnotationPage", Origin = origin
+        };
+
+        return new AdjunctIngestionContext(adjunct, null);
+    }
+
+    private static OriginResponse MakeOriginResponse(string content)
+        => new(new MemoryStream(Encoding.UTF8.GetBytes(content)));
+
+    // Annotation adjuncts - Optimised path (validate via OriginFetcher, no S3 copy)
+
+    [Fact]
+    public async Task IngestAdjunct_Annotation_Optimised_ValidJson_ReturnsSuccess()
+    {
+        // Arrange
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = true };
+        A.CallTo(() => originStrategy.LoadFromOrigin(context.Adjunct, cos, A<CancellationToken>._))
+            .Returns(MakeOriginResponse("""{"type":"AnnotationPage"}"""));
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Success);
+        A.CallTo(() =>
+                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos,
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task IngestAdjunct_Annotation_Optimised_InvalidJson_ReturnsFailed()
+    {
+        // Arrange
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = true };
+        A.CallTo(() => originStrategy.LoadFromOrigin(context.Adjunct, cos, A<CancellationToken>._))
+            .Returns(MakeOriginResponse("not valid json {{"));
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Failed);
+        context.Adjunct.Error.Should().Be("Annotation content is not valid JSON");
+        A.CallTo(() =>
+                assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, cos,
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Fact]
+    public async Task IngestAdjunct_Annotation_Optimised_EmptyResponse_ReturnsFailed()
+    {
+        // Arrange
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = true };
+        A.CallTo(() => originStrategy.LoadFromOrigin(context.Adjunct, cos, A<CancellationToken>._))
+            .Returns(OriginResponse.Empty);
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Failed);
+        context.Adjunct.Error.Should().Be("Unable to read annotation content for validation");
+    }
+
+    // Annotation adjuncts - non-Optimised path (validator callback passed to CopyOriginToStorage)
+
+    [Fact]
+    public async Task IngestAdjunct_Annotation_NonOptimised_ValidJson_ReturnsSuccess()
+    {
+        // Arrange
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = false };
+        var destination = new RegionalisedObjectInBucket("test-bucket", "annotation-key", "eu-west-1");
+        A.CallTo(() => storageKeyGenerator.GetStoredAdjunctLocation(context.AssetId, context.Adjunct))
+            .Returns(destination);
+        A.CallTo(() =>
+                assetToS3.CopyOriginToStorage(destination, context, true, cos,
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
+            .Returns(new AdjunctFromOrigin(context.Adjunct.Id, context.AssetId, 512L, "anywhere", "application/json"));
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Success);
+        A.CallTo(() =>
+                assetToS3.CopyOriginToStorage(destination, context, true, cos,
+                    A<Func<string, CancellationToken, Task<string?>>>.That.IsNotNull(), A<CancellationToken>._))
+            .MustHaveHappened();
+    }
+
+    [Fact]
+    public async Task IngestAdjunct_Annotation_NonOptimised_InvalidJson_ReturnsFailed()
+    {
+        // Arrange
+        var context = GetAnnotationAdjunctIngestionContext();
+        var cos = new CustomerOriginStrategy { Strategy = OriginStrategyType.S3Ambient, Optimised = false };
+        var destination = new RegionalisedObjectInBucket("test-bucket", "annotation-key", "eu-west-1");
+        A.CallTo(() => storageKeyGenerator.GetStoredAdjunctLocation(context.AssetId, context.Adjunct))
+            .Returns(destination);
+        A.CallTo(() =>
+                assetToS3.CopyOriginToStorage(destination, context, true, cos,
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
+            .Throws(new InvalidOperationException("Annotation content is not valid JSON"));
+
+        // Act
+        var result = await sut.Ingest(context, cos);
+
+        // Assert
+        result.Should().Be(IngestResultStatus.Failed);
+        context.Adjunct.Error.Should().Be("Annotation content is not valid JSON");
     }
     
     private static IngestionContext GetAssetIngestionContext(string assetId = "/1/2/something")

--- a/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToDiskTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToDiskTests.cs
@@ -33,7 +33,7 @@ public class AssetToDiskTests
 
         var engineSettings = new EngineSettings { ImageIngest = new ImageIngestSettings() };
         var optionsMonitor = OptionsHelpers.GetOptionsMonitor(engineSettings);
-        var originFetched = new OriginFetcher(null, resolver);
+        var originFetched = new OriginFetcher(resolver);
 
         sut = new AssetToDisk(originFetched,
             customerStorageRepository,

--- a/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Persistence/AssetToS3Tests.cs
@@ -63,7 +63,7 @@ public class AssetToS3Tests
         var ct = new CancellationToken();
 
         // Act
-        await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         A.CallTo(() => bucketWriter.CopyLargeObject(
@@ -102,7 +102,7 @@ public class AssetToS3Tests
         var ct = new CancellationToken();
 
         // Act
-        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         actual.Should().BeEquivalentTo(expected);
@@ -136,7 +136,7 @@ public class AssetToS3Tests
         var ct = new CancellationToken();
 
         // Act
-        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         actual.Should().BeEquivalentTo(expected);
@@ -168,7 +168,7 @@ public class AssetToS3Tests
         var ct = new CancellationToken();
 
         // Act
-        Func<Task> action = () => sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        Func<Task> action = () => sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         action.Should().ThrowAsync<ApplicationException>();
@@ -201,7 +201,7 @@ public class AssetToS3Tests
             .Returns(assetFromOrigin);
 
         // Act
-        await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         A.CallTo(() =>
@@ -232,7 +232,7 @@ public class AssetToS3Tests
             .Returns(assetOnDisk);
 
         // Act
-        var response = await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        var response = await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         A.CallTo(() => bucketWriter.WriteFileToBucket(A<ObjectInBucket>._, A<string>._, A<string>._, ct))
@@ -265,7 +265,7 @@ public class AssetToS3Tests
             .Returns(true);
 
         // Act
-        await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         A.CallTo(() => bucketWriter.WriteFileToBucket(
@@ -307,7 +307,7 @@ public class AssetToS3Tests
             .Returns(true);
 
         // Act
-        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        var actual = await sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         actual.Should().BeEquivalentTo(expected);
@@ -335,7 +335,7 @@ public class AssetToS3Tests
             .Returns(assetOnDisk);
 
         // Act
-        Func<Task> action = () => sut.CopyOriginToStorage(destination, context, true, originStrategy, ct);
+        Func<Task> action = () => sut.CopyOriginToStorage(destination, context, true, originStrategy, cancellationToken: ct);
 
         // Assert
         action.Should().ThrowAsync<ApplicationException>();

--- a/src/protagonist/Engine.Tests/Ingest/Workers/TimebasedIngesterWorkerTests.cs
+++ b/src/protagonist/Engine.Tests/Ingest/Workers/TimebasedIngesterWorkerTests.cs
@@ -43,7 +43,7 @@ public class TimebasedIngesterWorkerTests
         var asset = new Asset(AssetId.FromString("2/1/shallow"));
         A.CallTo(() =>
                 assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, true, A<CustomerOriginStrategy>._,
-                    A<CancellationToken>._))
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .ThrowsAsync(new Exception());
 
         // Act
@@ -62,7 +62,7 @@ public class TimebasedIngesterWorkerTests
         var asset = new Asset(AssetId.FromString($"{customerId}/1/shallow"));
         var assetFromOrigin = new AssetFromOrigin(asset.Id, 13, "/target/location", "application/json");
         A.CallTo(() => assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._,
-            A<CustomerOriginStrategy>._, A<CancellationToken>._)).Returns(assetFromOrigin);
+            A<CustomerOriginStrategy>._, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._)).Returns(assetFromOrigin);
 
         // Act
         await sut.Ingest(new IngestionContext(asset), new CustomerOriginStrategy());
@@ -70,7 +70,7 @@ public class TimebasedIngesterWorkerTests
         // Assert
         A.CallTo(() =>
             assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, !noStoragePolicyCheck,
-                A<CustomerOriginStrategy>._, A<CancellationToken>._))
+                A<CustomerOriginStrategy>._, A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .MustHaveHappened();
     }
 
@@ -82,7 +82,7 @@ public class TimebasedIngesterWorkerTests
 
         A.CallTo(() =>
                 assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, A<CustomerOriginStrategy>._,
-                    A<CancellationToken>._))
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AssetFromOrigin(asset.Id, 13, "target", "application/json"));
 
         var originLocation = new RegionalisedObjectInBucket("bucket", "key", "fake-region");
@@ -114,7 +114,7 @@ public class TimebasedIngesterWorkerTests
 
         A.CallTo(() =>
                 assetToS3.CopyOriginToStorage(A<ObjectInBucket>._, A<IngestionContext>._, A<bool>._, A<CustomerOriginStrategy>._,
-                    A<CancellationToken>._))
+                    A<Func<string, CancellationToken, Task<string?>>>._, A<CancellationToken>._))
             .Returns(new AssetFromOrigin(asset.Id, 13, "target", "application/json"));
 
         A.CallTo(() =>

--- a/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
+++ b/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
@@ -151,7 +151,7 @@ public class FileChannelWorker(
         await using var originResponse =
             await originFetcher.LoadFromOrigin(adjunct, customerOriginStrategy, cancellationToken);
 
-        if (originResponse.IsEmpty)
+        if (originResponse.IsEmpty || originResponse.Stream.IsNull())
         {
             logger.LogError(
                 "Unable to read annotation adjunct {AdjunctId} for Asset {AssetId} content from origin for validation",

--- a/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
+++ b/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
+using DLCS.Core.Streams;
 using DLCS.Model.Assets;
 using DLCS.Model.Customers;
 using DLCS.Repository.Strategy.Utils;
@@ -172,22 +173,23 @@ public class FileChannelWorker(
         return IngestResultStatus.Success;
     }
 
-    private static async Task<string?> IsValidAnnotationJsonFile(string filePath, CancellationToken cancellationToken)
+    private async Task<string?> IsValidAnnotationJsonFile(string filePath, CancellationToken cancellationToken)
     {
         await using var stream = System.IO.File.OpenRead(filePath);
         return await GetJsonValidationError(stream, cancellationToken);
     }
 
     /// <summary>Returns null if <paramref name="stream"/> contains valid JSON, or an error message if not.</summary>
-    private static async Task<string?> GetJsonValidationError(Stream stream, CancellationToken cancellationToken)
+    private async Task<string?> GetJsonValidationError(Stream stream, CancellationToken cancellationToken)
     {
         try
         {
             await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
             return null;
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            logger.LogTrace(ex, "Failed to parse JSON from stream");
             return AnnotationInvalidJsonError;
         }
     }

--- a/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
+++ b/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
@@ -59,37 +59,6 @@ public class FileChannelWorker(
         }
     }
 
-    private static void UpdateIngestionContext(IngestionContext ingestionContext, AssetFromOrigin itemInBucket,
-        RegionalisedObjectInBucket targetStorageLocation)
-    {
-        ingestionContext.StoredObjects[targetStorageLocation] = itemInBucket.AssetSize;
-
-        if (ingestionContext is AdjunctIngestionContext adjunctIngestionContext)
-        {
-            // We don't track individual adjunct size in the ImageStorage
-            // Instead, we run a running tally of all asset's adjuncts
-
-            // In creation of new adjunct scenario this is simple: we add the size as reported by the item in bucket
-            // For update, we're interested in the difference between previous and current size of the _specific_ adjunct,
-            // as it can be negative
-
-            // If the adjunct has been previously external one, then the API would've updated it's Size to 0, signifying
-            // it didn't use to count against limits. Otherwise, the Size of Adjunct retrieved from DB is the size
-            // of the previous version of a hosted adjunct
-
-            // size to add to the tally = size of the just uploaded adjunct minus size of a previous hosted version (or 0)
-            var adjunctSize = itemInBucket.AssetSize - (adjunctIngestionContext.Adjunct.Size ?? 0);
-
-            ingestionContext.WithStorage(adjunctSize: adjunctSize);
-        }
-        else
-        {
-            // Asset ingestion
-            // NOTE: should a third type (Asset, Adjunct, ?) appear, this will need a suitable case added
-            ingestionContext.WithStorage(assetSize: itemInBucket.AssetSize);
-        }
-    }
-
     public async Task<IngestResultStatus> Ingest(AdjunctIngestionContext ingestionContext,
         CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken = default)
     {
@@ -139,6 +108,37 @@ public class FileChannelWorker(
                 adjunct.Id, ingestionContext.AssetId);
             adjunct.Error = ex.Message;
             return IngestResultStatus.Failed;
+        }
+    }
+    
+    private static void UpdateIngestionContext(IngestionContext ingestionContext, AssetFromOrigin itemInBucket,
+        RegionalisedObjectInBucket targetStorageLocation)
+    {
+        ingestionContext.StoredObjects[targetStorageLocation] = itemInBucket.AssetSize;
+
+        if (ingestionContext is AdjunctIngestionContext adjunctIngestionContext)
+        {
+            // We don't track individual adjunct size in the ImageStorage
+            // Instead, we run a running tally of all asset's adjuncts
+
+            // In creation of new adjunct scenario this is simple: we add the size as reported by the item in bucket
+            // For update, we're interested in the difference between previous and current size of the _specific_ adjunct,
+            // as it can be negative
+
+            // If the adjunct has been previously external one, then the API would've updated it's Size to 0, signifying
+            // it didn't use to count against limits. Otherwise, the Size of Adjunct retrieved from DB is the size
+            // of the previous version of a hosted adjunct
+
+            // size to add to the tally = size of the just uploaded adjunct minus size of a previous hosted version (or 0)
+            var adjunctSize = itemInBucket.AssetSize - (adjunctIngestionContext.Adjunct.Size ?? 0);
+
+            ingestionContext.WithStorage(adjunctSize: adjunctSize);
+        }
+        else
+        {
+            // Asset ingestion
+            // NOTE: should a third type (Asset, Adjunct, ?) appear, this will need a suitable case added
+            ingestionContext.WithStorage(assetSize: itemInBucket.AssetSize);
         }
     }
 

--- a/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
+++ b/src/protagonist/Engine/Ingest/File/FileChannelWorker.cs
@@ -1,6 +1,9 @@
-﻿using DLCS.AWS.S3;
+﻿using System.Text.Json;
+using DLCS.AWS.S3;
 using DLCS.AWS.S3.Models;
+using DLCS.Model.Assets;
 using DLCS.Model.Customers;
+using DLCS.Repository.Strategy.Utils;
 using Engine.Ingest.Persistence;
 
 namespace Engine.Ingest.File;
@@ -12,6 +15,7 @@ public class FileChannelWorker(
     IAssetToS3 assetToS3,
     IAssetIngestorSizeCheck assetIngestorSizeCheck,
     IStorageKeyGenerator storageKeyGenerator,
+    OriginFetcher originFetcher,
     ILogger<FileChannelWorker> logger)
     : IAssetIngesterWorker, IAdjunctIngesterWorker
 {
@@ -35,7 +39,7 @@ public class FileChannelWorker(
                 ingestionContext,
                 !assetIngestorSizeCheck.CustomerHasNoStorageCheck(asset.Customer),
                 customerOriginStrategy,
-                cancellationToken);
+                cancellationToken: cancellationToken);
 
             ingestionContext.WithAssetFromOrigin(assetInBucket);
 
@@ -87,19 +91,24 @@ public class FileChannelWorker(
     }
 
     public async Task<IngestResultStatus> Ingest(AdjunctIngestionContext ingestionContext,
-        CustomerOriginStrategy customerOriginStrategy,
-        CancellationToken cancellationToken = default)
+        CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken = default)
     {
         var adjunct = ingestionContext.Adjunct;
+        var isAnnotation = adjunct.IIIFLink == IIIFLinkType.Annotations;
 
         try
         {
             if (customerOriginStrategy.Optimised)
             {
-                logger.LogDebug(
-                    "Adjunct {AdjunctId} for Asset {Asset} is at optimised origin, no 'file' handling required",
-                    adjunct.Id, ingestionContext.AssetId);
-                return IngestResultStatus.Success;
+                if (!isAnnotation)
+                {
+                    logger.LogDebug(
+                        "Non-annotation adjunct {AdjunctId} for Asset {Asset} is at optimised origin, no 'file' handling required",
+                        adjunct.Id, ingestionContext.AssetId);
+                    return IngestResultStatus.Success;
+                }
+
+                return await ValidateAnnotationAtOrigin(ingestionContext, customerOriginStrategy, cancellationToken);
             }
 
             var targetStorageLocation = storageKeyGenerator.GetStoredAdjunctLocation(ingestionContext.AssetId, adjunct);
@@ -108,6 +117,7 @@ public class FileChannelWorker(
                 ingestionContext,
                 !assetIngestorSizeCheck.CustomerHasNoStorageCheck(ingestionContext.Asset.Customer),
                 customerOriginStrategy,
+                isAnnotation ? IsValidAnnotationJsonFile : null,
                 cancellationToken);
 
             if (assetIngestorSizeCheck.DoesAssetFromOriginExceedAllowance(adjunctInBucket, adjunct))
@@ -131,4 +141,56 @@ public class FileChannelWorker(
             return IngestResultStatus.Failed;
         }
     }
+
+    private async Task<IngestResultStatus> ValidateAnnotationAtOrigin(AdjunctIngestionContext ingestionContext,
+        CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken)
+    {
+        var adjunct = ingestionContext.Adjunct;
+
+        await using var originResponse =
+            await originFetcher.LoadFromOrigin(adjunct, customerOriginStrategy, cancellationToken);
+
+        if (originResponse.IsEmpty)
+        {
+            logger.LogError(
+                "Unable to read annotation adjunct {AdjunctId} for Asset {AssetId} content from origin for validation",
+                adjunct.Id, ingestionContext.AssetId);
+            adjunct.Error = "Unable to read annotation content for validation";
+            return IngestResultStatus.Failed;
+        }
+
+        var validationError = await GetJsonValidationError(originResponse.Stream, cancellationToken);
+        if (validationError != null)
+        {
+            logger.LogError(
+                "Annotation adjunct {AdjunctId} for Asset {AssetId} content is not valid JSON",
+                adjunct.Id, ingestionContext.AssetId);
+            adjunct.Error = validationError;
+            return IngestResultStatus.Failed;
+        }
+
+        return IngestResultStatus.Success;
+    }
+
+    private static async Task<string?> IsValidAnnotationJsonFile(string filePath, CancellationToken cancellationToken)
+    {
+        await using var stream = System.IO.File.OpenRead(filePath);
+        return await GetJsonValidationError(stream, cancellationToken);
+    }
+
+    /// <summary>Returns null if <paramref name="stream"/> contains valid JSON, or an error message if not.</summary>
+    private static async Task<string?> GetJsonValidationError(Stream stream, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            return null;
+        }
+        catch (JsonException)
+        {
+            return AnnotationInvalidJsonError;
+        }
+    }
+
+    private const string AnnotationInvalidJsonError = "Annotation content is not valid JSON";
 }

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
@@ -17,7 +17,7 @@ public interface IAssetToS3
     /// Copy <see cref="IOriginItem"/> provided by the supplied <paramref name="context"/> from Origin to DLCS storage.
     /// Configuration determines if this is a direct S3-S3 copy, or S3-disk-S3.
     /// When <paramref name="validator"/> is provided the copy always goes via local disk so the validator can inspect
-    /// the file; the S3 write is skipped if the validator returns false.
+    /// the file; the S3 write is skipped if the validator returns an error.
     /// </summary>
     /// <param name="destination"><see cref="ObjectInBucket"/> where file is to copied to</param>
     /// <param name="context">Ingestion context containing the <see cref="IOriginItem"/> to be copied</param>

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
@@ -16,15 +16,21 @@ public interface IAssetToS3
     /// <summary>
     /// Copy <see cref="IOriginItem"/> provided by the supplied <paramref name="context"/> from Origin to DLCS storage.
     /// Configuration determines if this is a direct S3-S3 copy, or S3-disk-S3.
+    /// When <paramref name="validator"/> is provided the copy always goes via local disk so the validator can inspect
+    /// the file; the S3 write is skipped if the validator returns false.
     /// </summary>
     /// <param name="destination"><see cref="ObjectInBucket"/> where file is to copied to</param>
     /// <param name="context">Ingestion context containing the <see cref="IOriginItem"/> to be copied</param>
     /// <param name="verifySize">if True, size is validated that it does not exceed allowed size.</param>
     /// <param name="customerOriginStrategy"><see cref="CustomerOriginStrategy"/> to use to fetch item.</param>
+    /// <param name="validator">Optional callback invoked with the local file path after download but before S3 upload.
+    /// Return null to allow the upload; return an error message string to abort it.</param>
     /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
     /// <returns><see cref="AssetFromOrigin"/> containing new location, size etc</returns>
     Task<AssetFromOrigin> CopyOriginToStorage(ObjectInBucket destination, IngestionContext context, bool verifySize,
-        CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken = default);
+        CustomerOriginStrategy customerOriginStrategy,
+        Func<string, CancellationToken, Task<string?>>? validator = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -43,10 +49,13 @@ public class AssetToS3(
 
     public async Task<AssetFromOrigin> CopyOriginToStorage(ObjectInBucket destination, IngestionContext context,
         bool verifySize,
-        CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken = default)
+        CustomerOriginStrategy customerOriginStrategy,
+        Func<string, CancellationToken, Task<string?>>? validator = null,
+        CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
-        var copyResult = await DoItemCopy(destination, context, verifySize, customerOriginStrategy, cancellationToken);
+        var copyResult = await DoItemCopy(destination, context, verifySize, customerOriginStrategy, validator,
+            cancellationToken);
         stopwatch.Stop();
         logger.LogDebug("Copied item {Item} in {Elapsed}ms using {OriginStrategy}",
             context.GetOriginItem().Identifier(), stopwatch.ElapsedMilliseconds, customerOriginStrategy.Strategy);
@@ -55,17 +64,20 @@ public class AssetToS3(
     }
 
     private async Task<AssetFromOrigin> DoItemCopy(ObjectInBucket destination, IngestionContext context,
-        bool verifySize, CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken)
+        bool verifySize, CustomerOriginStrategy customerOriginStrategy,
+        Func<string, CancellationToken, Task<string?>>? validator,
+        CancellationToken cancellationToken)
     {
-        if (ShouldCopyBucketToBucket(customerOriginStrategy))
+        if (validator == null && ShouldCopyBucketToBucket(customerOriginStrategy))
         {
             // We have direct bucket access so can copy directly using SDK
             return await CopyAssetBucketToBucket(context, destination, verifySize, cancellationToken);
         }
 
-        // We don't have direct bucket access; or it's a non-S3 origin so copy S3->Disk->S3 
+        // We don't have direct bucket access; or it's a non-S3 origin so copy S3->Disk->S3.
+        // Also forced when a validator is provided, so the file is available on disk for inspection.
         return await IndirectAssetCopyBucketToBucket(context, destination, verifySize, customerOriginStrategy,
-            cancellationToken);
+            validator, cancellationToken);
     }
 
     private static bool ShouldCopyBucketToBucket(CustomerOriginStrategy customerOriginStrategy)
@@ -127,7 +139,9 @@ public class AssetToS3(
 
     private async Task<AssetFromOrigin> IndirectAssetCopyBucketToBucket(IngestionContext context,
         ObjectInBucket destination,
-        bool verifySize, CustomerOriginStrategy customerOriginStrategy, CancellationToken cancellationToken)
+        bool verifySize, CustomerOriginStrategy customerOriginStrategy,
+        Func<string, CancellationToken, Task<string?>>? validator,
+        CancellationToken cancellationToken)
     {
         var item = context.GetOriginItem();
 
@@ -147,12 +161,21 @@ public class AssetToS3(
                 return itemOnDisk;
             }
 
+            downloadedFile = itemOnDisk.Location;
+
+            if (validator != null)
+            {
+                var validationError = await validator(itemOnDisk.Location, cancellationToken);
+                if (validationError != null)
+                {
+                    throw new InvalidOperationException(validationError);
+                }
+            }
+
             logger.LogDebug("Copied '{Item}' to disk, copying to bucket..", item.Identifier());
 
             var success = await bucketWriter.WriteFileToBucket(destination, itemOnDisk.Location,
                 itemOnDisk.ContentType, cancellationToken);
-
-            downloadedFile = itemOnDisk.Location;
 
             if (!success)
             {

--- a/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
+++ b/src/protagonist/Engine/Ingest/Persistence/AssetToS3.cs
@@ -48,10 +48,8 @@ public class AssetToS3(
     private readonly EngineSettings engineSettings = engineSettings.CurrentValue;
 
     public async Task<AssetFromOrigin> CopyOriginToStorage(ObjectInBucket destination, IngestionContext context,
-        bool verifySize,
-        CustomerOriginStrategy customerOriginStrategy,
-        Func<string, CancellationToken, Task<string?>>? validator = null,
-        CancellationToken cancellationToken = default)
+        bool verifySize, CustomerOriginStrategy customerOriginStrategy,
+        Func<string, CancellationToken, Task<string?>>? validator = null, CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
         var copyResult = await DoItemCopy(destination, context, verifySize, customerOriginStrategy, validator,
@@ -65,8 +63,7 @@ public class AssetToS3(
 
     private async Task<AssetFromOrigin> DoItemCopy(ObjectInBucket destination, IngestionContext context,
         bool verifySize, CustomerOriginStrategy customerOriginStrategy,
-        Func<string, CancellationToken, Task<string?>>? validator,
-        CancellationToken cancellationToken)
+        Func<string, CancellationToken, Task<string?>>? validator, CancellationToken cancellationToken)
     {
         if (validator == null && ShouldCopyBucketToBucket(customerOriginStrategy))
         {
@@ -84,8 +81,7 @@ public class AssetToS3(
         => customerOriginStrategy is { Strategy: OriginStrategyType.S3Ambient };
 
     private async Task<AssetFromOrigin> CopyAssetBucketToBucket(IngestionContext context, ObjectInBucket destination,
-        bool verifySize,
-        CancellationToken cancellationToken)
+        bool verifySize, CancellationToken cancellationToken)
     {
         var item = context.GetOriginItem();
 
@@ -107,8 +103,7 @@ public class AssetToS3(
     }
 
     private async Task<LargeObjectCopyResult> CopyBucketToBucket(IOriginItem originItem, ObjectInBucket destination,
-        int customerId, bool verifySize, long preIngestionSize,
-        CancellationToken cancellationToken)
+        int customerId, bool verifySize, long preIngestionSize, CancellationToken cancellationToken)
     {
         var source = RegionalisedObjectInBucket.Parse(originItem.Origin!);
         if (source == null)

--- a/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
+++ b/src/protagonist/Engine/Ingest/Timebased/TimebasedIngesterWorker.cs
@@ -44,7 +44,7 @@ public class TimebasedIngesterWorker : IAssetIngesterWorker
                 targetStorageLocation,
                 ingestionContext,
                 !assetIngestorSizeCheck.CustomerHasNoStorageCheck(asset.Customer),
-                customerOriginStrategy, cancellationToken);
+                customerOriginStrategy, cancellationToken: cancellationToken);
             ingestionContext.WithAssetFromOrigin(assetInBucket);
 
             var jobMetadata = GetJobMetadata(ingestionContext);


### PR DESCRIPTION
## What does this change?

Resolves #1195 

Validate that hosted `"iiifLink": "annotations"` are valid JSON. Abort if not the case. 

Summary
* Extend `AssetToS3.CopyOriginToStorage()` to accept an optional validation function. If passed this is called after the object is downloaded. 
  * _This will affect direct s3->s3 bucket copies as the object will be downloaded first_. Passing this validator function makes everything use the "indirect" path.
  * This function returns an error message. If `null` is returned then the validation passes, if not-null is returned then an error has occurred and an exception is thrown. Returning string for error/null for okay is a strategy used elsewhere and is documented in xml comments and is an easy to understand approach.
* ``FileChannelWorker` will treat `"annotations"` and non-`"annotations"` slightly differently to handle validation step.

> [!CAUTION]
> This changes `S3AmbientOriginStrategy` very slightly. It now detects a null return value and sets `.IsEmpty` in returned object if this is the case. 
> This is a widely used method but should not affect any handling as `Stream.IsNull()` detection will still work.

