### PR TITLE
Delete CustomerStorage on space delete

### DIFF
--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -493,26 +493,32 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         var response = await httpClient.AsCustomer().PostAsync($"/customers/{customerId}/spaces", content);
         var space = await response.ReadAsHydraResponseAsync<Space>();
         var spaceCounterBeforeDeletion = await 
-            dbContext.EntityCounters.FirstOrDefaultAsync(s => 
+            dbContext.EntityCounters.SingleOrDefaultAsync(s => 
                 s.Customer == customerId && s.Scope == customerId.ToString() && s.Type == "space");
+        
+        var newSpaceId = space.ModelId!;
+        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId.Value, newSpaceId, 10000);
+        await dbContext.SaveChangesAsync();
 
         // Act
         var deleteResponse = await httpClient.AsCustomer()
-            .DeleteAsync($"/customers/{customerId}/spaces/{space.ModelId}");
+            .DeleteAsync($"/customers/{customerId}/spaces/{newSpaceId}");
         
         var spaceCounterAfterDeletion = await 
-            dbContext.EntityCounters.FirstOrDefaultAsync(s => 
+            dbContext.EntityCounters.SingleOrDefaultAsync(s => 
                 s.Customer == customerId && s.Scope == customerId.ToString() && s.Type == "space");
         
         // Assert
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
-        var deletedSpace = await dbContext.Spaces.SingleOrDefaultAsync(s => s.Id == space.ModelId && s.Customer == customerId );
+        var deletedSpace = await dbContext.Spaces.SingleOrDefaultAsync(s => s.Id == newSpaceId && s.Customer == customerId );
         deletedSpace.Should().BeNull();
 
         spaceCounterBeforeDeletion.Should().NotBeNull();
         spaceCounterAfterDeletion.Should().NotBeNull();
-        spaceCounterAfterDeletion.Next.Should().Be(spaceCounterBeforeDeletion.Next - 1
-                , "because we perform a decrement on the space entity counter on deletion");
+        spaceCounterAfterDeletion.Next.Should().Be(spaceCounterBeforeDeletion.Next - 1,
+            "because we perform a decrement on the space entity counter on deletion");
+        (await dbContext.CustomerStorages.AnyAsync(s => s.Customer == customerId && s.Space == newSpaceId))
+            .Should().BeFalse("CustomerStorage deleted");
     }
     
     [Fact]

--- a/src/protagonist/API.Tests/Integration/SpaceTests.cs
+++ b/src/protagonist/API.Tests/Integration/SpaceTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Text;
 using API.Client;
 using API.Tests.Integration.Infrastructure;
@@ -13,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json.Linq;
 using Test.Helpers.Integration;
 using Test.Helpers.Integration.Infrastructure;
+using CustomerStorage = DLCS.Model.Storage.CustomerStorage;
 
 namespace API.Tests.Integration;
 
@@ -137,6 +140,29 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
                 ec.Scope == next.ToString());
         spaceImageCounter.Should().NotBeNull();
         spaceImageCounter.Next.Should().Be(1); // Deliverator makes 0 here. But that doesn't feel right!
+    }
+    
+    [Fact]
+    public async Task Create_Space_Creates_CustomerStorage()
+    {
+        int? customerId = await EnsureCustomerForSpaceTests();
+
+        var currentCounter = await dbContext.CustomerStorages.AnyAsync(cs => cs.Customer == customerId && cs.Space > 0);
+        currentCounter.Should().BeFalse("Confirm no CustomerStorage beyond the defaults");
+
+        const string newSpaceJson = @"{
+  ""@type"": ""Space"",
+  ""name"": ""Entity Counter Test Space""
+}";
+        
+        var content = new StringContent(newSpaceJson, Encoding.UTF8, "application/json");
+        var postUrl = $"/customers/{customerId}/spaces";
+        var response = await httpClient.AsCustomer(customerId.Value).PostAsync(postUrl, content);
+        var apiSpace = await response.ReadAsHydraResponseAsync<Space>();
+
+        var spaceId = apiSpace.Id.GetLastPathElementAsInt();
+        var customerStorage = await dbContext.CustomerStorages.SingleAsync(cs => cs.Customer == customerId && cs.Space == spaceId);
+        customerStorage.Should().NotBeNull("Confirm CustomerStorage created");
     }
 
     [Fact]
@@ -263,7 +289,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Patch_Space_Updates_Name()
     {
-        int? customerId = await EnsureCustomerForSpaceTests("Patch_Space_Updates_Name");
+        int? customerId = await EnsureCustomerForSpaceTests();
         await dbContext.Spaces.AddTestSpace(customerId.Value, 1, "Patch Space Before");
         await dbContext.SaveChangesAsync();
         
@@ -283,7 +309,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Patch_Space_Prevents_Name_Conflict()
     {
-        int? customerId = await EnsureCustomerForSpaceTests("Patch_Space_Prevents_Name_Conflict");
+        int? customerId = await EnsureCustomerForSpaceTests();
         await dbContext.Spaces.AddTestSpace(customerId.Value, 1, "Patch Space Name 1");
         await dbContext.Spaces.AddTestSpace(customerId.Value, 2, "Patch Space Name 2");
         await dbContext.SaveChangesAsync();
@@ -302,7 +328,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Patch_Space_Leaves_Omitted_Fields_Intact()
     {
         // arrange
-        int? customerId = await EnsureCustomerForSpaceTests("Patch_Space_Leaves_Omitted_Fields_Intact");
+        int? customerId = await EnsureCustomerForSpaceTests();
         
         const string newSpaceJson = @"{
           ""@type"": ""Space"",
@@ -334,9 +360,13 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     }
     
     [Fact]
-    public async Task Put_Space_Creates_Space()
+    public async Task Put_Space_Creates_Space_AndCustomerStorage()
     {
-        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Creates_Space");
+        int? customerId = await EnsureCustomerForSpaceTests();
+        
+        var currentCounter = await dbContext.CustomerStorages.AnyAsync(cs => cs.Customer == customerId && cs.Space > 0);
+        currentCounter.Should().BeFalse("Confirm no CustomerStorage beyond the defaults");
+        
         const int spaceId = 1;
         
         const string newSpaceJson = @"{
@@ -357,12 +387,16 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         apiSpace.ModelId.Should().Be(spaceId);
         apiSpace.Name.Should().Be("Test Space");
         apiSpace.MaxUnauthorised.Should().Be(-1);
+        
+        var customerStorages = await dbContext.CustomerStorages.Where(cs => cs.Customer == customerId).ToListAsync();
+        var customerStorage = await dbContext.CustomerStorages.SingleAsync(cs => cs.Customer == customerId && cs.Space == spaceId);
+        customerStorage.Should().NotBeNull("Confirm CustomerStorage created");
     }
     
     [Fact]
     public async Task Put_Space_Updates_Name()
     {
-        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Updates_Name");
+        int? customerId = await EnsureCustomerForSpaceTests();
         await dbContext.Spaces.AddTestSpace(customerId.Value, 1, "Put Space Before");
         await dbContext.SaveChangesAsync();
         
@@ -382,7 +416,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     [Fact]
     public async Task Put_Space_Prevents_Name_Conflict()
     {
-        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Prevents_Name_Conflict");
+        int? customerId = await EnsureCustomerForSpaceTests();
         await dbContext.Spaces.AddTestSpace(customerId.Value, 1, "Put Space Name 1");
         await dbContext.Spaces.AddTestSpace(customerId.Value, 2, "Put Space Name 2");
         await dbContext.SaveChangesAsync();
@@ -401,7 +435,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task Put_Space_Leaves_Omitted_Fields_Intact()
     {
         // arrange
-        int? customerId = await EnsureCustomerForSpaceTests("Put_Space_Leaves_Omitted_Fields_Intact");
+        int? customerId = await EnsureCustomerForSpaceTests();
         
         const string newSpaceJson = @"{
           ""@type"": ""Space"",
@@ -432,8 +466,40 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
         putSpace.MaxUnauthorised.Should().Be(400);
     }
     
+    [Fact]
+    public async Task Put_Space_Creates_Space_IfCustomerStorageAlreadyExists()
+    {
+        int? customerId = await EnsureCustomerForSpaceTests();
+        const int spaceId = 1;
+
+        await dbContext.CustomerStorages.AddAsync(new CustomerStorage
+            { Customer = customerId.Value, Space = spaceId });
+        await dbContext.SaveChangesAsync();
+        
+        const string newSpaceJson = @"{
+          ""@type"": ""Space"",
+          ""name"": ""Test Space""
+        }";
+        
+        // Act
+        var content = new StringContent(newSpaceJson, Encoding.UTF8, "application/json");
+        var postUrl = $"/customers/{customerId}/spaces/{spaceId}";
+        var response = await httpClient.AsCustomer(customerId.Value).PutAsync(postUrl, content);
+        var apiSpace = await response.ReadAsHydraResponseAsync<Space>();
+        
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        
+        apiSpace.Should().NotBeNull();
+        apiSpace.ModelId.Should().Be(spaceId);
+        apiSpace.Name.Should().Be("Test Space");
+        apiSpace.MaxUnauthorised.Should().Be(-1);
+        
+        var customerStorage = await dbContext.CustomerStorages.SingleAsync(cs => cs.Customer == customerId && cs.Space == spaceId);
+        customerStorage.Should().NotBeNull("Confirm CustomerStorage created");
+    }
     
-    private async Task<int?> EnsureCustomerForSpaceTests(string customerName = "space-test-customer")
+    private async Task<int?> EnsureCustomerForSpaceTests([CallerMemberName] string customerName = "space-test-customer")
     {
         var spaceTestCustomer = await dbContext.Customers.SingleOrDefaultAsync(c => c.Name == customerName);
 
@@ -484,7 +550,7 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
     public async Task DeleteSpace_Returns_Ok()
     {
         // Arrange
-        int? customerId = await EnsureCustomerForSpaceTests(nameof(DeleteSpace_Returns_Ok));
+        int? customerId = await EnsureCustomerForSpaceTests();
         const string spaceJson = @"{
   ""name"": ""test space""
 }";
@@ -497,8 +563,6 @@ public class SpaceTests : IClassFixture<ProtagonistAppFactory<Startup>>
                 s.Customer == customerId && s.Scope == customerId.ToString() && s.Type == "space");
         
         var newSpaceId = space.ModelId!;
-        await dbContext.CustomerStorages.AddTestCustomerStorage(customerId.Value, newSpaceId, 10000);
-        await dbContext.SaveChangesAsync();
 
         // Act
         var deleteResponse = await httpClient.AsCustomer()

--- a/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
+++ b/src/protagonist/API/Features/Customer/Requests/CreateCustomer.cs
@@ -20,54 +20,35 @@ namespace API.Features.Customer.Requests;
 /// <summary>
 /// Create a new Customer
 /// </summary>
-public class CreateCustomer : IRequest<ModifyEntityResult<CustomerEntity>>, IInvalidateCaches
+public class CreateCustomer(string name, string displayName)
+    : IRequest<ModifyEntityResult<CustomerEntity>>, IInvalidateCaches
 {
     /// <summary>
     /// Customer name. Will be checked for uniqueness.
     /// Used as the URL component.
     /// </summary>
-    public string Name { get; }
-    
+    public string Name { get; } = name;
+
     /// <summary>
     /// Display name, must also be unique.
     /// </summary>
-    public string DisplayName { get; }
-    
-    public CreateCustomer(string name, string displayName)
-    {
-        Name = name;
-        DisplayName = displayName;
-    }
+    public string DisplayName { get; } = displayName;
 
-    public string[] InvalidatedCacheKeys => new[] { CacheKeys.CustomerIdLookup, CacheKeys.CustomerNameLookup };
+    public string[] InvalidatedCacheKeys => [CacheKeys.CustomerIdLookup, CacheKeys.CustomerNameLookup];
 }
 
-public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEntityResult<CustomerEntity>>
+public class CreateCustomerHandler(
+    DlcsContext dbContext,
+    IEntityCounterRepository entityCounterRepository,
+    IAuthServicesRepository authServicesRepository,
+    IStorageRepository storageRepository,
+    DapperNewCustomerDeliveryChannelRepository deliveryChannelPolicyRepository,
+    ICustomerNotificationSender customerNotificationSender,
+    ILogger<CreateCustomerHandler> logger)
+    : IRequestHandler<CreateCustomer, ModifyEntityResult<CustomerEntity>>
 {
     private const string CustomerNameTaken = "A customer with this name (url part) already exists.";
     private const string CustomerDisplayNameTaken = "A customer with this display name (label) already exists.";
-    private readonly DlcsContext dbContext;
-    private readonly IEntityCounterRepository entityCounterRepository;
-    private readonly IAuthServicesRepository authServicesRepository;
-    private readonly DapperNewCustomerDeliveryChannelRepository deliveryChannelPolicyRepository;
-    private readonly ICustomerNotificationSender customerNotificationSender;
-    private readonly ILogger<CreateCustomerHandler> logger;
-
-    public CreateCustomerHandler(
-        DlcsContext dbContext,
-        IEntityCounterRepository entityCounterRepository,
-        IAuthServicesRepository authServicesRepository,
-        DapperNewCustomerDeliveryChannelRepository deliveryChannelPolicyRepository,
-        ICustomerNotificationSender customerNotificationSender,
-        ILogger<CreateCustomerHandler> logger)
-    {
-        this.dbContext = dbContext;
-        this.entityCounterRepository = entityCounterRepository;
-        this.authServicesRepository = authServicesRepository;
-        this.deliveryChannelPolicyRepository = deliveryChannelPolicyRepository;
-        this.customerNotificationSender = customerNotificationSender;
-        this.logger = logger;
-    }
 
     public async Task<ModifyEntityResult<CustomerEntity>> Handle(CreateCustomer request, CancellationToken cancellationToken)
     {
@@ -105,33 +86,16 @@ public class CreateCustomerHandler : IRequestHandler<CreateCustomer,  ModifyEnti
                 Name = "stub-assets",
                 Created = DateTime.UtcNow,
                 ImageBucket = string.Empty,
-                Tags = Array.Empty<string>(),
-                Roles = Array.Empty<string>(),
+                Tags = [],
+                Roles = [],
                 MaxUnauthorised = -1
             }, cancellationToken);
 
             // Create null-space aggregate CustomerStorage row for storage tracking
-            await dbContext.CustomerStorages.AddAsync(new CustomerStorage
-            {
-                Customer = newCustomerId,
-                Space = null,
-                StoragePolicy = StoragePolicy.DefaultStoragePolicyName,
-                NumberOfStoredImages = 0,
-                TotalSizeOfStoredImages = 0,
-                TotalSizeOfThumbnails = 0
-            }, cancellationToken);
+            await storageRepository.TryCreateCustomerStorage(newCustomerId, null, cancellationToken: cancellationToken);
 
             // Pre-seed a per-space row for space 0 (stub-assets) so that Engine storage increments
-            // hit an existing row rather than silently no-oping on their first UPDATE.
-            await dbContext.CustomerStorages.AddAsync(new CustomerStorage
-            {
-                Customer = newCustomerId,
-                Space = 0,
-                StoragePolicy = StoragePolicy.DefaultStoragePolicyName,
-                NumberOfStoredImages = 0,
-                TotalSizeOfStoredImages = 0,
-                TotalSizeOfThumbnails = 0
-            }, cancellationToken);
+            await storageRepository.TryCreateCustomerStorage(newCustomerId, 0, cancellationToken: cancellationToken);
 
             await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/protagonist/API/Features/Space/Requests/DeleteSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/DeleteSpace.cs
@@ -8,31 +8,17 @@ namespace API.Features.Space.Requests;
 /// <summary>
 /// Deletes a specified space for customer
 /// </summary>
-public class DeleteSpace: IRequest<ResultMessage<DeleteResult>>
+public class DeleteSpace(int customerId, int spaceId) : IRequest<ResultMessage<DeleteResult>>
 {
-    public DeleteSpace(int customerId, int spaceId)
-    {
-        CustomerId = customerId;
-        SpaceId = spaceId;
-    }
-    
-    public int CustomerId { get; }
-    public int SpaceId { get; }
+    public int CustomerId { get; } = customerId;
+    public int SpaceId { get; } = spaceId;
 }
 
-public class DeleteSpaceHandler : IRequestHandler<DeleteSpace, ResultMessage<DeleteResult>>
+public class DeleteSpaceHandler(
+    ISpaceRepository spaceRepository,
+    ILogger<DeleteSpaceHandler> logger)
+    : IRequestHandler<DeleteSpace, ResultMessage<DeleteResult>>
 {
-    private readonly ISpaceRepository spaceRepository;
-    private readonly ILogger<DeleteSpaceHandler> logger;
-
-    public DeleteSpaceHandler(
-        ISpaceRepository spaceRepository,
-        ILogger<DeleteSpaceHandler> logger)
-    {
-        this.spaceRepository = spaceRepository;
-        this.logger = logger;
-    }
-    
     public async Task<ResultMessage<DeleteResult>> Handle(DeleteSpace request, CancellationToken cancellationToken)
     {
         if (request.SpaceId == 0)

--- a/src/protagonist/API/Features/Space/Requests/PutSpace.cs
+++ b/src/protagonist/API/Features/Space/Requests/PutSpace.cs
@@ -53,7 +53,7 @@ public class PutSpaceHandler : IRequestHandler<PutSpace, ModifyEntityResult<DLCS
                     WriteResult.Conflict);
         }
         
-        var putSpaceResult = await spaceRepository.PutSpace(
+        var putSpaceResult = await spaceRepository.UpsertSpace(
             request.CustomerId, request.SpaceId, request.Name, request.ImageBucket,
             request.MaxUnauthorised, request.Tags, request.Roles,
             cancellationToken);

--- a/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
+++ b/src/protagonist/DLCS.Model/Spaces/ISpaceRepository.cs
@@ -30,7 +30,7 @@ public interface ISpaceRepository
     Task<Space> PatchSpace(int customerId, int spaceId, string? name, int? maxUnauthorised, string[]? tags,
         string[]? roles, CancellationToken cancellationToken);
     
-    Task<Space> PutSpace(int customerId, int spaceId, string? name, string? imageBucket, int? maxUnauthorised, string[]? tags,
+    Task<Space> UpsertSpace(int customerId, int spaceId, string? name, string? imageBucket, int? maxUnauthorised, string[]? tags,
         string[]? roles, CancellationToken cancellationToken);
 
     Task<ResultMessage<DeleteResult>> DeleteSpace(int customerId, int spaceId, CancellationToken cancellationToken);

--- a/src/protagonist/DLCS.Model/Storage/IStorageRepository.cs
+++ b/src/protagonist/DLCS.Model/Storage/IStorageRepository.cs
@@ -19,4 +19,10 @@ public interface IStorageRepository
     /// Delete customer storage record
     /// </summary>
     public Task<bool> DeleteCustomerStorage(int customer, int space, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Create new customer storage record for given space
+    /// </summary>
+    public Task TryCreateCustomerStorage(int customer, int? space, string policy = StoragePolicy.DefaultStoragePolicyName,
+        CancellationToken cancellationToken = default);
 }

--- a/src/protagonist/DLCS.Model/Storage/IStorageRepository.cs
+++ b/src/protagonist/DLCS.Model/Storage/IStorageRepository.cs
@@ -14,4 +14,9 @@ public interface IStorageRepository
 
     /// <summary>Decrement adjunct counts in CustomerStorage and AdjunctSize in ImageStorage when there are multiple adjuncts being removed.</summary>
     public Task DecrementAdjunctStorage(AssetId assetId, long adjunctSize, int adjunctCount, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Delete customer storage record
+    /// </summary>
+    public Task<bool> DeleteCustomerStorage(int customer, int space, CancellationToken cancellationToken);
 }

--- a/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
@@ -93,9 +93,11 @@ public class SpaceRepositoryTests
     [Fact]
     public async Task DeleteSpace_ReturnsConflict_WhenSpaceHasImages()
     {
-        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/1"), ref1: "foobar");
+        const int customerId = 9903;
+        await dbContext.Images.AddTestAsset(AssetId.FromString("9903/1/1"), customer: customerId);
+        await dbContext.Spaces.AddTestSpace(customerId, 1);
         await dbContext.SaveChangesAsync();
-        var deleteResult = await sut.DeleteSpace(99, 1, CancellationToken.None);
+        var deleteResult = await sut.DeleteSpace(customerId, 1, CancellationToken.None);
 
         // Assert
         deleteResult.Value.Should().Be(DeleteResult.Conflict);
@@ -105,7 +107,7 @@ public class SpaceRepositoryTests
     public async Task DeleteSpace_ReturnsDeleted_AndCallsCleanup_WhenSuccessful()
     {
         // Arrange
-        const int customerId = 99;
+        const int customerId = 9901;
         const int spaceId = 2;
         dbContext.Spaces.Add(new Space
         {
@@ -122,9 +124,102 @@ public class SpaceRepositoryTests
         deleteResult.Value.Should().Be(DeleteResult.Deleted);
         A.CallTo(() => storageRepository.DeleteCustomerStorage(customerId, spaceId, A<CancellationToken>._))
             .MustHaveHappenedOnceExactly();
-        A.CallTo(() => entityCounterRepository.Decrement(customerId, KnownEntityCounters.CustomerSpaces, "99", 1))
+        A.CallTo(() => entityCounterRepository.Decrement(customerId, KnownEntityCounters.CustomerSpaces, "9901", 1))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => entityCounterRepository.Remove(customerId, KnownEntityCounters.SpaceImages, "2", 1))
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CreateSpace_ReturnsSpace_WithProvidedValues()
+    {
+        // Arrange
+        const int customer = 192239;
+        A.CallTo(() => entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .Returns(2L);
+
+        // Act
+        var space = await sut.CreateSpace(customer, "new-space", "my-bucket", ["tag1"], ["role1"], 400,
+            CancellationToken.None);
+
+        // Assert
+        space.Id.Should().Be(2);
+        space.Customer.Should().Be(customer);
+        space.Name.Should().Be("new-space");
+        space.ImageBucket.Should().Be("my-bucket");
+        space.Tags.Should().BeEquivalentTo(["tag1"]);
+        space.Roles.Should().BeEquivalentTo(["role1"]);
+        space.MaxUnauthorised.Should().Be(400);
+    }
+
+    [Fact]
+    public async Task CreateSpace_ReturnsSpace_WithDefaultValues_WhenOptionalParamsNull()
+    {
+        // Arrange
+        const int customer = 123929;
+        A.CallTo(() => entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .Returns(2L);
+
+        // Act
+        var space = await sut.CreateSpace(customer, "new-space", null, null, null, null, CancellationToken.None);
+
+        // Assert
+        space.ImageBucket.Should().BeEmpty();
+        space.Tags.Should().BeEmpty();
+        space.Roles.Should().BeEmpty();
+        space.MaxUnauthorised.Should().Be(-1);
+    }
+
+    [Fact]
+    public async Task CreateSpace_CreatesSpaceImagesCounter()
+    {
+        // Arrange
+        const int customer = 1929;
+        A.CallTo(() => entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .Returns(2L);
+
+        // Act
+        await sut.CreateSpace(customer, "new-space", null, null, null, null, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => entityCounterRepository.TryCreate(customer, KnownEntityCounters.SpaceImages, "2", 1))
+            .MustHaveHappenedOnceExactly();
+    }
+    
+    [Fact]
+    public async Task CreateSpace_CreatesCustomerStorage()
+    {
+        // Arrange
+        const int customer = 199;
+        A.CallTo(() => entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .Returns(2L);
+
+        // Act
+        await sut.CreateSpace(customer, "new-space", null, null, null, null, CancellationToken.None);
+
+        // Assert
+        A.CallTo(() => storageRepository.TryCreateCustomerStorage(customer, 2, "default", CancellationToken.None))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task CreateSpace_SkipsId_IfIdAlreadyInUse()
+    {
+        // Arrange - space 1 already exists; first call returns 1, second returns 2
+        const int customer = 13299;
+        dbContext.Spaces.Add(new Space { Id = 1, Customer = customer, Name = "space-already" });
+        await dbContext.SaveChangesAsync();
+        A.CallTo(() => entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .Returns(1L).Once()
+            .Then.Returns(2L);
+
+        // Act
+        var space = await sut.CreateSpace(customer, "new-space", null, null, null, null, CancellationToken.None);
+
+        // Assert
+        space.Id.Should().Be(2);
+        A.CallTo(() =>
+                entityCounterRepository.GetNext(customer, KnownEntityCounters.CustomerSpaces, customer.ToString(), 1))
+            .MustHaveHappenedTwiceExactly();
     }
 }

--- a/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
+++ b/src/protagonist/DLCS.Repository.Tests/Spaces/SpaceRepositoryTests.cs
@@ -1,11 +1,16 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using DLCS.Core;
 using DLCS.Core.Caching;
 using DLCS.Core.Types;
 using DLCS.Model;
+using DLCS.Model.Spaces;
+using DLCS.Model.Storage;
+using DLCS.Repository.Entities;
 using DLCS.Repository.Spaces;
 using FakeItEasy;
 using LazyCache.Mocks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Test.Helpers.Integration;
@@ -19,31 +24,35 @@ public class SpaceRepositoryTests
     private readonly DlcsContext dbContext;
     private readonly SpaceRepository sut;
     private readonly MockCachingService appCache;
-    
+    private readonly IEntityCounterRepository entityCounterRepository;
+    private readonly IStorageRepository storageRepository;
+
     public SpaceRepositoryTests(DlcsDatabaseFixture dbFixture)
     {
         dbContext = dbFixture.DbContext;
-        var cacheOptions = A.Fake<IOptions<CacheSettings>>();
+        // Create a dbContext for use in tests - this has change tracking etc like the normal injected context
+        var dlcsContext = new DlcsContext(
+            new DbContextOptionsBuilder<DlcsContext>()
+                .UseNpgsql(dbFixture.ConnectionString).Options
+        );
         appCache = new MockCachingService();
-        var entityCounterRepository = A.Fake<IEntityCounterRepository>();
+        entityCounterRepository = A.Fake<IEntityCounterRepository>();
+        storageRepository = A.Fake<IStorageRepository>();
 
-
-        sut = new SpaceRepository(dbFixture.DbContext, Options.Create(new CacheSettings()), appCache, new NullLogger<SpaceRepository>(), entityCounterRepository);
+        sut = new SpaceRepository(dlcsContext, Options.Create(new CacheSettings()), appCache,
+            entityCounterRepository, storageRepository, new NullLogger<SpaceRepository>());
 
         dbFixture.CleanUp();
-        dbContext.Images.AddTestAsset(AssetId.FromString("99/1/1"), ref1: "foobar");
-        dbContext.SaveChanges();
     }
     
     [Fact]
     public async Task DeleteSpace_ReturnsError_WhenCalledWithIncorrectDatabaseSetup()
     {
-        var sutTwo = new SpaceRepository(A.Fake<DlcsContext>(), 
-            Options.Create(new CacheSettings()), appCache, new NullLogger<SpaceRepository>(), 
-            A.Fake<IEntityCounterRepository>());
+        var sutTwo = new SpaceRepository(A.Fake<DlcsContext>(), Options.Create(new CacheSettings()), appCache,
+            A.Fake<IEntityCounterRepository>(), A.Fake<IStorageRepository>(), new NullLogger<SpaceRepository>());
         
         // Arrange and Act
-        var deleteResult = await sutTwo.DeleteSpace(1, 1, new CancellationToken());
+        var deleteResult = await sutTwo.DeleteSpace(1, 1, CancellationToken.None);
         
         // Assert
         deleteResult.Value.Should().Be(DeleteResult.Error);
@@ -53,7 +62,7 @@ public class SpaceRepositoryTests
     public async Task GetSpace_ReturnsSpace_WhenCalled()
     {
         // Arrange and Act
-        var getResult = await sut.GetSpace(99, 1, new CancellationToken());
+        var getResult = await sut.GetSpace(99, 1, CancellationToken.None);
 
         // Assert
         getResult.Customer.Should().Be(99);
@@ -64,10 +73,58 @@ public class SpaceRepositoryTests
     public async Task GetSpaceWithName_ReturnsSpace_WhenCalled()
     {
         // Arrange and Act
-        var getResult = await sut.GetSpace(99, "space-1", new CancellationToken());
+        var getResult = await sut.GetSpace(99, "space-1", CancellationToken.None);
 
         // Assert
         getResult.Customer.Should().Be(99);
         getResult.Id.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteSpace_ReturnsNotFound_WhenSpaceDoesNotExist()
+    {
+        // Act
+        var deleteResult = await sut.DeleteSpace(99, 999, CancellationToken.None);
+
+        // Assert
+        deleteResult.Value.Should().Be(DeleteResult.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteSpace_ReturnsConflict_WhenSpaceHasImages()
+    {
+        await dbContext.Images.AddTestAsset(AssetId.FromString("99/1/1"), ref1: "foobar");
+        await dbContext.SaveChangesAsync();
+        var deleteResult = await sut.DeleteSpace(99, 1, CancellationToken.None);
+
+        // Assert
+        deleteResult.Value.Should().Be(DeleteResult.Conflict);
+    }
+
+    [Fact]
+    public async Task DeleteSpace_ReturnsDeleted_AndCallsCleanup_WhenSuccessful()
+    {
+        // Arrange
+        const int customerId = 99;
+        const int spaceId = 2;
+        dbContext.Spaces.Add(new Space
+        {
+            Id = spaceId, Customer = customerId, Name = "space-to-delete", Created = DateTime.UtcNow,
+            ImageBucket = string.Empty, Tags = [], Roles = [],
+            MaxUnauthorised = -1
+        });
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        var deleteResult = await sut.DeleteSpace(customerId, spaceId, CancellationToken.None);
+
+        // Assert
+        deleteResult.Value.Should().Be(DeleteResult.Deleted);
+        A.CallTo(() => storageRepository.DeleteCustomerStorage(customerId, spaceId, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => entityCounterRepository.Decrement(customerId, KnownEntityCounters.CustomerSpaces, "99", 1))
+            .MustHaveHappenedOnceExactly();
+        A.CallTo(() => entityCounterRepository.Remove(customerId, KnownEntityCounters.SpaceImages, "2", 1))
+            .MustHaveHappenedOnceExactly();
     }
 }

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -55,35 +55,41 @@ public class SpaceRepository(
         var space = await GetSpaceInternal(customerId, spaceId, cancellationToken, null, true, noCache);
         return space;
     }
-    
-    public async Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken)
-    {
-        return await GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: true);
-    }
+
+    public Task<Space?> GetSpace(int customerId, string name, CancellationToken cancellationToken) =>
+        GetSpaceInternal(customerId, -1, cancellationToken, name, noCache: true);
 
     public async Task<Space> CreateSpace(int customer, string name, string? imageBucket, 
         string[]? tags, string[]? roles, int? maxUnauthorised, CancellationToken cancellationToken)
     {
         int newModelId = await GetIdForNewSpace(customer);
         
-        var space = new Space
-        {
-            Customer = customer,
-            Id = newModelId,
-            Name = name,
-            Created = DateTime.UtcNow,
-            ImageBucket = imageBucket ?? string.Empty,
-            Tags = tags ?? Array.Empty<string>(),
-            Roles = roles ?? Array.Empty<string>(),
-            MaxUnauthorised = maxUnauthorised ?? DefaultMaxUnauthorised 
-        };
-
-        await dlcsContext.Spaces.AddAsync(space, cancellationToken);
-        await entityCounterRepository.TryCreate(customer,  KnownEntityCounters.SpaceImages, space.Id.ToString());
+        var space = await CreateSpaceInternal(newModelId, customer, name, imageBucket, tags, roles, maxUnauthorised, cancellationToken);
         await dlcsContext.SaveChangesAsync(cancellationToken);
         return space;
     }
-    
+
+    private async Task<Space> CreateSpaceInternal(int spaceId, int customer, string name, string? imageBucket,
+        string[]? tags, string[]? roles, int? maxUnauthorised, CancellationToken cancellationToken)
+    {
+        var space = new Space
+        {
+            Customer = customer,
+            Id = spaceId,
+            Name = name,
+            Created = DateTime.UtcNow,
+            ImageBucket = imageBucket ?? string.Empty,
+            Tags = tags ?? [],
+            Roles = roles ?? [],
+            MaxUnauthorised = maxUnauthorised ?? DefaultMaxUnauthorised
+        };
+
+        await dlcsContext.Spaces.AddAsync(space, cancellationToken);
+        await entityCounterRepository.TryCreate(customer, KnownEntityCounters.SpaceImages, space.Id.ToString());
+        await storageRepository.TryCreateCustomerStorage(customer, spaceId, cancellationToken: cancellationToken);
+        return space;
+    }
+
     private async Task<int> GetIdForNewSpace(int requestCustomer)
     {
         int newModelId;
@@ -206,10 +212,8 @@ public class SpaceRepository(
         return retrievedSpace.ThrowIfNull(nameof(retrievedSpace));
     }
 
-    public async Task<Space> PutSpace(
-        int customerId, int spaceId, string? name, string? imageBucket,
-        int? maxUnauthorised, string[]? tags, string[]? roles, 
-        CancellationToken cancellationToken)
+    public async Task<Space> UpsertSpace(int customerId, int spaceId, string? name, string? imageBucket,
+        int? maxUnauthorised, string[]? tags, string[]? roles, CancellationToken cancellationToken)
     {
         var existingSpace = await dlcsContext.Spaces.SingleOrDefaultAsync(s =>
             s.Customer == customerId && s.Id == spaceId, cancellationToken: cancellationToken);
@@ -238,25 +242,13 @@ public class SpaceRepository(
         }
         else
         {
-            var space = new Space
-            {
-                Customer = customerId,
-                Id = spaceId,
-                Name = name,
-                Created = DateTime.UtcNow,
-                ImageBucket = imageBucket ?? string.Empty,
-                Tags = tags ?? Array.Empty<string>(),
-                Roles = roles ?? Array.Empty<string>(),
-                MaxUnauthorised = maxUnauthorised ?? DefaultMaxUnauthorised 
-            };
-        
-            await dlcsContext.Spaces.AddAsync(space, cancellationToken);
-            await entityCounterRepository.TryCreate(customerId, KnownEntityCounters.SpaceImages, space.Id.ToString()); 
+            await CreateSpaceInternal(spaceId, customerId, name ?? spaceId.ToString(), imageBucket, tags, roles,
+                maxUnauthorised, cancellationToken);
         }
-        
+
         await dlcsContext.SaveChangesAsync(cancellationToken);
-        
-        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache:true);
+
+        var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache: true);
         return retrievedSpace.ThrowIfNull(nameof(retrievedSpace));
     }
 

--- a/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
+++ b/src/protagonist/DLCS.Repository/Spaces/SpaceRepository.cs
@@ -4,9 +4,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using DLCS.Core;
 using DLCS.Core.Caching;
+using DLCS.Core.Guard;
 using DLCS.Core.Strings;
 using DLCS.Model;
 using DLCS.Model.Spaces;
+using DLCS.Model.Storage;
 using DLCS.Repository.Entities;
 using LazyCache;
 using Microsoft.EntityFrameworkCore;
@@ -15,30 +17,19 @@ using Microsoft.Extensions.Options;
 
 namespace DLCS.Repository.Spaces;
 
-public class SpaceRepository : ISpaceRepository
+public class SpaceRepository(
+    DlcsContext dlcsContext,
+    IOptions<CacheSettings> cacheOptions,
+    IAppCache appCache,
+    IEntityCounterRepository entityCounterRepository,
+    IStorageRepository storageRepository,
+    ILogger<SpaceRepository> logger)
+    : ISpaceRepository
 {
-    private readonly DlcsContext dlcsContext;
-    private readonly IEntityCounterRepository entityCounterRepository;
-    private readonly CacheSettings cacheSettings;
-    private readonly IAppCache appCache;
-    private readonly ILogger<SpaceRepository> logger;
-    
+    private readonly CacheSettings cacheSettings = cacheOptions.Value;
+
     private const int DefaultMaxUnauthorised = -1;
 
-    public SpaceRepository(
-        DlcsContext dlcsContext,
-        IOptions<CacheSettings> cacheOptions,
-        IAppCache appCache,
-        ILogger<SpaceRepository> logger,
-        IEntityCounterRepository entityCounterRepository )
-    {
-        this.dlcsContext = dlcsContext;
-        this.appCache = appCache;
-        cacheSettings = cacheOptions.Value;
-        this.entityCounterRepository = entityCounterRepository;
-        this.logger = logger;
-    }
-    
     public async Task<int?> GetImageCountForSpace(int customerId, int spaceId)
     {
         // NOTE - this is sub-optimal but EntityCounters are not reliable when using PUT
@@ -121,7 +112,7 @@ public class SpaceRepository : ISpaceRepository
             appCache.Remove(key);
         }
         
-        return await appCache.GetOrAddAsync(key, async entry =>
+        return await appCache.GetOrAddAsync(key, async _ =>
         {
             Space? space;
             if (name != null)
@@ -136,7 +127,7 @@ public class SpaceRepository : ISpaceRepository
                     s.Customer == customerId && s.Id == spaceId, cancellationToken: cancellationToken);
             }
 
-            if (space == null || withApproximateImageCount == false)
+            if (space == null || !withApproximateImageCount)
             {
                 return space;
             }
@@ -186,7 +177,9 @@ public class SpaceRepository : ISpaceRepository
         CancellationToken cancellationToken)
     {    
         var keys = new object[] {spaceId, customerId}; // Keys are in this order
-        var dbSpace = await dlcsContext.Spaces.FindAsync(keys, cancellationToken);
+        
+        // The caller should have confirmed space exists already
+        var dbSpace = (await dlcsContext.Spaces.FindAsync(keys, cancellationToken)).ThrowIfNull("dbSpace");
         if (name.HasText() && name != dbSpace.Name)
         {
             dbSpace.Name = name;
@@ -207,12 +200,10 @@ public class SpaceRepository : ISpaceRepository
             dbSpace.MaxUnauthorised = (int)maxUnauthorised;
         }
 
-        // ImageBucket?
-        
         await dlcsContext.SaveChangesAsync(cancellationToken);
 
         var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache: true);
-        return retrievedSpace;
+        return retrievedSpace.ThrowIfNull(nameof(retrievedSpace));
     }
 
     public async Task<Space> PutSpace(
@@ -266,7 +257,7 @@ public class SpaceRepository : ISpaceRepository
         await dlcsContext.SaveChangesAsync(cancellationToken);
         
         var retrievedSpace = await GetSpaceInternal(customerId, spaceId, cancellationToken, noCache:true);
-        return retrievedSpace;
+        return retrievedSpace.ThrowIfNull(nameof(retrievedSpace));
     }
 
     public async Task<ResultMessage<DeleteResult>> DeleteSpace(int customerId, int spaceId,
@@ -293,6 +284,7 @@ public class SpaceRepository : ISpaceRepository
             dlcsContext.Spaces.Remove(space);
             await dlcsContext.SaveChangesAsync(cancellationToken);
 
+            await storageRepository.DeleteCustomerStorage(customerId, spaceId, cancellationToken);
             await entityCounterRepository.Decrement(customerId, KnownEntityCounters.CustomerSpaces,
                 customerId.ToString());
             await entityCounterRepository.Remove(customerId, KnownEntityCounters.SpaceImages,

--- a/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
+++ b/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
@@ -69,6 +69,14 @@ public class CustomerStorageRepository : IStorageRepository
         await dlcsContext.ImageStorages.DecrementAdjunctSize(assetId, adjunctSize, cancellationToken);
     }
 
+    public async Task<bool> DeleteCustomerStorage(int customer, int space, CancellationToken cancellationToken)
+    {
+        var deleted = await dlcsContext.CustomerStorages
+            .Where(cs => cs.Customer == customer && cs.Space == space)
+            .DeleteFromQueryAsync(cancellationToken);
+        return deleted > 0;
+    }
+
     public async Task<AssetStorageMetric> GetStorageMetrics(int customerId, CancellationToken cancellationToken)
     {
         // The aggregate row is seeded by CreateCustomer and backfilled by migration - its absence is a bug.

--- a/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
+++ b/src/protagonist/DLCS.Repository/Storage/CustomerStorageRepository.cs
@@ -10,22 +10,12 @@ using Microsoft.Extensions.Logging;
 
 namespace DLCS.Repository.Storage;
 
-public class CustomerStorageRepository : IStorageRepository
+public class CustomerStorageRepository(
+    DlcsContext dlcsContext,
+    IPolicyRepository policyRepository,
+    ILogger<CustomerStorageRepository> logger)
+    : IStorageRepository
 {
-    private readonly DlcsContext dlcsContext;
-    private readonly IPolicyRepository policyRepository;
-    private readonly ILogger<CustomerStorageRepository> logger;
-
-    public CustomerStorageRepository(
-        DlcsContext dlcsContext,
-        IPolicyRepository policyRepository,
-        ILogger<CustomerStorageRepository> logger)
-    {
-        this.dlcsContext = dlcsContext;
-        this.policyRepository = policyRepository;
-        this.logger = logger;
-    }
-
     public async Task<CustomerStorageSummary> GetCustomerStorageSummary(
         int customerId, CancellationToken cancellationToken)
     {
@@ -75,6 +65,30 @@ public class CustomerStorageRepository : IStorageRepository
             .Where(cs => cs.Customer == customer && cs.Space == space)
             .DeleteFromQueryAsync(cancellationToken);
         return deleted > 0;
+    }
+
+    public async Task TryCreateCustomerStorage(int customer, int? space,
+        string policy = StoragePolicy.DefaultStoragePolicyName, CancellationToken cancellationToken = default)
+    {
+        var exists = await dlcsContext.CustomerStorages.AnyAsync(cs =>
+            cs.Customer == customer && cs.Space == space, cancellationToken: cancellationToken);
+
+        if (exists)
+        {
+            // NOTE - CustomerStorage creation on Space creation was added after some instances have been running for a 
+            // long time, so some instances may have duplicate rows. This is not a bug!
+            logger.LogWarning("CustomerStorage already exists for customer {CustomerId} and space {SpaceId}", customer,
+                space);
+            return;
+        }
+
+        await dlcsContext.CustomerStorages.AddAsync(new CustomerStorage
+        {
+            Customer = customer,
+            Space = space,
+            StoragePolicy = policy,
+        }, cancellationToken);
+        await dlcsContext.SaveChangesAsync(cancellationToken);
     }
 
     public async Task<AssetStorageMetric> GetStorageMetrics(int customerId, CancellationToken cancellationToken)


### PR DESCRIPTION
## What does this change?

Without this deleting a space then recreating one with the same id can result in the old CustomerStorage record being surfaced.

The main change is `SpaceRepository` calling `DeleteCustomerStorage`, other changes were cleanup and removing warnings.

Fixes #1212