### PR TITLE
Update wording of adjunct error message

### DIFF
--- a/src/protagonist/API.Tests/Integration/AdjunctTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctTests.cs
@@ -1084,9 +1084,8 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
-        (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be("One or more adjuncts were expected in request body but found none");;
+        (await tryRead.Should().ThrowAsync<DlcsException>()).WithMessage(
+            "One or more adjuncts were expected in request body but found none");
     }
     
     [Fact]
@@ -1130,9 +1129,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
-        (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be("'iiifLink' is required");
+        (await tryRead.Should().ThrowAsync<DlcsException>()).WithMessage("'iiifLink' is required");
         
         // verify db unchanged
         dbContext.Adjuncts.Count(a=>a.AssetId == assetId).Should().Be(0, "no adjuncts for this asset should have been created");
@@ -1183,8 +1180,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
         (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be("Create failed. Adjunct or adjuncts with id(s) in (someAdjunctId1,someAdjunctId2) already exists");
+            .WithMessage("Create failed. Adjunct or adjuncts with id(s) in (someAdjunctId1,someAdjunctId2) already exists");
         
         // verify db unchanged
         dbContext.Adjuncts.Count(a=>a.AssetId == assetId).Should().Be(1, "no additional adjuncts for this asset should have been created");
@@ -1231,8 +1227,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
         (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be($"Asset with id '{assetId}' not found");
+            .WithMessage($"Asset with id '{assetId}' not found");
     }
     
     [Fact]
@@ -1261,8 +1256,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
         (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be("One or more adjuncts were expected in request body but found none");
+            .WithMessage("One or more adjuncts were expected in request body but found none");
     }
     
     [Fact]
@@ -1314,8 +1308,7 @@ public class AdjunctTests : IClassFixture<ProtagonistAppFactory<Startup>>
         response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
         (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be($"One or more adjuncts for asset {assetId} failed submission for ingestion and will need to be resubmitted");
+            .WithMessage($"One or more adjuncts for asset {assetId} failed submission for ingestion and will need to be resubmitted");
         
         // verify db status
         dbContext.Adjuncts.Count(a=>a.AssetId == assetId).Should().Be(2, "creation in db worked, but we failed after saving");

--- a/src/protagonist/API.Tests/Integration/AdjunctUnexpectedErrorTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctUnexpectedErrorTests.cs
@@ -79,8 +79,7 @@ public class AdjunctUnexpectedErrorTests : IClassFixture<ProtagonistAppFactory<S
         response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
 
         Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
-        (await tryRead.Should().ThrowAsync<DlcsException>())
-            .Which.Message.Should()
-            .Be($"Unknown error processing adjuncts for {assetId}");
+        (await tryRead.Should().ThrowAsync<DlcsException>()).WithMessage(
+            $"Unknown error processing adjuncts for {assetId}");
     }
 }

--- a/src/protagonist/API.Tests/Integration/AdjunctUnexpectedErrorTests.cs
+++ b/src/protagonist/API.Tests/Integration/AdjunctUnexpectedErrorTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using API.Client;
+using API.Tests.Integration.Infrastructure;
+using DLCS.Model.Storage;
+using DLCS.Repository;
+using FakeItEasy;
+using Hydra.Model;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Test.Helpers.Data;
+using Test.Helpers.Integration;
+using Test.Helpers.Integration.Infrastructure;
+
+namespace API.Tests.Integration;
+
+[Trait("Category", "Integration")]
+[Collection(StorageCollection.CollectionName)]
+public class AdjunctUnexpectedErrorTests : IClassFixture<ProtagonistAppFactory<Startup>>
+{
+    private readonly HttpClient httpClient;
+    private readonly DlcsContext dbContext;
+
+    private static readonly IStorageRepository StorageRepository = A.Fake<IStorageRepository>();
+
+    public AdjunctUnexpectedErrorTests(StorageFixture storageFixture, ProtagonistAppFactory<Startup> factory)
+    {
+        httpClient = factory.ConfigureBasicAuthedIntegrationTestHttpClient(
+            storageFixture.DbFixture, "API-Test",
+            f => f.WithLocalStack(storageFixture.LocalStackFixture)
+                .WithTestServices(services =>
+                {
+                    services.AddAuthentication("API-Test")
+                        .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                            "API-Test", o => { o.TimeProvider = TimeProvider.System; });
+                    services.AddSingleton<IStorageRepository>(_ => StorageRepository);
+                }));
+        dbContext = storageFixture.DbFixture.DbContext;
+        storageFixture.DbFixture.CleanUp();
+    }
+
+    [Fact]
+    public async Task PutAdjunct_Returns500_WithCorrectMessage_WhenUnexpectedErrorOccurs()
+    {
+        // Arrange — seed a hosted adjunct (has an origin) so that a PUT without origin triggers hosted→external transition,
+        // causing DecrementAdjunctStorage to be called. The fake throws to simulate an unexpected error.
+        var assetId = AssetIdGenerator.GetAssetId();
+        const string adjunctId = "hosted-adjunct";
+
+        await dbContext.Images.AddTestAsset(assetId)
+            .WithTestAdjunct(adjunctId, origin: "https://example.com/file.jpg", size: 1024);
+        await dbContext.SaveChangesAsync();
+
+        A.CallTo(() => StorageRepository.DecrementAdjunctStorage(
+                A<int>._, A<int>._, A<long>._, A<CancellationToken>._))
+            .ThrowsAsync(new InvalidOperationException("Simulated unexpected error"));
+
+        // PUT the adjunct without origin to trigger the hosted→external transition
+        const string updateJson = $$"""
+                                    {
+                                      "id": "{{adjunctId}}",
+                                      "@type": "Image",
+                                      "externalId": "https://example.com/external",
+                                      "iiifLink": "seeAlso",
+                                      "mediaType": "image/jpeg"
+                                    }
+                                    """;
+
+        var path = $"{assetId.ToApiResourcePath()}/adjuncts/{adjunctId}";
+        var content = new StringContent(updateJson, Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await httpClient.AsCustomer(assetId.Customer).PutAsync(path, content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+
+        Func<Task> tryRead = () => response.ReadAsHydraResponseAsync<Error>();
+        (await tryRead.Should().ThrowAsync<DlcsException>())
+            .Which.Message.Should()
+            .Be($"Unknown error processing adjuncts for {assetId}");
+    }
+}

--- a/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
+++ b/src/protagonist/API/Features/Adjuncts/Requests/CreateOrUpdateAdjunct.cs
@@ -94,7 +94,7 @@ public class CreateOrUpdateAdjunctHandler(
         {
             await transaction.RollbackAsync(CancellationToken.None);
             logger.LogError(exception, "Error processing adjuncts for {AssetId}", assetId);
-            return ModifyEntityResult<Adjunct[]>.Failure($"Unknown database error saving adjuncts for {assetId}");
+            return ModifyEntityResult<Adjunct[]>.Failure($"Unknown error processing adjuncts for {assetId}");
         }
 
         // Reload all from db - this confirms all saved fine, and we also retrieve the asset object for use below


### PR DESCRIPTION
## What does this change?

This PR updates an error message to be closer to what is actually happening so that a user does not get confused with the issue being related to the database, as opposed to being a more general processing error